### PR TITLE
install.sh: install from PyPI instead of the git repo

### DIFF
--- a/src/treg/web/install.sh
+++ b/src/treg/web/install.sh
@@ -4,7 +4,9 @@
 set -e
 
 BASE="{BASE}"
-SRC="git+https://github.com/superdesigndev/tools-registry.git"
+# Install from PyPI (fast, public, no git clone). The base package is the light CLI; the FastAPI/DB
+# server stack is the `tools-registry[server]` extra, which people who self-host install separately.
+SRC="tools-registry"
 
 printf '\n\033[38;5;173m▚ tools-registry\033[0m - installing the treg CLI…\n\n'
 


### PR DESCRIPTION
`install.sh` now installs `tools-registry` from **PyPI** (`uv tool install tools-registry`) instead of `git+https://github.com/…`.

- **Faster** — no git clone + build
- **Works while the repo is private** — PyPI is public
- Installs the **light CLI** base package (the split)
- Improves every path that goes through install.sh: `curl | sh`, and the `@superdesign/treg` npm launcher

No change needed to the npm package itself — it's a zero-dependency launcher that calls install.sh.