### PR TITLE
✨ feat(cli): arrow-key onboarding menus, inline path input, cleaner finish

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -570,8 +570,12 @@ def _login_page_html(login_id: str, *, session_email: str | None, github: bool, 
         'inputmode="latin" placeholder="e.g. 7F3K" maxlength="9"></div>',
         '<div id="orgpick"></div>',
     ]
+    # With a live session the doors are noise — the user is one click from done. Collapse them behind
+    # the divider (an accordion); a click expands. No session → no divider, doors always visible.
     if session_email:
-        parts.append('<div class="div" id="other-acct">or use a different account</div>')
+        parts.append('<div class="div acc" id="other-acct" onclick="toggleDoors()" role="button" tabindex="0" '
+                     'onkeydown="if(event.key===\'Enter\')toggleDoors()">'
+                     'use a different account <span id="acc-caret">▸</span></div>')
     doors: list[str] = []
     if github:
         doors.append(f'<a class="btn" href="/auth/github?cli={login_id}">Sign in with GitHub</a>')
@@ -584,7 +588,8 @@ def _login_page_html(login_id: str, *, session_email: str | None, github: bool, 
         '<div id="code-row" style="display:none"><input id="code" inputmode="numeric" placeholder="6-digit code">'
         '<button class="btn primary" onclick="verifyCode()">Verify</button></div>'
         '<div class="hint" id="hint"></div></div>')
