### PR TITLE
docs(readme): bank-teller mental model (coat check implied key retrieval)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ with **no key on your machine** — the registry injects auth server-side. Run a
 
 Built for the Superdesign team, live at **`https://treg.superdesign.dev`** — anyone can self-host.
 
-**The mental model — a coat check:** you hand over your coat (the secret) once and get a ticket;
-later anyone with a valid ticket says "table 5's coat" and the attendant fetches the right one,
-they never carry it themselves. The proxy swaps a **tool reference** for the **real secret** on the
-way out.
+**The mental model - a bank teller:** you slide a request across the counter ("pay this invoice
+from my account"); the teller does the transaction inside the vault and slides back the result.
+You never enter the vault, and nothing in it ever crosses the counter - the proxy swaps your
+**tool reference** for the **real secret** server-side, on the way out to the upstream.
 
 - **tool** = something the registry calls for you with the org's credential. Two kinds:
   - **endpoint** - an upstream `base_url` + credential **bindings** (each binding injects one

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -30,7 +30,7 @@ tested):
 - **Email is your identity.** You *are* a verified email. Three doors prove it — **GitHub**, an emailed
   **one-time code** (OTP), or an **invite code**. The first time you prove an email you're *registered*;
   every proof after is a *login*. There is no separate sign-up (and no more `treg register`).
-- **The proxy = a coat check.** You call the real upstream API *through* the registry. It swaps your tool
+- **The proxy = a bank teller.** You call the real upstream API *through* the registry. It swaps your tool
   reference for the real secret and injects it server-side. The key never lands on your machine; your
   token authorises the call.
 - **A token = a (you, org) pair.** A **User** is an identity; an **Org** is a team that owns resources; a

--- a/src/treg/web/tutorial.js
+++ b/src/treg/web/tutorial.js
@@ -23,7 +23,7 @@
   const CONCEPTS = [
     { h: "Email is your identity",
       p: "You <b>are</b> a verified email. Three doors prove it - GitHub, an emailed <b>one-time code</b>, or an <b>invite code</b>. First proof registers you; every proof after is a login. No separate sign-up." },
-    { h: "The proxy = a coat check",
+    { h: "The proxy = a bank teller",
       p: "You call the real upstream API <i>through</i> the registry. It swaps your tool reference for the real secret and injects it server-side. The key never lands on your machine; your token authorises the call." },
     { h: "A token = a (you, org) pair",
       p: "A <b>User</b> is an identity; an <b>Org</b> is a team that owns resources; a <b>Membership</b> links them with a role. Your <b>identity token</b> works across every org you belong to - <code>org use</code> picks the active one." },

--- a/src/treg/web/tutorial.md
+++ b/src/treg/web/tutorial.md
@@ -27,7 +27,7 @@ was tested):
 - **Email is your identity.** You *are* a verified email. Three doors prove it - **GitHub**, an emailed
   **one-time code** (OTP), or an **invite code**. The first time you prove an email you're *registered*;
   every proof after is a *login*. There is no separate sign-up (and no more `treg register`).
-- **The proxy = a coat check.** You call the real upstream API *through* the registry. It swaps your tool
+- **The proxy = a bank teller.** You call the real upstream API *through* the registry. It swaps your tool
   reference for the real secret and injects it server-side. The key never lands on your machine; your
   token authorises the call.
 - **A token = a (you, org) pair.** A **User** is an identity; an **Org** is a team that owns resources; a


### PR DESCRIPTION
The coat-check analogy suggests a valid ticket gets the coat (the key) back - the opposite of treg's promise. The bank-teller frame matches the mechanism: requests cross the counter, secrets never do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)