### PR TITLE
Bug template: add a screenshot / recording field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,6 +27,16 @@ body:
         3. See error
     validations:
       required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / recording
+      description: |
+        If it helps, add a screenshot or a short screen recording. Drag the image or video
+        directly into this box to attach it. **Blur or crop out any secrets, tokens, or keys first.**
+      placeholder: Paste or drag an image/video here.
+    validations:
+      required: false
   - type: dropdown
     id: surface
     attributes:


### PR DESCRIPTION
Adds an optional **Screenshots / recording** field to the bug report form, right after the reproduction steps, with a reminder to redact secrets. Drag-and-drop of images/video into the box already works on GitHub — this just prompts for it.