### PR TITLE
docs(readme): Tool-Registry (singular) in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Treg (Tool-Registries)
+# Treg (Tool-Registry)
 
 ![treg — share skills & secrets without leaking keys](docs/assets/treg-hero.png)
 


### PR DESCRIPTION
One-word fix: the H1 said "Tool-Registries"; singular reads right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)