### PR TITLE
ci: least-privilege permissions block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+# Least-privilege: CI only reads the repo (checkout + tests + secret scan).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the CI workflow (resolves the two CodeQL missing-workflow-permissions alerts). CI only reads the repo.