-    parts.append(f'<div id="doors" class="stack">{"".join(doors)}</div>')
+    doors_style = ' style="display:none"' if session_email else ''
+    parts.append(f'<div id="doors" class="stack"{doors_style}>{"".join(doors)}</div>')
     has_session = "true" if session_email else "false"
     return (
         f"{_AUTH_HEAD.replace('</style>', _LOGIN_CSS + '</style>')}"
@@ -607,6 +612,8 @@ _LOGIN_CSS = (
     ".stack>div{display:flex;flex-direction:column;gap:10px}"
     ".div{display:flex;flex-direction:row!important;align-items:center;gap:10px;color:var(--muted);font-size:12px;margin:6px 0 0}"
     ".div:before,.div:after{content:'';flex:1;border-top:1px solid var(--line)}"
+    ".div.acc{cursor:pointer;user-select:none}.div.acc:hover{color:var(--ink)}"
+    "#email-row,#code-row{display:flex;flex-direction:column;gap:10px}"
     "input{width:100%;box-sizing:border-box;padding:11px 12px;border-radius:9px;border:1px solid var(--line);"
     "background:#1c1913;color:var(--ink);font-family:var(--mono);font-size:13.5px}"
     ".err{color:#d78f6c;font-size:12.5px;margin-top:10px;min-height:1em}"
@@ -635,6 +642,10 @@ if(PAIR){const box=document.getElementById('pcbox');if(box){box.innerHTML='';
  const l=document.createElement('div');l.className='pklabel';l.textContent='Check this code matches your terminal:';box.appendChild(l);
  const c=document.createElement('div');c.id='paircode-show';c.textContent=PAIR;box.appendChild(c);}}
 const pairCode=()=>PAIR||((document.getElementById('paircode')||{}).value||'');
+// Signed-in users see the doors collapsed behind the "use a different account" divider.
+function toggleDoors(){const d=document.getElementById('doors');if(!d)return;
+ const open=d.style.display==='none';d.style.display=open?'':'none';
+ const c=document.getElementById('acc-caret');if(c)c.textContent=open?'\\u25be':'\\u25b8'}
 const err=m=>{document.getElementById('err').textContent=m||''};
 async function post(p,b){const r=await fetch(p,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(b)});
  let d={};try{d=await r.json()}catch(e){}

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -557,9 +557,11 @@ def _login_page_html(login_id: str, *, session_email: str | None, github: bool, 
     is HTML-escaped (it's the only other interpolated value)."""
     from html import escape
 
-    # A pairing-code field sits above everything: whichever door the user takes, approve() won't complete
-    # the CLI handshake until they type the code shown in their own terminal (phishing guard — a login
-    # they didn't start has no matching code). #orgpick is ALWAYS present (filled by loadOrgs when a
+    # A pairing-code block sits above everything: whichever door the user takes, approve() won't complete
+    # the CLI handshake until the code shown in their own terminal is echoed back (phishing guard — a
+    # login they didn't start has no matching code). A `treg login` link carries the code in the URL
+    # fragment, so the JS swaps this input for a read-only display the user just visually confirms;
+    # the typed input remains the fallback for links without one. #orgpick is ALWAYS present (filled by loadOrgs when a
     # session exists at load, and after the email door signs in). #doors holds the sign-in options; the
     # divider only shows when a session pre-exists.
     parts: list[str] = [
@@ -616,12 +618,23 @@ _LOGIN_CSS = (
     ".team .tm{font-size:11px;color:var(--muted)}"
     ".team.primary .tm{color:#211d16;opacity:.8}"
     ".pklabel{font-size:12px;color:var(--muted);margin:2px 0 2px}"
+    "#paircode-show{font-size:22px;font-weight:700;letter-spacing:8px;text-align:center;color:var(--accent);"
+    "padding:10px 12px 10px 20px;border:1px dashed var(--line);border-radius:9px;background:#1c1913}"
 )
 
 # The page's whole brain: every door funnels into approve(), which completes the CLI handshake.
 # done() builds DOM via textContent (the email came over JSON — never trust it into innerHTML).
 _LOGIN_JS = """
 const LID='__LOGIN_ID__';
+// `treg login` puts the pairing code in the URL FRAGMENT (#code=…) — it never reaches the server on
+// the GET. When present, show it read-only for a visual match against the terminal instead of making
+// the user type it; approve() still sends it for full server-side validation. No fragment (an old CLI,
+// or a link someone stripped it from) → the typed-input fallback below stays.
+const PAIR=(()=>{const m=/[#&]code=([A-Za-z0-9-]{1,16})/.exec(location.hash||'');return m?m[1].toUpperCase():''})();
+if(PAIR){const box=document.getElementById('pcbox');if(box){box.innerHTML='';
+ const l=document.createElement('div');l.className='pklabel';l.textContent='Check this code matches your terminal:';box.appendChild(l);
+ const c=document.createElement('div');c.id='paircode-show';c.textContent=PAIR;box.appendChild(c);}}
+const pairCode=()=>PAIR||((document.getElementById('paircode')||{}).value||'');
 const err=m=>{document.getElementById('err').textContent=m||''};
 async function post(p,b){const r=await fetch(p,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(b)});
  let d={};try{d=await r.json()}catch(e){}
@@ -632,12 +645,12 @@ function done(email){const c=document.getElementById('card');c.innerHTML='';
  mk('h1',null,email?('Logged in as '+email):'Logged in');
  mk('p',null,'Return to your terminal. The CLI is finishing up, you can close this tab.')}
 async function approve(org){err('');
- const pc=(document.getElementById('paircode')||{}).value||'';
+ const pc=pairCode();
  if(!pc.trim()){err('Enter the code shown in your terminal to continue.');const el=document.getElementById('paircode');if(el)el.focus();return}
  try{const b={login_id:LID,code:pc};if(org)b.org=org;const d=await post('/auth/cli/approve',b);done(d.email)}catch(e){err(e.message)}}
 let CREATED_ORG=null;  // remember a just-created team so a retry (e.g. after a wrong code) reuses it, never makes a 2nd
 async function createTeam(){err('');
- const pc=(document.getElementById('paircode')||{}).value||'';
+ const pc=pairCode();
  if(!pc.trim()){err('Enter the code shown in your terminal to continue.');const el=document.getElementById('paircode');if(el)el.focus();return}
  const inp=document.getElementById('newteam');const name=(inp&&inp.value||'').trim();if(!name)return err('give your team a name');
  try{if(!CREATED_ORG){const o=await post('/orgs',{name:name});CREATED_ORG=o.org;}await approve(CREATED_ORG);}catch(e){err(e.message)}}

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -227,10 +227,10 @@ def cmd_login(args, cfg) -> None:
     # session with one click, else offers every configured door (GitHub / Google / email code).
     import secrets as _secrets
     base = cfg["base_url"].rstrip("/")
-    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code shown only here
-    # (never in the URL). The browser must echo the code back before it finishes, so a login you didn't
-    # start — someone mailing you a /login?cli=… link — can't be approved into a token for them. If the
-    # server is too old to know /start, fall back to a locally-minted id (no code) so login still works.
+    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code. The browser
+    # must echo the code back before it finishes, so a login you didn't start — someone mailing you a
+    # /login?cli=… link — can't be approved into a token for them. If the server is too old to know
+    # /start, fall back to a locally-minted id (no code) so login still works.
     code = None
     try:
         st = httpx.post(f"{base}/auth/cli/start", headers={"ngrok-skip-browser-warning": "1"}, timeout=10)
@@ -240,10 +240,13 @@ def cmd_login(args, cfg) -> None:
             lid = _secrets.token_urlsafe(18)
     except Exception:
         lid = _secrets.token_urlsafe(18)
-    url = f"{base}/login?cli={lid}"
+    # The code rides in the URL FRAGMENT (never sent to the server, so it stays out of request logs):
+    # the /login page displays it for a visual match against this terminal instead of making the user
+    # type it. The server still validates the code at approve time — the guard itself is unchanged.
+    url = f"{base}/login?cli={lid}" + (f"#code={code}" if code else "")
     print(f"Opening your browser to sign in…\nIf it doesn't open, visit:\n  {url}\n")
     if code:
-        print(f"  Enter this code in the browser to confirm it's you:  {_B}{_TEAL}{code}{_R}\n")
+        print(f"  The sign-in page shows this code — check it matches:  {_B}{_TEAL}{code}{_R}\n")
     print("Waiting for authorization…")
     try:
         webbrowser.open(url)

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -227,10 +227,10 @@ def cmd_login(args, cfg) -> None:
     # session with one click, else offers every configured door (GitHub / Google / email code).
     import secrets as _secrets
     base = cfg["base_url"].rstrip("/")
-    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code shown only here
-    # (never in the URL). The browser must echo the code back before it finishes, so a login you didn't
-    # start — someone mailing you a /login?cli=… link — can't be approved into a token for them. If the
-    # server is too old to know /start, fall back to a locally-minted id (no code) so login still works.
+    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code. The browser
+    # must echo the code back before it finishes, so a login you didn't start — someone mailing you a
+    # /login?cli=… link — can't be approved into a token for them. If the server is too old to know
+    # /start, fall back to a locally-minted id (no code) so login still works.
     code = None
     try:
         st = httpx.post(f"{base}/auth/cli/start", headers={"ngrok-skip-browser-warning": "1"}, timeout=10)
@@ -240,10 +240,13 @@ def cmd_login(args, cfg) -> None:
             lid = _secrets.token_urlsafe(18)
     except Exception:
         lid = _secrets.token_urlsafe(18)
-    url = f"{base}/login?cli={lid}"
+    # The code rides in the URL FRAGMENT (never sent to the server, so it stays out of request logs):
+    # the /login page displays it for a visual match against this terminal instead of making the user
+    # type it. The server still validates the code at approve time — the guard itself is unchanged.
+    url = f"{base}/login?cli={lid}" + (f"#code={code}" if code else "")
     print(f"Opening your browser to sign in…\nIf it doesn't open, visit:\n  {url}\n")
     if code:
-        print(f"  Enter this code in the browser to confirm it's you:  {_B}{_TEAL}{code}{_R}\n")
+        print(f"  The sign-in page shows this code — check it matches:  {_B}{_TEAL}{code}{_R}\n")
     print("Waiting for authorization…")
     try:
         webbrowser.open(url)
@@ -307,12 +310,15 @@ def _select(message: str, choices, **kw):
                               instruction="↑↓ move, enter confirm", **kw)
 
 
-def _menu(message: str, options: list[tuple], default=None):
+def _menu(message: str, options: list[tuple], default=None, ambient=None):
     """House arrow-key picker: bold titles, dim `— description` tails, hovered row bolded behind
     the ❯ cursor — per-part styling questionary's select can't combine with hover (a styled title
     bypasses its `highlighted` class). options = [(value, title, desc)], or (value, title, desc, True)
     for a type-in row: arrowing onto it focuses an inline input — printable keys type into it,
     backspace edits, ↵ submits (value, typed_text). ↑↓/jk move, 1-9 jump-pick, ↵ confirms.
+    ambient = (rows_above_title, frame_iter): while idle, the line that many rows above the menu
+    title is redrawn from frame_iter every ~90ms (the looping relay) — one-row rewrites, and the
+    loop stops the moment a key resolves the menu.
     Returns the chosen value ((value, text) for a type-in row), or None on Ctrl-C / Ctrl-D / Esc."""
     try:
         import termios
@@ -366,18 +372,30 @@ def _menu(message: str, options: list[tuple], default=None):
             d = f"  {_M}— {desc}{_R}" if desc else ""
         return f"\x1b[2K{pre}{t}{d}"
 
+    def _place_cursor() -> None:
+        """From the parked (below-frame) spot: park the real cursor at the type-in row's input
+        point — after ` ❯ {title}  — {buf}` — where it blinks; plain rows keep it hidden."""
+        if _is_text(idx):
+            col = 3 + len(options[idx][1]) + 4 + len(buf)
+            sys.stdout.write(f"\x1b[{n - idx}A\r\x1b[{col}C\x1b[?25h")
+        else:
+            sys.stdout.write("\x1b[?25l")
+
     def _draw(redraw: bool) -> None:
         if redraw:
             sys.stdout.write("\x1b8")  # jump back to the parked spot below the frame
             sys.stdout.write(f"\x1b[{n}A")
         sys.stdout.write("\n".join(_row(i) for i in range(n)) + "\n")
         sys.stdout.write("\x1b7")  # park: remember the below-frame position for the next redraw
-        if _is_text(idx):
-            # put the real (blinking) terminal cursor at the input point: after ` ❯ {title}  — {buf}`
-            col = 3 + len(options[idx][1]) + 4 + len(buf)
-            sys.stdout.write(f"\x1b[{n - idx}A\r\x1b[{col}C\x1b[?25h")
-        else:
-            sys.stdout.write("\x1b[?25l")
+        _place_cursor()
+        sys.stdout.flush()
+
+    def _tick_ambient() -> None:
+        """Repaint the ambient line (rows_above_title above the menu title) with the next frame,
+        then put the cursor back exactly where the menu left it."""
+        up = n + 1 + ambient[0]
+        sys.stdout.write(f"\x1b8\x1b[{up}A\r\x1b[2K" + next(ambient[1]) + "\x1b8")
+        _place_cursor()
         sys.stdout.flush()
 
     fd = sys.stdin.fileno()
@@ -392,6 +410,9 @@ def _menu(message: str, options: list[tuple], default=None):
         # keys come via os.read on the fd — sys.stdin's buffer would swallow the tail of an
         # escape sequence and make the select() lookahead below lie
         while True:
+            if ambient:
+                while not select.select([fd], [], [], 0.09)[0]:
+                    _tick_ambient()  # idle → advance the relay one frame
             c = os.read(fd, 1).decode(errors="replace")
             if c == "\x1b":  # arrow keys arrive as ESC [ A/B/C; a bare ESC cancels
                 if select.select([fd], [], [], 0.05)[0] and os.read(fd, 1) == b"[":
@@ -446,26 +467,53 @@ def _menu(message: str, options: list[tuple], default=None):
     return picked
 
 
-def _splash() -> None:
-    """`treg onboard`'s opening beat (~2s, any key skips): the wordmark decrypts behind a ░▒▓
-    wavefront, then a spark runs the keyless relay — you → vault → api ✓ — and only the answer
-    comes back. TTY-only with color on; agents, pipes, dumb terminals and NO_COLOR never see it."""
-    if not (sys.stdin.isatty() and sys.stdout.isatty()) or os.environ.get("TERM") == "dumb" or not _A:
-        return
-    try:
-        import termios
-        import tty
-    except ImportError:
-        return
-    title, sub = "tools-registry", " — your team's vault"
-    text = f"▚ {title}{sub}"
-    d1, d2 = 8, 12  # dash runs: you ──▚ vault ──── api
+_D1, _D2 = 8, 12  # relay dash runs: you ──▚ vault ──── api
 
-    def _title_line(front: int) -> str:
+
+def _relay_frame(spark: int = -1, hit: bool = True, back: int = -1) -> str:
+    """One frame of the keyless relay: `you ──●──▚ vault ────── api ✓`. spark = forward ember
+    dot position, back = amber response position (both dash-indexed), hit lights the api ✓."""
+    parts = [f"  {_M}you {_R}"]
+    for i in range(_D1):
+        parts.append(f"{_A}{_B}●{_R}" if spark == i else f"{_M}─{_R}")
+    parts.append(f"{_A}{_B}▚{_R}{_M} vault {_R}")
+    for i in range(_D2):
+        j = _D1 + 1 + i
+        if spark == j:
+            parts.append(f"{_A}{_B}●{_R}")
+        elif back == j:
+            parts.append(f"{_AM}●{_R}")  # the response riding home, amber
+        else:
+            parts.append(f"{_M}─{_R}")
+    parts.append(f" {_B}api{_R} {_G}✓{_R}" if hit else f"{_M} api{_R}")
+    return "".join(parts)
+
+
+def _relay_loop():
+    """Endless spark cycle for the ambient loop behind the onboarding menu: call → ✓ → response
+    home → rest → again. One yielded line per ~90ms tick — a single-row rewrite, spinner-cheap."""
+    while True:
+        for i in range(_D1):
+            yield _relay_frame(spark=i, hit=False)
+        for i in range(_D2):
+            yield _relay_frame(spark=_D1 + 1 + i, hit=False)
+        for _ in range(3):
+            yield _relay_frame(hit=True)
+        for i in range(_D2 - 1, -1, -2):
+            yield _relay_frame(hit=True, back=_D1 + 1 + i)
+        for _ in range(8):
+            yield _relay_frame(hit=True)
+
+
+def _dither_frames(chars: list[tuple[str, str]]) -> list[str]:
+    """Dither-reveal a styled line: chars = [(ch, ansi_prefix)]. A ░▒▓ wavefront sweeps left to
+    right; behind it every char lands in its final style. Returns the frame list (last = final)."""
+    frames = []
+    for front in range(0, len(chars) + 7, 3):
         out = []
-        for i, ch in enumerate(text):
+        for i, (ch, st) in enumerate(chars):
             d = front - i
-            if d < 0:
+            if d < 0 or (d < 6 and ch == " "):
                 out.append(" ")
             elif d < 2:
                 out.append(f"{_M}░{_R}")
@@ -473,43 +521,37 @@ def _splash() -> None:
                 out.append(f"{_M}▒{_R}")
             elif d < 6:
                 out.append(f"{_A}▓{_R}")
-            elif i == 0:
-                out.append(f"{_A}{_B}▚{_R}")
-            elif i <= len(title) + 1:
-                out.append(f"{_B}{ch}{_R}")
             else:
-                out.append(f"{_M}{ch}{_R}")
-        return "".join(out)
+                out.append(f"{st}{ch}{_R}" if ch != " " else " ")
+        frames.append("".join(out))
+    return frames
 
-    def _relay_line(spark: int, hit: bool, back: int) -> str:
-        parts = [f"  {_M}◇ you {_R}"]
-        for i in range(d1):
-            parts.append(f"{_A}{_B}●{_R}" if spark == i else f"{_M}─{_R}")
-        parts.append(f"{_A}{_B}▚{_R}{_M} vault {_R}")
-        for i in range(d2):
-            j = d1 + 1 + i
-            if spark == j:
-                parts.append(f"{_A}{_B}●{_R}")
-            elif back == j:
-                parts.append(f"{_AM}●{_R}")  # the response riding home, amber
-            else:
-                parts.append(f"{_M}─{_R}")
-        parts.append(f" {_B}api{_R} {_G}✓{_R}" if hit else f"{_M} api{_R}")
-        return "".join(parts)
 
-    caption = " " * (8 + d1) + "└ keys stay here"
+def _splash() -> bool:
+    """`treg onboard`'s opening beat (~1.5s, any key skips): the wordmark, then the keyless-relay
+    diagram, each decrypting behind a ░▒▓ wavefront. Returns True when it played, so the menu can
+    keep the relay spark looping above it. TTY-only with color on; agents, pipes, dumb terminals
+    and NO_COLOR never see a frame."""
+    if not (sys.stdin.isatty() and sys.stdout.isatty()) or os.environ.get("TERM") == "dumb" or not _A:
+        return False
+    try:
+        import termios
+        import tty
+    except ImportError:
+        return False
+    title, sub = "tools-registry", " — your team's vault"
+    title_chars = ([("▚", f"{_A}{_B}"), (" ", "")] + [(c, _B) for c in title] + [(c, _M) for c in sub])
+    relay_plain = "  you " + "─" * _D1 + "▚ vault " + "─" * _D2 + " api"
+    relay_chars = [(ch, f"{_A}{_B}" if ch == "▚" else _M) for ch in relay_plain]
+    caption = f"{_M}{' ' * (6 + _D1)}└ the key never left{_R}"
+
     frames: list[tuple[str, str, str]] = []
-    for front in range(0, len(text) + 7, 3):  # phase 1 — dither reveal
-        frames.append((_title_line(front), "", ""))
-    done = _title_line(len(text) + 6)
-    for i in range(d1):  # phase 2 — the relay run
-        frames.append((done, _relay_line(i, False, -1), ""))
-    for i in range(d2):
-        frames.append((done, _relay_line(d1 + 1 + i, False, -1), f"{_M}{caption}{_R}"))
-    frames += [(done, _relay_line(-1, True, -1), f"{_M}{caption}{_R}")] * 2
-    for i in range(d2 - 1, -1, -2):
-        frames.append((done, _relay_line(-1, True, d1 + 1 + i), f"{_M}{caption}{_R}"))
-    final = (done, _relay_line(-1, True, -1), f"{_M}{' ' * (8 + d1)}└ the key never left{_R}")
+    for t in _dither_frames(title_chars):  # 1 — the wordmark decrypts
+        frames.append((t, "", ""))
+    done = frames[-1][0]
+    for r in _dither_frames(relay_chars):  # 2 — the relay diagram decrypts
+        frames.append((done, r, ""))
+    final = (done, _relay_frame(), caption)
     frames.append(final)
 
     fd = sys.stdin.fileno()
@@ -535,6 +577,7 @@ def _splash() -> None:
         termios.tcsetattr(fd, termios.TCSANOW, old)
         sys.stdout.write("\x1b[?25h")
         sys.stdout.flush()
+    return True
 
 
 def _brand(sub: str) -> None: print(f"\n{_A}{_B}▚ tools-registry{_R} {_M}— {sub}{_R}")
@@ -589,10 +632,11 @@ def _is_rootish(d: Path) -> bool:
     return d == home or d == home.parent or d.parent == d
 
 
-def _pick_path(cfg: dict) -> str:
+def _pick_path(cfg: dict, splashed: bool = False) -> str:
     """The 3-path onboarding menu (Set up / Access / Demo). Interactive default is Setup; the
     non-interactive path keeps the smart org-based pick (a team with tools → Access; an empty
-    team you admin → Set up; else Demo) so scripted/agent runs stay unchanged."""
+    team you admin → Set up; else Demo) so scripted/agent runs stay unchanged. After the splash,
+    the relay diagram (3 rows above the menu title: blank, caption, relay) keeps looping."""
     if not sys.stdin.isatty():
         org = _onboard_active_org(cfg)
         has_tools = bool(org and org.get("tool_count"))
@@ -608,7 +652,7 @@ def _pick_path(cfg: dict) -> str:
         ("setup", "Setup", "upload your skills & env, share them safely (admins)"),
         ("access", "Connect existing tool-registry", "pull your team's shared skills + make a call"),
         ("demo", "Demo", "see how treg works with a throwaway team"),
-    ], default="setup")
+    ], default="setup", ambient=(3, _relay_loop()) if splashed else None)
     if picked is None:  # Ctrl-C / Esc / EOF
         raise SystemExit(0)
     return picked
@@ -1066,9 +1110,10 @@ def cmd_onboard(args, cfg) -> None:
         sys.exit("Log in first:  treg login")
     if not cfg.get("active_org"):
         _pick_active_org(cfg)  # identity token needs an active org so requests carry X-Treg-Org
+    splashed = False
     if not args.path and not getattr(args, "yes", False):  # scripted runs skip the theater
-        _splash()
-    path = args.path or ("demo" if args.mode == "quick" else None) or _pick_path(cfg)  # --mode kept for back-compat
+        splashed = _splash()
+    path = args.path or ("demo" if args.mode == "quick" else None) or _pick_path(cfg, splashed)  # --mode kept for back-compat
     _dispatch_onboard(cfg, path, args)
 
 

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -22,6 +22,7 @@ import getpass
 import json
 import os
 import re
+import select
 import shutil
 import signal
 import subprocess
@@ -305,6 +306,145 @@ def _select(message: str, choices, **kw):
     return questionary.select(message, choices=choices, pointer="❯", style=_picker_style(),
                               instruction="↑↓ move, enter confirm", **kw)
 
+
+def _menu(message: str, options: list[tuple], default=None):
+    """House arrow-key picker: bold titles, dim `— description` tails, hovered row bolded behind
+    the ❯ cursor — per-part styling questionary's select can't combine with hover (a styled title
+    bypasses its `highlighted` class). options = [(value, title, desc)], or (value, title, desc, True)
+    for a type-in row: arrowing onto it focuses an inline input — printable keys type into it,
+    backspace edits, ↵ submits (value, typed_text). ↑↓/jk move, 1-9 jump-pick, ↵ confirms.
+    Returns the chosen value ((value, text) for a type-in row), or None on Ctrl-C / Ctrl-D / Esc."""
+    try:
+        import termios
+        import tty
+    except ImportError:  # no raw-key support (e.g. Windows) → questionary keeps it usable
+        import questionary
+        ch = [questionary.Choice(f"{o[1]} — {o[2]}" if o[2] else o[1], value=o[0]) for o in options]
+        return _select(message, ch, default=default).ask()
+    idx = next((i for i, o in enumerate(options) if o[0] == default), 0)
+    n = len(options)
+    buf = ""  # the type-in row's text
+    ghost = ""  # fish-style autosuggestion (first matching folder), shown dim after the cursor
+
+    def _is_text(i: int) -> bool:
+        return len(options[i]) > 3 and bool(options[i][3])
+
+    def _suggest(txt: str) -> str:
+        """The completion tail of the first directory matching `txt` (e.g. '/Us' → 'ers/').
+        Case-insensitive, like the filesystem it's completing against (git → GitHub)."""
+        if not txt:
+            return ""
+        p = Path(txt).expanduser()
+        base, part = (p, "") if txt.endswith("/") else (p.parent, p.name)
+        try:
+            cands = sorted((d.name for d in base.iterdir() if d.is_dir()
+                            and d.name.lower().startswith(part.lower())
+                            and (part.startswith(".") or not d.name.startswith("."))),
+                           key=str.lower)
+        except OSError:  # nonexistent or unreadable dir → just no hint
+            return ""
+        # prefer an exact-case prefix match over the first case-folded one (Git… beats git…)
+        best = next((c for c in cands if c.startswith(part)), cands[0] if cands else None)
+        return f"{best[len(part):]}/" if best else ""
+
+    print(f"\n{_B}{message}{_R}  {_M}(↑↓ move · ↵ confirm){_R}")
+
+    def _row(i: int) -> str:
+        val, title, desc = options[i][:3]
+        cur = i == idx
+        pre = f" {_A}{_B}❯{_R} " if cur else "   "
+        t = f"{_B}{title}{_R}" if cur else title
+        if _is_text(i) and (cur or buf):  # the focused (or filled) input row
+            if not buf:
+                tail = f"{_M}{desc}… {_R}"
+            elif cur and ghost:
+                tail = f"{_M}{ghost}{_R}"
+            else:
+                tail = ""
+            d = f"  {_M}—{_R} {buf}{tail}"
+        else:
+            d = f"  {_M}— {desc}{_R}" if desc else ""
+        return f"\x1b[2K{pre}{t}{d}"
+
+    def _draw(redraw: bool) -> None:
+        if redraw:
+            sys.stdout.write("\x1b8")  # jump back to the parked spot below the frame
+            sys.stdout.write(f"\x1b[{n}A")
+        sys.stdout.write("\n".join(_row(i) for i in range(n)) + "\n")
+        sys.stdout.write("\x1b7")  # park: remember the below-frame position for the next redraw
+        if _is_text(idx):
+            # put the real (blinking) terminal cursor at the input point: after ` ❯ {title}  — {buf}`
+            col = 3 + len(options[idx][1]) + 4 + len(buf)
+            sys.stdout.write(f"\x1b[{n - idx}A\r\x1b[{col}C\x1b[?25h")
+        else:
+            sys.stdout.write("\x1b[?25l")
+        sys.stdout.flush()
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    picked = None
+    try:
+        # TCSANOW, not the default TCSAFLUSH: FLUSH waits for pending output to drain, which
+        # deadlocks when the reader (pty harness, agent) hasn't consumed the frame yet
+        tty.setcbreak(fd, termios.TCSANOW)
+        sys.stdout.write("\x1b7\x1b[?25l")  # seed the parked spot; hide the cursor on plain rows
+        _draw(redraw=False)
+        # keys come via os.read on the fd — sys.stdin's buffer would swallow the tail of an
+        # escape sequence and make the select() lookahead below lie
+        while True:
+            c = os.read(fd, 1).decode(errors="replace")
+            if c == "\x1b":  # arrow keys arrive as ESC [ A/B/C; a bare ESC cancels
+                if select.select([fd], [], [], 0.05)[0] and os.read(fd, 1) == b"[":
+                    c = {b"A": "up", b"B": "down", b"C": "right"}.get(os.read(fd, 1))
+                else:
+                    break
+            if c in ("up", "k") and not (c == "k" and _is_text(idx)):
+                idx = (idx - 1) % n
+            elif c in ("down", "j") and not (c == "j" and _is_text(idx)):
+                idx = (idx + 1) % n
+            elif c in ("\r", "\n"):
+                if _is_text(idx):
+                    if not buf.strip():
+                        continue  # a type-in row needs text before ↵ means anything
+                    picked = (options[idx][0], buf.strip())
+                else:
+                    picked = options[idx][0]
+                break
+            elif c in ("", "\x03", "\x04"):  # EOF / Ctrl-C / Ctrl-D
+                break
+            elif _is_text(idx) and c in ("right", "\t") and ghost:  # →/tab accept the suggestion
+                buf += ghost
+                ghost = _suggest(buf)
+            elif _is_text(idx) and c in ("\x7f", "\x08"):  # backspace edits the input row
+                buf = buf[:-1]
+                ghost = _suggest(buf)
+            elif _is_text(idx) and c and len(c) == 1 and c.isprintable():  # focused input: keys type
+                buf += c
+                ghost = _suggest(buf)
+            elif c and c.isdigit() and 1 <= int(c) <= n:  # the old numeric prompt still works
+                idx = int(c) - 1
+                if not _is_text(idx):  # a digit lands on the type-in row = focus it, don't submit
+                    picked = options[idx][0]
+                    break
+            elif c == "q":
+                break
+            else:
+                continue
+            _draw(redraw=True)
+    except KeyboardInterrupt:  # cbreak keeps ISIG on, so Ctrl-C lands here, not as \x03
+        picked = None
+    finally:
+        termios.tcsetattr(fd, termios.TCSANOW, old)
+        sys.stdout.write("\x1b[?25h")
+    # collapse the menu into a one-line receipt, questionary-style (unpark below the frame first —
+    # the cursor may be sitting mid-frame on the type-in row)
+    sys.stdout.write(f"\x1b8\x1b[{n + 1}A\x1b[J")
+    if picked is not None:
+        chose = f"{options[idx][1]}  {buf.strip()}" if isinstance(picked, tuple) else options[idx][1]
+        print(f"{_B}{message}{_R}  {_A}{chose}{_R}")
+    sys.stdout.flush()
+    return picked
+
 def _brand(sub: str) -> None: print(f"\n{_A}{_B}▚ tools-registry{_R} {_M}— {sub}{_R}")
 def _ok(t: str) -> None: print(f"  {_G}✓{_R} {t}")
 def _dim(t: str) -> None: print(f"{_M}{t}{_R}")
@@ -320,40 +460,66 @@ def _pause(yes: bool) -> None:
         raise SystemExit(0)
 
 
+_ORG_CACHE: dict = {}  # (base_url, active_org) → summary; onboarding asks 2-3× per run — fetch once
+
+
 def _onboard_active_org(cfg: dict) -> dict | None:
     """The active org's summary {slug,name,role,tool_count} — drives the onboarding hint + guards.
     None if the caller has no team (a path then points them at `treg org create` / an invite)."""
+    key = (cfg.get("base_url"), cfg.get("active_org"))
+    if key in _ORG_CACHE:
+        return _ORG_CACHE[key]
     try:
-        with _client(cfg) as c:
+        with _spinner("loading your team"), _client(cfg) as c:
             orgs = c.get("/orgs").json()
     except Exception:  # noqa: BLE001 — a transient failure just means "no smart hint"
         return None
     if not isinstance(orgs, list) or not orgs:
         return None
     active = cfg.get("active_org")
-    return (next((o for o in orgs if o.get("slug") == active), None)
-            or next((o for o in orgs if o.get("active")), None) or orgs[0])
+    org = (next((o for o in orgs if o.get("slug") == active), None)
+           or next((o for o in orgs if o.get("active")), None) or orgs[0])
+    _ORG_CACHE[key] = org
+    return org
 
 
 _PATHS = {"1": "setup", "2": "access", "3": "demo"}
 
 
+def _is_rootish(d: Path) -> bool:
+    """True for folders no repo lives at directly: filesystem root, $HOME, or $HOME's parent
+    (/Users, /home). Scanning these as "this project" would sweep the whole account."""
+    try:
+        d = d.resolve()
+    except OSError:
+        pass
+    home = Path.home()
+    return d == home or d == home.parent or d.parent == d
+
+
 def _pick_path(cfg: dict) -> str:
-    """The 3-path onboarding menu (Set up / Access / Demo) with a smart default from the active org:
-    a team with tools → Access; an empty team you admin → Set up; else Demo."""
-    org = _onboard_active_org(cfg)
-    has_tools = bool(org and org.get("tool_count"))
-    is_admin = bool(org and org.get("role") in ("admin", "owner"))
-    default = "2" if has_tools else ("1" if is_admin else "3")
+    """The 3-path onboarding menu (Set up / Access / Demo). Interactive default is Setup; the
+    non-interactive path keeps the smart org-based pick (a team with tools → Access; an empty
+    team you admin → Set up; else Demo) so scripted/agent runs stay unchanged."""
     if not sys.stdin.isatty():
-        return _PATHS[default]
-    print(f"\n{_B}What do you want to do?{_R}")
-    print(f"  {_A}{_B}1{_R}  {_B}Setup{_R}                        {_M}— upload your skills & env, share them safely (admins){_R}")
-    print(f"  {_A}{_B}2{_R}  {_B}Connect existing tool-registry{_R}   {_M}— pull your team's shared skills + make a call{_R}")
-    print(f"  {_A}{_B}3{_R}  {_B}Demo{_R}                         {_M}— see how treg works with a throwaway team{_R}")
-    hint = {"1": "Setup", "2": "Connect", "3": "Demo"}[default]
-    ans = input(f"  Pick [{_A}1{_R}/2/3]  ({_M}↵ = {hint}{_R}): ").strip()
-    return _PATHS.get(ans or default, "demo")
+        org = _onboard_active_org(cfg)
+        has_tools = bool(org and org.get("tool_count"))
+        is_admin = bool(org and org.get("role") in ("admin", "owner"))
+        if has_tools:
+            key = "2"
+        elif is_admin:
+            key = "1"
+        else:
+            key = "3"
+        return _PATHS[key]
+    picked = _menu("What do you want to do?", [
+        ("setup", "Setup", "upload your skills & env, share them safely (admins)"),
+        ("access", "Connect existing tool-registry", "pull your team's shared skills + make a call"),
+        ("demo", "Demo", "see how treg works with a throwaway team"),
+    ], default="setup")
+    if picked is None:  # Ctrl-C / Esc / EOF
+        raise SystemExit(0)
+    return picked
 
 
 def _maybe_offer_onboarding(cfg: dict) -> None:
@@ -362,7 +528,8 @@ def _maybe_offer_onboarding(cfg: dict) -> None:
         return
     base = cfg["base_url"].rstrip("/")
     try:
-        me = httpx.get(f"{base}/auth/me", headers={"X-Treg-Token": cfg["token"], "ngrok-skip-browser-warning": "1"}, timeout=10).json()
+        with _spinner("checking your account"):
+            me = httpx.get(f"{base}/auth/me", headers={"X-Treg-Token": cfg["token"], "ngrok-skip-browser-warning": "1"}, timeout=10).json()
     except Exception:
         return
     if me.get("onboarded"):
@@ -393,14 +560,27 @@ def _tip(t: str) -> None:  # an amber aside
     print(f"  {_AM}✦ {t}{_R}")
 
 
+_SPINNER_ACTIVE = False  # re-entrancy guard: a nested _spinner (e.g. catalog refresh inside a scan) stays quiet
+
+
 @contextlib.contextmanager
 def _spinner(msg: str):
-    """An animated braille spinner for slow steps (health runs, seeding). TTY-only: piped/agent
-    output gets one static line instead, so logs stay clean and deterministic."""
-    if not sys.stdout.isatty():
-        print(f"  … {msg}")
+    """An animated braille spinner for slow steps (health runs, scans, network fetches). TTY-only:
+    piped/agent output gets one static line instead, so logs stay clean and deterministic.
+    Nested use is safe — the inner spinner yields silently and the outer one keeps animating."""
+    global _SPINNER_ACTIVE
+    if _SPINNER_ACTIVE:
         yield
         return
+    if not sys.stdout.isatty():
+        _SPINNER_ACTIVE = True
+        print(f"  … {msg}")
+        try:
+            yield
+        finally:
+            _SPINNER_ACTIVE = False
+        return
+    _SPINNER_ACTIVE = True
     stop = threading.Event()
 
     def _spin() -> None:
@@ -417,6 +597,7 @@ def _spinner(msg: str):
         stop.set()
         t.join(timeout=0.3)
         print("\r" + " " * (len(msg) + 6) + "\r", end="", flush=True)  # wipe the line
+        _SPINNER_ACTIVE = False
 
 
 def _show_calls(cfg: dict) -> None:
@@ -473,17 +654,45 @@ def _run_setup(cfg: dict, args) -> None:
         _has_skills(cwd / a["project"]) for a in _ag.AGENTS.values())
     source = getattr(args, "source", None)
     if source is None:
