### PR TITLE
Community health: Code of Conduct, issue/PR templates, labeler config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in what you can —
+        the more detail, the faster we can help.
+        **Security issue?** Do NOT file it here — see [SECURITY.md](../blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: When I run `treg …`, I expected X but got Y.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands or actions. Redact any secrets.
+      placeholder: |
+        1. `treg …`
+        2. …
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did this happen?
+      options:
+        - CLI (treg)
+        - Web dashboard
+        - The API / proxy
+        - Self-hosted server
+        - Hosted (treg.superdesign.dev)
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `treg --version`, or the git commit if self-hosting.
+    validations:
+      required: false
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Python version, and whether you're on the hosted service or self-hosting.
+      placeholder: macOS 15, Python 3.13, self-hosted (Postgres)
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / output
+      description: Paste any error output. **Redact tokens, keys, and secrets first.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/superdesigndev/tools-registry/security/advisories/new
+    about: Report a security issue privately — never in a public issue. See SECURITY.md.
+  - name: Question / discussion
+    url: https://github.com/superdesigndev/tools-registry/discussions
+    about: Ask a question or discuss an idea (not a bug or feature request).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for the idea! Please describe the problem first, then your proposed solution.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. "I'm trying to … but …"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like to happen. A CLI command, an API, a UI change, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why this one is better.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+<!-- Thanks for contributing! Keep the description short and specific. -->
+
+## What this does
+
+<!-- One or two sentences. What changes, and why. Link any related issue: "Closes #123". -->
+
+## How it was tested
+
+<!-- Commands you ran, behavior you observed. New behavior should have a test. -->
+
+## Checklist
+
+- [ ] `uv run pytest -q` passes locally
+- [ ] Added or updated tests for the change (if it affects behavior)
+- [ ] Updated the relevant `docs/context/` fragment (if a subsystem changed)
+- [ ] No secrets in the diff (keys, tokens, `.env` values)

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+# Path → area label mapping for the PR auto-labeler (actions/labeler v5).
+# Keep in sync with the labels defined on the repo and the docs/context fragments.
+
+"area:api":
+  - changed-files:
+      - any-glob-to-any-file: 'src/treg/api.py'
+
+"area:proxy":
+  - changed-files:
+      - any-glob-to-any-file: 'src/treg/proxy.py'
+
+"area:auth-secrets":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/treg/injectors.py'
+          - 'src/treg/crypto.py'
+          - 'src/treg/oauth.py'
+          - 'src/treg/session.py'
+          - 'src/treg/email.py'
+          - 'src/treg/health.py'
+          - 'src/treg/ratestore.py'
+
+"area:cli":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/treg/cli.py'
+          - 'src/treg/convert.py'
+          - 'src/treg/shell.py'
+
+"area:runner":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'src/treg/runner.py'
+          - 'src/treg/localrun.py'
+          - 'src/treg/egress.py'
+          - 'src/treg/fsjail.py'
+
+"area:dashboard":
+  - changed-files:
+      - any-glob-to-any-file: 'src/treg/web/**'
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@superdesign.dev** (or **jason@superdesign.dev**).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
Adds the standard OSS community files (no code changes):

- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **.github/ISSUE_TEMPLATE/** — structured bug + feature forms, blank issues disabled, contact links to Security advisories + Discussions
- **.github/PULL_REQUEST_TEMPLATE.md** — what / testing / checklist
- **.github/labeler.yml** — path → `area:*` label mapping for the PR auto-labeler

The auto-labeler + stale-bot **workflows** are separate — they live under `.github/workflows/` and need the `workflow` token scope to push.