### PR TITLE
Skill sharing: shareable detail pages, one-click invite links, per-member visibility

### DIFF
--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -31,6 +31,9 @@ Faithfulness mechanics inside `relay()`:
 - request headers rebuilt from `request.headers.raw` into an `httpx.Headers` multidict (preserves
   duplicate headers / cookies); injection (`headers[name] = v`) overwrites only the named one.
 - query as a list from `request.query_params.multi_items()` (keeps duplicate keys like `?tag=a&tag=b`).
+- path rebuilt from `request.scope["raw_path"]` (in `call_tool`), not Starlette's URL-decoded path
+  param — percent-encoding survives to the upstream (npm's scoped publish `PUT /@scope%2fname` 404s
+  if `%2f` is decoded to a literal slash).
 - body streamed via `content=request.stream()` (stream, never buffer). Exception: a caller may
   base64/gzip-encode the body with `X-Treg-Body-Encoding` to slip SQL/HTML past a hosting-edge WAF;
   `_BodyDecodeMiddleware` (in api.py) then buffers + decodes it *before* `relay()` runs, so the relay

--- a/packages/npm/.gitignore
+++ b/packages/npm/.gitignore
@@ -1,0 +1,2 @@
+*.tgz
+node_modules/

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,0 +1,22 @@
+# @superdesign/treg
+
+npm launcher for **treg** — call your team's APIs through one credential-injecting
+proxy, with no keys on your machine.
+
+```bash
+npx @superdesign/treg login
+npx @superdesign/treg tool ls
+```
+
+Or install globally:
+
+```bash
+npm install -g @superdesign/treg
+treg login
+```
+
+treg itself is a Python CLI; this package finds it on your machine and runs it,
+installing it first (via `uv`, `pipx`, or `pip3`) if it's missing.
+
+- Docs & interactive tutorial: https://treg.superdesign.dev/tutorial
+- Source: https://github.com/superdesigndev/tools-registry

--- a/packages/npm/bin/treg.js
+++ b/packages/npm/bin/treg.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// @superdesign/treg — npm launcher for the treg CLI (a Python tool).
+// Finds an installed `treg`; if missing, installs it via the registry's
+// installer (https://treg.superdesign.dev/install.sh), then execs it.
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const BASE = process.env.TREG_BASE_URL || 'https://treg.superdesign.dev';
+const args = process.argv.slice(2);
+
+function findTreg() {
+  const probe = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['treg'], {
+    encoding: 'utf8',
+  });
+  if (probe.status === 0 && probe.stdout.trim()) return probe.stdout.trim().split('\n')[0];
+  // common install location not always on npm's PATH
+  const local = path.join(os.homedir(), '.local', 'bin', 'treg');
+  if (existsSync(local)) return local;
+  return null;
+}
+
+function run(bin) {
+  const res = spawnSync(bin, args, { stdio: 'inherit' });
+  process.exit(res.status === null ? 1 : res.status);
+}
+
+let bin = findTreg();
+if (bin) run(bin);
+
+if (process.platform === 'win32') {
+  console.error('treg is a Python CLI. Install it with:');
+  console.error('  uv tool install git+https://github.com/superdesigndev/tools-registry.git');
+  console.error('(get uv: https://docs.astral.sh/uv/getting-started/installation/)');
+  process.exit(1);
+}
+
+console.error(`treg not found — installing from ${BASE} ...`);
+const install = spawnSync('sh', ['-c', `curl -fsSL ${BASE}/install.sh | sh`], {
+  stdio: 'inherit',
+});
+if (install.status !== 0) {
+  console.error('\nAutomatic install failed. Install manually:');
+  console.error(`  curl -fsSL ${BASE}/install.sh | sh`);
+  process.exit(install.status === null ? 1 : install.status);
+}
+
+bin = findTreg();
+if (!bin) {
+  console.error('\nInstalled, but `treg` is not on PATH. Add ~/.local/bin to your PATH and retry.');
+  process.exit(1);
+}
+run(bin);

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@superdesign/treg",
+  "version": "0.1.0",
+  "description": "treg — call your team's APIs through one credential-injecting proxy, with no keys on your machine. npm launcher for the treg CLI.",
+  "bin": {
+    "treg": "bin/treg.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://treg.superdesign.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/superdesigndev/tools-registry.git",
+    "directory": "packages/npm"
+  },
+  "keywords": [
+    "treg",
+    "tools-registry",
+    "credentials",
+    "secrets",
+    "proxy",
+    "api-keys",
+    "agents",
+    "cli"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1700,7 +1700,7 @@ async def create_invite(
         await db.delete(prior)
     days = max(1, min(body.expires_days, 3650))  # clamp BOTH ends — a huge value overflows datetime → 500
     expires_at = _utcnow_naive() + timedelta(days=days)
-    tool_access = _normalize_tool_access(body.tool_access, await _known_tool_names(org_id, db))
+    tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
     if body.landing is not None and not _LANDING_RE.match(body.landing):
         raise HTTPException(status_code=422, detail="landing must be a detail path like /app/skills/<name>")
     code = crypto.new_token()
@@ -2183,16 +2183,23 @@ async def _known_tool_names(org_id: int, db: AsyncSession) -> set[str]:
     return {r[0] for r in rows}
 
 
+async def _known_access_names(org_id: int, db: AsyncSession) -> set[str]:
+    """Everything an access list may name: tool names (the call/run gate) plus bundle names (the
+    skill-visibility gate) — so a recipe-only skill can be granted even though it has no tool."""
+    bundles = (await db.execute(select(Bundle.name).where(Bundle.org_id == org_id))).all()
+    return await _known_tool_names(org_id, db) | {r[0] for r in bundles}
+
+
 def _normalize_tool_access(names: list[str] | None, known: set[str]) -> list[str] | None:
-    """Validate a requested tool_access list against the org's tools. None → None (all). A list must
-    name only real tools (else 422). A list covering EVERY tool collapses to None (unrestricted)."""
+    """Validate a requested access list against the org's tools + skills. None → None (all). A list
+    must name only real tools/skills (else 422). A list covering EVERYTHING collapses to None."""
     if names is None:
         return None
     unknown = [t for t in names if t not in known]
     if unknown:
-        raise HTTPException(status_code=422, detail=f"unknown tool(s): {', '.join(sorted(set(unknown)))}")
+        raise HTTPException(status_code=422, detail=f"unknown tool/skill(s): {', '.join(sorted(set(unknown)))}")
     chosen = set(names)
-    return None if chosen >= known and known else sorted(chosen)  # all tools checked → 'all' (NULL)
+    return None if chosen >= known and known else sorted(chosen)  # everything checked → 'all' (NULL)
 
 
 @app.patch("/orgs/{org_id}/members/{user_id}/access")
@@ -2210,7 +2217,7 @@ async def set_member_access(
         raise HTTPException(status_code=404, detail="not a member of this org")
     if membership.role == "owner":
         raise HTTPException(status_code=403, detail="an owner always has full access; it can't be restricted")
-    membership.tool_access = _normalize_tool_access(body.tool_access, await _known_tool_names(org_id, db))
+    membership.tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
     membership.local_run_enabled = body.local_run_enabled
     await db.commit()
     return {"user_id": user_id, "org_id": org_id, "tool_access": membership.tool_access,
@@ -3010,12 +3017,25 @@ async def import_skill_folder(
         shutil.rmtree(root, ignore_errors=True)
 
 
+async def _bundle_allowed(caller: Caller, bundle: Bundle, db: AsyncSession) -> bool:
+    """Skill visibility for a tool-restricted member: the access list may grant a bundle by its own
+    name (recipe-only skills) or via any of its tools. Owner / NULL access see everything."""
+    if caller.role == "owner" or caller.membership.tool_access is None:
+        return True
+    access = set(caller.membership.tool_access)
+    if bundle.name in access:
+        return True
+    tools = (await db.execute(select(Tool.name).where(Tool.bundle_id == bundle.id))).all()
+    return any(r[0] in access for r in tools)
+
+
 @app.get("/bundles")
 async def list_bundles(
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
 ) -> list[dict]:
     rows = (await db.execute(select(Bundle).where(Bundle.org_id == caller.org_id))).scalars().all()
-    return [{"id": b.id, "name": b.name, "owner": b.owner} for b in rows]
+    return [{"id": b.id, "name": b.name, "owner": b.owner}
+            for b in rows if await _bundle_allowed(caller, b, db)]
 
 
 @app.get("/bundles/by-name/{name}")
@@ -3028,6 +3048,9 @@ async def get_bundle_by_name(
     )).scalars().first()
     if bundle is None:
         raise HTTPException(status_code=404, detail="bundle not found")
+    if not await _bundle_allowed(caller, bundle, db):
+        raise HTTPException(status_code=403, detail=(
+            f"you don't have access to the skill {name!r} in this team — an admin can grant it"))
     return await _bundle_view(bundle.id, db)
 
 
@@ -3038,6 +3061,9 @@ async def get_bundle(
     bundle = await db.get(Bundle, bundle_id)
     if bundle is None or bundle.org_id != caller.org_id:
         raise HTTPException(status_code=404, detail="bundle not found")
+    if not await _bundle_allowed(caller, bundle, db):  # `treg skill install` uses this route too
+        raise HTTPException(status_code=403, detail=(
+            f"you don't have access to the skill {bundle.name!r} in this team — an admin can grant it"))
     return await _bundle_view(bundle_id, db)
 
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1297,6 +1297,22 @@ def _require_tool_access(caller: Caller, tool_name: str) -> None:
             "(dashboard → Team, or `treg org access <you> --tools …`)"))
 
 
+async def _visible_secret_ids(caller: Caller, db: AsyncSession) -> set[int] | None:
+    """The secret ids a tool-restricted member may SEE: the ones wired into their allowed tools
+    (HTTP bindings + cli.inject). None = unrestricted (owner / NULL tool_access) — show all. The
+    ACL isn't just a call gate: listings must not reveal credentials the member can't use."""
+    if caller.role == "owner" or caller.membership.tool_access is None:
+        return None
+    tools = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id))).scalars().all()
+    ids: set[int] = set()
+    for t in tools:
+        if not _tool_allowed(caller, t.name):
+            continue
+        ids |= {b.get("secret_id") for b in (t.bindings or []) if b.get("secret_id") is not None}
+        ids |= {e.get("secret_id") for e in ((t.cli or {}).get("inject") or []) if e.get("secret_id") is not None}
+    return ids
+
+
 def _require_local_run(caller: Caller) -> None:
     """Gate the LOCAL run tier on the member's `local_run_enabled` (owner exempt). Off → server only."""
     if caller.role != "owner" and not caller.membership.local_run_enabled:
@@ -2300,6 +2316,9 @@ async def list_secrets(
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
 ) -> list[dict]:
     rows = (await db.execute(select(Secret).where(Secret.org_id == caller.org_id))).scalars().all()
+    visible = await _visible_secret_ids(caller, db)
+    if visible is not None:  # tool-restricted member: only the keys wired into their allowed tools
+        rows = [s for s in rows if s.id in visible]
     return [_secret_view(s) for s in rows]
 
 
@@ -2508,7 +2527,8 @@ async def list_tools(
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
 ) -> list[dict]:
     rows = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id))).scalars().all()
-    return [_tool_view(t) for t in rows]
+    # The per-member tool ACL hides what it gates: a restricted member's listing shows only their tools.
+    return [_tool_view(t) for t in rows if _tool_allowed(caller, t.name)]
 
 
 @app.get("/tools/by-name/{name}")
@@ -2521,6 +2541,7 @@ async def get_tool_by_name(
     )).scalars().first()
     if tool is None:
         raise HTTPException(status_code=404, detail="tool not found")
+    _require_tool_access(caller, tool.name)  # a 403 names the fix (ask an admin) — clearer than a fake 404
     return _tool_view(tool)
 
 
@@ -3235,6 +3256,9 @@ async def get_health(
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
 ) -> list[dict]:
     rows = (await db.execute(select(Secret).where(Secret.org_id == caller.org_id))).scalars().all()