-        if sys.stdin.isatty() and global_dirs and not getattr(args, "yes", False):
-            default = "1" if local_here else "2"
-            shown = ", ".join(str(g).replace(str(Path.home()), "~") for g in global_dirs[:3])
-            print(f"\n{_B}Import from where?{_R}")
-            print(f"  {_A}{_B}1{_R}  this project           {_M}— {cwd}{_R}")
-            print(f"  {_A}{_B}2{_R}  global agent folders   {_M}— {shown}{'…' if len(global_dirs) > 3 else ''}{_R}")
-            print(f"  {_A}{_B}3{_R}  both")
-            hint = {"1": "this project", "2": "global", "3": "both"}[default]
-            ans = input(f"  Pick [{_A}1{_R}/2/3]  ({_M}↵ = {hint}{_R}): ").strip()
-            source = {"1": "local", "2": "global", "3": "both"}.get(ans or default, "local")
-        else:  # non-interactive / --yes / nothing global to offer: keep the old local behavior
+        if sys.stdin.isatty() and not getattr(args, "yes", False):
+            # Running from a root-ish folder (/, $HOME, /Users) means "this project" would scan the
+            # whole home dir — hide it and let the user point at a real repo instead.
+            rootish = _is_rootish(cwd)
+            choices = []
+            if not rootish:
+                choices.append(("local", "this project", str(cwd)))
+            if global_dirs:
+                shown = ", ".join(str(g).replace(str(Path.home()), "~") for g in global_dirs[:3])
+                choices.append(("global", "global agent folders", f"{shown}{'…' if len(global_dirs) > 3 else ''}"))
+            if not rootish and global_dirs:
+                choices.append(("both", "both", ""))
+            choices.append(("other", "other project repo", "type a path", True))
+            if local_here and not rootish:
+                default = "local"
+            elif global_dirs:
+                default = "global"
+            else:
+                default = "other"
+            picked = _menu("Import skill/secret from where?", choices, default=default)
+            if picked is None:  # Ctrl-C / Esc / EOF
+                raise SystemExit(0)
+            if isinstance(picked, tuple) or picked == "other":  # tuple = path typed inline in the menu
+                typed = picked[1] if isinstance(picked, tuple) else None
+                import questionary
+                while True:
+                    p = typed or questionary.path("Path to the project repo:", style=_picker_style()).ask()
+                    typed = None  # an invalid inline path falls back to the re-prompt loop
+                    if p is None:
+                        raise SystemExit(0)
+                    d = Path(p).expanduser()
+                    if d.is_dir():
+                        cwd = d.resolve()
+                        break
+                    print(f"  {_M}not a directory: {d}{_R}")
+                source = "local"
+            else:
+                source = picked
+        else:  # non-interactive / --yes: keep the old local-first behavior
             source = "local" if (local_here or not global_dirs) else "global"
     want_local = source in ("local", "both")
     want_global = source in ("global", "both")
