### PR TITLE
CI: PR auto-labeler + stale-bot

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: PR labeler
+
+# Auto-applies area:* labels to a PR based on the files it changes (mapping in .github/labeler.yml).
+on: [pull_request_target]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    - cron: "30 1 * * *"   # daily, 01:30 UTC
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: "security,needs-triage,help wanted,pinned"
+          exempt-pr-labels: "security,pinned"
+          stale-issue-message: >
+            This issue has had no activity for 60 days, so it is now marked stale.
+            Comment to keep it open — otherwise it will close in 14 days.
+          stale-pr-message: >
+            This pull request has had no activity for 60 days, so it is now marked stale.
+            Push a commit or comment to keep it open — otherwise it will close in 14 days.
+          close-issue-message: "Closing after 14 more days of inactivity. Reopen any time if it's still relevant."
+          close-pr-message: "Closing after 14 more days of inactivity. Reopen any time to continue."


### PR DESCRIPTION
Adds the two triage/maintenance workflows:

- **labeler.yml** — auto-applies `area:*` labels to a PR based on the files it changes (path map in `.github/labeler.yml`).
- **stale.yml** — marks issues/PRs stale after 60 days of inactivity and closes after 14 more; exempts `security`, `needs-triage`, `help wanted`, `pinned`. Runs daily + on demand.

Completes the issue-triage automation you asked for (on top of the CI + gitleaks already in place).