### PR TITLE
Split CLI from server (light pip install) + v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,15 @@ scripts/dev-local.sh reset       # wipe the dev DB + CLI sandbox for a fresh sta
 Or run the server directly, without tmux:
 
 ```bash
-uv sync                        # create the venv from uv.lock
+uv sync                        # create the venv from uv.lock (pulls the server deps for dev)
 uv run python -m treg          # serve on 0.0.0.0:18790 (add --reload for dev)
 uv run python -m treg keygen   # print a fresh Fernet key for TREG_SECRET_KEY
 ```
+
+> **Installing to run a server (not from source):** the base package is the **CLI only**. To run a
+> registry, install the server extra — `pip install "tools-registry[server]"` — which adds FastAPI, the
+> database drivers, and encryption. `pip install tools-registry` alone gives just the `treg` command for
+> talking to an existing registry.
 
 The team instance is hosted on **Render** (web service + Postgres) at `treg.superdesign.dev`.
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -92,7 +92,8 @@ its own sqlite DB and email dev mode.
 
 ## Render (Blueprint)
 `render.yaml` at the repo root deploys the whole thing as **one web service + a managed Postgres**
-(region `oregon`): `buildCommand: pip install .` (the wheel ships every web asset via the package),
+(region `oregon`): `buildCommand: pip install ".[server]"` — the base install is the **CLI only**, so the
+server deploy needs the `[server]` extra (FastAPI/DB/crypto); the wheel ships every web asset via the package.
 `startCommand: python -m treg`, health check on `/meta`. The DB URL is auto-wired via `fromDatabase`
 (config's validator adds the asyncpg driver). Secrets are **dashboard-managed** (`sync: false` — the
 Fernet key, session/admin tokens, GitHub OAuth pair, Resend key); `TREG_PUBLIC_URL`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,29 +1,61 @@
 [project]
 name = "tools-registry"
-version = "0.0.1"
+version = "0.2.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
+readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.12,<3.14"
+authors = [
+    { name = "Unclecode", email = "unclecode@superdesign.dev" },
+    { name = "SuperDesign" },
+]
+maintainers = [{ name = "Unclecode", email = "unclecode@superdesign.dev" }]
+keywords = ["registry", "cli", "proxy", "credentials", "secrets", "api", "tools", "agents"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: Other/Proprietary License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development",
+    "Topic :: Utilities",
+]
+# Base install = just the CLI. Light + pure-Python, so `pip install tools-registry` (and Homebrew) are
+# fast. Everything needed to RUN a registry server lives in the `[server]` extra below.
 dependencies = [
+    "httpx>=0.27",
+    "questionary>=2.0",
+]
+
+[project.optional-dependencies]
+# The registry SERVER — host your own. The FastAPI app, the DB drivers, and encryption. Not needed to
+# USE the CLI against a hosted registry, only to RUN one. Install with: pip install "tools-registry[server]"
+server = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.32",
-    "httpx>=0.27",
     "sqlmodel>=0.0.22",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.20",
     "asyncpg>=0.30",
     "cryptography>=43",
     "pydantic-settings>=2.5",
-    "questionary>=2.0",
 ]
 
 [project.scripts]
 treg = "treg.cli:main"
 
+[project.urls]
+Homepage = "https://treg.superdesign.dev"
+Repository = "https://github.com/superdesigndev/tools-registry"
+Issues = "https://github.com/superdesigndev/tools-registry/issues"
+
 [dependency-groups]
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
+    "tools-registry[server]",   # the test suite imports the server (api, models, …), so dev pulls it in
 ]
 
 [tool.pytest.ini_options]

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,9 @@
 # /llms.txt + /install.sh) backed by a managed Postgres. See docs/context/ops/deploy.md.
 #
 # The app is a single FastAPI service: `python -m treg` honors $PORT (Render routes + health-checks
-# it). Web assets ship in the wheel via pyproject `force-include src/treg/web`, so a plain
-# `pip install .` bundles everything — no separate frontend build.
+# it). Web assets ship in the wheel via pyproject `force-include src/treg/web`, so `pip install .[server]`
+# bundles everything — no separate frontend build. The `[server]` extra pulls the FastAPI/DB/crypto stack
+# (the base install is the CLI only — see pyproject).
 #
 # Secrets (Fernet key, OAuth, Resend, admin/session tokens) are NOT in this file — they are set once
 # in the Render dashboard (sync:false below marks them as dashboard-managed). The Postgres URL is