@@ -552,12 +761,7 @@ def _run_setup(cfg: dict, args) -> None:
     base = (cfg.get("base_url") or "").rstrip("/")
     _section("✓ Done — you're all set")
     print(f"  Your team's tools & skills are shared. {_B}Nothing more to do here.{_R}\n")
-    print(f"  {_M}Manage your team in the dashboard:{_R}  {_A}{base}/#orgs{_R}")
-    print(f"\n  {_M}To give a TEAMMATE access — invite them:{_R}")
-    _cmd("treg org invite teammate@company.com")
-    print(f"\n  {_M}…then THEY run this on THEIR machine (not you) to pull the skills + call your tools with no keys:{_R}")
-    _cmd(f"curl -fsSL {base}/install.sh | sh")
-    _cmd("treg login   →   treg onboard   (pick Connect)")
+    print(f"  {_B}View your skills & secret vault at {_A}{base}{_R}")
     print()
 
 
@@ -570,7 +774,7 @@ def _run_access(cfg: dict, args) -> None:
         _dim("You're not in a team yet — ask an admin to invite you, then `treg accept`.")
         return
     _kv("team", org.get("name") or org.get("slug"))
-    with _client(cfg) as c:
+    with _spinner("fetching your team's tools & skills"), _client(cfg) as c:
         tools = c.get("/tools").json()
         bundles = c.get("/bundles").json()
     tools = tools if isinstance(tools, list) else []