+    visible = await _visible_secret_ids(caller, db)
+    if visible is not None:  # same visibility rule as /secrets — health mustn't leak hidden keys
+        rows = [s for s in rows if s.id in visible]
     return [
         {
             "secret_id": s.id,
@@ -3556,6 +3580,15 @@ async def call_tool(
     caller: Caller = Depends(require_member),
     db: AsyncSession = Depends(get_session),
 ):
+    # Faithful-relay: use the RAW request path, not Starlette's decoded path param. Decoding is
+    # lossy — an encoded slash (`%2f`) in `rest` would become a real `/` and change the upstream
+    # route (npm's scoped publish `PUT /@scope%2fname` 404s as `/@scope/name`). httpx preserves
+    # valid percent-escapes, so the original bytes travel through to the upstream one-to-one.
+    raw_path = request.scope.get("raw_path")
+    if raw_path:
+        _, sep, raw_rest = raw_path.decode("ascii", "replace").partition("/call/")
+        if sep:
+            rest = raw_rest
     tool, upstream_url = await _resolve_call(rest, caller.org_id, db)
     _require_tool_access(caller, tool.name)  # per-member tool ACL (NULL access = all; admins exempt)
     await _enforce_daily_cap(caller, db)  # per-user daily cap (skips sandbox + unmetered members)

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -895,7 +895,11 @@ async def auth_invite_signin_confirm(request: Request, db: AsyncSession = Depend
     invite.email_token_hash = None  # consume: one sign-in per emailed link
     db.add(invite)
     await db.commit()
-    resp = RedirectResponse(f"/?invite_org={invite.org_id}", status_code=303)
+    # A share-born invite lands on the shared page itself (the SPA auto-accepts + switches org);
+    # a plain invite lands on the dashboard with the accept banner, as before. `landing` was
+    # allowlist-validated at create time, so this can never redirect off-app.
+    dest = f"{invite.landing}?invite_org={invite.org_id}" if invite.landing else f"/?invite_org={invite.org_id}"
+    resp = RedirectResponse(dest, status_code=303)
     resp.set_cookie(sess.COOKIE, sess.make(user.id, token_version=user.token_version), httponly=True,
                     samesite="lax", secure=_is_https(request), max_age=sess.TTL_SECONDS)
     return resp
@@ -1319,6 +1323,12 @@ class InviteIn(BaseModel):
     # tool names; local_run may be turned off. Both default to the unrestricted state.
     tool_access: list[str] | None = None
     local_run_enabled: bool = True
+    landing: str | None = None  # a shared detail page ("/app/skills/<name>") to land on after sign-in
+
+
+# Landing must be one of OUR detail paths — a path-only allowlist so an emailed invite link can never
+# become an open redirect (no scheme, no host, no traversal, single trailing name segment).
+_LANDING_RE = re.compile(r"^/app/(skills|tools)/[A-Za-z0-9][A-Za-z0-9._%-]*$")
 
 
 class AcceptIn(BaseModel):
@@ -1675,6 +1685,8 @@ async def create_invite(
     days = max(1, min(body.expires_days, 3650))  # clamp BOTH ends — a huge value overflows datetime → 500
     expires_at = _utcnow_naive() + timedelta(days=days)
     tool_access = _normalize_tool_access(body.tool_access, await _known_tool_names(org_id, db))
+    if body.landing is not None and not _LANDING_RE.match(body.landing):
+        raise HTTPException(status_code=422, detail="landing must be a detail path like /app/skills/<name>")
     code = crypto.new_token()
     # A SECOND secret for the email link only. The admin gets `code` back (out-of-band relay) so the
     # code can never be a sign-in factor; `email_token` is never returned here — only the inbox sees
@@ -1684,7 +1696,7 @@ async def create_invite(
         org_id=org_id, email=email, role=body.role,
         code_hash=crypto.hash_token(code), email_token_hash=crypto.hash_token(email_token),
         invited_by=caller.email, expires_at=expires_at,
-        tool_access=tool_access, local_run_enabled=body.local_run_enabled,
+        tool_access=tool_access, local_run_enabled=body.local_run_enabled, landing=body.landing,
     )
     db.add(invite)
     await db.commit()
@@ -1692,9 +1704,13 @@ async def create_invite(
     if not email.endswith("@" + demo_seed.DEMO_DOMAIN):  # don't email the onboarding's fake teammate domain
         scheme = "https" if _is_https(request) else request.url.scheme
         host = request.headers.get("host", "")
+        shared = ""  # share-born invite → the email leads with what was shared
+        if body.landing:
+            kind, _, name = body.landing.removeprefix("/app/").partition("/")
+            shared = f'the {"skill" if kind == "skills" else "tool"} “{name}”'
         await email_sender.send_invite(  # best-effort; the code is also returned for out-of-band relay
             email, caller.email, (org.name if org else email), body.role, code, email_token,
-            expires_at.isoformat(), link_base=(f"{scheme}://{host}" if host else "")
+            expires_at.isoformat(), link_base=(f"{scheme}://{host}" if host else ""), shared=shared,
         )
     return {"code": code, "email": email, "role": body.role, "org_id": org_id,
             "expires_at": expires_at.isoformat()}  # email_token deliberately NOT returned (inbox-only)
@@ -1771,7 +1787,7 @@ async def my_invites(
             continue
         out.append({
             "id": inv.id, "org": org.slug, "org_id": org.id, "name": org.name, "role": inv.role,
-            "invited_by": inv.invited_by,
+            "invited_by": inv.invited_by, "landing": inv.landing,
             "expires_at": inv.expires_at.isoformat() if inv.expires_at else None,
             "created_at": inv.created_at.isoformat() if inv.created_at else None,
         })

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -930,6 +930,37 @@ async def dashboard():
     return FileResponse(index, headers={"Cache-Control": "no-cache"})
 
 
+def _spa_with_og(kind: str, name: str):
+    """Serve the SPA at a shareable detail path (/app/skills/x, /app/tools/x) with per-resource
+    og/twitter meta so link unfurls show what was shared. The meta echoes only the URL's own
+    name segment — no DB read, so an unauthenticated crawler learns nothing it didn't send."""
+    index = _WEB_DIR / "index.html"
+    if not index.exists():
+        return HTMLResponse("<h3>tools-registry API. Dashboard not bundled.</h3>")
+    label = "skill" if kind == "skills" else "tool"
+    safe = _esc_html(name)
+    html = index.read_text(encoding="utf-8").replace(
+        "<title>tools-registry</title>",
+        f"<title>{safe} · tools-registry</title>\n"
+        f'<meta property="og:title" content="{safe} — shared {label}"/>\n'
+        f'<meta property="og:description" content="A {label} shared via tools-registry. '
+        f'Sign in to preview it and get the one-command install."/>\n'
+        f'<meta name="twitter:card" content="summary"/>',
+        1,
+    )
+    return HTMLResponse(html, headers={"Cache-Control": "no-cache"})
+
+
+@app.get("/app/skills/{name}", include_in_schema=False)
+async def dashboard_skill_page(name: str):
+    return _spa_with_og("skills", name)
+
+
+@app.get("/app/tools/{name}", include_in_schema=False)
+async def dashboard_tool_page(name: str):
+    return _spa_with_og("tools", name)
+
+
 @app.get("/llms.txt", include_in_schema=False)
 async def llms_txt():
     """Agent-readable overview (llms.txt convention) — an AI agent that fetches this learns the
@@ -2464,6 +2495,19 @@ async def list_tools(
     return [_tool_view(t) for t in rows]
 
 
+@app.get("/tools/by-name/{name}")
+async def get_tool_by_name(
+    name: str, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """Name-keyed lookup so shareable detail URLs (/app/tools/<name>) resolve without an id."""
+    tool = (await db.execute(
+        select(Tool).where(Tool.org_id == caller.org_id, Tool.name == name)
+    )).scalars().first()
+    if tool is None:
+        raise HTTPException(status_code=404, detail="tool not found")
+    return _tool_view(tool)
+
+
 @app.patch("/tools/{tool_id}")
 async def update_tool(
     tool_id: int,
@@ -2935,6 +2979,19 @@ async def list_bundles(
 ) -> list[dict]:
     rows = (await db.execute(select(Bundle).where(Bundle.org_id == caller.org_id))).scalars().all()
     return [{"id": b.id, "name": b.name, "owner": b.owner} for b in rows]
+
+
+@app.get("/bundles/by-name/{name}")
+async def get_bundle_by_name(
+    name: str, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """Name-keyed lookup so shareable detail URLs (/app/skills/<name>) resolve without an id."""
+    bundle = (await db.execute(
+        select(Bundle).where(Bundle.org_id == caller.org_id, Bundle.name == name)
+    )).scalars().first()
+    if bundle is None:
+        raise HTTPException(status_code=404, detail="bundle not found")
+    return await _bundle_view(bundle.id, db)
 
 
 @app.get("/bundles/{bundle_id}")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -160,6 +160,13 @@ def _show(resp: httpx.Response) -> None:
         sys.exit(1)
 
 
+def _detail_url(cfg: dict, kind: str, name: str) -> str:
+    """The shareable dashboard page for a registered skill/tool. Printed after every registration so
+    sharing is just forwarding the link — the page carries the preview + the agent install prompt."""
+    base = (cfg.get("base_url") or "https://treg.superdesign.dev").rstrip("/")
+    return f"{base}/app/{'skills' if kind == 'skill' else 'tools'}/{quote(str(name), safe='')}"
+
+
 # ---- auth --------------------------------------------------------------------------------
 def cmd_config(args, cfg) -> None:
     if args.base_url:
@@ -1047,7 +1054,8 @@ def _import_env(args, cfg, env_path: str) -> None:
                         print(f"  ✗ {a.tool_name}: {a.secret_name} has no value in the env — skipped"); continue
                 if a.tool_name in existing_tools:               # already registered → skip (or replace) BEFORE writing a secret
                     if not args.replace:
-                        print(f"  · {a.tool_name}: already registered (use --replace)"); continue
+                        print(f"  · {a.tool_name}: already registered (use --replace)")
+                        print(f"    ↗ {_detail_url(cfg, 'tool', a.tool_name)}"); continue
                     c.delete(f"/tools/{existing_tools[a.tool_name]}")
                     if a.secret_name in existing_secrets:
                         c.delete(f"/secrets/{existing_secrets[a.secret_name]}")
@@ -1065,7 +1073,8 @@ def _import_env(args, cfg, env_path: str) -> None:
                 rt = c.post("/tools", json=tool_body)
                 if rt.status_code >= 400:
                     print(f"  ✗ {a.tool_name}: tool failed ({rt.status_code}) {rt.text[:100]}"); continue
-                print(f"  ✓ {a.tool_name:<14} {a.base_url}"); ok += 1
+                print(f"  ✓ {a.tool_name:<14} {a.base_url}")
+                print(f"    ↗ {_detail_url(cfg, 'tool', a.tool_name)}"); ok += 1
             print(f"\nRegistered {ok}/{len(chosen)} tools.")
         if oauth_dets:
             if not args.no_oauth and sys.stdin.isatty():
@@ -1120,7 +1129,7 @@ def _import_clis(args, cfg, env_path: str) -> None:
                 if name in existing:  # --replace: delete-then-recreate
                     c.delete(f"/tools/{existing[name]}")
                 registered.append((name, d["tier"], _register_cli_tool(c, entry, cli, d, envvar, _val)))
-    _print_cli_report(scanned, registered, report_only, args.status)
+    _print_cli_report(scanned, registered, report_only, args.status, cfg)
 
 
 def _register_cli_tool(c, entry, cli, decision, envvar, val_getter) -> str:
@@ -1198,6 +1207,7 @@ def _import_add_cli(args, cfg) -> None:
     # An unknown bin is NOT on the server allow-list (the RCE guard), so it runs LOCALLY; server-run needs
     # an admin to allow-list the bin. If a key was bound it's also a callable HTTP tool.
     print(f"✓ Registered '{name}'. Run it locally: `treg run {name}`.")
+    print(f"  ↗ {_detail_url(cfg, 'tool', name)}")
     if bindings:
         print(f"  (key stored — also a callable API tool; to run '{bin_}' on the SERVER too, an admin adds it to TREG_RUN_ALLOWED_BINS.)")
     import json as _json
@@ -1207,7 +1217,7 @@ def _import_add_cli(args, cfg) -> None:
     print("\nShare this to add it to the catalog for everyone:\n  " + _json.dumps(entry))
 
 
-def _print_cli_report(scanned, registered, report_only, verbose) -> None:
+def _print_cli_report(scanned, registered, report_only, verbose, cfg=None) -> None:
     """Group the scan into an actionable report: what's ready (and where it runs), what needs a key or a
     login (with the exact next step), what isn't supported, and how many catalog CLIs aren't installed."""
     from collections import defaultdict
@@ -1229,6 +1239,10 @@ def _print_cli_report(scanned, registered, report_only, verbose) -> None:
     if local:
         print(f"{verb} (local, uses your login):")
         _list(local)
+    if cfg and not report_only:  # each registered CLI's shareable page (send the link to share it)
+        for n, _t, r in registered:
+            if r in ("ok", "exists"):
+                print(f"  ↗ {_detail_url(cfg, 'tool', n)}")
     if buckets["needs_key"] or buckets["needs_login"]:
         print("\nNeeds setup before it can register:")
         for _e, cli, d, _v in buckets["needs_key"]:
@@ -1517,7 +1531,8 @@ def _import_skills(args, cfg, skills_dir, env_path: str) -> None:
             clash = d.name in existing_bundles or (d.kind != "recipe_only" and d.name in existing_tools)
             if clash:
                 if not args.replace:
-                    print(f"  · {d.name}: already registered (use --replace to update)"); continue
+                    print(f"  · {d.name}: already registered (use --replace to update)")
+                    print(f"    ↗ {_detail_url(cfg, 'skill', d.name)}"); continue
                 for bid in existing_bundles.get(d.name, []):   # delete the old bundle (cascades its tool+secrets)
                     c.delete(f"/bundles/{bid}")
             try:
@@ -1531,8 +1546,10 @@ def _import_skills(args, cfg, skills_dir, env_path: str) -> None:
                 print(f"  ✗ {d.name}: {r.status_code} {r.text[:100]}"); continue
             wrote = sk.write_contract(d)                        # only after a successful push
             tag = "recipe" if d.kind == "recipe_only" else "tool"
-            print(f"  ✓ {d.name:<28} ({tag})" + ("  [wrote treg.json]" if wrote else "")); ok += 1
-    print(f"\nImported {ok}/{len(chosen)} skills.")
+            print(f"  ✓ {d.name:<28} ({tag})" + ("  [wrote treg.json]" if wrote else ""))
+            print(f"    ↗ {_detail_url(cfg, 'skill', d.name)}"); ok += 1
+    print(f"\nImported {ok}/{len(chosen)} skills. Share a skill by sending its ↗ link — "
+          "the page previews it and carries the agent install prompt.")
 
 
 # ---- tools --------------------------------------------------------------------------------
@@ -1602,7 +1619,9 @@ def cmd_add(args, cfg) -> None:
             body.update(secret_id=sid, injector="env", auth_in="header",
                         auth_name=args.header or "Authorization",
                         auth_format=args.format or "Bearer {secret}", secret_field="access_token")
-        _show(c.post("/tools", json=body))
+        r = c.post("/tools", json=body)
+        _show(r)
+    print(f"↗ {_detail_url(cfg, 'tool', args.name)}")
 
 
 def cmd_tool_ls(args, cfg) -> None:
@@ -2196,6 +2215,8 @@ def cmd_skill_push(args, cfg) -> None:
         sys.exit(f"could not read skill file {args.file!r}: {exc}")
     with _client(cfg) as c:
         _show(c.post("/skills", json=body))
+    if body.get("name"):
+        print(f"↗ {_detail_url(cfg, 'skill', body['name'])}")
 
 
 def cmd_skill_init(args, cfg) -> None:
@@ -2232,6 +2253,7 @@ def cmd_skill_add(args, cfg) -> None:
         sys.exit(str(exc))
     with _client(cfg) as c:
         _show(c.post("/skills", json=payload))
+    print(f"↗ {_detail_url(cfg, 'skill', payload['name'])}")
 
 
 def cmd_skill_ls(args, cfg) -> None:

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2518,25 +2518,23 @@ def cmd_org_invite(args, cfg) -> None:
         if org_id is None:
             sys.exit("no active org")
         # --skill/--tool = a SHARE invite: the invitee lands on that detail page after the emailed
-        # sign-in, and (unless --tools/--all-tools overrides) their calls are scoped to just it.
-        landing, share_tools = None, None
+        # sign-in. Access matches the dashboard's Share default — the FULL vault; scope with
+        # --tools (e.g. --tools <skill>,<its-tool>) to restrict what they can see and call.
+        landing = None
         if getattr(args, "skill", None):
             r = c.get(f"/bundles/by-name/{quote(args.skill, safe='')}")
             if r.status_code >= 400:
                 sys.exit(f"no skill named {args.skill!r} in the active org")
             landing = f"/app/skills/{quote(args.skill, safe='')}"
-            # the skill's own name too — the access list also gates which skills a member can SEE
-            share_tools = sorted({args.skill, *(t["name"] for t in (r.json().get("tools") or []))})
         elif getattr(args, "tool", None):
             r = c.get(f"/tools/by-name/{quote(args.tool, safe='')}")
             if r.status_code >= 400:
                 sys.exit(f"no tool named {args.tool!r} in the active org")
             landing = f"/app/tools/{quote(args.tool, safe='')}"
-            share_tools = [args.tool]
         if landing is None or args.all_tools or getattr(args, "tools", None):
             access = _resolve_tool_access(c, org_id, args)
         else:
-            access = share_tools
+            access = None  # full vault access — the dashboard Share modal's default
         body = {"email": args.email, "role": args.role, "expires_days": args.expires_days,
                 "tool_access": access,
                 "local_run_enabled": getattr(args, "local_run", "on") != "off",
@@ -2828,10 +2826,10 @@ def build_parser() -> argparse.ArgumentParser:
             "treg org invite bob@company.com --role member",
             "treg org invite bob@company.com --tools stripe,gh   # only these tools",
             "treg org invite bob@company.com --all-tools --local-run off",
-            "treg org invite bob@company.com --skill slideshow   # share ONE skill: lands on its page, calls scoped to its tools")
+            "treg org invite bob@company.com --skill slideshow   # share invite: they land on its page (full access; add --tools to scope)")
     oi.add_argument("email", help="the invitee's email"); oi.add_argument("--role", default="member", choices=["viewer", "member", "admin"], help="role to grant (default: member)")
-    oi.add_argument("--skill", help="share invite: land them on this skill's page + scope access to its tools")
-    oi.add_argument("--tool", help="share invite: land them on this tool's page + scope access to it")
+    oi.add_argument("--skill", help="share invite: land them on this skill's page (full vault access; scope with --tools)")
+    oi.add_argument("--tool", help="share invite: land them on this tool's page (full vault access; scope with --tools)")
     oi.add_argument("--expires-days", type=int, default=7, help="invite validity in days (default: 7)")
     oi.add_argument("--tools", help="comma-separated tool names this member may use (default: prompt / all)")
     oi.add_argument("--all-tools", dest="all_tools", action="store_true", help="grant access to every tool (skip the prompt)")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2507,10 +2507,36 @@ def cmd_org_invite(args, cfg) -> None:
         org_id = _active_org_id(cfg, c)
         if org_id is None:
             sys.exit("no active org")
+        # --skill/--tool = a SHARE invite: the invitee lands on that detail page after the emailed
+        # sign-in, and (unless --tools/--all-tools overrides) their calls are scoped to just it.
+        landing, share_tools = None, None
+        if getattr(args, "skill", None):
+            r = c.get(f"/bundles/by-name/{quote(args.skill, safe='')}")
+            if r.status_code >= 400:
+                sys.exit(f"no skill named {args.skill!r} in the active org")
+            landing = f"/app/skills/{quote(args.skill, safe='')}"
+            share_tools = [t["name"] for t in (r.json().get("tools") or [])]
+        elif getattr(args, "tool", None):
+            r = c.get(f"/tools/by-name/{quote(args.tool, safe='')}")
+            if r.status_code >= 400:
+                sys.exit(f"no tool named {args.tool!r} in the active org")
+            landing = f"/app/tools/{quote(args.tool, safe='')}"
+            share_tools = [args.tool]
+        if landing is None or args.all_tools or getattr(args, "tools", None):
+            access = _resolve_tool_access(c, org_id, args)
+        else:
+            access = share_tools or None  # recipe-only skill: nothing to scope
         body = {"email": args.email, "role": args.role, "expires_days": args.expires_days,
-                "tool_access": _resolve_tool_access(c, org_id, args),
-                "local_run_enabled": getattr(args, "local_run", "on") != "off"}
-        _show(c.post(f"/orgs/{org_id}/invites", json=body))
+                "tool_access": access,
+                "local_run_enabled": getattr(args, "local_run", "on") != "off",
+                "landing": landing}
+        r = c.post(f"/orgs/{org_id}/invites", json=body)
+        _show(r)
+    if landing is not None:  # _show exits on error, so this only prints on success
+        base = (cfg.get("base_url") or "https://treg.superdesign.dev").rstrip("/")
+        print(f"↗ share link: {base}{landing}")
+        print("  The invite email's button signs them in and lands them on this page. DM alternative:"
+              f" send the link — after they sign in with {args.email}, the invite auto-appears.")
 
 
 def cmd_org_access(args, cfg) -> None:
@@ -2790,8 +2816,11 @@ def build_parser() -> argparse.ArgumentParser:
     oi = mk(og, "invite", "Invite someone to the active team by email (choose their tool access).",
             "treg org invite bob@company.com --role member",
             "treg org invite bob@company.com --tools stripe,gh   # only these tools",
-            "treg org invite bob@company.com --all-tools --local-run off")
+            "treg org invite bob@company.com --all-tools --local-run off",
+            "treg org invite bob@company.com --skill slideshow   # share ONE skill: lands on its page, calls scoped to its tools")
     oi.add_argument("email", help="the invitee's email"); oi.add_argument("--role", default="member", choices=["viewer", "member", "admin"], help="role to grant (default: member)")
+    oi.add_argument("--skill", help="share invite: land them on this skill's page + scope access to its tools")
+    oi.add_argument("--tool", help="share invite: land them on this tool's page + scope access to it")
     oi.add_argument("--expires-days", type=int, default=7, help="invite validity in days (default: 7)")
     oi.add_argument("--tools", help="comma-separated tool names this member may use (default: prompt / all)")
     oi.add_argument("--all-tools", dest="all_tools", action="store_true", help="grant access to every tool (skip the prompt)")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2525,7 +2525,8 @@ def cmd_org_invite(args, cfg) -> None:
             if r.status_code >= 400:
                 sys.exit(f"no skill named {args.skill!r} in the active org")
             landing = f"/app/skills/{quote(args.skill, safe='')}"
-            share_tools = [t["name"] for t in (r.json().get("tools") or [])]
+            # the skill's own name too — the access list also gates which skills a member can SEE
+            share_tools = sorted({args.skill, *(t["name"] for t in (r.json().get("tools") or []))})
         elif getattr(args, "tool", None):
             r = c.get(f"/tools/by-name/{quote(args.tool, safe='')}")
             if r.status_code >= 400:
@@ -2535,7 +2536,7 @@ def cmd_org_invite(args, cfg) -> None:
         if landing is None or args.all_tools or getattr(args, "tools", None):
             access = _resolve_tool_access(c, org_id, args)
         else:
-            access = share_tools or None  # recipe-only skill: nothing to scope
+            access = share_tools
         body = {"email": args.email, "role": args.role, "expires_days": args.expires_days,
                 "tool_access": access,
                 "local_run_enabled": getattr(args, "local_run", "on") != "off",

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -1671,11 +1671,21 @@ def cmd_call(args, cfg) -> None:
     # httpx serializes a list of tuples preserving duplicates; a dict would drop all but the last.
     params = [tuple(kv.split("=", 1)) for kv in args.query]
     content = Path(args.file).read_bytes() if args.file else (args.data.encode() if args.data else None)
+    # Content-Type: explicit flag wins; otherwise sniff JSON so `--data '{...}'` / `--file doc.json`
+    # reach upstreams that require `application/json` (e.g. npm publish) without extra flags.
+    ctype = args.content_type
+    if ctype is None and content:
+        try:
+            json.loads(content)
+            ctype = "application/json"
+        except ValueError:
+            pass
+    headers = {"content-type": ctype} if ctype else {}
     rest = args.target.rstrip("/")
     if args.path:
         rest += "/" + args.path.lstrip("/")
     with _client(cfg) as c:
-        _show(c.request(args.method, f"/call/{rest}", params=params, content=content))
+        _show(c.request(args.method, f"/call/{rest}", params=params, content=content, headers=headers))
 
 
 def cmd_calls(args, cfg) -> None:
@@ -2534,9 +2544,9 @@ def cmd_org_invite(args, cfg) -> None:
         _show(r)
     if landing is not None:  # _show exits on error, so this only prints on success
         base = (cfg.get("base_url") or "https://treg.superdesign.dev").rstrip("/")
-        print(f"↗ share link: {base}{landing}")
-        print("  The invite email's button signs them in and lands them on this page. DM alternative:"
-              f" send the link — after they sign in with {args.email}, the invite auto-appears.")
+        print(f"↗ share link: {base}{landing}?invite={quote(args.email, safe='')}")
+        print("  One click for them: sign in as that email → invite auto-accepts → this page opens."
+              "  (The invite email's button does the same.)")
 
 
 def cmd_org_access(args, cfg) -> None:
@@ -2916,6 +2926,8 @@ def build_parser() -> argparse.ArgumentParser:
     cl.add_argument("--method", default="GET", help="HTTP method (default: GET)")
     cl.add_argument("--query", action="append", default=[], metavar="K=V", help="a query param (repeatable)")
     cl.add_argument("--data", help="request body (string)"); cl.add_argument("--file", help="request body from a file")
+    cl.add_argument("--content-type", dest="content_type", metavar="TYPE",
+                    help="Content-Type for the body (default: sniffed — a body that parses as JSON sends application/json)")
     cl.set_defaults(fn=cmd_call)
 
     ca = mk(sub, "calls", "Show the audit log: who called what, when, and the result.", "treg calls --limit 20")

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -142,6 +142,11 @@ def _migrate_to_orgs(conn) -> None:
     if "invite" in tables and "email_token_hash" not in {c["name"] for c in insp.get_columns("invite")}:
         conn.execute(text("ALTER TABLE invite ADD COLUMN email_token_hash VARCHAR"))
 
+    # (A14) additive: invite.landing — the shared detail page ("/app/skills/<name>") the invitee
+    # lands on after invite-signin. Nullable: a plain invite lands on the dashboard as before.
+    if "invite" in tables and "landing" not in {c["name"] for c in insp.get_columns("invite")}:
+        conn.execute(text("ALTER TABLE invite ADD COLUMN landing VARCHAR"))
+
     # (B) legacy backfill — guarded
     if "org" not in tables:
         return  # defensive: create_all should have made it

--- a/src/treg/email.py
+++ b/src/treg/email.py
@@ -63,7 +63,10 @@ async def send_otp(email: str, code: str, ttl_minutes: int = 10) -> bool:
 
 
 async def send_invite(email: str, inviter: str, org_name: str, role: str, code: str,
-                      email_token: str, expires_at: str = "", link_base: str = "") -> bool:
+                      email_token: str, expires_at: str = "", link_base: str = "",
+                      shared: str = "") -> bool:
+    """`shared` = a human phrase for a share-born invite (e.g. 'the skill “slideshow”') — the email
+    then leads with what was shared and its button lands on that page after sign-in."""
     s = get_settings()
     from urllib.parse import quote
     # The link should open on the SAME deployment the inviter was using. The request origin
@@ -74,8 +77,10 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
     # The visible code below stays the out-of-band credential the admin also holds — join-only.
     url = f"{base}/auth/invite-signin?t={quote(email_token)}"
     exp = f" It expires on {expires_at[:10]}." if expires_at else ""
+    headline = (f'<b>{_esc(inviter)}</b> shared {_esc(shared)} with you — join <b>{_esc(org_name)}</b> to use it'
+                if shared else f'<b>{_esc(inviter)}</b> invited you to <b>{_esc(org_name)}</b>')
     body = (
-        f'<p style="margin:0 0 6px;color:#201c15;font-size:15px"><b>{_esc(inviter)}</b> invited you to <b>{_esc(org_name)}</b></p>'
+        f'<p style="margin:0 0 6px;color:#201c15;font-size:15px">{headline}</p>'
         f'<p style="margin:0 0 16px;color:#877e6c;font-size:13px">You\'ve been added as <b style="color:#201c15">{_esc(role)}</b> on tools-registry — call the team\'s tools with no API keys on your machine.{exp}</p>'
         f'<a href="{url}" style="display:inline-block;background:#b8461f;color:#fff;text-decoration:none;font-weight:600;font-size:14px;padding:11px 20px;border-radius:8px">Sign in &amp; accept →</a>'
         f'<p style="margin:16px 0 6px;color:#877e6c;font-size:12px">Sign in with <b>{_esc(email)}</b> and the invite appears automatically. Prefer a code? Use this one:</p>'
@@ -83,11 +88,14 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
     )
     html = _WRAP.format(body=body)
     text = (
-        f"{inviter} invited you to {org_name} as {role} on tools-registry.\n"
-        f"Sign in at {url} with {email} and the invite appears automatically.\n"
+        (f"{inviter} shared {shared} with you on tools-registry (team {org_name}, as {role}).\n" if shared
+         else f"{inviter} invited you to {org_name} as {role} on tools-registry.\n")
+        + f"Sign in at {url} with {email} and the invite appears automatically.\n"
         f"Or accept with this one-time code: {code}.{exp}"
     )
-    return await _send(email, f"{inviter} invited you to {org_name} on tools-registry", html, text)
+    subject = (f"{inviter} shared {shared} with you on tools-registry" if shared
+               else f"{inviter} invited you to {org_name} on tools-registry")
+    return await _send(email, subject, html, text)
 
 
 def _esc(s: str) -> str:

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -105,6 +105,9 @@ class Invite(SQLModel, table=True):
     # time, modify later). NULL tool_access = all tools; a list = the allowed tool names.
     tool_access: list | None = Field(default=None, sa_column=Column("tool_access", JSON, nullable=True))
     local_run_enabled: bool = Field(default=True)
+    # Where the invitee lands after sign-in — a shared detail page ("/app/skills/<name>") when the
+    # invite was minted from a share, else NULL for the plain dashboard. Path-only, validated on create.
+    landing: str | None = Field(default=None)
     created_at: datetime = Field(default_factory=_now)
 
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -967,11 +967,11 @@ th{background:rgba(0,0,0,.25)}
                 <tr v-if="editAccess===m.user_id">
                   <td colspan="7" style="background:color-mix(in srgb,var(--accent) 5%,transparent)">
                     <div style="padding:6px 2px">
-                      <div class="sub" style="margin-bottom:6px">Tools <b>{{m.email}}</b> may use — uncheck to withhold. All checked = full access (and new tools apply automatically).</div>
-                      <div v-if="!tools.length" class="muted" style="font-size:12px">No tools registered yet.</div>
+                      <div class="sub" style="margin-bottom:6px">Tools &amp; skills <b>{{m.email}}</b> may use/see — uncheck to withhold. All checked = full access (and new ones apply automatically).</div>
+                      <div v-if="!accessNames.length" class="muted" style="font-size:12px">No tools registered yet.</div>
                       <div style="display:flex;flex-wrap:wrap;gap:6px 16px">
-                        <label v-for="t in tools" :key="t.id" class="tgl" style="min-width:150px">
-                          <input type="checkbox" v-model="accessDraft[t.name]"/><span>{{t.name}}</span>
+                        <label v-for="n in accessNames" :key="n" class="tgl" style="min-width:150px">
+                          <input type="checkbox" v-model="accessDraft[n]"/><span>{{n}}</span>
                         </label>
                       </div>
                       <div style="margin-top:10px;display:flex;gap:8px">
@@ -1002,7 +1002,7 @@ th{background:rgba(0,0,0,.25)}
                 <div class="sub" style="font-size:12px;margin-bottom:4px">Tools this member may use (all checked by default — uncheck to withhold):</div>
                 <div v-if="!tools.length" class="muted" style="font-size:12px">No tools registered yet.</div>
                 <div style="display:flex;flex-wrap:wrap;gap:6px 16px">
-                  <label v-for="t in tools" :key="t.id" class="tgl" style="min-width:150px"><input type="checkbox" v-model="inviteToolSel[t.name]"/><span>{{t.name}}</span></label>
+                  <label v-for="n in accessNames" :key="n" class="tgl" style="min-width:150px"><input type="checkbox" v-model="inviteToolSel[n]"/><span>{{n}}</span></label>
                 </div>
               </div>
               <div v-if="lastInvite" class="tut-notice" style="max-width:560px">
@@ -1861,6 +1861,9 @@ createApp({
     canRegister(){ return this.activeRole!=='viewer'; },  // members+ may create secrets/tools
     secretRowsReady(){ return this.secretRows.filter(r=>(r.name||'').trim()&&r.value).length; },
     // ---- detail pages ----
+    accessNames(){  // the grantable universe: tool names + recipe-only skill names (an integration
+      // skill is reachable through its tool's name; recipe-only bundles need their own entry)
+      return [...new Set([...this.tools.map(t=>t.name), ...this.recipes.map(r=>r.name)])].sort(); },
     detailShareUrl(){ if(!this.detail) return ''; return location.origin+'/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name); },
     shareInviteUrl(){  // the DM-able one-click link: page URL + the invited email (prefills sign-in; the
       // invite then auto-accepts on landing-match). Deliberately NOT the emailed token — that secret can
@@ -2131,18 +2134,18 @@ createApp({
       // typo like "foo bar" becomes a permanently-unacceptable dead invite cluttering the list.
       if(!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)){ this.orgErr='Enter a valid email address.'; return; }
       this.orgBusy=true; this.orgErr='';
-      const chosen=this.tools.filter(t=>this.inviteToolSel[t.name]).map(t=>t.name);
-      const tool_access = !this.inviteCustomize ? null : (chosen.length===this.tools.length ? null : chosen);
+      const chosen=this.accessNames.filter(n=>this.inviteToolSel[n]);
+      const tool_access = !this.inviteCustomize ? null : (chosen.length===this.accessNames.length ? null : chosen);
       try{ this.lastInvite=await this.api('/orgs/'+this.activeOrgId+'/invites',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({email,role:this.inviteRole,tool_access,local_run_enabled:this.inviteLocalRun})});
         this.inviteEmail=''; this.inviteCustomize=false; this.orgInvites=await this.api('/orgs/'+this.activeOrgId+'/invites'); }
       catch(e){ this.orgErr='Invite failed: '+(e.detail||e.status); } finally{ this.orgBusy=false; } },
-    openInviteCustomize(){ this.inviteCustomize=true; const d={}; this.tools.forEach(t=>d[t.name]=true); this.inviteToolSel=d; },
+    openInviteCustomize(){ this.inviteCustomize=true; const d={}; this.accessNames.forEach(n=>d[n]=true); this.inviteToolSel=d; },
     openAccess(m){ if(m.role==='owner') return;
       if(this.editAccess===m.user_id){ this.editAccess=null; return; }
-      this.editAccess=m.user_id; const d={}; this.tools.forEach(t=>{ d[t.name]=(m.tool_access===null || m.tool_access.includes(t.name)); }); this.accessDraft=d; },
-    setAllAccess(v){ const d={}; this.tools.forEach(t=>d[t.name]=v); this.accessDraft=d; },
-    async saveAccess(m){ const names=this.tools.filter(t=>this.accessDraft[t.name]).map(t=>t.name);
-      const tool_access = (names.length===this.tools.length) ? null : names;  // all checked → 'all' (NULL)
+      this.editAccess=m.user_id; const d={}; this.accessNames.forEach(n=>{ d[n]=(m.tool_access===null || m.tool_access.includes(n)); }); this.accessDraft=d; },
+    setAllAccess(v){ const d={}; this.accessNames.forEach(n=>d[n]=v); this.accessDraft=d; },
+    async saveAccess(m){ const names=this.accessNames.filter(n=>this.accessDraft[n]);
+      const tool_access = (names.length===this.accessNames.length) ? null : names;  // all checked → 'all' (NULL)
       try{ await this.api('/orgs/'+this.activeOrgId+'/members/'+m.user_id+'/access',{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({tool_access, local_run_enabled:m.local_run_enabled})}); this.editAccess=null; }
       catch(e){ this.orgErr='Set access failed: '+(e.detail||e.status); }
       await this.loadOrgAdmin(); },
@@ -2587,14 +2590,14 @@ createApp({
       if(this.share.member) return;  // already on the team — the modal now says "just send the link"
       this.share.busy=true; this.share.err='';
       const landing='/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name);
-      // Scope a skill share to just its bundled tools (viewer + limited tools ≈ share one capability);
-      // a tool share scopes to that tool. Unchecked = full org tool access.
+      // Scope a skill share to the skill itself + its bundled tools (the access list also gates which
+      // skills a restricted member can SEE); a tool share scopes to that tool. Unchecked = full access.
       let tool_access=null;
       if(this.share.scope){
         tool_access = this.detail.kind==='skill'
-          ? ((this.detailData&&this.detailData.tools)||[]).map(t=>t.name)
+          ? [this.detail.name].concat((((this.detailData&&this.detailData.tools)||[]).map(t=>t.name)))
           : [this.detail.name];
-        if(!tool_access.length) tool_access=null;  // recipe-only skill: nothing to scope
+        tool_access=[...new Set(tool_access)];
       }
       try{
         const r=await this.api('/orgs/'+this.activeOrgId+'/invites',{method:'POST',headers:{'content-type':'application/json'},

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1729,7 +1729,7 @@ createApp({
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
       // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
       detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'', detailNote:'',
-      share:{on:false, email:'', role:'viewer', scope:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
+      share:{on:false, email:'', role:'viewer', scope:false, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
       welcome:{on:false, name:'', busy:false, err:''},  // first-run: name your team (the primary path)
@@ -2580,7 +2580,7 @@ createApp({
       return false;
     },
     openShare(){
-      this.share={on:true, email:'', role:'viewer', scope:this.detail.kind==='skill', busy:false, err:'', sent:null, member:null};
+      this.share={on:true, email:'', role:'viewer', scope:false, busy:false, err:'', sent:null, member:null};
       if(this.canAdmin) this.loadOrgAdmin().catch(()=>{}); },
     async sendShare(){ const email=(this.share.email||'').trim(); if(!email){ this.share.err='Enter their email.'; return; }
       this.share.member=(this.orgMembers||[]).find(m=>(m.email||'').toLowerCase()===email.toLowerCase())||null;

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -428,6 +428,21 @@ th{background:rgba(0,0,0,.25)}
 <div id="app">
   <!-- LANDING (logged-out) -->
   <div v-if="!authed" class="lp">
+    <!-- SHARE-LINK GATE: a /app/skills|tools/<name> deep link while logged out gets a focused
+         sign-in page (no sandbox demo, no tour) — the marketing landing is for the front door. -->
+    <template v-if="shareGate">
+      <header class="lp-nav">
+        <div class="brand">▚ tools-registry</div>
+        <nav class="lp-links"><a href="/tutorial">Docs</a><button class="iconbtn" @click="toggleTheme" :aria-label="theme==='dark'?'Light theme':'Dark theme'">{{theme==='dark'?'◐':'◑'}}</button></nav>
+      </header>
+      <section class="lp-hero" style="min-height:55vh">
+        <div class="lp-eyebrow">shared with you</div>
+        <h1 class="lp-h1">{{shareGate.name}} <span style="color:var(--accent)">· {{shareGate.kind}}</span></h1>
+        <p class="lp-lead">A teammate shared this {{shareGate.kind}} with you. Sign in and you'll land right on its page — no API key ever touches your machine.</p>
+        <div class="lp-cta"><button class="btn primary lg" @click="demo.signin=true">Sign in to view</button></div>
+      </section>
+    </template>
+    <template v-else>
     <header class="lp-nav">
       <div class="brand">▚ tools-registry</div>
       <nav class="lp-links">
@@ -596,14 +611,16 @@ th{background:rgba(0,0,0,.25)}
     </section>
 
     <footer class="lp-foot">tools-registry · a credential-injecting proxy · <a href="/tutorial">tutorial</a> · <a href="/llms.txt">llms.txt</a></footer>
+    </template>
 
-    <!-- SIGN-IN MODAL -->
+    <!-- SIGN-IN MODAL (shared by the landing and the share-link gate) -->
     <div class="lc-scrim" :class="{open:demo.signin}" @click.self="demo.signin=false">
       <div class="lc-modal" role="dialog" aria-modal="true" aria-label="Sign in">
         <button class="cls" @click="demo.signin=false" aria-label="Close">✕</button>
         <div style="font-size:26px">▚</div>
-        <h2 style="margin:8px 0 2px;font-family:var(--mono)">{{invitePrefill?'Accept your invite':'Make it yours'}}</h2>
+        <h2 style="margin:8px 0 2px;font-family:var(--mono)">{{invitePrefill?'Accept your invite':(shareGate?'Sign in to view it':'Make it yours')}}</h2>
         <p v-if="invitePrefill" class="sub">Sign in with <b>{{invitePrefill}}</b> and you'll drop straight into the team.</p>
+        <p v-else-if="shareGate" class="sub">You'll land on “{{shareGate.name}}” right after.</p>
         <p v-else class="sub">Bring the sandbox into a real account.</p>
         <button v-if="meta.github" class="btn primary" style="width:100%;padding:11px;margin-bottom:8px" @click="githubLogin">Continue with GitHub</button>
         <button v-if="meta.google" class="btn" style="width:100%;padding:11px;margin-bottom:8px" @click="googleLogin">Continue with Google</button>
@@ -1731,6 +1748,7 @@ createApp({
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
       // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
       detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'', detailNote:'',
+      shareGate:null,  // logged-out arrival at a shared detail link: {kind,name} → focused sign-in page (no sandbox/tour)
       share:{on:false, email:'', role:'viewer', full:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
@@ -2769,8 +2787,8 @@ createApp({
       return; }  // GitHub/email session
     if(this.token){ await this.loadAll(); if(route) this.openDetail(route.kind, route.name, true); return; }      // token-in-browser fallback
     if(!inv && !linkOrg && !route && !qs.get('invite_expired')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door
-    this.sbxInit();                                 // logged-out invite/deep-link flow → the in-app landing + sign-in modal
-    if(route){ this.demo.signin=true; }             // shared link while logged out: sign in, then land on it (email verify reloads in place; OAuth restores via the treg-next stash)
+    if(route){ this.shareGate=route; this.demo.signin=true; }  // shared link while logged out: the focused gate (no sandbox mint, no tour); after sign-in the boot lands on it (email verify reloads in place; OAuth restores via the treg-next stash)
+    else this.sbxInit();                            // other logged-out flows → the in-app landing + sign-in modal
     if(inv){ this.invitePrefill=inv; this.emailInput=inv; this.emailStage=false; this.demo.signin=true; }  // legacy code link while logged out: prefill + open sign-in; the invite auto-accepts after login (maybeOnboard)
   },
 }).mount('#app');

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -726,11 +726,11 @@ th{background:rgba(0,0,0,.25)}
           <div class="tgroup" v-for="grp in toolGroups" :key="grp.key" v-show="grp.rows.length && (toolTab==='all'||toolTab===grp.key)">
             <div class="tgh">{{grp.label}} <span class="tgh-n">{{grp.rows.length}}</span><span class="tgh-hint">{{grp.hint}}</span></div>
             <div class="ttable-wrap"><table class="ttable">
-              <tr v-for="t in grp.rows" :key="t.id">
-                <td class="tn"><b>{{t.name}}</b></td>
+              <tr v-for="t in grp.rows" :key="t.id" @click="rowOpen(t)" style="cursor:pointer" :title="'Open the '+rowTarget(t).kind+'’s page (shareable link)'">
+                <td class="tn"><a :href="rowHref(t)" @click.prevent.stop="rowOpen(t)" style="color:inherit;text-decoration:none"><b>{{t.name}}</b></a></td>
                 <td class="th"><span class="mono">{{t.host}}</span></td>
                 <td class="ta"><span v-if="t.cli" class="chip run" :title="localRunTitle(t)">⌘ run{{t.cli.enabled?'':' off'}}</span><span v-if="t.server_runnable" class="chip ok" title="Runs on the server — the key is injected there, never on a member's machine">server</span><span v-else-if="t.cli" class="chip" title="Local only — this CLI authenticates from the member's own machine (treg run --local)">local-only</span><span class="chip" :class="w.kind" v-for="(w,wi) in credChips(t)" :key="'w'+wi" :title="w.title">{{w.label}}</span></td>
-                <td class="tx"><button v-if="t.cli && canRegister" class="btn sm ico" :class="{on:t.cli.enabled}" @click="toggleLocalRun(t)" :title="localRunTitle(t)">⌘</button><button class="btn sm ico" @click="openCopy(t)" title="Copy a call snippet">⧉</button><button class="btn sm ico" @click="openUse(t)" title="Use it - API call or CLI run">▶</button><button v-if="canRegister" class="btn sm ico" @click="openEditTool(t)" title="Edit">✎</button><button v-if="canRegister" class="btn sm ico" :class="{danger:confirmDelTool===t.id}" @click="deleteTool(t)" :title="confirmDelTool===t.id?'Click again to delete':'Delete'">✕</button></td>
+                <td class="tx" @click.stop><button v-if="t.cli && canRegister" class="btn sm ico" :class="{on:t.cli.enabled}" @click="toggleLocalRun(t)" :title="localRunTitle(t)">⌘</button><button class="btn sm ico" @click="openCopy(t)" title="Copy a call snippet">⧉</button><button class="btn sm ico" @click="openUse(t)" title="Use it - API call or CLI run">▶</button><button v-if="canRegister" class="btn sm ico" @click="openEditTool(t)" title="Edit">✎</button><button v-if="canRegister" class="btn sm ico" :class="{danger:confirmDelTool===t.id}" @click="deleteTool(t)" :title="confirmDelTool===t.id?'Click again to delete':'Delete'">✕</button></td>
               </tr>
             </table></div>
           </div>
@@ -738,10 +738,10 @@ th{background:rgba(0,0,0,.25)}
           <div class="tgroup" v-show="recipes.length && (toolTab==='all'||toolTab==='recipes')">
             <div class="tgh">Skills <span class="tgh-n">{{recipes.length}}</span><span class="tgh-hint">knowledge skills - pull with the CLI</span></div>
             <div class="ttable-wrap"><table class="ttable">
-              <tr v-for="r in recipes" :key="r.id">
-                <td class="tn"><b>{{r.name}}</b></td>
+              <tr v-for="r in recipes" :key="r.id" @click="openDetail('skill',r.name)" style="cursor:pointer" title="Open the skill’s page (shareable link)">
+                <td class="tn"><a :href="'/app/skills/'+encodeURIComponent(r.name)" @click.prevent.stop="openDetail('skill',r.name)" style="color:inherit;text-decoration:none"><b>{{r.name}}</b></a></td>
                 <td class="th" colspan="2"><span class="mono muted">treg skill install {{r.name}}</span></td>
-                <td class="tx"><button class="btn sm ico" @click="openRecipeCopy(r)" title="How to install / use">⧉</button><button class="btn sm ico" @click="openRecipeView(r)" title="View the SKILL.md">✎</button><button v-if="canRegister" class="btn sm ico" :class="{danger:confirmDelBundle===r.id}" @click="deleteRecipe(r)" :title="confirmDelBundle===r.id?'Click again to delete':'Delete'">✕</button></td>
+                <td class="tx" @click.stop><button class="btn sm ico" @click="openRecipeCopy(r)" title="How to install / use">⧉</button><button class="btn sm ico" @click="openRecipeView(r)" title="View the SKILL.md">✎</button><button v-if="canRegister" class="btn sm ico" :class="{danger:confirmDelBundle===r.id}" @click="deleteRecipe(r)" :title="confirmDelBundle===r.id?'Click again to delete':'Delete'">✕</button></td>
               </tr>
             </table></div>
           </div>
@@ -774,6 +774,86 @@ th{background:rgba(0,0,0,.25)}
             </template>
           </div>
           </div>
+        </template>
+
+        <!-- DETAIL (shareable deep links: /app/skills/<name> + /app/tools/<name>) -->
+        <template v-if="view==='detail' && detail">
+          <div class="tut-head">
+            <div>
+              <p class="sub" style="margin:0 0 4px"><a href="/app#tools" @click.prevent="go('tools')">← Tools</a></p>
+              <h1 style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">{{detail.name}}
+                <span class="chip">{{detail.kind==='skill' ? 'skill' : (detailData&&detailData.cli ? 'endpoint + CLI' : 'endpoint')}}</span>
+                <span v-if="detailData&&detailData.owner" class="chip" :title="'shared by '+detailData.owner">{{detailData.owner}}</span>
+              </h1>
+            </div>
+            <div class="tut-actions">
+              <button class="btn sm" @click="copyDetail(detailShareUrl,'url')" title="Copy this page's URL — anyone on the team can open it">{{detailCopied==='url'?'✓ copied':'⧉ Copy link'}}</button>
+            </div>
+          </div>
+          <div v-if="detailErr" class="banner" style="margin-top:12px">{{detailErr}}</div>
+          <p v-if="detailLoading" class="sub">Loading…</p>
+
+          <template v-if="detailData && detail.kind==='skill'">
+            <div style="max-width:860px;border:1px solid var(--line);border-radius:16px;padding:16px 18px;margin:14px 0;background:var(--panel)">
+              <h3 style="margin:0 0 6px;font-size:14px">Use with your agent</h3>
+              <p class="sub" style="margin:0 0 10px">Send someone this page's link, or paste this into a coding agent (Claude Code / Codex / Gemini) — it installs the CLI, signs them in as themselves, and pulls just this skill. <template v-if="(detailData.secrets||[]).length">Its credential{{detailData.secrets.length>1?'s stay':' stays'}} server-side — calls go through the proxy, no key lands on their machine.</template></p>
+              <pre class="code" style="white-space:pre-wrap;max-height:34vh;overflow:auto">{{detailPrompt}}</pre>
+              <div style="margin-top:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+                <button class="btn primary" @click="copyDetail(detailPrompt,'prompt')">⧉ {{detailCopied==='prompt'?'Copied!':'Copy prompt'}}</button>
+                <button class="btn" @click="copyDetail('treg skill install '+detail.name,'cli')" title="Just the CLI command, if treg is already set up">{{detailCopied==='cli'?'✓ copied':'treg skill install '+detail.name}}</button>
+              </div>
+            </div>
+            <div v-if="(detailData.tools||[]).length || (detailData.secrets||[]).length" style="max-width:860px;margin:0 0 14px;display:flex;gap:8px;flex-wrap:wrap;align-items:center">
+              <span class="sub" style="margin:0">Bundled:</span>
+              <a v-for="t in detailData.tools" :key="'dt'+t.id" class="chip" :href="'/app/tools/'+encodeURIComponent(t.name)" @click.prevent="openDetail('tool',t.name)" style="cursor:pointer" :title="'tool · '+(t.host||t.base_url)">⚒ {{t.name}}</a>
+              <span v-for="s in detailData.secrets" :key="'ds'+s.id" class="chip" title="credential — stored encrypted server-side, injected by the proxy, never shown">🔒 {{s.name||s.local_name}}</span>
+            </div>
+            <div style="max-width:860px;border:1px solid var(--line);border-radius:16px;overflow:hidden;display:flex;min-height:280px;background:var(--panel)">
+              <div style="width:220px;flex:none;border-right:1px solid var(--line);padding:10px 0;overflow:auto;max-height:60vh">
+                <div v-for="row in detailTree" :key="row.path"
+                     :style="{padding:'4px 12px 4px '+(14+row.depth*14)+'px', cursor:row.dir?'default':'pointer', fontSize:'12.5px',
+                              color:row.dir?'var(--muted)':'var(--ink)', background:(!row.dir&&detailFile===row.path)?'var(--panel2)':'transparent'}"
+                     @click="!row.dir && (detailFile=row.path)">{{row.dir?'▸ ':'· '}}{{row.name}}</div>
+              </div>
+              <pre class="code" style="flex:1;margin:0;border:0;border-radius:0;white-space:pre-wrap;word-break:break-word;overflow:auto;max-height:60vh">{{detailFileContent}}</pre>
+            </div>
+          </template>
+
+          <template v-if="detailData && detail.kind==='tool'">
+            <div style="max-width:860px;border:1px solid var(--line);border-radius:16px;padding:16px 18px;margin:14px 0;background:var(--panel)">
+              <h3 style="margin:0 0 6px;font-size:14px">Use with your agent</h3>
+              <p class="sub" style="margin:0 0 10px">Send someone this page's link, or paste this into a coding agent. Calls go through the proxy — the credential is injected server-side, never on their machine.</p>
+              <pre class="code" style="white-space:pre-wrap;max-height:34vh;overflow:auto">{{detailPrompt}}</pre>
+              <div style="margin-top:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+                <button class="btn primary" @click="copyDetail(detailPrompt,'prompt')">⧉ {{detailCopied==='prompt'?'Copied!':'Copy prompt'}}</button>
+                <button class="btn" @click="openCopy(detailData)" title="Language-specific call snippets (cURL / Python / Node / …)">⧉ Call snippets</button>
+                <button class="btn" @click="openUse(detailData)" title="Try it right here">▶ Try it</button>
+              </div>
+            </div>
+            <div style="max-width:860px;border:1px solid var(--line);border-radius:16px;padding:16px 18px;background:var(--panel)">
+              <div class="lbl">Upstream</div>
+              <p style="margin:2px 0 12px"><span class="mono">{{detailData.base_url}}</span></p>
+              <div class="lbl">Credentials</div>
+              <p class="sub" style="margin:2px 0 12px" v-if="(detailData.bindings||[]).length || (detailData.cli&&(detailData.cli.inject||[]).length)"><span class="chip" v-for="(w,wi) in credChips(detailData)" :key="'dw'+wi" :class="w.kind" :title="w.title">{{w.label}}</span> injected server-side on every call — the value never appears here or on a caller's machine.</p>
+              <p class="sub" style="margin:2px 0 12px" v-else>none — a public upstream, no credential needed.</p>
+              <template v-if="(detailData.examples||[]).length">
+                <div class="lbl">Examples</div>
+                <div class="exrow" style="margin:4px 0 12px"><span v-for="(ex,exi) in detailData.examples" :key="'de'+exi" class="exchip"><span class="m">{{ex.method||'GET'}}</span>{{ex.note||ex.path}}</span></div>
+              </template>
+              <template v-if="detailData.cli">
+                <div class="lbl">CLI</div>
+                <p class="sub" style="margin:2px 0 12px"><span class="mono">treg run {{detail.name}} -- &lt;args&gt;</span>
+                  <span class="chip ok" v-if="detailData.server_runnable" title="Runs on the server — the key is injected there, never on a member's machine">server</span>
+                  <span class="chip" v-else title="Local only — this CLI authenticates from the member's own machine (treg run --local)">local-only</span>
+                  <span class="chip run" v-if="!detailData.cli.enabled" title="The owner has local runs switched off for this tool">⌘ run off</span>
+                </p>
+              </template>
+              <template v-if="detailParentSkill">
+                <div class="lbl">From skill</div>
+                <p style="margin:2px 0 0"><a :href="'/app/skills/'+encodeURIComponent(detailParentSkill.name)" @click.prevent="openDetail('skill',detailParentSkill.name)">▚ {{detailParentSkill.name}}</a> — the recipe + files that registered this tool.</p>
+              </template>
+            </div>
+          </template>
         </template>
 
         <!-- SECRETS -->
@@ -1611,6 +1691,8 @@ createApp({
       sessionMode:false, activeSlug: localStorage.getItem('treg-active')||null, meta:{github:false, public_url:location.origin},
       view:'tools', q:'', err:'', loading:false, toolTab:'all', bundles:[], confirmDelBundle:null, installCopied:null,
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
+      // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
+      detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'',
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
       welcome:{on:false, name:'', busy:false, err:''},  // first-run: name your team (the primary path)
@@ -1741,6 +1823,45 @@ createApp({
     isOwner(){ return this.activeRole==='owner'; },
     canRegister(){ return this.activeRole!=='viewer'; },  // members+ may create secrets/tools
     secretRowsReady(){ return this.secretRows.filter(r=>(r.name||'').trim()&&r.value).length; },
+    // ---- detail pages ----
+    detailShareUrl(){ if(!this.detail) return ''; return location.origin+'/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name); },
+    detailTree(){  // the bundle's files as a flat, indent-rendered tree: synthesized dir rows + file rows
+      const files=Object.keys((this.detailData&&this.detailData.files)||{}).sort();
+      const rows=[{path:'SKILL.md', name:'SKILL.md', depth:0, dir:false}]; const seen=new Set();
+      for(const p of files){ const parts=p.split('/');
+        for(let i=0;i<parts.length-1;i++){ const d=parts.slice(0,i+1).join('/');
+          if(!seen.has(d)){ seen.add(d); rows.push({path:d, name:parts[i]+'/', depth:i, dir:true}); } }
+        rows.push({path:p, name:parts[parts.length-1], depth:parts.length-1, dir:false}); }
+      return rows; },
+    detailFileContent(){ if(!this.detailData) return '';
+      if(this.detailFile==='SKILL.md') return this.detailData.recipe||'';
+      return (this.detailData.files||{})[this.detailFile]||''; },
+    detailParentSkill(){ if(!this.detail||this.detail.kind!=='tool'||!this.detailData||!this.detailData.bundle_id) return null;
+      return this.bundles.find(b=>b.id===this.detailData.bundle_id)||null; },
+    detailPrompt(){  // the copyable "give this to your agent" instruction — no token embedded, the
+      // recipient signs in as themselves (this text is meant to be forwarded)
+      if(!this.detail) return '';
+      const B=(this.proxy||location.origin).replace(/\/$/,''); const n=this.detail.name;
+      const head=[`I want to use the shared ${this.detail.kind==='skill'?'skill':'tool'} "${n}" from my team's tools-registry at ${B} .`,``,
+        `1. Install the treg CLI (skip if \`treg\` already works) and sign me in:`,
+        `   curl -fsSL ${B}/install.sh | sh`,`   treg login`,``];
+      if(this.detail.kind==='skill'){
+        const t=(this.detailData&&this.detailData.tools&&this.detailData.tools[0])||null;
+        return head.concat([
+          `2. Install the skill into this project (writes the skill folder into my agent skills dir):`,
+          `   treg skill install ${n}`,``,
+          ...(t?[`3. The skill's API calls go through treg's proxy — the credential is injected server-side, never on this machine:`,
+                `   treg call ${t.name} <PATH>   # or prefix the real URL: ${B}/call/<full upstream URL>`,``]:[]),
+          `Then use the "${n}" skill for my request.`,``,
+          `Full protocol reference: ${B}/llms.txt`]).join('\n');
+      }
+      const t=this.detailData||{};
+      return head.concat([
+        `2. Call it through the proxy — the credential is injected server-side, never on this machine:`,
+        `   treg call ${n} <PATH>   # PATH = the ${t.host||'upstream'} path you'd normally call`,
+        ...(t.cli?[``,`   # it's also a CLI — run it with the key injected:`,`   treg run ${n} -- <cli args>`]:[]),``,
+        `Full protocol reference: ${B}/llms.txt`]).join('\n');
+    },
   },
   watch:{
     // a11y (WCAG 2.4.3): when a dialog/drawer opens, move focus INTO it (was left on the trigger)
@@ -1776,8 +1897,10 @@ createApp({
     save(){ localStorage.setItem(LS, JSON.stringify(this.cfg)); },
     connected(slug){ return this.sessionMode || !!this.cfg.orgs[slug]; },
     toggleTheme(){ this.theme=this.theme==='dark'?'light':'dark'; document.documentElement.dataset.theme=this.theme; localStorage.setItem('treg-theme',this.theme); },
-    githubLogin(){ location.href='/auth/github'; },
-    googleLogin(){ location.href='/auth/google'; },
+    _stashNext(){  // OAuth callbacks land on /app, losing a /app/skills/<x> deep link — stash it to restore after boot
+      const d=this.routeFromPath(location.pathname); if(d) localStorage.setItem('treg-next', location.pathname); },
+    githubLogin(){ this._stashNext(); location.href='/auth/github'; },
+    googleLogin(){ this._stashNext(); location.href='/auth/google'; },
     demoScroll(){ this.$refs.demo && this.$refs.demo.scrollIntoView({behavior:'smooth',block:'start'}); },
     scrollToSignin(){ this.$refs.signin && this.$refs.signin.scrollIntoView({behavior:'smooth',block:'start'}); },
     async sbx(path, opts={}){  // fetch against the sandbox, carrying the sandbox token explicitly
@@ -2350,8 +2473,29 @@ createApp({
       this.go('orgs'); },
     resetConfirms(){ this.confirmDelTool=null; this.confirmDelSecret=null; this.confirmDelBundle=null; this.confirmRemove=null; this.confirmLeave=false; this.confirmDel=''; this.confirmAdmUser=null; this.confirmAdmOrg=null; },
     go(v, fromPop){ this.resetConfirms();  // stale inline "Confirm" states must not survive a view switch (accidental-delete risk)
-      this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage();} if(v==='usage')this.loadUsage(); if(v==='secrets')this.loadSecrets();
-      if(!fromPop) history.pushState({view:v}, '', '#'+v); },  // push history so browser Back navigates BETWEEN views instead of leaving the app
+      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage();} if(v==='usage')this.loadUsage(); if(v==='secrets')this.loadSecrets();
+      // push history so browser Back navigates BETWEEN views instead of leaving the app; the '/app'
+      // pathname also walks back from a /app/skills/<x> detail URL so reload doesn't reopen the detail
+      if(!fromPop) history.pushState({view:v}, '', '/app#'+v); },
+    // ---- detail pages (shareable deep links) ----
+    routeFromPath(path){ const m=/^\/app\/(skills|tools)\/(.+)$/.exec(path||'');
+      return m ? {kind:m[1]==='skills'?'skill':'tool', name:decodeURIComponent(m[2])} : null; },
+    openDetail(kind, name, fromPop){ this.resetConfirms();
+      this.detail={kind, name}; this.view='detail'; this.detailFile='SKILL.md'; this.detailCopied='';
+      if(!fromPop) history.pushState({detail:{kind,name}}, '', '/app/'+(kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(name));
+      this.loadDetail(); },
+    async loadDetail(){ if(!this.detail) return; this.detailErr=''; this.detailLoading=true; this.detailData=null;
+      try{ this.detailData=await this.api((this.detail.kind==='skill'?'/bundles/by-name/':'/tools/by-name/')+encodeURIComponent(this.detail.name)); }
+      catch(e){ this.detailErr = e.status===404
+        ? 'Not found in this team. If someone shared this link with you, make sure you’re in their team (switch teams above, or ask them for an invite).'
+        : 'Could not load: '+(e.detail||e.status); }
+      finally{ this.detailLoading=false; } },
+    async copyDetail(text, tag){ if(!(await this.toClipboard(text))) return; this.detailCopied=tag; setTimeout(()=>{ if(this.detailCopied===tag) this.detailCopied=''; },1500); },
+    rowTarget(t){  // where a tools-list row leads: a skill-born tool opens its SKILL (the shareable thing), a bare endpoint opens the tool page
+      if(t.bundle_id){ const b=this.bundles.find(x=>x.id===t.bundle_id); if(b) return {kind:'skill', name:b.name}; }
+      return {kind:'tool', name:t.name}; },
+    rowHref(t){ const d=this.rowTarget(t); return '/app/'+(d.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(d.name); },
+    rowOpen(t){ const d=this.rowTarget(t); this.openDetail(d.kind, d.name); },
     async loadAll(){ this.err=''; this.loading=true;
       try{
         this.myOrgs=await this.api('/orgs');
@@ -2476,6 +2620,8 @@ createApp({
     window.addEventListener('scroll', ()=>{ if(this.orgMenu) this.placeOrgMenu(); }, true);
     window.addEventListener('resize', ()=>{ if(this.orgMenu) this.placeOrgMenu(); });
     window.addEventListener('popstate', e=>{  // browser Back moves between views (was exiting the app)
+      const d=(e.state&&e.state.detail)||this.routeFromPath(location.pathname);
+      if(d){ this.openDetail(d.kind, d.name, true); return; }
       const v=(e.state&&e.state.view)||(location.hash||'').replace('#','')||'tools';
       if(['tools','orgs','activity','usage','admin','help','secrets','start'].includes(v)) this.go(v, true);
     });
@@ -2492,11 +2638,17 @@ createApp({
     const linkOrg = qs.get('invite_org'), inv = qs.get('invite');
     if(linkOrg || inv || qs.get('invite_expired')){ history.replaceState(null,'',location.pathname+location.hash); }  // strip one-shot params so reload/share doesn't replay them
     if(linkOrg){ this.inviteLinkOrg=parseInt(linkOrg,10)||null; }
+    // A shared detail deep link (/app/skills/<x>, /app/tools/<x>) — from the URL itself, or stashed
+    // before an OAuth hop (the callback always lands on /app, which would otherwise drop the path).
+    let route=this.routeFromPath(location.pathname);
+    const stashed=localStorage.getItem('treg-next');
+    if(stashed){ localStorage.removeItem('treg-next'); if(!route){ route=this.routeFromPath(stashed); if(route) history.replaceState(null,'',stashed); } }
     const me = await fetch('/auth/me',{credentials:'include',headers:{'ngrok-skip-browser-warning':'1'}}).then(r=>r.ok?r.json():null).catch(()=>null);
-    if(me){ this.sessionMode=true; this.me=me.email; this.isAdmin=!!me.is_superadmin; this.onboarded=!!me.onboarded; await this.loadAll(); this.maybeOnboard(); return; }  // GitHub/email session
-    if(this.token){ this.loadAll(); return; }      // token-in-browser fallback
-    if(!inv && !linkOrg && !qs.get('invite_expired')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door
-    this.sbxInit();                                 // logged-out invite flow → the in-app landing + sign-in modal
+    if(me){ this.sessionMode=true; this.me=me.email; this.isAdmin=!!me.is_superadmin; this.onboarded=!!me.onboarded; await this.loadAll(); this.maybeOnboard(); if(route) this.openDetail(route.kind, route.name, true); return; }  // GitHub/email session
+    if(this.token){ await this.loadAll(); if(route) this.openDetail(route.kind, route.name, true); return; }      // token-in-browser fallback
+    if(!inv && !linkOrg && !route && !qs.get('invite_expired')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door
+    this.sbxInit();                                 // logged-out invite/deep-link flow → the in-app landing + sign-in modal
+    if(route){ this.demo.signin=true; }             // shared link while logged out: sign in, then land on it (email verify reloads in place; OAuth restores via the treg-next stash)
     if(inv){ this.invitePrefill=inv; this.emailInput=inv; this.emailStage=false; this.demo.signin=true; }  // legacy code link while logged out: prefill + open sign-in; the invite auto-accepts after login (maybeOnboard)
   },
 }).mount('#app');

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -792,6 +792,7 @@ th{background:rgba(0,0,0,.25)}
             </div>
           </div>
           <div v-if="detailErr" class="banner" style="margin-top:12px">{{detailErr}}</div>
+          <div v-if="detailNote" class="tut-notice" style="margin-top:12px;max-width:860px">{{detailNote}}</div>
           <p v-if="detailLoading" class="sub">Loading…</p>
 
           <template v-if="detailData && detail.kind==='skill'">
@@ -1606,10 +1607,12 @@ th{background:rgba(0,0,0,.25)}
         <div style="padding:16px 18px">
           <template v-if="share.sent">
             <p class="explain">✓ Invite sent to <b>{{share.sent.email}}</b> — the email's button signs them in and lands them right on this page.</p>
-            <p class="sub" style="margin:0 0 8px">No email arrived? Send them this link + one-time code instead:</p>
-            <pre class="code" style="white-space:pre-wrap">{{detailShareUrl}}
-code: {{share.sent.code}}   (treg org join {{share.sent.code}} --email {{share.sent.email}})</pre>
-            <div style="margin-top:12px"><button class="btn primary" @click="copyDetail(detailShareUrl+'\n'+'code: '+share.sent.code,'sharecopy')">⧉ {{detailCopied==='sharecopy'?'Copied!':'Copy link + code'}}</button></div>
+            <p class="sub" style="margin:0 0 8px">Or DM them this link — it opens the sign-in with their email prefilled; once they sign in, the invite accepts itself and this page opens:</p>
+            <pre class="code" style="white-space:pre-wrap;word-break:break-all">{{shareInviteUrl}}</pre>
+            <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+              <button class="btn primary" @click="copyDetail(shareInviteUrl,'sharecopy')">⧉ {{detailCopied==='sharecopy'?'Copied!':'Copy invite link'}}</button>
+              <span class="sub" style="margin:0;font-size:12px">backup code: <span class="mono">{{share.sent.code}}</span> (<span class="mono">treg org join</span>)</span>
+            </div>
           </template>
           <template v-else>
             <p class="explain">Already on the team? Just send them the page link (⧉ Copy link). This invites someone <b>new</b> — after one click in the email they land on this exact page.</p>
@@ -1725,7 +1728,7 @@ createApp({
       view:'tools', q:'', err:'', loading:false, toolTab:'all', bundles:[], confirmDelBundle:null, installCopied:null,
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
       // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
-      detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'',
+      detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'', detailNote:'',
       share:{on:false, email:'', role:'viewer', scope:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
@@ -1859,6 +1862,10 @@ createApp({
     secretRowsReady(){ return this.secretRows.filter(r=>(r.name||'').trim()&&r.value).length; },
     // ---- detail pages ----
     detailShareUrl(){ if(!this.detail) return ''; return location.origin+'/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name); },
+    shareInviteUrl(){  // the DM-able one-click link: page URL + the invited email (prefills sign-in; the
+      // invite then auto-accepts on landing-match). Deliberately NOT the emailed token — that secret can
+      // mint a session and must never leave the inbox; this link still requires proving the email.
+      return this.share.sent ? this.detailShareUrl+'?invite='+encodeURIComponent(this.share.sent.email) : ''; },
     detailTree(){  // the bundle's files as a flat, indent-rendered tree: synthesized dir rows + file rows
       const files=Object.keys((this.detailData&&this.detailData.files)||{}).sort();
       const rows=[{path:'SKILL.md', name:'SKILL.md', depth:0, dir:false}]; const seen=new Set();
@@ -2516,7 +2523,7 @@ createApp({
     routeFromPath(path){ const m=/^\/app\/(skills|tools)\/(.+)$/.exec(path||'');
       return m ? {kind:m[1]==='skills'?'skill':'tool', name:decodeURIComponent(m[2])} : null; },
     openDetail(kind, name, fromPop){ this.resetConfirms();
-      this.detail={kind, name}; this.view='detail'; this.detailFile='SKILL.md'; this.detailCopied='';
+      this.detail={kind, name}; this.view='detail'; this.detailFile='SKILL.md'; this.detailCopied=''; this.detailNote='';
       if(!fromPop) history.pushState({detail:{kind,name}}, '', '/app/'+(kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(name));
       this.loadDetail(); },
     async loadDetail(){ if(!this.detail) return; this.detailErr=''; this.detailLoading=true; this.detailData=null;
@@ -2750,7 +2757,11 @@ createApp({
       let landed=false;
       if(route) landed=await this.autoAcceptShare(route);
       if(!landed) this.maybeOnboard();
-      if(route) this.openDetail(route.kind, route.name, true); return; }  // GitHub/email session
+      if(route){ this.openDetail(route.kind, route.name, true);
+        // a ?invite=<email> share link opened by a DIFFERENT signed-in account: say why it won't resolve
+        if(!landed && inv && this.me && inv.toLowerCase()!==this.me.toLowerCase())
+          this.detailNote='This share link was sent to '+inv+' — you’re signed in as '+this.me+'. Sign out (⏻) and sign in with that email to accept the invite.'; }
+      return; }  // GitHub/email session
     if(this.token){ await this.loadAll(); if(route) this.openDetail(route.kind, route.name, true); return; }      // token-in-browser fallback
     if(!inv && !linkOrg && !route && !qs.get('invite_expired')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door
     this.sbxInit();                                 // logged-out invite/deep-link flow → the in-app landing + sign-in modal

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2281,7 +2281,7 @@ createApp({
       catch(e){ this.err='Save failed: '+(e.detail||e.status); } },
     recipeSnippet(tab){ const r=this.copyRecipe; if(!r) return {text:'',html:''};
       const proxy=(this.proxy||location.origin).replace(/\/$/,'');
-      const tok=this.myToken||'$TREG_TOKEN', tokS=tok.length>28?tok.slice(0,12)+'…'+tok.slice(-6):tok;
+      const tok=this.myToken||'$TREG_TOKEN', tokS=tok;  // full token in the preview — matches the copied text
       const esc=s=>String(s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
       const P=s=>`<span class="s-proxy">${esc(s)}</span>`, A=s=>`<span class="s-path">${esc(s)}</span>`,
             T=s=>`<span class="s-token">${esc(s)}</span>`, C=s=>`<span class="s-cmt">${esc(s)}</span>`, K=s=>`<span class="s-kw">${esc(s)}</span>`;
@@ -2667,7 +2667,7 @@ createApp({
       const urlH=`${P(proxy)}${C('/call/')}${H(up)}/${A(path)}`;
       const hint=(t.examples||[]).length?`e.g. ${t.examples[0].path}`:'the part after the domain';
       const tok=this.myToken||'$TREG_TOKEN', org=(this.activeOrg&&this.activeOrg.slug)||'$TREG_ORG';  // real token+org so a copied snippet runs as-is
-      const tokShort=tok.length>28?tok.slice(0,12)+'…'+tok.slice(-6):tok;  // DISPLAY only — the copied text keeps the full token
+      const tokShort=tok;  // show the full real token — the preview must match what Copy puts on the clipboard
       switch(tab){
         case 'Claude Code': return {
           text:`# Call "${t.name}" through treg - your key is injected server-side.\n${m} ${urlT}\nX-Treg-Token: ${tok}\nX-Treg-Org: ${org}\n\n# PATH = the ${t.host} path you'd normally call (${hint}).`,

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -788,6 +788,7 @@ th{background:rgba(0,0,0,.25)}
             </div>
             <div class="tut-actions">
               <button class="btn sm" @click="copyDetail(detailShareUrl,'url')" title="Copy this page's URL — anyone on the team can open it">{{detailCopied==='url'?'✓ copied':'⧉ Copy link'}}</button>
+              <button v-if="canAdmin && detailData" class="btn sm primary" @click="openShare" title="Invite someone outside the team — they'll land right on this page">Share…</button>
             </div>
           </div>
           <div v-if="detailErr" class="banner" style="margin-top:12px">{{detailErr}}</div>
@@ -1599,6 +1600,38 @@ th{background:rgba(0,0,0,.25)}
         </div></div>
     </div>
 
+    <!-- SHARE A DETAIL PAGE (invite someone new; they land right here after sign-in) -->
+    <div class="scrim" role="dialog" aria-modal="true" v-if="share.on && detail" @click.self="share.on=false">
+      <div class="modal" style="width:min(560px,95vw)"><div class="hd"><b>Share “{{detail.name}}”</b><button class="btn sm ico" @click="share.on=false" aria-label="Close">✕</button></div>
+        <div style="padding:16px 18px">
+          <template v-if="share.sent">
+            <p class="explain">✓ Invite sent to <b>{{share.sent.email}}</b> — the email's button signs them in and lands them right on this page.</p>
+            <p class="sub" style="margin:0 0 8px">No email arrived? Send them this link + one-time code instead:</p>
+            <pre class="code" style="white-space:pre-wrap">{{detailShareUrl}}
+code: {{share.sent.code}}   (treg org join {{share.sent.code}} --email {{share.sent.email}})</pre>
+            <div style="margin-top:12px"><button class="btn primary" @click="copyDetail(detailShareUrl+'\n'+'code: '+share.sent.code,'sharecopy')">⧉ {{detailCopied==='sharecopy'?'Copied!':'Copy link + code'}}</button></div>
+          </template>
+          <template v-else>
+            <p class="explain">Already on the team? Just send them the page link (⧉ Copy link). This invites someone <b>new</b> — after one click in the email they land on this exact page.</p>
+            <div v-if="share.member" class="tut-notice" style="margin:0 0 10px"><b>{{share.member.email}}</b> is already a member — just send them the link, no invite needed.</div>
+            <div class="field" style="margin-bottom:10px"><input v-model="share.email" type="email" placeholder="teammate@company.com" @keyup.enter="sendShare"/></div>
+            <div style="display:flex;gap:14px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
+              <label style="display:flex;gap:6px;align-items:center;font-size:12.5px">role
+                <select v-model="share.role" style="background:var(--panel2);border:1px solid var(--line);color:var(--ink);border-radius:6px;padding:4px 8px;font-family:var(--mono)">
+                  <option value="viewer">viewer (use, not edit)</option><option value="member">member</option><option v-if="isOwner" value="admin">admin</option>
+                </select>
+              </label>
+              <label v-if="detail.kind==='tool' || ((detailData&&detailData.tools)||[]).length" style="display:flex;gap:8px;align-items:center;font-size:12.5px;cursor:pointer">
+                <input type="checkbox" v-model="share.scope"/> limit their calls to just {{detail.kind==='skill'?'this skill’s tools':'this tool'}}
+              </label>
+            </div>
+            <p class="sub" style="margin:0 0 12px;font-size:12px">They'll see the team's skill pages, but with the limit on they can only <b>call</b> what you're sharing. Local CLI runs stay off.</p>
+            <div v-if="share.err" class="banner" style="margin:0 0 10px">{{share.err}}</div>
+            <button class="btn primary" @click="sendShare" :disabled="share.busy">{{share.busy?'Sending…':'Send invite'}}</button>
+          </template>
+        </div></div>
+    </div>
+
     <!-- VIEW A RECIPE (the SKILL.md content) -->
     <div class="scrim" role="dialog" aria-modal="true" v-if="viewRecipe" @click.self="viewRecipe=null">
       <div class="modal" style="width:min(760px,95vw)"><div class="hd"><b>{{viewRecipe.name}} <span class="sub" style="font-weight:400">· SKILL.md</span></b><button class="btn sm ico" @click="viewRecipe=null" aria-label="Close">✕</button></div>
@@ -1693,6 +1726,7 @@ createApp({
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
       // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
       detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'',
+      share:{on:false, email:'', role:'viewer', scope:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
       welcome:{on:false, name:'', busy:false, err:''},  // first-run: name your team (the primary path)
@@ -2345,7 +2379,8 @@ createApp({
         // Enter the team the email link pointed at when it was accepted; otherwise the first accepted.
         const linked=joined.find(j=>j.inv.org_id===this.inviteLinkOrg)||joined[0];
         if(linked.r&&linked.r.org) this.switchOrg({slug:linked.r.org});
-        this.inviteChoice=false; this.inviteLinkOrg=null; this.go('tools');
+        this.inviteChoice=false; this.inviteLinkOrg=null;
+        if(this.detail) this.openDetail(this.detail.kind, this.detail.name, true); else this.go('tools');  // accepting while on a shared page = stay on it
         this.orgMsg='You joined '+joined.map(j=>(j.r&&j.r.name)||j.inv.name).join(', ')
           +(failed.length?' (could not join '+failed.join(', ')+')':'')
           +'. Here are the shared tools & skills — call any with no key on your machine.';
@@ -2486,9 +2521,11 @@ createApp({
       this.loadDetail(); },
     async loadDetail(){ if(!this.detail) return; this.detailErr=''; this.detailLoading=true; this.detailData=null;
       try{ this.detailData=await this.api((this.detail.kind==='skill'?'/bundles/by-name/':'/tools/by-name/')+encodeURIComponent(this.detail.name)); }
-      catch(e){ this.detailErr = e.status===404
-        ? 'Not found in this team. If someone shared this link with you, make sure you’re in their team (switch teams above, or ask them for an invite).'
-        : 'Could not load: '+(e.detail||e.status); }
+      catch(e){
+        if(e.status===404 && await this.findDetailOrg()) return void (this.detailLoading=false);  // it lives in another of my teams — switched
+        this.detailErr = e.status===404
+          ? 'Not found in your teams. This link needs an invite — ask the person who shared it to invite you (Share… on their side), then click the link again.'
+          : 'Could not load: '+(e.detail||e.status); }
       finally{ this.detailLoading=false; } },
     async copyDetail(text, tag){ if(!(await this.toClipboard(text))) return; this.detailCopied=tag; setTimeout(()=>{ if(this.detailCopied===tag) this.detailCopied=''; },1500); },
     rowTarget(t){  // where a tools-list row leads: a skill-born tool opens its SKILL (the shareable thing), a bare endpoint opens the tool page
@@ -2496,6 +2533,68 @@ createApp({
       return {kind:'tool', name:t.name}; },
     rowHref(t){ const d=this.rowTarget(t); return '/app/'+(d.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(d.name); },
     rowOpen(t){ const d=this.rowTarget(t); this.openDetail(d.kind, d.name); },
+    async autoAcceptShare(route){  // a share-link invite: clicking the emailed "Sign in & accept" IS the consent — accept silently, enter that team
+      // Match by the email link's org param, or — for a DM'd bare link — by an invite whose landing IS this page.
+      const path=route?'/app/'+(route.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(route.name):null;
+      const inv=this.pendingInvites.find(i=>i.org_id===this.inviteLinkOrg)
+              ||(path&&this.pendingInvites.find(i=>i.landing===path));
+      if(!inv) return false;
+      try{
+        const r=await this.api('/invites/'+inv.id+'/accept',{method:'POST'});
+        this.pendingInvites=this.pendingInvites.filter(i=>i.id!==inv.id);
+        this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){}
+        if(r&&r.org){ this.activeSlug=r.org; localStorage.setItem('treg-active',r.org); }
+        await this.loadAll();
+        this.inviteLinkOrg=null;
+        this.orgMsg='You joined '+((r&&r.name)||inv.name)+' — this page was shared with you.';
+        return true;
+      }catch(e){ return false; }  // revoked/used → the detail page's not-found message explains
+    },
+    async findDetailOrg(){  // the link may belong to another of MY teams — probe them, switch silently on a unique hit
+      if(!this.detail) return false;
+      const others=(this.myOrgs||[]).filter(o=>o.slug!==this.activeSlugNow);
+      const path=(this.detail.kind==='skill'?'/bundles/by-name/':'/tools/by-name/')+encodeURIComponent(this.detail.name);
+      for(const o of others){
+        let h;
+        if(this.sessionMode) h={'X-Treg-Org':o.slug};
+        else { const t=(this.cfg.orgs[o.slug]||{}).token; if(!t) continue; h={'X-Treg-Token':t}; }
+        try{
+          const r=await fetch(path,{credentials:'include',headers:{'ngrok-skip-browser-warning':'1',...h}});
+          if(!r.ok) continue;
+          const data=await r.json();
+          if(this.sessionMode){ this.activeSlug=o.slug; localStorage.setItem('treg-active',o.slug); }
+          else { this.cfg.active=o.slug; this.save(); }
+          this.detailData=data; this.detailErr='';
+          this.orgMsg='Switched to '+(o.name||o.slug)+' — this '+this.detail.kind+' lives there.';
+          await this.loadAll();
+          return true;
+        }catch(_){}
+      }
+      return false;
+    },
+    openShare(){
+      this.share={on:true, email:'', role:'viewer', scope:this.detail.kind==='skill', busy:false, err:'', sent:null, member:null};
+      if(this.canAdmin) this.loadOrgAdmin().catch(()=>{}); },
+    async sendShare(){ const email=(this.share.email||'').trim(); if(!email){ this.share.err='Enter their email.'; return; }
+      this.share.member=(this.orgMembers||[]).find(m=>(m.email||'').toLowerCase()===email.toLowerCase())||null;
+      if(this.share.member) return;  // already on the team — the modal now says "just send the link"
+      this.share.busy=true; this.share.err='';
+      const landing='/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name);
+      // Scope a skill share to just its bundled tools (viewer + limited tools ≈ share one capability);
+      // a tool share scopes to that tool. Unchecked = full org tool access.
+      let tool_access=null;
+      if(this.share.scope){
+        tool_access = this.detail.kind==='skill'
+          ? ((this.detailData&&this.detailData.tools)||[]).map(t=>t.name)
+          : [this.detail.name];
+        if(!tool_access.length) tool_access=null;  // recipe-only skill: nothing to scope
+      }
+      try{
+        const r=await this.api('/orgs/'+this.activeOrgId+'/invites',{method:'POST',headers:{'content-type':'application/json'},
+          body:JSON.stringify({email, role:this.share.role, landing, tool_access, local_run_enabled:false})});
+        this.share.sent=r;
+      }catch(e){ this.share.err='Invite failed: '+(e.detail||e.status); }
+      finally{ this.share.busy=false; } },
     async loadAll(){ this.err=''; this.loading=true;
       try{
         this.myOrgs=await this.api('/orgs');
@@ -2601,7 +2700,7 @@ createApp({
       this.orgMenuStyle={position:'fixed', top:(r.bottom+6)+'px', left:r.left+'px'};
     },
     toggleOrgMenu(){ this.orgMenu=!this.orgMenu; if(this.orgMenu) this.placeOrgMenu(); },
-    closeOverlays(){ this.newTool=false; this.newSkill=false; this.showJoin=false; this.newOrg=false; this.addOrg=false; this.tryTool=null; this.copyTool=null; this.orgMenu=false; },
+    closeOverlays(){ this.newTool=false; this.newSkill=false; this.showJoin=false; this.newOrg=false; this.addOrg=false; this.tryTool=null; this.copyTool=null; this.orgMenu=false; this.share.on=false; },
   },
   async mounted(){
     document.documentElement.dataset.theme=this.theme;
@@ -2644,7 +2743,14 @@ createApp({
     const stashed=localStorage.getItem('treg-next');
     if(stashed){ localStorage.removeItem('treg-next'); if(!route){ route=this.routeFromPath(stashed); if(route) history.replaceState(null,'',stashed); } }
     const me = await fetch('/auth/me',{credentials:'include',headers:{'ngrok-skip-browser-warning':'1'}}).then(r=>r.ok?r.json():null).catch(()=>null);
-    if(me){ this.sessionMode=true; this.me=me.email; this.isAdmin=!!me.is_superadmin; this.onboarded=!!me.onboarded; await this.loadAll(); this.maybeOnboard(); if(route) this.openDetail(route.kind, route.name, true); return; }  // GitHub/email session
+    if(me){ this.sessionMode=true; this.me=me.email; this.isAdmin=!!me.is_superadmin; this.onboarded=!!me.onboarded; await this.loadAll();
+      // Share-born arrival (/app/skills/x?invite_org=N from the invite email): accept silently and
+      // enter that team — the emailed "Sign in & accept" click was the consent. Otherwise the normal
+      // first-run / invite-banner flow.
+      let landed=false;
+      if(route) landed=await this.autoAcceptShare(route);
+      if(!landed) this.maybeOnboard();
+      if(route) this.openDetail(route.kind, route.name, true); return; }  // GitHub/email session
     if(this.token){ await this.loadAll(); if(route) this.openDetail(route.kind, route.name, true); return; }      // token-in-browser fallback
     if(!inv && !linkOrg && !route && !qs.get('invite_expired')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door
     this.sbxInit();                                 // logged-out invite/deep-link flow → the in-app landing + sign-in modal

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1624,11 +1624,11 @@ th{background:rgba(0,0,0,.25)}
                   <option value="viewer">viewer (use, not edit)</option><option value="member">member</option><option v-if="isOwner" value="admin">admin</option>
                 </select>
               </label>
-              <label v-if="detail.kind==='tool' || ((detailData&&detailData.tools)||[]).length" style="display:flex;gap:8px;align-items:center;font-size:12.5px;cursor:pointer">
-                <input type="checkbox" v-model="share.scope"/> limit their calls to just {{detail.kind==='skill'?'this skill’s tools':'this tool'}}
+              <label style="display:flex;gap:8px;align-items:center;font-size:12.5px;cursor:pointer">
+                <input type="checkbox" v-model="share.full"/> Share full vault access
               </label>
             </div>
-            <p class="sub" style="margin:0 0 12px;font-size:12px">They'll see the team's skill pages, but with the limit on they can only <b>call</b> what you're sharing. Local CLI runs stay off.</p>
+            <p class="sub" style="margin:0 0 12px;font-size:12px">Full access = they see and can use the whole team vault. Uncheck to scope them to just {{detail.kind==='skill'?'this skill':'this tool'}} — they'll only see and call what you're sharing. Local CLI runs stay off either way.</p>
             <div v-if="share.err" class="banner" style="margin:0 0 10px">{{share.err}}</div>
             <button class="btn primary" @click="sendShare" :disabled="share.busy">{{share.busy?'Sending…':'Send invite'}}</button>
           </template>
@@ -1729,7 +1729,7 @@ createApp({
       copyRecipe:null, recipeTab:'cURL', viewRecipe:null, recipeSaved:false,
       // detail pages (shareable /app/skills/<name> + /app/tools/<name> deep links)
       detail:null, detailData:null, detailErr:'', detailLoading:false, detailFile:'SKILL.md', detailCopied:'', detailNote:'',
-      share:{on:false, email:'', role:'viewer', scope:false, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
+      share:{on:false, email:'', role:'viewer', full:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
       welcome:{on:false, name:'', busy:false, err:''},  // first-run: name your team (the primary path)
@@ -2583,17 +2583,17 @@ createApp({
       return false;
     },
     openShare(){
-      this.share={on:true, email:'', role:'viewer', scope:false, busy:false, err:'', sent:null, member:null};
+      this.share={on:true, email:'', role:'viewer', full:true, busy:false, err:'', sent:null, member:null};
       if(this.canAdmin) this.loadOrgAdmin().catch(()=>{}); },
     async sendShare(){ const email=(this.share.email||'').trim(); if(!email){ this.share.err='Enter their email.'; return; }
       this.share.member=(this.orgMembers||[]).find(m=>(m.email||'').toLowerCase()===email.toLowerCase())||null;
       if(this.share.member) return;  // already on the team — the modal now says "just send the link"
       this.share.busy=true; this.share.err='';
       const landing='/app/'+(this.detail.kind==='skill'?'skills':'tools')+'/'+encodeURIComponent(this.detail.name);
-      // Scope a skill share to the skill itself + its bundled tools (the access list also gates which
-      // skills a restricted member can SEE); a tool share scopes to that tool. Unchecked = full access.
+      // Full vault access (default) = no restriction. Unchecked = scope to the skill itself + its
+      // bundled tools (the access list also gates which skills a restricted member can SEE).
       let tool_access=null;
-      if(this.share.scope){
+      if(!this.share.full){
         tool_access = this.detail.kind==='skill'
           ? [this.detail.name].concat((((this.detailData&&this.detailData.tools)||[]).map(t=>t.name)))
           : [this.detail.name];

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1618,12 +1618,14 @@ th{background:rgba(0,0,0,.25)}
             <p class="explain">Already on the team? Just send them the page link (⧉ Copy link). This invites someone <b>new</b> — after one click in the email they land on this exact page.</p>
             <div v-if="share.member" class="tut-notice" style="margin:0 0 10px"><b>{{share.member.email}}</b> is already a member — just send them the link, no invite needed.</div>
             <div class="field" style="margin-bottom:10px"><input v-model="share.email" type="email" placeholder="teammate@company.com" @keyup.enter="sendShare"/></div>
-            <div style="display:flex;gap:14px;align-items:center;margin-bottom:10px;flex-wrap:wrap">
+            <div style="margin-bottom:10px">
               <label style="display:flex;gap:6px;align-items:center;font-size:12.5px">role
                 <select v-model="share.role" style="background:var(--panel2);border:1px solid var(--line);color:var(--ink);border-radius:6px;padding:4px 8px;font-family:var(--mono)">
                   <option value="viewer">viewer (use, not edit)</option><option value="member">member</option><option v-if="isOwner" value="admin">admin</option>
                 </select>
               </label>
+            </div>
+            <div style="margin-bottom:10px">
               <label style="display:flex;gap:8px;align-items:center;font-size:12.5px;cursor:pointer">
                 <input type="checkbox" v-model="share.full"/> Share full vault access
               </label>

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -1,6 +1,6 @@
 ---
 name: tools-registry
-description: Call shared team tools without holding their credentials, and turn your local skills into shareable tools. Use when you need to hit an upstream API (PostHog, GSC, Google Ads, Intercom, Stripe, …) but don't have the key locally, or when you want to register/share a skill so teammates' agents can call it. Three personas in one skill — consumer (call), creator (register/share), admin (manage).
+description: How to use the treg CLI (tools-registry) — call shared team tools without holding their credentials, and turn your local skills into shareable tools. Use when working with the `treg` command, or when you need to hit an upstream API (PostHog, GSC, Google Ads, Intercom, Stripe, …) but don't have the key locally, or when you want to register/share a skill so teammates' agents can call it. Three personas in one skill — consumer (call), creator (register/share), admin (manage).
 ---
 
 # tools-registry — call shared tools, share your own

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def make_upstream(hook_hits: list | None = None) -> FastAPI:
             "query": dict(request.query_params),
             "query_multi": request.query_params.multi_items(),  # preserves duplicate keys
             "body": body,
+            "raw_path": request.scope.get("raw_path", b"").decode(),  # pre-decode bytes, for %2f fidelity asserts
         }
 
     return up

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -176,3 +176,27 @@ async def test_tool_access_hides_listings_and_keys(env):
     await _set_access(env, None)
     assert {t["name"] for t in (await env.c.get("/tools", headers=m)).json()} == {"alpha", "beta"}
     assert {s["name"] for s in (await env.c.get("/secrets", headers=m)).json()} >= {"a-key"}
+
+
+async def test_tool_access_gates_skill_visibility(env):
+    """The access list also gates which SKILLS a restricted member can see: granted by the bundle's
+    own name (recipe-only skills) or via any of its tools. /bundles + both bundle getters comply."""
+    await env.c.post("/skills", headers=_h(env.owner),
+                     json={"name": "gamma", "recipe": "# gamma", "secrets": [], "tools": []})
+    m = _h(env.member)
+
+    await _set_access(env, ["alpha"])  # a bare endpoint grant — no skills granted at all
+    assert {b["name"] for b in (await env.c.get("/bundles", headers=m)).json()} == set()
+    assert (await env.c.get("/bundles/by-name/beta", headers=m)).status_code == 403
+
+    await _set_access(env, ["gamma"])  # recipe-only skill granted by its own name
+    assert {b["name"] for b in (await env.c.get("/bundles", headers=m)).json()} == {"gamma"}
+    ok = await env.c.get("/bundles/by-name/gamma", headers=m)
+    assert ok.status_code == 200
+    assert (await env.c.get(f"/bundles/{ok.json()['id']}", headers=m)).status_code == 200  # skill install route
+
+    await _set_access(env, ["beta"])  # an integration skill granted via its tool's name
+    assert {b["name"] for b in (await env.c.get("/bundles", headers=m)).json()} == {"beta"}
+
+    # the owner is never restricted
+    assert {b["name"] for b in (await env.c.get("/bundles", headers=_h(env.owner))).json()} == {"beta", "gamma"}

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -159,3 +159,20 @@ async def test_empty_list_blocks_every_tool(env):
     assert (await env.c.get("/call/alpha", headers=_h(env.member))).status_code == 403
     assert (await env.c.get("/call/beta", headers=_h(env.member))).status_code == 403
     assert (await env.c.post("/run", headers=_h(env.member), json={"tool": "alpha"})).status_code == 403
+
+
+async def test_tool_access_hides_listings_and_keys(env):
+    """The ACL isn't just a call gate — a restricted member's dashboard listings must not reveal
+    the tools and credentials they can't use (/tools, /secrets, /health, /tools/by-name)."""
+    await _set_access(env, ["alpha"])
+    m = _h(env.member)
+    assert {t["name"] for t in (await env.c.get("/tools", headers=m)).json()} == {"alpha"}
+    assert {s["name"] for s in (await env.c.get("/secrets", headers=m)).json()} == {"a-key"}
+    assert {h["name"] for h in (await env.c.get("/health", headers=m)).json()} == {"a-key"}
+    assert (await env.c.get("/tools/by-name/alpha", headers=m)).status_code == 200
+    assert (await env.c.get("/tools/by-name/beta", headers=m)).status_code == 403  # names the fix, not a fake 404
+    # the owner and an unrestricted member still see everything
+    assert {t["name"] for t in (await env.c.get("/tools", headers=_h(env.owner))).json()} == {"alpha", "beta"}
+    await _set_access(env, None)
+    assert {t["name"] for t in (await env.c.get("/tools", headers=m)).json()} == {"alpha", "beta"}
+    assert {s["name"] for s in (await env.c.get("/secrets", headers=m)).json()} >= {"a-key"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,8 +142,8 @@ class _FakeClient:
     def __init__(self): self.calls = []
     def __enter__(self): return self
     def __exit__(self, *a): return False
-    def request(self, method, url, params=None, content=None):
-        self.calls.append((method, url, params, content)); return _FakeResp()
+    def request(self, method, url, params=None, content=None, headers=None):
+        self.calls.append((method, url, params, content, headers)); return _FakeResp()
 
 
 def test_call_preserves_duplicate_query_keys(monkeypatch):
@@ -152,7 +152,7 @@ def test_call_preserves_duplicate_query_keys(monkeypatch):
     monkeypatch.setattr(cli, "_show", lambda r: None)
     args = cli.build_parser().parse_args(["call", "echo", "--query", "tag=a", "--query", "tag=b"])
     cli.cmd_call(args, {"base_url": "http://x"})
-    _, _, params, _ = fake.calls[0]
+    _, _, params, _, _ = fake.calls[0]
     assert params == [("tag", "a"), ("tag", "b")]  # both survive; a dict would drop tag=a
 
 
@@ -372,3 +372,23 @@ def test_org_access_and_invite_access_parsers():
     assert a.fn is cli.cmd_org_access and a.user_id == 5 and a.tools == "stripe,gh" and a.local_run == "off"
     b = p.parse_args(["org", "invite", "x@y.z", "--all-tools", "--local-run", "off"])
     assert b.fn is cli.cmd_org_invite and b.all_tools is True and b.local_run == "off"
+
+
+def test_call_content_type_flag_and_json_sniff(monkeypatch):
+    """`call` sends a Content-Type: explicit --content-type wins; else a JSON body sniffs to
+    application/json (npm publish et al. reject an untyped body); a non-JSON body sends none."""
+    p = cli.build_parser()
+    assert p.parse_args(["call", "t", "p", "--content-type", "text/plain"]).content_type == "text/plain"
+
+    fake = _FakeClient()
+    monkeypatch.setattr(cli, "_client", lambda cfg: fake)
+    monkeypatch.setattr(cli, "_show", lambda r: None)
+    cfg = {"base_url": "http://x", "token": "T"}
+
+    def sent_headers(*extra) -> dict:
+        cli.cmd_call(p.parse_args(["call", "t", "p", "--method", "PUT", *extra]), cfg)
+        return fake.calls[-1][4]
+
+    assert sent_headers("--data", '{"ok":1}') == {"content-type": "application/json"}  # sniffed from JSON body
+    assert sent_headers("--data", "plain text") == {}  # non-JSON body: no guess
+    assert sent_headers("--data", "plain", "--content-type", "text/csv") == {"content-type": "text/csv"}  # flag wins

--- a/tests/test_detail_pages.py
+++ b/tests/test_detail_pages.py
@@ -1,0 +1,75 @@
+"""Shareable detail pages: name-keyed lookups (/bundles/by-name, /tools/by-name) and the
+SPA deep-link routes (/app/skills/<name>, /app/tools/<name>) with per-resource og meta.
+
+These back the share flow: every CLI registration prints the page URL; the page previews
+the resource and carries the agent install prompt.
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+
+SKILL = {
+    "name": "intercom",
+    "recipe": "# intercom\nTalk to the Intercom API.\n",
+    "files": {"reference/fields.md": "# fields\n", "scripts/run.py": "print('hi')\n"},
+    "secrets": [{"local_name": "key", "kind": "env", "value": "SECRET-123"}],
+    "tools": [
+        {
+            "name": "intercom",
+            "base_url": "http://upstream",
+            "bindings": [{"secret": "key", "injector": "env", "location": "header",
+                          "name": "Authorization", "format": "Bearer {secret}"}],
+        }
+    ],
+}
+
+
+async def test_bundle_by_name_returns_full_view(clients: AsyncClient):
+    await clients.post("/skills", json=SKILL)
+    r = await clients.get("/bundles/by-name/intercom")
+    assert r.status_code == 200, r.text
+    b = r.json()
+    assert b["name"] == "intercom"
+    assert b["recipe"].startswith("# intercom")
+    assert set(b["files"]) == {"reference/fields.md", "scripts/run.py"}  # nested paths preserved
+    assert b["tools"][0]["name"] == "intercom"
+    assert "SECRET-123" not in r.text  # secret VALUES never appear in a bundle view
+
+
+async def test_tool_by_name_returns_tool_view(clients: AsyncClient):
+    await clients.post("/skills", json=SKILL)
+    r = await clients.get("/tools/by-name/intercom")
+    assert r.status_code == 200, r.text
+    t = r.json()
+    assert t["base_url"] == "http://upstream"
+    assert t["bundle_id"] is not None  # links back to its parent skill for the detail page
+
+
+async def test_by_name_404s(clients: AsyncClient):
+    assert (await clients.get("/bundles/by-name/ghost")).status_code == 404
+    assert (await clients.get("/tools/by-name/ghost")).status_code == 404
+
+
+async def test_by_name_is_org_scoped(clients: AsyncClient):
+    await clients.post("/skills", json=SKILL)
+    r = await clients.post("/users", json={"email": "stranger@elsewhere.dev"})
+    other = {"X-Treg-Token": r.json()["token"]}
+    assert (await clients.get("/bundles/by-name/intercom", headers=other)).status_code == 404
+    assert (await clients.get("/tools/by-name/intercom", headers=other)).status_code == 404
+
+
+async def test_detail_page_serves_spa_with_og_meta(clients: AsyncClient):
+    r = await clients.get("/app/skills/intercom")  # unauthenticated is fine — the page itself gates on login
+    assert r.status_code == 200
+    assert 'og:title' in r.text and "intercom" in r.text
+    r = await clients.get("/app/tools/stripe")
+    assert r.status_code == 200
+    assert 'og:title' in r.text and "shared tool" in r.text
+
+
+async def test_detail_page_escapes_name(clients: AsyncClient):
+    r = await clients.get('/app/skills/%3Cscript%3Ealert(1)%3C-x')
+    assert r.status_code == 200
+    assert "<script>alert(1)" not in r.text  # the echoed name is HTML-escaped

--- a/tests/test_invites_mine.py
+++ b/tests/test_invites_mine.py
@@ -112,8 +112,9 @@ def sent_invites(monkeypatch):
     from treg import email as email_mod
     sent = []
 
-    async def _capture(email, inviter, org_name, role, code, email_token, expires_at="", link_base=""):
-        sent.append({"email": email, "code": code, "email_token": email_token})
+    async def _capture(email, inviter, org_name, role, code, email_token, expires_at="", link_base="",
+                       shared=""):
+        sent.append({"email": email, "code": code, "email_token": email_token, "shared": shared})
         return True
 
     monkeypatch.setattr(email_mod, "send_invite", _capture)
@@ -212,3 +213,57 @@ async def test_invites_mine_newest_first_with_created_at(client, sent_invites):
     mine = (await client.get("/invites/mine", headers=_h(bob))).json()
     assert [m["org"] for m in mine] == [org2["org"], org1["org"]]  # newest first
     assert all(m.get("created_at") for m in mine)
+
+
+# ---- share-born invites: landing on the shared detail page (Phase 3 of the share flow) ----
+
+SHARE_SKILL = {
+    "name": "intercom",
+    "recipe": "# intercom\n",
+    "secrets": [{"local_name": "key", "kind": "env", "value": "K"}],
+    "tools": [{"name": "intercom", "base_url": "http://upstream",
+               "bindings": [{"secret": "key", "injector": "env", "location": "header",
+                             "name": "Authorization", "format": "Bearer {secret}"}]}],
+}
+
+
+async def test_share_invite_landing_roundtrip_and_redirect(client, sent_invites):
+    """An invite created with a landing page: surfaces in /invites/mine, scopes tool access,
+    flavours the email, and the emailed link's POST lands on the shared page (not the dashboard)."""
+    tok = await _otp(client, "tom@sd.io")
+    org = (await client.post("/orgs", json={"name": "Superdesign"}, headers=_h(tok))).json()
+    await client.post("/skills", json=SHARE_SKILL, headers=_h(tok, org["org"]))
+    r = await client.post(
+        f"/orgs/{org['org_id']}/invites",
+        json={"email": "bob@x.io", "role": "viewer", "landing": "/app/skills/intercom",
+              "tool_access": ["intercom"], "local_run_enabled": False},
+        headers=_h(tok, org["org"]))
+    assert r.status_code == 200, r.text
+    assert "the skill" in sent_invites[0]["shared"] and "intercom" in sent_invites[0]["shared"]
+
+    bob = await _otp(client, "bob@x.io")
+    mine = (await client.get("/invites/mine", headers=_h(bob))).json()
+    assert mine[0]["landing"] == "/app/skills/intercom"
+
+    t = sent_invites[0]["email_token"]
+    async with await _fresh() as visitor:
+        resp = await visitor.post("/auth/invite-signin", content=f"t={t}",
+                                  headers={"content-type": "application/x-www-form-urlencoded"},
+                                  follow_redirects=False)
+        assert resp.status_code == 303
+        assert resp.headers["location"] == f"/app/skills/intercom?invite_org={org['org_id']}"
+
+
+async def test_share_invite_landing_is_allowlisted(client):
+    """landing is a path-only allowlist — an emailed invite link must never become an open redirect."""
+    tok = await _otp(client, "tom@sd.io")
+    org = (await client.post("/orgs", json={"name": "Superdesign"}, headers=_h(tok))).json()
+    for bad in ("https://evil.com", "//evil.com/x", "/app/skills/../../etc", "/app/other/x",
+                "/app/skills/", "/app/skills/a/b", "javascript:alert(1)"):
+        r = await client.post(f"/orgs/{org['org_id']}/invites",
+                              json={"email": "bob@x.io", "landing": bad}, headers=_h(tok, org["org"]))
+        assert r.status_code == 422, f"{bad!r} should be rejected, got {r.status_code}"
+    ok = await client.post(f"/orgs/{org['org_id']}/invites",
+                           json={"email": "bob@x.io", "landing": "/app/tools/stripe-cli"},
+                           headers=_h(tok, org["org"]))
+    assert ok.status_code == 200

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -97,3 +97,19 @@ async def test_orgs_reports_tool_count(clients: AsyncClient):
     await _register(clients, "stripe", "https://api.stripe.com/v1")
     orgs = (await clients.get("/orgs")).json()
     assert sum(o["tool_count"] for o in orgs) == 1          # the count reflects the registered tool
+
+
+async def test_encoded_slash_preserved_named_form(clients: AsyncClient):
+    """An encoded slash in the path must reach the upstream still encoded (`%2f`, not `/`) —
+    npm's scoped publish route (`PUT /@scope%2fname`) 404s if the proxy decodes it."""
+    await _register(clients, "npmreg", "https://registry.npm.test")
+    r = await clients.put("/call/npmreg/@superdesign%2ftreg", content=b"{}")
+    assert r.status_code == 200, r.text
+    assert r.json()["raw_path"].endswith("/@superdesign%2ftreg")
+
+
+async def test_encoded_slash_preserved_passthrough_form(clients: AsyncClient):
+    await _register(clients, "npmreg2", "https://registry.npm2.test")
+    r = await clients.put("/call/https://registry.npm2.test/@superdesign%2ftreg", content=b"{}")
+    assert r.status_code == 200, r.text
+    assert r.json()["raw_path"].endswith("/@superdesign%2ftreg")


### PR DESCRIPTION
## What

Share one skill (or tool) with a single link — the full flow from `treg upload` to a teammate's agent having the skill installed, without the credential ever leaving the server.

### Shareable detail pages (dashboard)
- Path-routed pages at `/app/skills/<name>` and `/app/tools/<name>`: rendered SKILL.md + nested file-tree viewer, bundled tool/secret chips, copyable "give this to your agent" prompt, per-resource OG meta for link unfurls.
- List rows are clickable; skill-born tools open their skill's page; tool ⇄ parent-skill cross-links.
- Logged-out visits get a focused "shared with you" sign-in gate (no sandbox demo / tour), then land on the page after sign-in (email code reloads in place; OAuth restores the path via a stash).
- Members in the wrong active team are auto-switched when the resource lives in another of their teams.

### Sharing with people outside the team
- `Invite.landing` (path-only allowlist — never an open redirect): the invite email leads with what was shared and its button signs the recipient in and lands them **on the shared page**, invite auto-accepted.
- **Share…** modal on detail pages: email + role + "Share full vault access" (default ON; unchecked scopes them to just this skill/tool), existing-member guard, one-click DM link fallback (`…?invite=<email>` — prefills sign-in; deliberately *not* the inbox-only token).
- CLI: `treg org invite <email> --skill/--tool <name>` mirrors the modal (full access by default, `--tools` to scope) and prints the share link. Every registration path (`treg upload`, `skill add/push`, `add`) now prints its page's ↗ URL.

### Access-control fixes (found while building)
- `tool_access` was only enforced at call/run time — restricted members could still *see* every tool, key, and skill. Now: `/tools` lists only allowed tools; `/secrets` + `/health` only the credentials wired into them; the access list also accepts **skill names**, gating skill visibility (`/bundles` + both getters); Team-panel access/invite checkboxes include recipe-only skills so grants aren't dropped on edit.

### Also riding along
- `fix(proxy)`: `/call` rebuilds the upstream path from `raw_path` so percent-encoding survives (npm scoped publish `PUT /@scope%2fname`); `treg call --content-type` + JSON body sniffing; regression tests + proxy-model context-fragment update.
- `feat(npm)`: `packages/npm` — the published `@superdesign/treg@0.1.0` launcher.
- `fix(dashboard)`: snippet previews show the full token (matches what Copy puts on the clipboard).

## Testing
- 534 tests pass (13 new: by-name lookups + org isolation + OG escaping, landing round-trip + open-redirect allowlist, ACL visibility, raw-path fidelity, content-type matrix).
- Headless-browser E2E: owner shares via modal → outsider opens link → focused gate → email-code sign-in → auto-join as viewer → lands on the skill page. Also: row-click routing, org auto-switch, Back-button behavior.
- Deploy note: includes an additive auto-migration (`invite.landing` column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)