@@ -22,7 +23,7 @@ services:
     region: oregon
     plan: starter
     branch: main
-    buildCommand: pip install .
+    buildCommand: pip install ".[server]"
     startCommand: python -m treg
     healthCheckPath: /meta
     autoDeploy: true

--- a/src/treg/localrun.py
+++ b/src/treg/localrun.py
@@ -19,12 +19,17 @@ import json
 import re
 from datetime import datetime, timezone
 
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from typing import TYPE_CHECKING
 
-from . import crypto, oauth
-from .injectors import _token_from_json
-from .models import Secret, Tool
+from .injectors import _token_from_json  # light: pure JSON/token helpers, no DB
+
+# The DB/crypto/oauth deps are used at runtime ONLY in `render_grant` (the server-side grant path — the
+# CLI client never calls it). Keeping them out of the module's top-level imports lets the CLI install
+# without the heavy `tools-registry[server]` stack. They are imported lazily inside render_grant; here
+# they're TYPE_CHECKING-only for the annotations (safe under `from __future__ import annotations`).
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from .models import Tool
 
 # OAuth grants may release ONLY the short-lived leaf (access token). Releasing refresh_token /
 # client_secret would hand the whole re-mintable identity to the member — never allowed.
@@ -211,6 +216,9 @@ async def render_grant(tool: Tool, profile: dict, db: AsyncSession, http) -> dic
     The CLIENT decides HOW to hand each item to the CLI (an env var, a flag, or a private socket); the
     server only resolves + renders the value. Raises LookupError (a referenced secret is missing) or lets
     an oauth refresh error propagate — the endpoint maps both to the same statuses the /call path uses."""
+    from sqlmodel import select  # lazy: server-only deps (part of the tools-registry[server] extra)
+    from . import crypto, oauth
+    from .models import Secret
     inject = profile.get("inject") or []
     if not inject:
         # A self-authenticating CLI (auto-import "local tier": gh, gcloud, vercel — the credential lives

--- a/uv.lock
+++ b/uv.lock
@@ -553,16 +553,20 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.0.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
+    { name = "questionary" },
+]
+
+[package.optional-dependencies]
+server = [
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "cryptography" },
     { name = "fastapi" },
-    { name = "httpx" },
     { name = "pydantic-settings" },
-    { name = "questionary" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlmodel" },
     { name = "uvicorn", extra = ["standard"] },
@@ -570,28 +574,37 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiosqlite" },
+    { name = "asyncpg" },
+    { name = "cryptography" },
+    { name = "fastapi" },
+    { name = "pydantic-settings" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlmodel" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiosqlite", specifier = ">=0.20" },
-    { name = "asyncpg", specifier = ">=0.30" },
-    { name = "cryptography", specifier = ">=43" },
-    { name = "fastapi", specifier = ">=0.115" },
+    { name = "aiosqlite", marker = "extra == 'server'", specifier = ">=0.20" },
+    { name = "asyncpg", marker = "extra == 'server'", specifier = ">=0.30" },
+    { name = "cryptography", marker = "extra == 'server'", specifier = ">=43" },
+    { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "pydantic-settings", specifier = ">=2.5" },
+    { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.5" },
     { name = "questionary", specifier = ">=2.0" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
-    { name = "sqlmodel", specifier = ">=0.0.22" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
+    { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'server'", specifier = ">=2.0" },
+    { name = "sqlmodel", marker = "extra == 'server'", specifier = ">=0.0.22" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "tools-registry", extras = ["server"] },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes `pip install tools-registry` a **light CLI** and moves the server stack behind a `[server]` extra — so pip and Homebrew installs are fast (no Rust/C builds).

- **base deps** = `httpx` + `questionary` only (~13 pure-Python packages)
- **`pip install "tools-registry[server]"`** adds FastAPI, DB drivers, crypto — to *host* a registry
- `localrun.py`: server-only imports (used only in `render_grant`) made lazy/TYPE_CHECKING — the one leak of the server stack into CLI paths
- `render.yaml`: build now `pip install ".[server]"`; dev group self-refs the extra so `uv sync` + CI still install the server
- bump **0.1.0 → 0.2.0**; add Unclecode as author + maintainer

**Verified:** base install = 13 light packages (no fastapi/asyncpg/cryptography); full server + **521 tests pass**; `render_grant` works live.