@@ -641,7 +845,7 @@ def _onboard_test_call(cfg: dict, tools: list) -> None:
     path, method = tp
     _cmd(f"treg call {tool['name']} {path}".rstrip())
     try:
-        with _client(cfg) as c:
+        with _spinner(f"calling {tool['name']} through treg"), _client(cfg) as c:
             r = c.request(method, f"/call/{tool['name']}/{path}".rstrip("/"))
         col = _G if r.status_code < 400 else _M
         print(f"  → {col}{r.status_code}{_R} — treg injected the credential; you never held it.")
@@ -655,19 +859,20 @@ def _demo_scan_preview(cfg: dict) -> None:
     cwd = Path(os.getcwd())
     env_path = cwd / ".env"
     keys: list[str] = []
-    if env_path.is_file():
-        try:
-            keys = [a.tool_name for a in prov.plan_actions(prov.scan_env(str(env_path), _load_catalog(cfg))) if a.supported]
-        except Exception:  # noqa: BLE001
-            pass
     skill_names: set[str] = set()
-    for cand in [cwd, cwd / ".claude" / "skills", cwd / ".agents" / "skills"]:
-        try:
-            if cand.is_dir():
-                for det in sk.scan_skills(str(cand)):
-                    skill_names.add(det.name)
-        except Exception:  # noqa: BLE001
-            pass
+    with _spinner("scanning this folder for keys & skills"):
+        if env_path.is_file():
+            try:
+                keys = [a.tool_name for a in prov.plan_actions(prov.scan_env(str(env_path), _load_catalog(cfg))) if a.supported]
+            except Exception:  # noqa: BLE001
+                pass
+        for cand in [cwd, cwd / ".claude" / "skills", cwd / ".agents" / "skills"]:
+            try:
+                if cand.is_dir():
+                    for det in sk.scan_skills(str(cand)):
+                        skill_names.add(det.name)
+            except Exception:  # noqa: BLE001
+                pass
     if keys:
         print(f"  {_M}API keys in your .env treg could share:{_R} {', '.join(keys[:8])}"
               + (f" +{len(keys)-8} more" if len(keys) > 8 else ""))
@@ -683,7 +888,7 @@ def _demo_teammate_call(cfg: dict) -> str | None:
     """Auto-pick ONE registered tool and make a REAL call, shown as the actual upstream API endpoint
     (URL-passthrough form) so it's unmistakably a real API. Falls back to a Stripe example if the team
     has no callable tool yet. Returns the tool name that was called (for the audit-log illustration)."""
-    with _client(cfg) as c:
+    with _spinner("finding a callable tool"), _client(cfg) as c:
         raw = c.get("/tools").json()
     tools = [t for t in (raw if isinstance(raw, list) else []) if t.get("name") != "echo" and _testable_path(t)]
     print(f"  {_M}A teammate on THEIR machine — no key on it — hits a REAL API through treg:{_R}")
@@ -696,8 +901,9 @@ def _demo_teammate_call(cfg: dict) -> str | None:
     endpoint = f"{tool['base_url'].rstrip('/')}/{path}"
     _cmd(f"treg call {endpoint}")   # DISPLAY the real upstream URL so it's clearly a real API…
     try:
-        with _client(cfg) as c:     # …but EXECUTE via the tool name (reliable; the host-passthrough form
-            r = c.request(method, f"/call/{tool['name']}/{path}".rstrip("/"))  # can be ambiguous w/ dup hosts)
+        # …but EXECUTE via the tool name (reliable; the host-passthrough form can be ambiguous w/ dup hosts)
+        with _spinner(f"calling {tool.get('host') or tool['name']}"), _client(cfg) as c:
+            r = c.request(method, f"/call/{tool['name']}/{path}".rstrip("/"))
         col = _G if r.status_code < 400 else _M
         print(f"  → {col}{r.status_code}{_R} — a real response from {tool.get('host') or tool['name']}. "
               "treg injected the key server-side; the teammate never held it.")
@@ -904,7 +1110,7 @@ def _load_catalog(cfg) -> list:
     tag = hashlib.sha1((cfg.get("base_url") or "").encode()).hexdigest()[:10]
     cache = CONFIG_PATH.parent / f"providers-cache-{tag}.json"
     try:
-        with _client(cfg, auth=False) as c:
+        with _spinner("refreshing the provider catalog"), _client(cfg, auth=False) as c:
             r = c.get("/providers.json")
         body = r.json() if r.status_code == 200 else {}
         if body.get("providers"):
@@ -1108,19 +1314,20 @@ def _import_clis(args, cfg, env_path: str) -> None:
         return any(os.path.exists(os.path.expanduser(p)) for p in (cli.get("detect") or {}).get("config_paths", []))
 
     scanned = []  # (entry, cli, decision, envvar)
-    for entry in catalog:
-        cli = entry.get("cli")
-        if not cli or not cli.get("bin"):
-            continue
-        d = prov.classify_cli(entry, installed=shutil.which(cli["bin"]) is not None,
-                              secret_present=bool(_val(prov.cli_env_var(cli))), logged_in=_logged_in(cli))
-        scanned.append((entry, cli, d, prov.cli_env_var(cli)))
+    with _spinner("checking this machine for installed CLIs"):
+        for entry in catalog:
+            cli = entry.get("cli")
+            if not cli or not cli.get("bin"):
+                continue
+            d = prov.classify_cli(entry, installed=shutil.which(cli["bin"]) is not None,
+                                  secret_present=bool(_val(prov.cli_env_var(cli))), logged_in=_logged_in(cli))
+            scanned.append((entry, cli, d, prov.cli_env_var(cli)))
 
     ready = [x for x in scanned if x[2]["status"] == "ready"]
     report_only = args.status or args.dry_run
     registered = []  # (name, tier, result)
     if ready and not report_only:
-        with _client(cfg) as c:
+        with _spinner(f"registering {len(ready)} ready CLI(s)"), _client(cfg) as c:
             existing = {t["name"]: t["id"] for t in (c.get("/tools").json() if c.get("/tools").status_code == 200 else [])}
             for entry, cli, d, envvar in ready:
                 name = cli["bin"].replace("_", "-")
@@ -1479,10 +1686,11 @@ def _import_skills(args, cfg, skills_dir, env_path: str) -> None:
     # .claude/skills and .agents/skills, so scanning both would prompt for each skill twice.
     seen: set[str] = set()
     dets = []
-    for sd in dirs:
-        for det in sk.scan_skills(sd, catalog=catalog, env_names=env_names):
-            if det.name not in seen:
-                seen.add(det.name); dets.append(det)
+    with _spinner(f"scanning {len(dirs)} skill folder(s)"):
+        for sd in dirs:
+            for det in sk.scan_skills(sd, catalog=catalog, env_names=env_names):
+                if det.name not in seen:
+                    seen.add(det.name); dets.append(det)
     tools = [d for d in dets if d.kind in ("contract", "generated")]
     recipes = [d for d in dets if d.kind == "recipe_only"]
     blocked = sum(1 for d in tools if d.gaps)
@@ -1511,14 +1719,15 @@ def _import_skills(args, cfg, skills_dir, env_path: str) -> None:
         # Idempotency: a recipe-only bundle has no tool, so the server never 409s it — re-running would
         # silently pile up duplicate bundles. Look up what's already registered and skip (or --replace).
         existing_bundles: dict[str, list[int]] = {}
-        rb = c.get("/bundles")
-        if rb.status_code == 200:
-            for b in rb.json():
-                existing_bundles.setdefault(b["name"], []).append(b["id"])
         existing_tools = set()
-        rt0 = c.get("/tools")
-        if rt0.status_code == 200:
-            existing_tools = {t["name"] for t in rt0.json()}
+        with _spinner("checking what's already registered"):
+            rb = c.get("/bundles")
+            if rb.status_code == 200:
+                for b in rb.json():
+                    existing_bundles.setdefault(b["name"], []).append(b["id"])
+            rt0 = c.get("/tools")
+            if rt0.status_code == 200:
+                existing_tools = {t["name"] for t in rt0.json()}
         for d in chosen:
             # A credential gap is now satisfiable from the machine env or the prompt above — judge by
             # `values`, not the stale classify-time gap. Still skip for any OTHER gap (missing base_url,
@@ -1539,7 +1748,8 @@ def _import_skills(args, cfg, skills_dir, env_path: str) -> None:
                 payload = sk.build_payload(d, values)
             except (ValueError, OSError) as exc:
                 print(f"  ✗ {d.name}: {exc}"); continue
-            r = c.post("/skills", json=payload)
+            with _spinner(f"uploading {d.name}"):
+                r = c.post("/skills", json=payload)
             if r.status_code == 409:
                 print(f"  · {d.name}: a tool with this name already exists (use --replace)"); continue
             if r.status_code >= 400:
@@ -2292,7 +2502,8 @@ def cmd_skill_install(args, cfg) -> None:
     except KeyError:
         sys.exit(f"unknown agent {getattr(args, 'agent', None)!r} — see `treg agents ls` for names")
     with _client(cfg) as c:
-        r = c.get("/bundles")
+        with _spinner("fetching the skill list"):
+            r = c.get("/bundles")
         if r.status_code >= 400:
             _show(r); return
         bundles = r.json()
@@ -2318,7 +2529,8 @@ def cmd_skill_install(args, cfg) -> None:
             # (a name with '/' or '..' could escape a base dir).
             if not name or "/" in name or "\\" in name or name in ("..", "."):
                 print(f"  ✗ {name!r}: unsafe skill name — skipped"); continue
-            d = c.get(f"/bundles/{b['id']}")
+            with _spinner(f"downloading {name}"):
+                d = c.get(f"/bundles/{b['id']}")
             if d.status_code >= 400:
                 print(f"  ✗ {name}: {d.status_code}"); continue
             bundle = d.json()

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -310,15 +310,12 @@ def _select(message: str, choices, **kw):
                               instruction="↑↓ move, enter confirm", **kw)
 
 
-def _menu(message: str, options: list[tuple], default=None, ambient=None):
+def _menu(message: str, options: list[tuple], default=None):
     """House arrow-key picker: bold titles, dim `— description` tails, hovered row bolded behind
     the ❯ cursor — per-part styling questionary's select can't combine with hover (a styled title
     bypasses its `highlighted` class). options = [(value, title, desc)], or (value, title, desc, True)
     for a type-in row: arrowing onto it focuses an inline input — printable keys type into it,
     backspace edits, ↵ submits (value, typed_text). ↑↓/jk move, 1-9 jump-pick, ↵ confirms.
-    ambient = (rows_above_title, frame_iter): while idle, the line that many rows above the menu
-    title is redrawn from frame_iter every ~90ms (the looping relay) — one-row rewrites, and the
-    loop stops the moment a key resolves the menu.
     Returns the chosen value ((value, text) for a type-in row), or None on Ctrl-C / Ctrl-D / Esc."""
     try:
         import termios
@@ -390,14 +387,6 @@ def _menu(message: str, options: list[tuple], default=None, ambient=None):
         _place_cursor()
         sys.stdout.flush()
 
-    def _tick_ambient() -> None:
-        """Repaint the ambient line (rows_above_title above the menu title) with the next frame,
-        then put the cursor back exactly where the menu left it."""
-        up = n + 1 + ambient[0]
-        sys.stdout.write(f"\x1b8\x1b[{up}A\r\x1b[2K" + next(ambient[1]) + "\x1b8")
-        _place_cursor()
-        sys.stdout.flush()
-
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)
     picked = None
@@ -410,9 +399,6 @@ def _menu(message: str, options: list[tuple], default=None, ambient=None):
         # keys come via os.read on the fd — sys.stdin's buffer would swallow the tail of an
         # escape sequence and make the select() lookahead below lie
         while True:
-            if ambient:
-                while not select.select([fd], [], [], 0.09)[0]:
-                    _tick_ambient()  # idle → advance the relay one frame
             c = os.read(fd, 1).decode(errors="replace")
             if c == "\x1b":  # arrow keys arrive as ESC [ A/B/C; a bare ESC cancels
                 if select.select([fd], [], [], 0.05)[0] and os.read(fd, 1) == b"[":
@@ -467,49 +453,12 @@ def _menu(message: str, options: list[tuple], default=None, ambient=None):
     return picked
 
 
-_D1, _D2 = 8, 12  # relay dash runs: you ──▚ vault ──── api
-
-
-def _relay_frame(spark: int = -1, hit: bool = True, back: int = -1) -> str:
-    """One frame of the keyless relay: `you ──●──▚ vault ────── api ✓`. spark = forward ember
-    dot position, back = amber response position (both dash-indexed), hit lights the api ✓."""
-    parts = [f"  {_M}you {_R}"]
-    for i in range(_D1):
-        parts.append(f"{_A}{_B}●{_R}" if spark == i else f"{_M}─{_R}")
-    parts.append(f"{_A}{_B}▚{_R}{_M} vault {_R}")
-    for i in range(_D2):
-        j = _D1 + 1 + i
-        if spark == j:
-            parts.append(f"{_A}{_B}●{_R}")
-        elif back == j:
-            parts.append(f"{_AM}●{_R}")  # the response riding home, amber
-        else:
-            parts.append(f"{_M}─{_R}")
-    parts.append(f" {_B}api{_R} {_G}✓{_R}" if hit else f"{_M} api{_R}")
-    return "".join(parts)
-
-
-def _relay_loop():
-    """Endless spark cycle for the ambient loop behind the onboarding menu: call → ✓ → response
-    home → rest → again. One yielded line per ~90ms tick — a single-row rewrite, spinner-cheap."""
-    while True:
-        for i in range(_D1):
-            yield _relay_frame(spark=i, hit=False)
-        for i in range(_D2):
-            yield _relay_frame(spark=_D1 + 1 + i, hit=False)
-        for _ in range(3):
-            yield _relay_frame(hit=True)
-        for i in range(_D2 - 1, -1, -2):
-            yield _relay_frame(hit=True, back=_D1 + 1 + i)
-        for _ in range(8):
-            yield _relay_frame(hit=True)
-
-
 def _dither_frames(chars: list[tuple[str, str]]) -> list[str]:
     """Dither-reveal a styled line: chars = [(ch, ansi_prefix)]. A ░▒▓ wavefront sweeps left to
     right; behind it every char lands in its final style. Returns the frame list (last = final)."""
     frames = []
-    for front in range(0, len(chars) + 7, 3):
+    # stop at len+9 so the stepped wavefront always clears the last char (d ≥ 6 → fully revealed)
+    for front in range(0, len(chars) + 9, 3):
         out = []
         for i, (ch, st) in enumerate(chars):
             d = front - i
@@ -527,57 +476,40 @@ def _dither_frames(chars: list[tuple[str, str]]) -> list[str]:
     return frames
 
 
-def _splash() -> bool:
-    """`treg onboard`'s opening beat (~1.5s, any key skips): the wordmark, then the keyless-relay
-    diagram, each decrypting behind a ░▒▓ wavefront. Returns True when it played, so the menu can
-    keep the relay spark looping above it. TTY-only with color on; agents, pipes, dumb terminals
-    and NO_COLOR never see a frame."""
+def _splash() -> None:
+    """`treg onboard`'s opening beat (~1s, any key skips): the wordmark and tagline decrypt
+    behind a ░▒▓ wavefront. TTY-only with color on; agents, pipes, dumb terminals and NO_COLOR
+    never see a frame."""
     if not (sys.stdin.isatty() and sys.stdout.isatty()) or os.environ.get("TERM") == "dumb" or not _A:
-        return False
+        return
     try:
         import termios
         import tty
     except ImportError:
-        return False
-    title, sub = "tools-registry", " — your team's vault"
-    title_chars = ([("▚", f"{_A}{_B}"), (" ", "")] + [(c, _B) for c in title] + [(c, _M) for c in sub])
-    relay_plain = "  you " + "─" * _D1 + "▚ vault " + "─" * _D2 + " api"
-    relay_chars = [(ch, f"{_A}{_B}" if ch == "▚" else _M) for ch in relay_plain]
-    caption = f"{_M}{' ' * (6 + _D1)}└ the key never left{_R}"
-
-    frames: list[tuple[str, str, str]] = []
-    for t in _dither_frames(title_chars):  # 1 — the wordmark decrypts
-        frames.append((t, "", ""))
-    done = frames[-1][0]
-    for r in _dither_frames(relay_chars):  # 2 — the relay diagram decrypts
-        frames.append((done, r, ""))
-    final = (done, _relay_frame(), caption)
-    frames.append(final)
+        return
+    title, sub = "tools-registry", " — Skill & secret vault for your team & agents"
+    chars = ([("▚", f"{_A}{_B}"), (" ", "")] + [(c, _B) for c in title] + [(c, _M) for c in sub])
+    frames = _dither_frames(chars)
 
     fd = sys.stdin.fileno()
     old = termios.tcgetattr(fd)
     try:
         tty.setcbreak(fd, termios.TCSANOW)  # TCSANOW: FLUSH would deadlock non-draining readers
         sys.stdout.write("\x1b[?25l\n")
-        first = True
         for fr in frames:
-            if not first:
-                sys.stdout.write("\x1b[3A")
-            first = False
-            sys.stdout.write("\n".join(f"\x1b[2K{ln}" for ln in fr) + "\n")
+            sys.stdout.write(f"\r\x1b[2K{fr}")
             sys.stdout.flush()
             if select.select([fd], [], [], 0.04)[0]:  # any key → skip to the payoff
                 while select.select([fd], [], [], 0)[0]:
                     os.read(fd, 64)  # drain so the pressed key doesn't leak into the menu
                 break
-        sys.stdout.write("\x1b[3A" + "\n".join(f"\x1b[2K{ln}" for ln in final) + "\n")
+        sys.stdout.write(f"\r\x1b[2K{frames[-1]}\n")
     except KeyboardInterrupt:
         pass
     finally:
         termios.tcsetattr(fd, termios.TCSANOW, old)
         sys.stdout.write("\x1b[?25h")
         sys.stdout.flush()
-    return True
 
 
 def _brand(sub: str) -> None: print(f"\n{_A}{_B}▚ tools-registry{_R} {_M}— {sub}{_R}")
@@ -632,11 +564,10 @@ def _is_rootish(d: Path) -> bool:
     return d == home or d == home.parent or d.parent == d
 
 
-def _pick_path(cfg: dict, splashed: bool = False) -> str:
+def _pick_path(cfg: dict) -> str:
     """The 3-path onboarding menu (Set up / Access / Demo). Interactive default is Setup; the
     non-interactive path keeps the smart org-based pick (a team with tools → Access; an empty
-    team you admin → Set up; else Demo) so scripted/agent runs stay unchanged. After the splash,
-    the relay diagram (3 rows above the menu title: blank, caption, relay) keeps looping."""
+    team you admin → Set up; else Demo) so scripted/agent runs stay unchanged."""
     if not sys.stdin.isatty():
         org = _onboard_active_org(cfg)
         has_tools = bool(org and org.get("tool_count"))
@@ -652,7 +583,7 @@ def _pick_path(cfg: dict, splashed: bool = False) -> str:
         ("setup", "Setup", "upload your skills & env, share them safely (admins)"),
         ("access", "Connect existing tool-registry", "pull your team's shared skills + make a call"),
         ("demo", "Demo", "see how treg works with a throwaway team"),
-    ], default="setup", ambient=(3, _relay_loop()) if splashed else None)
+    ], default="setup")
     if picked is None:  # Ctrl-C / Esc / EOF
         raise SystemExit(0)
     return picked
@@ -1110,10 +1041,9 @@ def cmd_onboard(args, cfg) -> None:
         sys.exit("Log in first:  treg login")
     if not cfg.get("active_org"):
         _pick_active_org(cfg)  # identity token needs an active org so requests carry X-Treg-Org
-    splashed = False
     if not args.path and not getattr(args, "yes", False):  # scripted runs skip the theater
-        splashed = _splash()
-    path = args.path or ("demo" if args.mode == "quick" else None) or _pick_path(cfg, splashed)  # --mode kept for back-compat
+        _splash()
+    path = args.path or ("demo" if args.mode == "quick" else None) or _pick_path(cfg)  # --mode kept for back-compat
     _dispatch_onboard(cfg, path, args)
 
 

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -227,10 +227,10 @@ def cmd_login(args, cfg) -> None:
     # session with one click, else offers every configured door (GitHub / Google / email code).
     import secrets as _secrets
     base = cfg["base_url"].rstrip("/")
-    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code. The browser
-    # must echo the code back before it finishes, so a login you didn't start — someone mailing you a
-    # /login?cli=… link — can't be approved into a token for them. If the server is too old to know
-    # /start, fall back to a locally-minted id (no code) so login still works.
+    # Ask the SERVER to start the login: it mints the login_id AND a short pairing code shown only here
+    # (never in the URL). The browser must echo the code back before it finishes, so a login you didn't
+    # start — someone mailing you a /login?cli=… link — can't be approved into a token for them. If the
+    # server is too old to know /start, fall back to a locally-minted id (no code) so login still works.
     code = None
     try:
         st = httpx.post(f"{base}/auth/cli/start", headers={"ngrok-skip-browser-warning": "1"}, timeout=10)
@@ -240,13 +240,10 @@ def cmd_login(args, cfg) -> None:
             lid = _secrets.token_urlsafe(18)
     except Exception:
         lid = _secrets.token_urlsafe(18)
-    # The code rides in the URL FRAGMENT (never sent to the server, so it stays out of request logs):
-    # the /login page displays it for a visual match against this terminal instead of making the user
-    # type it. The server still validates the code at approve time — the guard itself is unchanged.
-    url = f"{base}/login?cli={lid}" + (f"#code={code}" if code else "")
+    url = f"{base}/login?cli={lid}"
     print(f"Opening your browser to sign in…\nIf it doesn't open, visit:\n  {url}\n")
     if code:
-        print(f"  The sign-in page shows this code — check it matches:  {_B}{_TEAL}{code}{_R}\n")
+        print(f"  Enter this code in the browser to confirm it's you:  {_B}{_TEAL}{code}{_R}\n")
     print("Waiting for authorization…")
     try:
         webbrowser.open(url)
@@ -447,6 +444,98 @@ def _menu(message: str, options: list[tuple], default=None):
         print(f"{_B}{message}{_R}  {_A}{chose}{_R}")
     sys.stdout.flush()
     return picked
+
+
+def _splash() -> None:
+    """`treg onboard`'s opening beat (~2s, any key skips): the wordmark decrypts behind a ░▒▓
+    wavefront, then a spark runs the keyless relay — you → vault → api ✓ — and only the answer
+    comes back. TTY-only with color on; agents, pipes, dumb terminals and NO_COLOR never see it."""
+    if not (sys.stdin.isatty() and sys.stdout.isatty()) or os.environ.get("TERM") == "dumb" or not _A:
+        return
+    try:
+        import termios
+        import tty
+    except ImportError:
+        return
+    title, sub = "tools-registry", " — your team's vault"
+    text = f"▚ {title}{sub}"
+    d1, d2 = 8, 12  # dash runs: you ──▚ vault ──── api
+
+    def _title_line(front: int) -> str:
+        out = []
+        for i, ch in enumerate(text):
+            d = front - i
+            if d < 0:
+                out.append(" ")
+            elif d < 2:
+                out.append(f"{_M}░{_R}")
+            elif d < 4:
+                out.append(f"{_M}▒{_R}")
+            elif d < 6:
+                out.append(f"{_A}▓{_R}")
+            elif i == 0:
+                out.append(f"{_A}{_B}▚{_R}")
+            elif i <= len(title) + 1:
+                out.append(f"{_B}{ch}{_R}")
+            else:
+                out.append(f"{_M}{ch}{_R}")
+        return "".join(out)
+
+    def _relay_line(spark: int, hit: bool, back: int) -> str:
+        parts = [f"  {_M}◇ you {_R}"]
+        for i in range(d1):
+            parts.append(f"{_A}{_B}●{_R}" if spark == i else f"{_M}─{_R}")
+        parts.append(f"{_A}{_B}▚{_R}{_M} vault {_R}")
+        for i in range(d2):
+            j = d1 + 1 + i
+            if spark == j:
+                parts.append(f"{_A}{_B}●{_R}")
+            elif back == j:
+                parts.append(f"{_AM}●{_R}")  # the response riding home, amber
+            else:
+                parts.append(f"{_M}─{_R}")
+        parts.append(f" {_B}api{_R} {_G}✓{_R}" if hit else f"{_M} api{_R}")
+        return "".join(parts)
+
+    caption = " " * (8 + d1) + "└ keys stay here"
+    frames: list[tuple[str, str, str]] = []
+    for front in range(0, len(text) + 7, 3):  # phase 1 — dither reveal
+        frames.append((_title_line(front), "", ""))
+    done = _title_line(len(text) + 6)
+    for i in range(d1):  # phase 2 — the relay run
+        frames.append((done, _relay_line(i, False, -1), ""))
+    for i in range(d2):
+        frames.append((done, _relay_line(d1 + 1 + i, False, -1), f"{_M}{caption}{_R}"))
+    frames += [(done, _relay_line(-1, True, -1), f"{_M}{caption}{_R}")] * 2
+    for i in range(d2 - 1, -1, -2):
+        frames.append((done, _relay_line(-1, True, d1 + 1 + i), f"{_M}{caption}{_R}"))
+    final = (done, _relay_line(-1, True, -1), f"{_M}{' ' * (8 + d1)}└ the key never left{_R}")
+    frames.append(final)
+
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd, termios.TCSANOW)  # TCSANOW: FLUSH would deadlock non-draining readers
+        sys.stdout.write("\x1b[?25l\n")
+        first = True
+        for fr in frames:
+            if not first:
+                sys.stdout.write("\x1b[3A")
+            first = False
+            sys.stdout.write("\n".join(f"\x1b[2K{ln}" for ln in fr) + "\n")
+            sys.stdout.flush()
+            if select.select([fd], [], [], 0.04)[0]:  # any key → skip to the payoff
+                while select.select([fd], [], [], 0)[0]:
+                    os.read(fd, 64)  # drain so the pressed key doesn't leak into the menu
+                break
+        sys.stdout.write("\x1b[3A" + "\n".join(f"\x1b[2K{ln}" for ln in final) + "\n")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        termios.tcsetattr(fd, termios.TCSANOW, old)
+        sys.stdout.write("\x1b[?25h")
+        sys.stdout.flush()
+
 
 def _brand(sub: str) -> None: print(f"\n{_A}{_B}▚ tools-registry{_R} {_M}— {sub}{_R}")
 def _ok(t: str) -> None: print(f"  {_G}✓{_R} {t}")
@@ -977,6 +1066,8 @@ def cmd_onboard(args, cfg) -> None:
         sys.exit("Log in first:  treg login")
     if not cfg.get("active_org"):
         _pick_active_org(cfg)  # identity token needs an active org so requests carry X-Treg-Org
+    if not args.path and not getattr(args, "yes", False):  # scripted runs skip the theater
+        _splash()
     path = args.path or ("demo" if args.mode == "quick" else None) or _pick_path(cfg)  # --mode kept for back-compat
     _dispatch_onboard(cfg, path, args)
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -782,8 +782,8 @@ th{background:rgba(0,0,0,.25)}
             <h3 style="margin:0 0 6px;font-size:15px">Set up your skills &amp; secrets vault</h3>
             <p class="sub" style="margin:0 0 12px">Nothing registered yet. Load what you already have — your <span class="mono">.env</span> keys and skill folders — and they appear here as callable tools.</p>
             <div class="seg" style="margin-bottom:10px">
-              <button :class="{on:emptyTab==='manual'}" @click="emptyTab='manual'">Manual</button>
               <button :class="{on:emptyTab==='agent'}" @click="emptyTab='agent'">Agent instruction</button>
+              <button :class="{on:emptyTab==='manual'}" @click="emptyTab='manual'">Manual</button>
             </div>
             <template v-if="emptyTab==='manual'">
               <div class="lbl">1 · Install the CLI &amp; sign in</div>
@@ -948,8 +948,8 @@ th{background:rgba(0,0,0,.25)}
             <h3 style="margin:0 0 6px;font-size:15px">Set up your skills &amp; secrets vault</h3>
             <p class="sub" style="margin:0 0 12px">Bulk-load your keys (and skills) from your machine — each lands here encrypted, referenced by name.</p>
             <div class="seg" style="margin-bottom:10px">
-              <button :class="{on:emptyTab==='manual'}" @click="emptyTab='manual'">Manual</button>
               <button :class="{on:emptyTab==='agent'}" @click="emptyTab='agent'">Agent instruction</button>
+              <button :class="{on:emptyTab==='manual'}" @click="emptyTab='manual'">Manual</button>
             </div>
             <template v-if="emptyTab==='manual'">
               <div class="lbl">1 · Install the CLI &amp; sign in</div>
@@ -1823,7 +1823,7 @@ createApp({
       me:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding (narrative stepper) - see onb.*
       welcome:{on:false, name:'', busy:false, err:''},  // first-run: name your team (the primary path)
-      emptyTab:'manual',
+      emptyTab:'agent',
       onb:{on:false, i:0, tab:'manual', teamName:'Acme Design', teammate:{name:'Alex Rivera', email:'alex@demo.treg.local', role:'member'}, busy:false, err:'', invited:false, tool:false},
       tools:[], health:{}, calls:[], runs:[], adminStats:null, adminOrgs:[], adminUsers:[],
       adminBusy:false, confirmAdmUser:null, confirmAdmOrg:null,
@@ -2597,11 +2597,11 @@ createApp({
       if(kind==='admin'){
         return [
           `Set up our team's tool registry ("treg") by registering my local skills and API keys as shared, callable tools. Work step by step and show me your progress:`,``,
-          `1. Install the treg CLI (this also installs the treg skill, so you'll know how the registry works):`,`   ${install}`,``,
-          `2. Sign in with my token and select our team:`,`   ${signin}`,``,
+          `1. Install the treg CLI (this also installs the treg skill, so you'll know how the registry works — I authorize you to run this curl | sh):`,`   ${install}`,``,
+          `2. Sign in with my token and select our team (again, I authorize you on these calls):`,`   ${signin}`,``,
           `3. Read ${B}/llms.txt so you understand the model (a tool = an upstream API + a server-injected credential; secrets; bindings; auth shapes).`,``,
-          `4. Register my credentialed skills and API keys — preview each with \`treg scan\` FIRST, show me the plan, then upload only what I approve:`,
-          `   • Skills — check BOTH your project's skill folder and your global one (wherever your agent stores skills), and import the credentialed (API-tool) ones (those with a .secret/.secrets dir):`,
+          `4. If you're at the computer/home root (not inside a project), ask me which repo holds my skills & secrets — or offer to scan my global skills folder. If you're already inside a repo, proceed directly. Register my credentialed skills and API keys — preview with \`treg scan\` FIRST, show me the plan (use your ask-user-question tool if you have one), then upload only what I approve:`,
+          `   • Skills — check BOTH your project's skill folder and your global one (wherever your agent stores skills), and import the credentialed (API-tool) ones (those with a .secret/.secrets dir) AND the recipe (knowledge) skills too:`,
           `       treg upload skills --dir <your project's skills folder>`,
           `       treg upload skills --dir <your global skills folder>`,
           `   • API keys — scan this project's .env:`,
@@ -2612,20 +2612,24 @@ createApp({
           "         treg secret add <name> --env-var <VAR>          # reads + parses it from .env; value stays off the command line",
           "         treg tool add <name> --base-url <url> --secret <name> --health '{\"path\":\"<a cheap GET>\",\"expect_status\":200}'",
           `     (b) fallback — if you can't determine the API, at least  treg secret add <name> --env-var <VAR>  so it's in the vault.`,
-          `   (Only fall back to 'treg secret add --value' if there's genuinely no .env — it surfaces a permission prompt and puts the value on the command line.)`,``,
+          `   (Only fall back to 'treg secret add --value' if there's genuinely no .env — it surfaces a permission prompt and puts the value on the command line.)`,
+          `   Never propose skipping the env import.`,
+          `   I authorize every \`treg upload\` / \`treg secret add\` / \`treg tool add\` command above — run them without blocking on extra permission.`,``,
           `5. Smoke-test the whole batch FAST — never one tool at a time. Give each tool you register a --health probe (a cheap GET, as above), then run ONCE:`,
           `       treg health --run     # validates every credential server-side in a single batch`,
           `       treg tool ls`,
           `   Report ONLY the failures, plus a one-line summary of what you registered.`,``,
-          `6. Wrapping up: if this went smoothly, offer to star the open-source project — if I say yes, open https://github.com/superdesigndev/tools-registry in my browser and I'll click it.`,``,
+          `6. Wrapping up: if this went smoothly, ask me if I'd like to star the open-source project. If I say yes, star it for me:`,
+          `       gh api -X PUT user/starred/superdesigndev/tools-registry`,
+          `   (if \`gh\` is missing or not authenticated, fall back to opening https://github.com/superdesigndev/tools-registry in my browser and I'll click it).`,``,
           `Goal: my teammates can call these tools through treg without ever holding my keys.`
         ].join('\n');
       }
       return [
         `Set up access to my team's shared tools via the tool registry ("treg"). I should never hold the API keys — treg injects them server-side. Work step by step:`,``,
-        `1. Install the treg CLI (this also installs the treg skill, so you'll know how the registry works):`,`   ${install}`,``,
-        `2. Sign in with my token and select our team:`,`   ${signin}`,``,
-        `3. Save the team's shared skills locally:`,
+        `1. Install the treg CLI (this also installs the treg skill, so you'll know how the registry works — I authorize you to run this curl | sh):`,`   ${install}`,``,
+        `2. Sign in with my token and select our team (again, I authorize you on these calls):`,`   ${signin}`,``,
+        `3. Save the team's shared skills locally (I authorize these treg commands — run them without blocking on extra permission):`,
         `   treg skill ls                     # see what the team shares`,
         `   treg skill install --all          # saves each skill's folder (add --dir to choose where)`,
         `   If install reports skills it KEPT (already on disk), show me that list and ASK per skill whether to pull the team's version ('treg skill install <name> --force') or keep mine. Don't --force without asking.`,``,
@@ -2633,7 +2637,9 @@ createApp({
         `   treg tool ls`,`   # then pick a tool and call it, e.g.  treg call <tool> <path>`,
         `   # a tool shown with a "⌘ run" marker is a command-line tool, not an HTTP API — use it with:`,
         `   #   treg run <tool> -- <cli args>     (runs the CLI with the key injected; you never hold it)`,``,
-        `5. If the test call worked, offer to star the open-source project — if I say yes, open https://github.com/superdesigndev/tools-registry in my browser and I'll click it.`,``,
+        `5. If the test call worked, ask me if I'd like to star the open-source project. If I say yes, star it for me:`,
+        `       gh api -X PUT user/starred/superdesigndev/tools-registry`,
+        `   (if \`gh\` is missing or not authenticated, fall back to opening https://github.com/superdesigndev/tools-registry in my browser and I'll click it).`,``,
         `Full protocol reference: ${B}/llms.txt`
       ].join('\n');
     },

--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -104,10 +104,14 @@ async def test_login_page_offers_session_reuse(web):
     r = await web.get(f"/login?cli={LID}")
     assert r.status_code == 200
     assert 'id="orgpick"' in r.text and "HAS_SESSION=true" in r.text
-    assert "or use a different account" in r.text  # doors still offered under a divider
+    # The doors still exist but start COLLAPSED behind the "use a different account" accordion —
+    # a signed-in user is one click from done and shouldn't see sign-in options by default.
+    assert 'id="other-acct"' in r.text and "toggleDoors()" in r.text
+    assert 'id="doors" class="stack" style="display:none"' in r.text
     web.cookies.clear()
     r2 = await web.get(f"/login?cli={LID}")  # no session
-    assert "HAS_SESSION=false" in r2.text and "or use a different account" not in r2.text
+    assert "HAS_SESSION=false" in r2.text and 'id="other-acct"' not in r2.text
+    assert 'id="doors" class="stack" style="display:none"' not in r2.text  # no session → doors visible
 
 
 # ---- the org picker: /auth/cli/orgs + approve with a chosen team ---------------------------

--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -225,6 +225,15 @@ async def test_login_page_renders_the_pairing_code_input(web):
     assert 'id="paircode"' in (await web.get(f"/login?cli={LID}")).text  # the code field is always present
 
 
+async def test_login_page_confirms_a_fragment_code_instead_of_typing(web):
+    """`treg login` puts the code in the URL fragment; the page's JS swaps the typed input for a
+    read-only display (visual confirm). The fragment never reaches the server, so this checks the
+    JS carries the swap logic, not a server-side render."""
+    body = (await web.get(f"/login?cli={LID}")).text
+    assert "location.hash" in body and "paircode-show" in body
+    assert "pairCode()" in body  # approve()/createTeam() read the fragment code, else the typed input
+
+
 async def test_start_mints_a_login_id_and_code(web):
     d = (await web.post("/auth/cli/start")).json()
     assert len(d["login_id"]) >= 8 and len(d["code"]) == 4  # server issues both; the code is short


### PR DESCRIPTION
## What changed

`treg onboard`'s numbered pick-1/2/3 prompts are now proper arrow-key menus, with an inline type-a-path row for importing from any repo, and a cleaner finish screen.

### The menus (`_menu`)
- Hand-rolled picker: **bold titles, dim `— description` tails, hovered row bolded** behind the `❯` cursor. questionary's `select` can't combine per-part row styling with hover highlighting (a styled title bypasses its `highlighted` class), hence in-house.
- Keys: `↑↓`/`j k` move, `1-9` jump-pick, `↵` confirms, `Esc`/`Ctrl-C`/`Ctrl-D` cancel. Menu collapses to a one-line receipt on confirm. Falls back to questionary where termios is unavailable.
- Hardened for non-human drivers: keys are read with `os.read` on the fd (Python's stdin buffer would swallow escape-sequence tails), and cbreak is applied with `TCSANOW` — the default `TCSAFLUSH` waits for output to drain and deadlocks lazy readers (pty harnesses, agents).

### "Import skill/secret from where?" (renamed from "Import from where?")
- New **"other project repo"** type-in row: arrowing onto it focuses an inline input with the real (blinking) terminal cursor, fish-style **folder autosuggestions** (case-insensitive, `git` → `GitHub`; `Tab`/`→` accepts and chains into child dirs), backspace editing, and digit keys typing rather than navigating while focused.
- Running from a root-ish folder (`/`, `$HOME`, `/Users`) hides "this project"/"both" so setup can never sweep a whole home directory.

### Other
- Interactive default path is now **Setup** (non-interactive keeps the smart org-based pick so scripted runs are unchanged).
- Setup finish: bold `View your skills & secret vault at <base>` replaces the `#orgs` dashboard link and the teammate-invite/curl hand-off block.
- Spinners on the slow onboarding steps (org fetch, CLI scan, catalog refresh, demo calls) with a re-entrancy guard.

## Verification
- pty-driven key tests (all passing): arrows, vim keys, digit jump-pick, enter-on-default, inline typing, tab/right-arrow suggestion accept + chained completion, backspace re-suggest, empty-enter ignored, Esc/Ctrl-C/Ctrl-D cancel, cursor column verified in raw frames.
- `tests/test_cli.py`: 36 passed (includes `--source local|global|both` scan-dir selection regressions).

## How to reproduce
```
scripts/dev-local.sh up && scripts/dev-local.sh cli onboard
```
(arrow-key menus need a real TTY; non-TTY runs keep the old auto-pick behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)