### PR TITLE
feat(landing): live Stripe wire — every sandbox gets one real endpoint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -56,3 +56,8 @@ services:
         sync: false
       - key: TREG_RESEND_API_KEY
         sync: false
+      # Landing live-wire demo (optional — unset = sandbox calls all synthesize / webhook 404s).
+      - key: TREG_DEMO_STRIPE_KEY       # Stripe sandbox restricted key (Charges only) for the live wire
+        sync: false
+      - key: TREG_DEMO_STRIPE_WEBHOOK_SECRET # whsec_… from the DEMO Stripe sandbox's webhook endpoint
+        sync: false

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -34,7 +34,7 @@ import httpx
 from pathlib import Path
 
 from fastapi import Cookie, Depends, FastAPI, Header, HTTPException, Request
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
@@ -42,7 +42,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
 from . import audit, crypto, demo as demo_seed, email as email_sender, health, injectors, localrun, oauth
-from . import ratestore, runner, sandbox as demo_sandbox, session as sess
+from . import pubfeed, ratestore, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings
 from .db import get_session, init_db
 from .models import ROLE_RANK, Bundle, CallRecord, Invite, Membership, Org, PendingOAuth, RunRecord, Secret, Tool, User
@@ -1156,6 +1156,14 @@ async def require_identity(
     """Just *who* the caller is (no org): a token's user, or a session user. 401 otherwise."""
     if x_treg_token:
         m = await _membership_by_token(x_treg_token, db)
+        if m is not None:
+            # A published public-demo token must never act as a USER — user-level endpoints mint
+            # identity tokens (/auth/cli-token), create real orgs, and accept invites, all of which
+            # would let a stranger escape the demo org. Admin+ (the real operator) is exempt.
+            org = await db.get(Org, m.org_id)
+            if org is not None and org.public_demo and not _role_at_least(m.role, "admin"):
+                raise HTTPException(status_code=403, detail=(
+                    "this is a public demo token — it can only call the demo team's tools"))
         user = await db.get(User, m.user_id) if m else await _user_from_identity_token(x_treg_token, db)
         if user is not None and not user.suspended:
             return user
@@ -1210,6 +1218,7 @@ async def _user_from_identity_token(token: str, db: AsyncSession) -> User | None
 
 
 async def require_member(
+    request: Request,
     x_treg_token: str = Header(default=""),
     x_treg_org: str = Header(default=""),
     treg_session: str = Cookie(default=""),
@@ -1244,6 +1253,13 @@ async def require_member(
         raise HTTPException(status_code=403, detail="account suspended")
     if org.suspended:
         raise HTTPException(status_code=403, detail="org suspended")
+    # Public-demo lockdown: the published token (non-admin roles) may ONLY call tools and read.
+    # Centralized here — not per-endpoint — so every mutation (tools, secrets, skills, members,
+    # leave, runs) is frozen no matter what routes are added later. Admin+ keeps full control.
+    if org.public_demo and not _role_at_least(membership.role, "admin"):
+        if not (request.url.path.startswith("/call/") or request.method in ("GET", "HEAD", "OPTIONS")):
+            raise HTTPException(status_code=403, detail=(
+                "this is a public demo team — its token can only call tools and read"))
     return Caller(membership=membership, user=user, org=org)
 
 
@@ -1877,6 +1893,12 @@ SANDBOX_HIT_NS = "sandbox_hit"
 SANDBOX_RATE_MAX = 12          # sandboxes per IP per window
 SANDBOX_RATE_WINDOW_S = 3600   # 1 hour
 
+# Per-IP limiter for /call with a PUBLIC-DEMO token (the landing page publishes one shared member
+# token, so the per-user daily cap is meaningless there — thousands of strangers are one "user").
+PUBLIC_DEMO_HIT_NS = "pubdemo_call"
+PUBLIC_DEMO_RATE_MAX = 10      # calls per IP per window
+PUBLIC_DEMO_RATE_WINDOW_S = 60
+
 
 def _client_ip(request: Request) -> str:
     """Best-effort client IP — first hop of X-Forwarded-For behind the reverse proxy (Render), else the socket peer."""
@@ -1884,6 +1906,20 @@ def _client_ip(request: Request) -> str:
     if xff:
         return xff.split(",")[0].strip()
     return request.client.host if request.client else "?"
+
+
+async def _enforce_public_demo_ip_cap(request: Request, db: AsyncSession) -> None:
+    """Per-IP cap for a call made with a SHARED public credential — the published demo token or
+    the sandbox live wire. Both are one identity for thousands of strangers, so meter by client IP
+    rather than by user. Commits the sweep + recorded hit (get_session never auto-commits) and
+    raises 429 when the window is exhausted."""
+    await ratestore.sweep(db, PUBLIC_DEMO_HIT_NS)
+    allowed = await ratestore.rate_check(
+        db, PUBLIC_DEMO_HIT_NS, [(_client_ip(request), PUBLIC_DEMO_RATE_MAX)], PUBLIC_DEMO_RATE_WINDOW_S)
+    await db.commit()
+    if not allowed:
+        raise HTTPException(status_code=429, detail=(
+            f"demo limit reached ({PUBLIC_DEMO_RATE_MAX} calls/min per IP) — try again in a minute"))
 
 
 async def _enforce_sandbox_cap(caller: Caller, model, cap: int, noun: str, db: AsyncSession) -> None:
@@ -2001,7 +2037,50 @@ async def demo_sandbox_mint(request: Request, db: AsyncSession = Depends(get_ses
         raise HTTPException(status_code=429, detail="too many demo sandboxes from here — try again later")
     await db.commit()  # persist the recorded hit before minting
     await demo_sandbox.gc(db)  # opportunistic reap of expired sandboxes
-    return await demo_sandbox.mint(db)
+    out = await demo_sandbox.mint(db)
+    out["live"] = bool(get_settings().demo_stripe_key)  # is the seeded stripe tool a real wire?
+    return out
+
+
+@app.get("/demo/sandbox/live")
+async def demo_sandbox_live(caller: Caller = Depends(require_member)) -> dict:
+    """Live-wire facts for an EXISTING sandbox (the browser reuses one via localStorage, so it may
+    predate the mint response carrying them): is the wire on, and who am I in the feed."""
+    if not demo_sandbox.is_sandbox(caller.org):
+        raise HTTPException(status_code=400, detail="live-wire info is for the landing-page sandbox only")
+    return {"live": bool(get_settings().demo_stripe_key),
+            "visitor": demo_sandbox.visitor_name(caller.org.slug)}
+
+
+# ---- landing-page live payments feed (the public Stripe demo — see pubfeed.py) --------------
+@app.post("/stripe/webhook", include_in_schema=False)
+async def stripe_webhook(request: Request) -> dict:
+    """Stripe → treg: a signed event from the demo sandbox account. Only `charge.succeeded` feeds
+    the landing ticker; everything else is acknowledged and dropped. 404 when unconfigured, so a
+    deploy without the secret exposes no unauthenticated POST surface."""
+    secret = get_settings().demo_stripe_webhook_secret
+    if not secret:
+        raise HTTPException(status_code=404)
+    payload = await request.body()
+    if not pubfeed.verify_signature(payload, request.headers.get("stripe-signature", ""), secret):
+        raise HTTPException(status_code=400, detail="bad signature")
+    try:
+        event = json.loads(payload)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="bad payload")
+    if event.get("type") == "charge.succeeded":
+        pubfeed.push_charge(event.get("data", {}).get("object", {}) or {})
+    return {"received": True}
+
+
+@app.get("/landing/stripe-feed", include_in_schema=False)
+async def landing_stripe_feed() -> StreamingResponse:
+    """SSE stream for the landing demo pane: recent charges, then live ones. Unauthenticated by
+    design — it carries only server-chosen fields (amount/currency/created/id-suffix)."""
+    return StreamingResponse(pubfeed.stream(), media_type="text/event-stream", headers={
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",  # tell the reverse proxy not to buffer the stream
+    })
 
 
 @app.get("/demo/sandbox/skill")
@@ -2325,6 +2404,63 @@ async def delete_org(
     return {"deleted_org": org_id}
 
 
+# ---- public demo token: a publishable, call-only credential for this org -------------------
+PUBLIC_DEMO_DOMAIN = "public-demo.treg.local"  # unroutable — the public identity can never log in
+
+
+def _public_demo_email(org: Org) -> str:
+    return f"pub-{org.slug}@{PUBLIC_DEMO_DOMAIN}"
+
+
+@app.post("/orgs/{org_id}/public-token")
+async def create_public_token(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """Mint (or ROTATE) the org's publishable token: flips the org to `public_demo` and returns a
+    viewer-role token bound to a dedicated can't-log-in identity. Safe to print on a web page:
+    the lockdown in require_member/require_identity limits it to /call + reads, /call is per-IP
+    rate-limited, and calling this endpoint again replaces the token (instant revocation of the
+    old one). Owner-only — publishing a credential is an org-level decision."""
+    _require_owner_of(org_id, caller)
+    org = caller.org
+    email = _public_demo_email(org)
+    user = (await db.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if user is None:
+        user = User(email=email, demo=True)  # demo: excluded from stats; the domain can't receive mail
+        db.add(user)
+        await db.flush()
+    token = crypto.new_token()
+    membership = (await db.execute(select(Membership).where(
+        Membership.user_id == user.id, Membership.org_id == org_id))).scalar_one_or_none()
+    if membership is None:
+        db.add(Membership(user_id=user.id, org_id=org_id, role="viewer", token_hash=crypto.hash_token(token)))
+    else:
+        membership.token_hash = crypto.hash_token(token)  # rotate: the previous published token dies here
+    org.public_demo = True
+    await db.commit()
+    return {"token": token, "org": org.slug, "role": "viewer", "email": email,
+            "rate_limit": f"{PUBLIC_DEMO_RATE_MAX} calls per {PUBLIC_DEMO_RATE_WINDOW_S}s per IP",
+            "note": "this token can only call this org's tools and read — safe to publish; POST again to rotate"}
+
+
+@app.delete("/orgs/{org_id}/public-token")
+async def delete_public_token(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """Revoke the publishable token and lift the org's public_demo lockdown."""
+    _require_owner_of(org_id, caller)
+    org = caller.org
+    user = (await db.execute(select(User).where(User.email == _public_demo_email(org)))).scalar_one_or_none()
+    if user is not None:
+        membership = (await db.execute(select(Membership).where(
+            Membership.user_id == user.id, Membership.org_id == org_id))).scalar_one_or_none()
+        if membership is not None:
+            await db.delete(membership)
+    org.public_demo = False
+    await db.commit()
+    return {"public_token_revoked": True, "org": org.slug}
+
+
 # ---- secrets (values are write-only — never returned) -------------------------------------
 @app.post("/secrets")
 async def create_secret(
@@ -2365,6 +2501,7 @@ async def update_secret(
         raise HTTPException(status_code=404, detail="secret not found")
     if not _can_manage(caller, secret):
         raise HTTPException(status_code=403, detail="only the creator or an admin can edit this secret")
+    _require_not_live_demo_secret(caller, secret)
     fields = body.model_dump(exclude_unset=True)
     for k in ("name", "value", "kind"):  # these map to NOT-NULL columns; explicit null is a 422, not a 500
         if k in fields and fields[k] is None:
@@ -2398,6 +2535,7 @@ async def delete_secret(
         raise HTTPException(status_code=404, detail="secret not found")
     if not _can_manage(caller, secret):
         raise HTTPException(status_code=403, detail="only the creator or an admin can delete this secret")
+    _require_not_live_demo_secret(caller, secret)
     # bindings live in a JSON column — scan tools IN THIS ORG (registry-scale N is small).
     tools = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id))).scalars().all()
     if any(b.get("secret_id") == secret_id for t in tools for b in t.bindings):
@@ -2409,6 +2547,25 @@ async def delete_secret(
     await db.delete(secret)
     await db.commit()
     return {"deleted": secret_id}
+
+
+def _require_not_live_demo_tool(caller: Caller, tool: Tool) -> None:
+    """The sandbox's seeded live-wire tool (`stripe`, pinned base) is the demo's centerpiece —
+    editing or removing it would break the visitor's own live pane, so refuse. Only the seeded
+    name is frozen; visitor-created tools stay fully editable. No-op outside sandboxes / with
+    the wire off."""
+    if (demo_sandbox.is_sandbox(caller.org) and get_settings().demo_stripe_key
+            and tool.name == "stripe" and demo_sandbox.is_live_tool(tool)):
+        raise HTTPException(status_code=403, detail=(
+            "the live stripe demo endpoint is part of the sandbox — add your own endpoints instead"))
+
+
+def _require_not_live_demo_secret(caller: Caller, secret: Secret) -> None:
+    """Companion guard for the seeded STRIPE_KEY the live tool is bound to."""
+    if (demo_sandbox.is_sandbox(caller.org) and get_settings().demo_stripe_key
+            and secret.name == "STRIPE_KEY"):
+        raise HTTPException(status_code=403, detail=(
+            "STRIPE_KEY powers the live stripe demo — add your own keys instead"))
 
 
 # ---- tools --------------------------------------------------------------------------------
@@ -2588,6 +2745,7 @@ async def update_tool(
         raise HTTPException(status_code=404, detail="tool not found")
     if not _can_manage(caller, tool):
         raise HTTPException(status_code=403, detail="only the creator or an admin can edit this tool")
+    _require_not_live_demo_tool(caller, tool)
     fields = body.model_dump(exclude_unset=True)
     if "base_url" in fields and fields["base_url"] is None:  # NOT-NULL column + feeds _host_of — 422, not 500
         raise HTTPException(status_code=422, detail="base_url cannot be null")
@@ -2621,6 +2779,7 @@ async def delete_tool(
         raise HTTPException(status_code=404, detail="tool not found")
     if not _can_manage(caller, tool):
         raise HTTPException(status_code=403, detail="only the creator or an admin can delete this tool")
+    _require_not_live_demo_tool(caller, tool)
     await db.delete(tool)
     await db.commit()
     return {"deleted": tool_id}
@@ -3617,7 +3776,31 @@ async def _resolve_call(rest: str, org_id: int, db: AsyncSession) -> tuple[Tool,
     ).scalar_one_or_none()
     if tool is None:
         raise HTTPException(status_code=404, detail=f"no tool {name!r} in this org")
-    return tool, f"{tool.base_url.rstrip('/')}/{path.lstrip('/')}"
+    base = tool.base_url.rstrip("/")
+    # No path → the base URL itself, WITHOUT a trailing slash: a base pinned to a full resource
+    # (e.g. .../v1/charges) must relay as-is — Stripe 404s `/v1/charges/`.
+    return tool, (f"{base}/{path.lstrip('/')}" if path else base)
+
+
+async def _relay_live_demo(request: Request, upstream_url: str, key: str, visitor: str):
+    """The sandbox's ONE real upstream call (the landing live wire). Deliberately narrower than
+    relay(): form-encoded only, auth header built here from the env key (never from a sandbox
+    secret), and `metadata[visitor]` is OVERRIDDEN server-side so the landing feed's name is
+    always ours, whatever the caller put in the body."""
+    from urllib.parse import parse_qsl, urlencode
+    http: httpx.AsyncClient = request.app.state.http
+    headers = {"Authorization": f"Bearer {key}"}
+    content = None
+    if request.method == "POST":
+        body = (await request.body()).decode("utf-8", "replace")
+        pairs = [(k, v) for k, v in parse_qsl(body, keep_blank_values=True) if k != "metadata[visitor]"]
+        pairs.append(("metadata[visitor]", visitor))
+        content = urlencode(pairs)
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    r = await http.request(request.method, upstream_url, params=request.query_params.multi_items(),
+                           content=content, headers=headers)
+    return Response(content=r.content, status_code=r.status_code,
+                    media_type=r.headers.get("content-type", "application/json"))
 
 
 @app.api_route(
@@ -3642,6 +3825,8 @@ async def call_tool(
     tool, upstream_url = await _resolve_call(rest, caller.org_id, db)
     _require_tool_access(caller, tool.name)  # per-member tool ACL (NULL access = all; admins exempt)
     await _enforce_daily_cap(caller, db)  # per-user daily cap (skips sandbox + unmetered members)
+    if caller.org.public_demo and not _role_at_least(caller.role, "admin"):
+        await _enforce_public_demo_ip_cap(request, db)  # shared token → meter by client IP, not user
 
     def _audit(status_code: int) -> None:  # audit the attempt too — failures are results worth recording
         audit.record_call(
@@ -3649,10 +3834,22 @@ async def call_tool(
             method=request.method, path=upstream_url, status_code=status_code,
         )
 
-    # Landing-page sandbox: never touch the network. Run the REAL injectors, return a labelled dummy
-    # response (see sandbox.synthesize). Same code path serves the browser demo AND a `treg call` from
-    # the visitor's terminal, so both behave identically for the TTL.
+    # Landing-page sandbox: never touch the network — EXCEPT the one live wire. A call to the
+    # exact seeded stripe tool (fingerprint-matched; see sandbox.is_live_tool) relays to the real
+    # Stripe test API with the env-held demo key. Any tampered/lookalike tool falls through to
+    # synthesize below, so there is never a key to exfiltrate from a sandbox org.
     if demo_sandbox.is_sandbox(caller.org):
+        live_key = get_settings().demo_stripe_key
+        if live_key and demo_sandbox.is_live_tool(tool) and request.method in ("GET", "POST"):
+            await _enforce_public_demo_ip_cap(request, db)  # one shared wire → meter by client IP
+            try:
+                response = await _relay_live_demo(
+                    request, upstream_url, live_key, demo_sandbox.visitor_name(caller.org.slug))
+            except httpx.RequestError as exc:
+                _audit(502)
+                raise HTTPException(status_code=502, detail=f"upstream request failed: {exc}")
+            _audit(response.status_code)
+            return response
         secrets = {}
         for sid in {b.get("secret_id") for b in tool.bindings if b.get("secret_id") is not None}:
             s = await db.get(Secret, sid)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -33,6 +33,16 @@ class Settings(BaseSettings):
     # The single bootstrap caller token for the MVP. Per-user/org tokens come in Step 3.
     api_token: str = "dev-token"
 
+    # DEMO Stripe webhook signing secret (env TREG_DEMO_STRIPE_WEBHOOK_SECRET) for the landing page's live
+    # payments feed (see pubfeed.py). Empty = the /stripe/webhook endpoint is off (404).
+    demo_stripe_webhook_secret: str = ""
+
+    # The Stripe sandbox restricted key (env TREG_DEMO_STRIPE_KEY) behind the landing sandbox's ONE
+    # live wire: a sandbox call to the exact seeded stripe tool relays for real with THIS key
+    # injected — the key never exists in any sandbox org (see sandbox.is_live_tool / api.call_tool).
+    # Empty = every sandbox call synthesizes, exactly as before the live wire existed.
+    demo_stripe_key: str = ""
+
     # Cross-tenant super-admin bearer (env TREG_ADMIN_TOKEN). Presenting it authorizes every
     # /admin/* endpoint regardless of org. Empty = the env key is disabled (only is_superadmin
     # users can reach /admin). Keep it long + secret; it sees ALL orgs.

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -89,6 +89,9 @@ def _migrate_to_orgs(conn) -> None:
     _ensure_bool_col(conn, insp, tables, "user", "demo")
     _ensure_bool_col(conn, insp, tables, "org", "demo")
 
+    # (A15) additive: org.public_demo — a team whose member token is published; locked to /call + reads.
+    _ensure_bool_col(conn, insp, tables, "org", "public_demo")
+
     # (A4) additive: tool.examples (JSON list of {method,path,note}) for the dashboard
     if "tool" in tables and "examples" not in {c["name"] for c in insp.get_columns("tool")}:
         conn.execute(text("ALTER TABLE tool ADD COLUMN examples JSON"))
@@ -163,7 +166,7 @@ def _migrate_to_orgs(conn) -> None:
 
     if legacy_users:
         conn.execute(
-            text("INSERT INTO org (name, slug, suspended, demo, created_at) VALUES ('superdesign', 'superdesign', false, false, :t)"),
+            text("INSERT INTO org (name, slug, suspended, demo, public_demo, created_at) VALUES ('superdesign', 'superdesign', false, false, false, :t)"),
             {"t": now},
         )
         org_id = conn.execute(text("SELECT id FROM org WHERE slug = 'superdesign'")).scalar()

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -36,6 +36,9 @@ class Org(SQLModel, table=True):
     slug: str = Field(index=True, unique=True)
     suspended: bool = Field(default=False)  # a suspended org's members are locked out (403)
     demo: bool = Field(default=False)  # a sandbox team seeded by onboarding — labeled + one-click removable
+    # A team whose token is published (e.g. on the landing page): non-admin members are locked to
+    # /call + reads, and may never act as a user (see api.require_member / require_identity).
+    public_demo: bool = Field(default=False)
     created_at: datetime = Field(default_factory=_now)
 
 

--- a/src/treg/pubfeed.py
+++ b/src/treg/pubfeed.py
@@ -1,0 +1,129 @@
+"""The landing page's live payments feed (the public Stripe demo).
+
+A visitor curls the published demo token → treg relays a test charge to Stripe → Stripe fires
+`charge.succeeded` at our webhook → the charge appears on the landing page over SSE, no refresh.
+
+Deliberately tiny and in-memory: the feed is a marketing surface, not a system of record. A
+dropped event on restart costs nothing (Stripe retries webhooks anyway), and multi-instance
+deploys just mean each instance streams the events its own webhook delivery landed on.
+
+Only server-chosen fields travel (amount/currency/created/id-suffix) — NEVER `description` or
+any other visitor-controlled string, so the feed cannot be defaced (see landing-sandbox.md's
+graffiti lesson).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from collections import deque
+from collections.abc import AsyncIterator
+
+FEED_MAX = 20               # replayed to a fresh subscriber
+KEEPALIVE_S = 25            # SSE comment ping so proxies don't reap the idle stream
+SIG_TOLERANCE_S = 300       # reject webhook timestamps older than this (replay guard)
+_MAX_SUBSCRIBER_LAG = 100   # a stalled subscriber is dropped, not buffered forever
+
+_events: deque[dict] = deque(maxlen=FEED_MAX)
+_subscribers: set[asyncio.Queue] = set()
+
+# The visitor "name" on each charge. The landing page bakes a wordlist name into the copyable
+# command's `description`; since a visitor can edit the command freely, a description is shown
+# ONLY when both words come from these exact lists (numbers ≤999). Anything else falls back to a
+# name DERIVED from the charge id — so every row gets a friendly identity and hand-typed text can
+# never reach the page. Keep these lists in sync with LIVE_ADJ/LIVE_ANIMAL in web/landing.html.
+ADJECTIVES = (
+    "swift", "brave", "calm", "clever", "cosmic", "daring", "eager", "fuzzy",
+    "gentle", "golden", "happy", "jolly", "lucky", "mellow", "mighty", "neon",
+    "nifty", "plucky", "proud", "quick", "shiny", "snappy", "solar", "sunny",
+)
+ANIMALS = (
+    "otter", "fox", "lynx", "panda", "koala", "falcon", "heron", "badger",
+    "dolphin", "gecko", "ibis", "jaguar", "kiwi", "lemur", "marmot", "narwhal",
+    "ocelot", "puffin", "quokka", "raven", "seal", "tapir", "walrus", "wombat",
+)
+
+
+def _derived_name(charge_id: str) -> str:
+    """A deterministic wordlist name from the charge id — the safe fallback for any charge whose
+    description wasn't (or was tampered to not be) one of ours."""
+    h = int(hashlib.sha256(charge_id.encode()).hexdigest(), 16)
+    return f"{ADJECTIVES[h % len(ADJECTIVES)]}-{ANIMALS[(h // 100) % len(ANIMALS)]}-{h % 1000}"
+
+
+def _is_wordlist_name(s) -> bool:
+    if not isinstance(s, str):
+        return False
+    parts = s.split("-")
+    return (len(parts) == 3 and parts[0] in ADJECTIVES and parts[1] in ANIMALS
+            and parts[2].isdigit() and len(parts[2]) <= 3)
+
+
+def _display_name(obj: dict) -> str:
+    # metadata[visitor] is stamped by OUR relay (sandbox live wire) over whatever the caller sent,
+    # so it's first choice; description covers page-generated commands. Both still pass the
+    # wordlist gate — defense in depth against any path that lets caller text through.
+    meta = obj.get("metadata") or {}
+    for cand in (meta.get("visitor") if isinstance(meta, dict) else None, obj.get("description")):
+        if _is_wordlist_name(cand):
+            return cand
+    return _derived_name(str(obj.get("id", "")))
+
+
+def verify_signature(payload: bytes, header: str, secret: str) -> bool:
+    """Stripe-Signature: `t=<unix>,v1=<hexhmac>[,v1=…]`. The signed payload is `{t}.{body}`.
+    Constant-time compare; a stale timestamp fails (replayed capture)."""
+    pairs = [kv.split("=", 1) for kv in header.split(",") if "=" in kv]
+    t = next((v for k, v in pairs if k == "t"), "")
+    if not t.isdigit() or abs(time.time() - int(t)) > SIG_TOLERANCE_S:
+        return False
+    expected = hmac.new(secret.encode(), f"{t}.".encode() + payload, hashlib.sha256).hexdigest()
+    # Stripe may send several v1 signatures during secret rotation — any match passes.
+    candidates = [v for k, v in pairs if k == "v1"]
+    return any(hmac.compare_digest(expected, c) for c in candidates)
+
+
+def push_charge(obj: dict) -> None:
+    """Record a charge for the feed — server-chosen fields only, never visitor-typed text.
+    The receipt link is the skeptic-proof: a page rendered by pay.stripe.com, not by us."""
+    receipt = obj.get("receipt_url")
+    event = {
+        "amount": obj.get("amount"),
+        "currency": obj.get("currency"),
+        "created": obj.get("created"),
+        "id_suffix": str(obj.get("id", ""))[-6:],  # enough for "that's MY charge", useless otherwise
+        "name": _display_name(obj),
+        "receipt_url": receipt if isinstance(receipt, str) and receipt.startswith("https://pay.stripe.com/") else None,
+    }
+    _events.append(event)
+    for q in list(_subscribers):
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:  # a stalled consumer — drop it rather than buffer unboundedly
+            _subscribers.discard(q)
+
+
+async def stream() -> AsyncIterator[str]:
+    """SSE generator: replay the ring buffer, then live events, with keepalive pings."""
+    q: asyncio.Queue = asyncio.Queue(maxsize=_MAX_SUBSCRIBER_LAG)
+    _subscribers.add(q)
+    try:
+        for event in list(_events):
+            yield f"data: {json.dumps(event)}\n\n"
+        while True:
+            try:
+                event = await asyncio.wait_for(q.get(), timeout=KEEPALIVE_S)
+                yield f"data: {json.dumps(event)}\n\n"
+            except asyncio.TimeoutError:
+                yield ": ping\n\n"
+    finally:
+        _subscribers.discard(q)
+
+
+def reset() -> None:
+    """Test hook: forget all events and subscribers."""
+    _events.clear()
+    _subscribers.clear()

--- a/src/treg/sandbox.py
+++ b/src/treg/sandbox.py
@@ -19,6 +19,7 @@ them distinct from the onboarding demo teams (also `demo`, but team-named). Self
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -29,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import crypto, injectors
 from .models import Bundle, CallRecord, Invite, Membership, Org, PendingOAuth, Secret, Tool, User
+from .pubfeed import ADJECTIVES as _ADJ, ANIMALS as _ANIMALS  # wordlists shared with the live feed (leaf module, no cycle)
 
 SANDBOX_DOMAIN = "sandbox.treg.local"     # throwaway visitor identities live here (can never log in)
 SANDBOX_TTL_MIN = 60
@@ -45,10 +47,32 @@ MAX_SECRETS = 3
 # prefilled with the real PostHog API + this placeholder and the visitor's first action is a single Add.
 DEFAULTS = [
     {"secret": "STRIPE_KEY",  "value": "sk_live_DEMO0000PLACEHOLDER", "tool": "stripe",
-     "base": "https://api.stripe.com",  "host": "api.stripe.com",
-     "example": {"method": "GET", "path": "v1/charges", "note": "list charges"}},
+     "base": "https://api.stripe.com/v1/charges",  "host": "api.stripe.com",
+     "example": {"method": "GET", "path": "", "note": "list charges"}},
     {"secret": "POSTHOG_KEY", "value": "phx_DEMO0000PLACEHOLDER"},  # vault-only (no tool); the add-row uses it
 ]
+
+# ---- the ONE live wire ----------------------------------------------------------------------
+# The seeded stripe tool above is special: when TREG_DEMO_STRIPE_KEY is configured, a sandbox call
+# to a tool matching this EXACT fingerprint relays to the real Stripe test API — with the key
+# injected from env, so no sandbox org ever holds it. Edit anything about the tool (base_url,
+# bindings, a lookalike) and it stops matching, silently falling back to synthesize(): tampering
+# can't exfiltrate a key that isn't there. The base is pinned to the charges resource, so the only
+# reachable surface is list/create test charges (the key is also Stripe-restricted to Charges).
+LIVE_HOST = "api.stripe.com"
+LIVE_BASE = "https://api.stripe.com/v1/charges"
+
+def is_live_tool(tool: Tool) -> bool:
+    """Does this sandbox tool match the seeded live-wire fingerprint exactly?"""
+    return tool.host == LIVE_HOST and (tool.base_url or "").rstrip("/") == LIVE_BASE
+
+
+def visitor_name(slug: str) -> str:
+    """Deterministic adjective-animal-nn identity for a sandbox org, derived from its slug. The
+    server injects it into every live charge as `metadata[visitor]`, overriding anything the
+    caller sent — so the name on the landing feed is always server-chosen."""
+    h = int(hashlib.sha256((slug or "").encode()).hexdigest(), 16)
+    return f"{_ADJ[h % len(_ADJ)]}-{_ANIMALS[(h // 100) % len(_ANIMALS)]}-{h % 1000}"
 
 # Brand-shaped dummy payloads so "what the API received" feels like the real endpoint (keyed by host).
 SAMPLE_BODIES = {
@@ -109,6 +133,7 @@ async def mint(db: AsyncSession) -> dict:
     return {
         "token": token,
         "org_slug": org.slug,
+        "visitor": visitor_name(org.slug),  # the identity live charges carry (metadata[visitor])
         "max_tools": MAX_TOOLS,
         "max_secrets": MAX_SECRETS,
         "ttl_min": SANDBOX_TTL_MIN,

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -287,6 +287,90 @@ pre.dimothers .ln.fcs{background:var(--blue-tint);border-color:rgba(0,94,255,.45
   color:var(--ink70);font-size:13.5px;line-height:1.5}
 .card .cf b{color:var(--green);font-weight:600}
 
+/* ---------- live wire: vault window + call panel (view mode of the sandbox) ---------- */
+@keyframes livepulse{50%{opacity:.35}}
+.steplbl{display:flex;align-items:center;gap:10px;margin:30px 2px 12px;font-family:var(--mono);
+  font-size:10.5px;letter-spacing:.16em;text-transform:uppercase;color:var(--ink55)}
+.steplbl b{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;
+  border-radius:999px;background:rgba(129,255,125,.12);color:var(--green);font-size:10px}
+.steplbl .ln{flex:1;height:1px;background:var(--line)}
+/* same card treatment as the studio's vault bar (.vbar): panel bg + inset top highlight */
+.vw{background:var(--panel);border:1px solid var(--line);border-radius:20px;overflow:hidden;
+  box-shadow:rgba(255,255,255,.12) 0 1px 0 inset}
+.vw-bar{display:flex;align-items:center;gap:8px;padding:11px 15px;border-bottom:1px solid var(--line);
+  font-family:var(--mono);font-size:12px;color:var(--ink70)}
+.vw-bar i{width:9px;height:9px;border-radius:99px;background:#2e2e2e;display:block}
+.vw-bar b{color:var(--link);font-weight:700}
+.vw-edit{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--ink55);
+  border:1px solid var(--line);border-radius:6px;padding:3px 9px;background:none;cursor:pointer}
+.vw-edit:hover{color:var(--ink)}
+.vw-row{display:flex;align-items:center;gap:9px;padding:7px 15px;font-family:var(--mono);font-size:13px;color:var(--ink)}
+.vw-row.head{padding-top:12px;font-size:15px;font-weight:700}
+.vw-row.sub{padding:4px 15px 4px 34px;color:var(--ink70);font-size:12.5px}
+.vw-row.last{padding-bottom:12px}
+.vw-row .rt{margin-left:auto;display:flex;align-items:baseline;gap:8px;white-space:nowrap;text-align:right}
+.vw-row .t{font-size:10px;letter-spacing:.1em;color:var(--ink55);text-transform:uppercase;font-weight:400}
+.vw-row .ok{color:var(--green);font-size:11.5px;font-weight:400}
+.vw-row .dots{color:var(--ink55);letter-spacing:2px;font-weight:400}
+.vwchip{font-family:var(--mono);font-size:9.5px;letter-spacing:.06em;border-radius:5px;padding:1.5px 7px;font-weight:400}
+.vwchip.skill{color:var(--link);background:var(--blue-tint)}
+.vwchip.keyc{color:var(--ink70);border:1px solid var(--line)}
+.vwchip.ep{color:var(--link);background:rgba(107,196,255,.10)}
+.vwdim{color:var(--ink55);font-weight:400}
+.vw-slogo{width:17px;height:17px;flex:none;border-radius:4px;display:block}
+/* the title truncates (never wraps) so the edit button stays put; statuses may drop to their
+   own right-aligned line on narrow screens instead of colliding with the row content */
+.vw-bar .vw-t{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.vw-edit{flex:none;white-space:nowrap}
+.vw-row{flex-wrap:wrap}
+@media (max-width:640px){
+  .vw-sub{display:none}
+  .vw-row{font-size:12px;gap:7px;padding:6px 12px}
+  .vw-row.head{font-size:13.5px;padding-top:11px}
+  .vw-row.sub{padding-left:26px;font-size:11.5px}
+  .vw-row .ok{font-size:10.5px}
+  .vw-feedbar{padding:9px 12px}
+  .vw-feedbar .you{width:100%;margin:2px 0 0}
+  .frow,.live-row{font-size:12px;gap:9px;padding:7px 12px}
+}
+.vw-feedbar{display:flex;align-items:center;gap:8px;padding:10px 15px;border-top:1px solid var(--line);
+  border-bottom:1px solid var(--line);font-family:var(--mono);font-size:10.5px;letter-spacing:.12em;
+  text-transform:uppercase;color:var(--ink55)}
+.vw-feedbar .you{margin-left:auto;letter-spacing:0;text-transform:none}
+.vw-feedbar .you b{color:var(--green);font-family:var(--mono);font-weight:600}
+.vw-feedbar .dot,.dot{width:8px;height:8px;border-radius:99px;background:var(--green);
+  box-shadow:0 0 8px var(--green);animation:livepulse 2s infinite}
+.live-rows{min-height:120px;max-height:240px;overflow-y:auto;padding:6px 0}
+.live-row{display:flex;align-items:baseline;gap:12px;padding:8px 18px;font-family:var(--mono);font-size:13px}
+.live-row .amt{color:var(--green);font-weight:600;min-width:72px}
+.live-row .cur{color:var(--ink55);font-size:11px;text-transform:uppercase}
+.live-row .idsfx{color:var(--ink55);margin-left:auto;font-size:11px}
+.live-row.fresh{animation:liverow .8s ease-out}
+@keyframes liverow{from{background:rgba(63,185,80,.18);transform:translateY(-4px)}to{background:transparent;transform:none}}
+.live-empty{padding:26px 18px;font-family:var(--mono);font-size:12.5px;color:var(--ink55);text-align:center}
+.live-row .who{color:var(--ink);min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.live-row .when{color:var(--ink55);font-size:11px}
+.live-row .rcpt{margin-left:auto;font-size:11px;color:var(--link);text-decoration:none;white-space:nowrap;opacity:.85}
+.live-row .rcpt:hover{text-decoration:underline;opacity:1}
+/* tabbed command box */
+.live-tabs{display:flex;gap:2px;width:max-content;background:rgba(0,0,0,.3);border:1px solid var(--line);
+  border-bottom:0;border-radius:12px 12px 0 0;padding:6px 6px 0}
+.live-tab{font-family:var(--mono);font-size:11.5px;color:var(--ink55);background:transparent;border:0;
+  padding:7px 14px;border-radius:8px 8px 0 0;cursor:pointer}
+.live-tab.on{color:var(--ink);background:var(--panel2)}
+.live-pane{display:none}
+.live-pane.on{display:block}
+.live-pane .codewrap{border-top-left-radius:0}
+/* syntax roles inside the command */
+.lw-dim{color:var(--ink35, rgba(255,255,255,.35))}
+.lw-api{color:var(--green);font-weight:600;border-bottom:1px dashed rgba(129,255,125,.45)}
+.lw-tok{color:var(--link)}
+.lw-amt{color:#FFD43B}
+.lw-cmt{color:rgba(255,255,255,.35);font-style:italic}
+.vlive{font-family:var(--mono);font-size:9px;letter-spacing:.14em;font-weight:700;color:var(--page);
+  background:var(--green);border-radius:4px;padding:2px 6px;box-shadow:0 0 10px rgba(129,255,125,.35);
+  animation:livepulse 2s infinite}
+
 /* ---------- try-it sandbox (ported "test section", sparkle skin) ---------- */
 .sbx-sec{padding:170px 0 0}
 .guide{display:flex;align-items:center;justify-content:center;gap:12px;flex-wrap:wrap;
@@ -1117,25 +1201,27 @@ p.lead,p.sub{font-family:var(--mono);font-size:15px;line-height:1.65}
 <!-- ===== try it live (the test section, sparkle skin) ===== -->
 <section class="sbx-sec" id="try">
   <div class="narrow">
-    <div class="eyebrow rv">try it live · no signup</div>
     <h2 class="rv">Try it live</h2>
+    <div class="eyebrow rv" style="margin-top:14px">hack it if you can</div>
   </div>
   <div class="wrap" style="max-width:900px">
-    <div class="guide rv" style="margin-top:26px">
+    <div class="guide rv" id="sbx-guide" style="margin-top:26px">
       <span><b>1</b> keys stay in the vault</span><span class="ga">→</span>
       <span><b>2</b> point at an API or a skill</span><span class="ga">→</span>
       <span><b>3</b> call it with just a token</span>
     </div>
 
+    <div id="sbx-studio">
     <!-- vault bar -->
     <div class="vbar rv">
       <span class="vl">🔒 vault</span>
       <span id="vchips" style="display:flex;gap:8px;flex-wrap:wrap"></span>
-      <span class="vadd">
+      <span class="vadd" id="vadd">
         <input class="kn" id="ns-name" placeholder="NEW_KEY" onkeyup="if(event.key==='Enter')sbxAddSecret()"/>
         <input class="kv" id="ns-value" placeholder="value" onkeyup="if(event.key==='Enter')sbxAddSecret()"/>
         <button class="minibtn" onclick="sbxAddSecret()">＋ add key</button>
       </span>
+      <button class="minibtn" id="vault-edit" style="display:none" onclick="toggleVaultEdit()">✎ edit vault</button>
     </div>
     <div class="vhint">treg holds these · referenced by name · never downloaded to a machine</div>
 
@@ -1195,6 +1281,40 @@ p.lead,p.sub{font-family:var(--mono);font-size:15px;line-height:1.65}
 
       </div>
     </div>
+    </div><!-- /sbx-studio -->
+
+<!-- live wire (view mode): step 1 vault window · step 2 call panel. Hidden while editing
+     or when the wire is off (then the classic studio above is the whole section). -->
+    <div id="sbx-view" style="display:none">
+      <div id="vw-wrap">
+        <div class="steplbl"><b>1</b> the live vault with our stripe key <span class="ln"></span></div>
+        <div class="vw rv">
+          <div class="vw-bar"><i></i><i></i><i></i>
+            <span class="vw-t">🔒 <b>Live vault</b><span class="vw-sub"> · a real Stripe account's key, sealed</span></span>
+            <button class="vw-edit" onclick="enterEdit()">✎ edit</button></div>
+          <div id="vw-rows"></div>
+        </div>
+      </div>
+
+      <div class="steplbl"><b>2</b> call it — your token, our key <span class="ln"></span></div>
+      <div class="vw rv">
+        <div class="live-tabs" role="tablist" style="border:0;background:none;padding:8px 8px 0">
+          <button class="live-tab on" data-pane="curl" onclick="liveTab('curl')">curl</button>
+          <button class="live-tab" data-pane="cli" onclick="liveTab('cli')">treg CLI</button>
+        </div>
+        <div class="live-pane on" id="lw-pane-curl">
+          <div class="codewrap" style="border-radius:0;border-left:0;border-right:0"><button class="cp" onclick="copyEl('lw-curl',this)">copy</button><pre id="lw-curl"></pre></div>
+        </div>
+        <div class="live-pane" id="lw-pane-cli">
+          <div class="codewrap" style="border-radius:0;border-left:0;border-right:0"><button class="cp" onclick="copyEl('lw-cli',this)">copy</button><pre id="lw-cli"></pre></div>
+        </div>
+        <div class="vw-feedbar"><span class="dot"></span> live · our stripe sandbox
+          <span class="you">you are <b id="lw-you">…</b></span></div>
+        <div class="live-rows" id="live-rows"><div class="live-empty">waiting for the first charge…</div></div>
+      </div>
+      <p class="vhint" style="text-align:left">the green URL is Stripe's real API · the key is injected in our proxy, your sandbox never holds it · every row links to a receipt hosted by Stripe</p>
+    </div>
+
   </div>
 </section>
 
@@ -1715,7 +1835,56 @@ logorow.innerHTML = [...PROVIDERS, ...PROVIDERS].map(([name, slug]) =>
 const $ = id => document.getElementById(id);
 function esc(x){ return String(x).replace(/&/g,'&amp;').replace(/</g,'&lt;'); }
 const SBX = { token:null, org_slug:'', secrets:[], tools:[], samples:[], skills:[],
-              ran:null, addOpen:false, skAddOpen:false };
+              ran:null, addOpen:false, skAddOpen:false, live:false, visitor:'', editing:false };
+// With the live wire ON the section has two modes: a VIEW (vault window + call panel, #sbx-view)
+// and an EDIT mode (the original studio, #sbx-studio). With the wire off, only the studio exists
+// and everything edits freely — the original behavior, untouched.
+function editingOn(){ return SBX.editing || !SBX.live; }
+function enterEdit(){ SBX.editing = true; applyMode(); renderVault(); }
+function toggleVaultEdit(){ SBX.editing = !SBX.editing; applyMode(); renderVault(); }
+function applyMode(){
+  const live = SBX.live && !!SBX.token;
+  // live: the call panel (step 2) is ALWAYS on screen; editing only swaps the vault window
+  // for the studio. wire off: the original studio is the whole section, untouched.
+  $('sbx-view').style.display = live ? '' : 'none';
+  $('vw-wrap').style.display = (live && !SBX.editing) ? '' : 'none';
+  $('sbx-studio').style.display = (live && !SBX.editing) ? 'none' : '';
+  $('sbx-guide').style.display = live ? 'none' : '';  // the step labels tell the story when live
+  $('vadd').style.display = editingOn() ? '' : 'none';
+  const b = $('vault-edit');
+  b.style.display = SBX.live ? '' : 'none';
+  b.textContent = '✓ done';
+  if (live && !SBX.editing) renderVaultView();
+}
+// Stripe's S mark (brand badge) for the live bundle row — inline so nothing is fetched.
+const STRIPE_BADGE =
+  '<svg class="vw-slogo" viewBox="0 0 24 24" aria-hidden="true"><rect width="24" height="24" rx="5" fill="#635BFF"/>' +
+  '<path fill="#fff" transform="translate(4.56,4.56) scale(0.62)" d="M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 ' +
+  '0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 ' +
+  '6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 ' +
+  '0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 ' +
+  '4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.594-7.305h.003z"/></svg>';
+function renderVaultView(){
+  const rows = [];
+  const liveT = SBX.tools.find(isLiveTool);
+  if (liveT){
+    rows.push(`<div class="vw-row head">${STRIPE_BADGE} stripe-billing-skill <span class="vlive">LIVE</span>` +
+              `<span class="rt"><span class="t">SKILL.MD</span></span></div>`);
+    rows.push(`<div class="vw-row sub">└ ⚡ api.stripe.com<span class="vwdim">/v1/charges</span> <span class="vwchip ep">endpoint</span>` +
+              `<span class="rt"><span class="ok">wired ✓</span></span></div>`);
+    rows.push(`<div class="vw-row sub last">└ 🔑 STRIPE_KEY <span class="vwchip keyc">key</span>` +
+              `<span class="rt"><span class="ok">bound ✓ · never leaves</span></span></div>`);
+  }
+  // seeded POSTHOG_KEY stays out of the exhibit (it exists for the edit-mode "add your own" flow);
+  // keys the VISITOR added do show.
+  for (const k of SBX.secrets.filter(x => x.name !== 'STRIPE_KEY' && x.name !== 'POSTHOG_KEY'))
+    rows.push(`<div class="vw-row">🔑 ${esc(k.name)} <span class="vwchip keyc">key</span><span class="dots">••••••</span>` +
+              `<span class="rt"><span class="t">standalone</span></span></div>`);
+  for (const t of SBX.tools.filter(x => !isLiveTool(x)))
+    rows.push(`<div class="vw-row">⚡ ${esc(t.base_url.replace(/^https?:\/\//, ''))} <span class="vwchip ep">endpoint</span>` +
+              `<span class="rt"><span class="ok">wired ✓</span></span></div>`);
+  $('vw-rows').innerHTML = rows.join('');
+}
 const REAL_APIS = [
   { name:'posthog', url:'https://app.posthog.com/api/projects/@current/events', key:'POSTHOG_KEY' },
   { name:'openai',  url:'https://api.openai.com/v1/models',                     key:'OPENAI_KEY' },
@@ -1742,24 +1911,53 @@ async function sbxInit(){
   const saved = localStorage.getItem('treg-sbx');
   if (saved){
     SBX.token = saved;
-    try { await sbxFreshStart(); return; }
+    try {
+      // live-wire facts FIRST — sbxFreshStart needs SBX.live to know to spare the live tool
+      try { const lw = await sbxFetch('/demo/sandbox/live'); SBX.live = lw.live; SBX.visitor = lw.visitor; } catch(e){}
+      await sbxFreshStart();
+      liveInit();
+      return;
+    }
     catch(e){ SBX.token = null; localStorage.removeItem('treg-sbx'); }
   }
   try {
     const m = await sbxFetch('/demo/sandbox', { method:'POST' });
     SBX.token = m.token; SBX.org_slug = m.org_slug;
+    SBX.live = !!m.live; SBX.visitor = m.visitor || '';
     localStorage.setItem('treg-sbx', m.token);
     await sbxFreshStart();
+    liveInit();
   } catch(e){ sbxErr(e, 'Could not start the sandbox — please retry.'); }
 }
 async function sbxFreshStart(){
   // every visit tells the story from the top: the ADD state. Wipe the sandbox's
   // tools (keys stay in the vault) so the visitor's first action is hitting Add,
   // and the "call it from any terminal" payoff appears as a result of THEIR click.
+  // EXCEPT the live wire: its terminal commands must work the moment the page shows
+  // them, so the seeded live stripe tool survives the reset and starts selected.
   await sbxRefresh();
-  for (const t of [...SBX.tools]) await sbxFetch('/tools/' + t.id, { method:'DELETE' }).catch(() => {});
-  if (SBX.tools.length) await sbxRefresh();
+  const gone = SBX.tools.filter(t => !isLiveTool(t));
+  for (const t of gone) await sbxFetch('/tools/' + t.id, { method:'DELETE' }).catch(() => {});
+  if (gone.length) await sbxRefresh();
+  await ensureLiveTool();
+  if (SBX.live && !SBX.skills.length){
+    // the exhibit opens stocked: the stripe skill card sits in the Skills tab from the start
+    const sm = SBX.samples.find(x => x.name === 'stripe-billing');
+    if (sm && haveKey(sm.key)) SBX.skills.push({ ...sm, tab: 0, runOpen: false });
+  }
+  applyMode();
   prefillAdd();
+  const live = SBX.tools.find(isLiveTool);
+  if (live) selectTool(live.id);
+}
+async function ensureLiveTool(){
+  // sandboxes minted before the live wire shipped lack the pinned tool — recreate it silently
+  if (!SBX.live || SBX.tools.some(isLiveTool)) return;
+  const k = SBX.secrets.find(s => s.name === 'STRIPE_KEY');
+  if (!k) return;
+  await sbxFetch('/tools', { method:'POST', body: JSON.stringify({ name:'stripe', base_url: LIVE_API,
+    bindings: [{ secret_id: k.id, injector:'env', location:'header', name:'Authorization', format:'Bearer {secret}' }] }) }).catch(() => {});
+  await sbxRefresh();
 }
 async function sbxRefresh(){
   const [secrets, tools, samples] = await Promise.all([
@@ -1780,22 +1978,31 @@ function callPath(t){
 }
 function haveKey(name){ return !!name && SBX.secrets.some(k => k.name === name); }
 function renderVault(){
-  $('vchips').innerHTML = SBX.secrets.map(k =>
-    `<span class="vchip"><span class="kn">${esc(k.name)}</span><span class="kv">••••••</span>` +
-    `<button class="x" onclick="sbxRmSecret(${k.id})" aria-label="remove">✕</button></span>`).join('');
+  $('vchips').innerHTML = SBX.secrets.map(k => {
+    const isLiveKey = SBX.live && k.name === 'STRIPE_KEY';
+    const live = isLiveKey ? '<span class="vlive">LIVE</span>' : '';
+    const x = (editingOn() && !isLiveKey)  // the live key is never removable, even in edit mode
+      ? `<button class="x" onclick="sbxRmSecret(${k.id})" aria-label="remove">✕</button>` : '';
+    return `<span class="vchip"><span class="kn">${esc(k.name)}</span><span class="kv">••••••</span>${live}${x}</span>`;
+  }).join('');
   renderTools(); renderSkills();
+}
+function isLiveTool(t){  // mirror of sandbox.is_live_tool — the exact seeded fingerprint
+  return SBX.live && (t.base_url || '').replace(/\/$/, '') === LIVE_API;
 }
 function renderTools(){
   $('trows').innerHTML = SBX.tools.map(t => {
     const key = bindKeyName(t), host = t.base_url.replace(/^https?:\/\//,'').split('/')[0];
+    const x = (editingOn() && !isLiveTool(t))  // the live endpoint is never removable
+      ? `<button class="x" onclick="event.stopPropagation();sbxRmTool(${t.id})">✕</button>` : '';
     return `<div class="trow ${SBX.ran === t.id ? 'on' : ''}" onclick="selectTool(${t.id})">` +
       `<span class="meth">GET</span><span class="host">${esc(host)}<span class="path">${esc(callPath(t))}</span></span>` +
-      `<span class="key ${key === '—' ? 'warn' : ''}">🔑 ${esc(key)}</span><span class="sp"></span>` +
-      `<button class="x" onclick="event.stopPropagation();sbxRmTool(${t.id})">✕</button></div>`;
+      (isLiveTool(t) ? '<span class="vlive">LIVE</span>' : '') +
+      `<span class="key ${key === '—' ? 'warn' : ''}">🔑 ${esc(key)}</span><span class="sp"></span>` + x + `</div>`;
   }).join('');
-  const showAdd = SBX.tools.length === 0 || SBX.addOpen;
+  const showAdd = editingOn() && (SBX.tools.length === 0 || SBX.addOpen);
   $('addwrap').style.display = showAdd ? 'block' : 'none';
-  $('addmore').style.display = showAdd ? 'none' : 'inline-flex';
+  $('addmore').style.display = (editingOn() && !showAdd) ? 'inline-flex' : 'none';
   const prev = $('nt-key').value;
   $('nt-key').innerHTML = SBX.secrets.map(k => `<option value="${k.id}">${esc(k.name)}</option>`).join('');
   if ([...$('nt-key').options].some(o => o.value === prev)) $('nt-key').value = prev;
@@ -1879,7 +2086,7 @@ function renderSkills(){
       <div class="skh"><span>📦</span><b>${esc(sk.name)}</b><span class="skbadge">skill</span>
         <span class="sp" style="flex:1"></span>
         <span style="font-family:var(--mono);font-size:10.5px;color:${have ? 'var(--silver,#d8d2c2)' : '#f08a7a'};border:1px solid var(--line2);border-radius:900px;padding:2px 9px">needs 🔑 ${esc(sk.key)} ${have ? '✓' : '— missing'}</span>
-        <button class="x" style="border:0;background:none;color:var(--ink55);cursor:pointer;font-size:13px" onclick="skRm(${n})">✕</button></div>
+        ${editingOn() ? `<button class="x" style="border:0;background:none;color:var(--ink55);cursor:pointer;font-size:13px" onclick="skRm(${n})">✕</button>` : ''}</div>
       <div class="skmeta">A folder your agent loads. It calls its API through treg with <b>your</b> token — the key stays in the vault.</div>
       <div class="sktabs">${tabs}</div>
       <div class="skbody" id="skbody-${n}">${esc((sk.files || {})[files[sk.tab || 0]] || '')}</div>
@@ -1890,9 +2097,9 @@ function renderSkills(){
     </div>`;
   }).join('');
   const remaining = SBX.samples.filter(sm => !SBX.skills.some(sk => sk.name === sm.name));
-  const showAdd = (SBX.skills.length === 0 || SBX.skAddOpen) && remaining.length > 0;
+  const showAdd = editingOn() && (SBX.skills.length === 0 || SBX.skAddOpen) && remaining.length > 0;
   $('skadd').style.display = showAdd ? 'block' : 'none';
-  $('skaddmore').style.display = (!showAdd && remaining.length > 0) ? 'inline-flex' : 'none';
+  $('skaddmore').style.display = (editingOn() && !showAdd && remaining.length > 0) ? 'inline-flex' : 'none';
   if (showAdd){
     const prev = $('sk-pick').value;
     $('sk-pick').innerHTML = remaining.map(sm => `<option value="${esc(sm.name)}">${esc(sm.label || sm.name)}</option>`).join('');
@@ -1952,6 +2159,72 @@ function copyEl(id, btn){
 }
 sbxTab('endpoints');
 sbxInit();
+
+/* ===== live wire: the sandbox's ONE real endpoint =====
+   Uses the visitor's OWN sandbox token (SBX.token) — everyone gets a unique credential, which IS
+   the product story. The server decides whether the wire is live (TREG_DEMO_STRIPE_KEY set) and
+   who you are in the feed (`visitor`, injected into every charge as metadata server-side). When
+   the wire is off, the grid stays hidden and the sandbox behaves exactly as before. */
+const LIVE_MAX_ROWS = 8;
+const LIVE_API = 'https://api.stripe.com/v1/charges';
+function liveTab(name){
+  document.querySelectorAll('.live-tab').forEach(t => t.classList.toggle('on', t.dataset.pane === name));
+  ['curl','cli'].forEach(p => $(`lw-pane-${p}`).classList.toggle('on', p === name));
+}
+function liveSnippets(token, visitor){
+  const amount = Math.floor(Math.random() * 9900) + 100;  // $1.00–$99.99 (Stripe minimum is 50¢)
+  $('lw-you').textContent = visitor;
+  const E = esc, dim = s => `<span class="lw-dim">${E(s)}</span>`, api = `<span class="lw-api">${LIVE_API}</span>`,
+        tok = `<span class="lw-tok">${E(token)}</span>`, amt = s => `<span class="lw-amt">${E(s)}</span>`,
+        cmt = s => `<span class="lw-cmt">${E(s)}</span>`;
+  const dataHtml = `"${amt('amount=' + amount)}&amp;currency=usd&amp;source=tok_visa"`;
+  $('lw-curl').innerHTML =
+    `curl -X POST ${dim(location.origin + '/call/')}${api} \\\n` +
+    `  -H "X-Treg-Token: ${tok}" \\\n` +
+    `  -d ${amt('amount=' + amount)} -d currency=usd -d source=tok_visa`;
+  $('lw-cli').innerHTML =
+    cmt('# 1 · install the treg CLI (once — it points here automatically)') + `\n` +
+    `curl -fsSL ${dim(location.origin)}/install.sh | sh\n\n` +
+    cmt('# 2 · sign in with YOUR token') + `\n` +
+    `treg login --token ${tok}\n\n` +
+    cmt('# 3 · call Stripe — the key is injected server-side, never downloaded') + `\n` +
+    `treg call ${api} --method POST \\\n` +
+    `  --data ${dataHtml}`;
+}
+function liveRow(e, fresh){
+  const row = document.createElement('div');
+  row.className = 'live-row' + (fresh ? ' fresh' : '');
+  const when = e.created ? new Date(e.created * 1000).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) : '';
+  row.innerHTML = `<span class="amt"></span><span class="who"></span><span class="when"></span>`;
+  row.children[0].textContent = `$${(e.amount / 100).toFixed(2)}`;
+  row.children[1].textContent = e.name || `…${e.id_suffix || ''}`;
+  row.children[2].textContent = when;
+  if (e.receipt_url && e.receipt_url.indexOf('https://pay.stripe.com/') === 0){
+    const a = document.createElement('a');
+    a.className = 'rcpt'; a.href = e.receipt_url; a.target = '_blank'; a.rel = 'noopener';
+    a.textContent = 'receipt on stripe.com ↗';
+    row.appendChild(a);
+  }
+  return row;
+}
+function liveInit(){
+  if (!SBX.live || !SBX.token || !SBX.visitor || SBX._es) return;  // wire off / already wired
+  liveSnippets(SBX.token, SBX.visitor);
+  renderVault();  // repaint so the STRIPE_KEY chip picks up its LIVE badge
+  applyMode();
+  const rows = $('live-rows');
+  const t0 = Date.now();
+  let any = false;
+  const es = SBX._es = new EventSource('/landing/stripe-feed');
+  es.onmessage = m => {
+    const e = JSON.parse(m.data);
+    if (!any){ rows.textContent = ''; any = true; }
+    // the ring-buffer replay lands in the first moments of the stream — render it quietly;
+    // anything after that is a live charge and gets the flash.
+    rows.prepend(liveRow(e, Date.now() - t0 > 1500));
+    while (rows.children.length > LIVE_MAX_ROWS) rows.lastChild.remove();
+  };
+}
 
 /* ===== sign-in ===== */
 function openSignin(){ document.getElementById('signin-scrim').classList.add('open');

--- a/tests/test_live_wire.py
+++ b/tests/test_live_wire.py
@@ -1,0 +1,165 @@
+"""The sandbox live wire: the ONE fingerprint-matched real call inside the anonymous sandbox.
+
+Threat model: the sandbox token is anonymous and self-served, and sandbox visitors can edit their
+tools freely. The live relay must (a) inject the env key only for the EXACT seeded stripe tool,
+(b) stamp the server-chosen visitor identity over anything the caller sent, and (c) fall back to
+the classic synthesize() for anything tampered — because no sandbox org ever holds the real key.
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+import treg.api as api_mod
+from treg import pubfeed, sandbox
+
+ENV_KEY = "rk_test_ENV_ONLY_KEY"
+
+
+def _h(token: str) -> dict:
+    return {"X-Treg-Token": token}
+
+
+async def _mint(c: AsyncClient) -> dict:
+    r = await c.post("/demo/sandbox", headers={"X-Treg-Token": ""})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _enable_live(monkeypatch, key: str = ENV_KEY):
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_key", key)
+
+
+# ---- identity -------------------------------------------------------------------------------
+def test_visitor_name_is_deterministic_and_wordlist_shaped():
+    a, b = sandbox.visitor_name("sbx-abc123def456"), sandbox.visitor_name("sbx-abc123def456")
+    assert a == b
+    adj, animal, n = a.split("-")
+    assert adj in pubfeed.ADJECTIVES and animal in pubfeed.ANIMALS and n.isdigit()
+    assert sandbox.visitor_name("sbx-000000000000") != sandbox.visitor_name("sbx-ffffffffffff")
+
+
+async def test_mint_and_live_endpoint_report_the_wire(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    assert m["live"] is True
+    assert m["visitor"] == sandbox.visitor_name(m["org_slug"])
+    lw = await clients.get("/demo/sandbox/live", headers=_h(m["token"]))
+    assert lw.json() == {"live": True, "visitor": m["visitor"]}
+    # a non-sandbox caller has no business here
+    assert (await clients.get("/demo/sandbox/live")).status_code == 400
+
+
+async def test_mint_reports_wire_off_when_unconfigured(clients: AsyncClient, monkeypatch):
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_key", "")
+    assert (await _mint(clients))["live"] is False
+
+
+# ---- the live relay -------------------------------------------------------------------------
+async def test_live_call_relays_with_env_key_and_stamped_visitor(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    r = await clients.post("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]),
+                           content="amount=420&currency=usd&source=tok_visa")
+    assert r.status_code == 200, r.text
+    echo = r.json()
+    assert "sandbox" not in echo  # a REAL relay, not synthesize()
+    assert echo["auth"] == f"Bearer {ENV_KEY}"  # env key injected — never a sandbox secret
+    body = echo["body"].replace("%5B", "[").replace("%5D", "]")
+    assert f"metadata[visitor]={m['visitor']}" in body
+
+
+async def test_caller_supplied_visitor_metadata_is_overridden(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    r = await clients.post("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]),
+                           content="amount=1&metadata[visitor]=rude-words-1")
+    body = r.json()["body"].replace("%5B", "[").replace("%5D", "]")
+    assert "rude-words-1" not in body
+    assert f"metadata[visitor]={m['visitor']}" in body
+    assert body.count("metadata[visitor]") == 1
+
+
+async def test_live_get_lists_for_real(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    r = await clients.get("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]))
+    assert r.status_code == 200
+    assert r.json()["auth"] == f"Bearer {ENV_KEY}"  # relayed, key injected
+
+
+# ---- containment ----------------------------------------------------------------------------
+async def test_unconfigured_wire_synthesizes_as_before(clients: AsyncClient, monkeypatch):
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_key", "")
+    m = await _mint(clients)
+    r = await clients.post("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]),
+                           content="amount=420")
+    assert r.json().get("sandbox") is True  # the classic dummy — network untouched
+
+
+async def test_live_tool_and_key_are_frozen(clients: AsyncClient, monkeypatch):
+    """The demo centerpiece can't be edited or removed — not via UI, not via raw API."""
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    tools = (await clients.get("/tools", headers=_h(m["token"]))).json()
+    stripe = next(t for t in tools if t["name"] == "stripe")
+    secrets = (await clients.get("/secrets", headers=_h(m["token"]))).json()
+    key = next(s for s in secrets if s["name"] == "STRIPE_KEY")
+    for method, path, payload in [
+        ("patch", f"/tools/{stripe['id']}", {"base_url": "https://api.stripe.com/v1/customers"}),
+        ("delete", f"/tools/{stripe['id']}", None),
+        ("patch", f"/secrets/{key['id']}", {"value": "sk_evil"}),
+        ("delete", f"/secrets/{key['id']}", None),
+    ]:
+        r = await getattr(clients, method)(path, headers=_h(m["token"]),
+                                           **({"json": payload} if payload else {}))
+        assert r.status_code == 403, f"{method} {path} → {r.status_code}: {r.text}"
+
+
+async def test_lookalike_tool_relays_but_stays_deletable(clients: AsyncClient, monkeypatch):
+    """A visitor-made tool with the pinned base also rides the wire (same privilege, no extra
+    exposure — the key is still env-injected) but is NOT frozen: only the seeded 'stripe' is."""
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    r = await clients.post("/tools", headers=_h(m["token"]), json={
+        "name": "mystripe", "base_url": "https://api.stripe.com/v1/charges", "bindings": []})
+    assert r.status_code == 200, r.text
+    tid = r.json()["id"]
+    assert (await clients.delete(f"/tools/{tid}", headers=_h(m["token"]))).status_code == 200
+
+
+async def test_wire_off_leaves_seeded_tool_editable(clients: AsyncClient, monkeypatch):
+    """Without the env key there's no live wire — the sandbox is the classic freely-editable
+    studio, and a repointed stripe tool just synthesizes (nothing to protect)."""
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_key", "")
+    m = await _mint(clients)
+    tools = (await clients.get("/tools", headers=_h(m["token"]))).json()
+    stripe = next(t for t in tools if t["name"] == "stripe")
+    r = await clients.patch(f"/tools/{stripe['id']}", headers=_h(m["token"]),
+                            json={"base_url": "https://api.stripe.com/v1/customers"})
+    assert r.status_code == 200, r.text
+    r = await clients.post("/call/https://api.stripe.com/v1/customers/x", headers=_h(m["token"]),
+                           content="ignored")
+    assert r.json().get("sandbox") is True  # dummy, NOT a real relay
+
+
+async def test_other_sandbox_tools_still_synthesize(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    m = await _mint(clients)
+    await clients.post("/tools", headers=_h(m["token"]), json={
+        "name": "mine", "base_url": "http://upstream/anything",
+        "bindings": []})
+    r = await clients.get("/call/mine/x", headers=_h(m["token"]))
+    assert r.json().get("sandbox") is True
+
+
+async def test_live_calls_are_rate_limited_per_ip(clients: AsyncClient, monkeypatch):
+    _enable_live(monkeypatch)
+    monkeypatch.setattr(api_mod, "PUBLIC_DEMO_RATE_MAX", 2)
+    m = await _mint(clients)
+    for _ in range(2):
+        assert (await clients.post("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]),
+                                   content="amount=1")).status_code == 200
+    r = await clients.post("/call/https://api.stripe.com/v1/charges", headers=_h(m["token"]),
+                           content="amount=1")
+    assert r.status_code == 429

--- a/tests/test_pubfeed.py
+++ b/tests/test_pubfeed.py
@@ -1,0 +1,148 @@
+"""The landing page's live payments feed: webhook signature checks + the SSE ring buffer."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+from httpx import AsyncClient
+
+import treg.api as api_mod
+from treg import pubfeed
+
+SECRET = "whsec_test_secret"
+
+
+def _sign(payload: bytes, secret: str = SECRET, t: int | None = None) -> str:
+    t = int(time.time()) if t is None else t
+    mac = hmac.new(secret.encode(), f"{t}.".encode() + payload, hashlib.sha256).hexdigest()
+    return f"t={t},v1={mac}"
+
+
+def _charge_event(amount: int = 420, desc: str = "GRAFFITI <script>", **extra) -> bytes:
+    return json.dumps({"type": "charge.succeeded", "data": {"object": {
+        "id": "ch_3AbCdEfGhIjKlMnO", "amount": amount, "currency": "usd",
+        "created": 1784000000, "description": desc, **extra,
+    }}}).encode()
+
+
+@pytest.fixture(autouse=True)
+def _clean_feed(monkeypatch):
+    pubfeed.reset()
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_webhook_secret", SECRET)
+    yield
+    pubfeed.reset()
+
+
+# ---- signature verification ----------------------------------------------------------------
+def test_signature_roundtrip():
+    body = _charge_event()
+    assert pubfeed.verify_signature(body, _sign(body), SECRET)
+    assert not pubfeed.verify_signature(body, _sign(body, secret="whsec_wrong"), SECRET)
+    assert not pubfeed.verify_signature(b"tampered" + body, _sign(body), SECRET)
+    assert not pubfeed.verify_signature(body, "", SECRET)
+
+
+def test_signature_rejects_stale_timestamp():
+    body = _charge_event()
+    old = int(time.time()) - pubfeed.SIG_TOLERANCE_S - 10
+    assert not pubfeed.verify_signature(body, _sign(body, t=old), SECRET)
+
+
+def test_signature_accepts_any_v1_during_rotation():
+    body = _charge_event()
+    t = int(time.time())
+    good = _sign(body, t=t).split("v1=")[1]
+    header = f"t={t},v1={'0' * 64},v1={good}"
+    assert pubfeed.verify_signature(body, header, SECRET)
+
+
+# ---- the webhook endpoint -------------------------------------------------------------------
+async def test_webhook_is_404_when_unconfigured(clients: AsyncClient, monkeypatch):
+    monkeypatch.setattr(api_mod.get_settings(), "demo_stripe_webhook_secret", "")
+    r = await clients.post("/stripe/webhook", content=_charge_event())
+    assert r.status_code == 404
+
+
+async def test_webhook_rejects_bad_signature(clients: AsyncClient):
+    r = await clients.post("/stripe/webhook", content=_charge_event(),
+                           headers={"Stripe-Signature": "t=1,v1=deadbeef"})
+    assert r.status_code == 400
+    assert len(pubfeed._events) == 0
+
+
+async def test_webhook_feeds_only_server_chosen_fields(clients: AsyncClient):
+    body = _charge_event(amount=777, desc="visitor-typed junk",
+                         receipt_url="https://pay.stripe.com/receipts/payment/CAca123")
+    r = await clients.post("/stripe/webhook", content=body, headers={"Stripe-Signature": _sign(body)})
+    assert r.status_code == 200
+    assert len(pubfeed._events) == 1
+    event = pubfeed._events[0]
+    assert event["amount"] == 777 and event["currency"] == "usd" and event["id_suffix"] == "jKlMnO"
+    assert event["receipt_url"] == "https://pay.stripe.com/receipts/payment/CAca123"
+    # a hand-typed description never reaches the page — it's replaced by an id-derived name
+    assert "visitor-typed junk" not in json.dumps(event)
+    assert event["name"] == pubfeed._derived_name("ch_3AbCdEfGhIjKlMnO")
+
+
+def test_display_name_accepts_only_wordlist_names():
+    ours = f"{pubfeed.ADJECTIVES[0]}-{pubfeed.ANIMALS[0]}-42"
+    assert pubfeed._display_name({"id": "ch_x", "description": ours}) == ours
+    for bad in ("rude-words-42", "swift-otter-4200", "swift-otter", "swift-otter-42-extra",
+                "SWIFT-OTTER-42", "", None, 123):
+        name = pubfeed._display_name({"id": "ch_x", "description": bad})
+        assert name == pubfeed._derived_name("ch_x"), bad
+    # derived names are themselves wordlist-shaped (adj-animal-nn)
+    adj, animal, n = pubfeed._derived_name("ch_whatever").split("-")
+    assert adj in pubfeed.ADJECTIVES and animal in pubfeed.ANIMALS and n.isdigit()
+
+
+def test_metadata_visitor_beats_description():
+    ours = f"{pubfeed.ADJECTIVES[1]}-{pubfeed.ANIMALS[1]}-7"
+    got = pubfeed._display_name({"id": "ch_x", "description": "whatever the caller typed",
+                                 "metadata": {"visitor": ours}})
+    assert got == ours
+    # a forged non-wordlist metadata value is still rejected
+    got = pubfeed._display_name({"id": "ch_x", "metadata": {"visitor": "hand<crafted>"}})
+    assert got == pubfeed._derived_name("ch_x")
+
+
+def test_receipt_url_must_be_stripe_hosted():
+    pubfeed.push_charge({"id": "ch_a", "amount": 1, "currency": "usd", "created": 1,
+                         "receipt_url": "https://evil.example/phish"})
+    assert pubfeed._events[-1]["receipt_url"] is None
+    pubfeed.push_charge({"id": "ch_b", "amount": 1, "currency": "usd", "created": 1,
+                         "receipt_url": "https://pay.stripe.com/receipts/x"})
+    assert pubfeed._events[-1]["receipt_url"] == "https://pay.stripe.com/receipts/x"
+
+
+async def test_webhook_ignores_other_event_types(clients: AsyncClient):
+    body = json.dumps({"type": "customer.created", "data": {"object": {"id": "cus_1"}}}).encode()
+    r = await clients.post("/stripe/webhook", content=body, headers={"Stripe-Signature": _sign(body)})
+    assert r.status_code == 200
+    assert len(pubfeed._events) == 0
+
+
+# ---- the SSE stream -------------------------------------------------------------------------
+async def test_stream_replays_ring_buffer_then_live():
+    pubfeed.push_charge({"id": "ch_1", "amount": 100, "currency": "usd", "created": 1})
+    gen = pubfeed.stream()
+    first = await gen.__anext__()
+    got = json.loads(first.removeprefix("data: "))
+    assert got == {"amount": 100, "currency": "usd", "created": 1, "id_suffix": "ch_1",
+                   "name": pubfeed._derived_name("ch_1"), "receipt_url": None}
+    pubfeed.push_charge({"id": "ch_2", "amount": 200, "currency": "usd", "created": 2})
+    second = await gen.__anext__()
+    assert json.loads(second.removeprefix("data: "))["amount"] == 200
+    await gen.aclose()
+    assert len(pubfeed._subscribers) == 0  # unsubscribed on close
+
+
+async def test_ring_buffer_is_bounded():
+    for i in range(pubfeed.FEED_MAX + 15):
+        pubfeed.push_charge({"id": f"ch_{i}", "amount": i, "currency": "usd", "created": i})
+    assert len(pubfeed._events) == pubfeed.FEED_MAX
+    assert pubfeed._events[0]["amount"] == 15  # oldest were evicted

--- a/tests/test_public_demo.py
+++ b/tests/test_public_demo.py
@@ -1,0 +1,131 @@
+"""Public-demo token: a publishable, call-only credential (the landing-page Stripe demo).
+
+The threat model: the token is printed on a public web page, so a stranger holds a real
+membership token. The lockdown must hold at BOTH auth layers — require_member (org-scoped
+mutations) and require_identity (user-level escape hatches like /auth/cli-token and POST /orgs).
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+import treg.api as api_mod
+
+
+def _h(token: str) -> dict:
+    return {"X-Treg-Token": token}
+
+
+async def _org_with_stripe_tool(c: AsyncClient) -> int:
+    """The default client (owner of their personal org) registers a pinned secret + tool.
+    Returns the org id."""
+    org_id = next(o["org_id"] for o in (await c.get("/orgs")).json() if o["active"])
+    s = await c.post("/secrets", json={"name": "STRIPE_KEY", "value": "rk_test_x"})
+    assert s.status_code == 200, s.text
+    t = await c.post("/tools", json={
+        "name": "stripe", "base_url": "http://upstream/v1/charges", "secret_id": s.json()["id"]})
+    assert t.status_code == 200, t.text
+    return org_id
+
+
+async def _mint_public(c: AsyncClient, org_id: int) -> str:
+    r = await c.post(f"/orgs/{org_id}/public-token")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["role"] == "viewer"
+    return body["token"]
+
+
+# ---- minting ------------------------------------------------------------------------------
+async def test_mint_is_owner_only(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    # a joined member may not publish the org's credential
+    code = (await clients.post(f"/orgs/{org_id}/invites",
+                               json={"email": "m@x.dev", "role": "member"})).json()["code"]
+    mtok = (await clients.post("/invites/accept", json={"code": code, "email": "m@x.dev"})).json()["token"]
+    r = await clients.post(f"/orgs/{org_id}/public-token", headers=_h(mtok))
+    assert r.status_code == 403
+    assert (await clients.post(f"/orgs/{org_id}/public-token")).status_code == 200
+
+
+async def test_public_token_calls_and_key_is_injected(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    r = await clients.post("/call/http://upstream/v1/charges", headers=_h(pub), content="amount=420")
+    assert r.status_code == 200, r.text
+    assert r.json()["auth"] == "Bearer rk_test_x"  # the vaulted key was injected server-side
+
+
+async def test_named_call_with_empty_path_has_no_trailing_slash(clients: AsyncClient):
+    """A base pinned to a full resource (…/v1/charges) must relay AS-IS: Stripe 404s `/v1/charges/`."""
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    r = await clients.post("/call/stripe", headers=_h(pub), content="amount=1")
+    assert r.status_code == 200, r.text
+    assert r.json()["raw_path"] == "/v1/charges"
+
+
+# ---- the lockdown -------------------------------------------------------------------------
+async def test_public_token_reads_but_cannot_mutate(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    assert (await clients.get("/tools", headers=_h(pub))).status_code == 200
+    assert (await clients.get("/secrets", headers=_h(pub))).status_code == 200
+    for method, path, payload in [
+        ("post", "/secrets", {"name": "EVIL", "value": "x"}),
+        ("post", "/tools", {"name": "exfil", "base_url": "http://attacker.example"}),
+        ("post", f"/orgs/{org_id}/leave", None),
+        ("delete", f"/orgs/{org_id}", None),
+        ("post", f"/orgs/{org_id}/public-token", None),  # can't rotate itself
+    ]:
+        r = await getattr(clients, method)(path, headers=_h(pub), **({"json": payload} if payload else {}))
+        assert r.status_code == 403, f"{method} {path} → {r.status_code}: {r.text}"
+
+
+async def test_public_token_cannot_act_as_a_user(clients: AsyncClient):
+    """The user-level escape hatches: minting an identity token or creating a real org."""
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    assert (await clients.get("/auth/cli-token", headers=_h(pub))).status_code == 403
+    assert (await clients.post("/orgs", headers=_h(pub), json={"name": "escape"})).status_code == 403
+
+
+async def test_owner_keeps_full_control_of_a_public_demo_org(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    await _mint_public(clients, org_id)
+    # the owner's own token still mutates freely — the lockdown is role-scoped, not org-wide
+    r = await clients.post("/secrets", json={"name": "ANOTHER", "value": "y"})
+    assert r.status_code == 200, r.text
+
+
+# ---- rotation + revocation ----------------------------------------------------------------
+async def test_reminting_rotates_the_token(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    old = await _mint_public(clients, org_id)
+    new = await _mint_public(clients, org_id)
+    assert (await clients.get("/tools", headers=_h(old))).status_code == 401
+    assert (await clients.get("/tools", headers=_h(new))).status_code == 200
+
+
+async def test_delete_revokes_and_unlocks(clients: AsyncClient):
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    r = await clients.delete(f"/orgs/{org_id}/public-token")
+    assert r.status_code == 200
+    assert (await clients.get("/tools", headers=_h(pub))).status_code == 401  # membership gone
+    # the org is a normal team again (flag off) — owner unaffected throughout
+    org = next(o for o in (await clients.get("/orgs")).json() if o["org_id"] == org_id)
+    assert org["slug"]  # still listed
+
+
+# ---- per-IP rate limit on /call -----------------------------------------------------------
+async def test_public_calls_are_rate_limited_per_ip(clients: AsyncClient, monkeypatch):
+    org_id = await _org_with_stripe_tool(clients)
+    pub = await _mint_public(clients, org_id)
+    monkeypatch.setattr(api_mod, "PUBLIC_DEMO_RATE_MAX", 3)
+    for _ in range(3):
+        assert (await clients.post("/call/stripe", headers=_h(pub), content="a=1")).status_code == 200
+    r = await clients.post("/call/stripe", headers=_h(pub), content="a=1")
+    assert r.status_code == 429
+    # the owner's own calls are NOT metered by the public limiter
+    assert (await clients.post("/call/stripe", content="a=1")).status_code == 200


### PR DESCRIPTION
## What

The landing sandbox's seeded stripe tool becomes **one real wire**: a fingerprint-matched call (exact pinned base `https://api.stripe.com/v1/charges`) relays to Stripe's test API with a restricted key injected from env. Every other sandbox call still synthesizes, exactly as before. Real charges flow back to the page via a signature-verified Stripe webhook → in-memory ring buffer → SSE ticker, each row linking to its `pay.stripe.com` receipt as third-party proof.

The "Try it live" section gains a view mode: a compact **Live vault** window (Stripe-badged bundle, statuses pinned right) above a call panel (curl / treg CLI tabs, live feed, per-visitor identity). ✎ edit swaps the vault window for the original studio; with the wire off (no env key) the section is the untouched original.

## Security model

- The Stripe key exists **only** in `TREG_DEMO_STRIPE_KEY` — never in any `Secret` row — so no read/export/grant path can return it
- Tampered or lookalike tools silently fall back to `synthesize()`; the seeded live tool + `STRIPE_KEY` are frozen (403 on edit/delete)
- The relay stamps `metadata[visitor]` (wordlist name derived from the sandbox slug) over anything the caller sent; the feed displays only wordlist-gated names + server-chosen fields — visitor-typed text can never reach the page
- Live calls are per-IP rate-limited (DB-backed sliding window); receipt links pass through only if `pay.stripe.com`-hosted
- Blast-radius backstop: the key is a test-mode restricted key (Charges only)

## Also included

- `public_demo` org lockdown: publishable call-only viewer tokens (`POST/DELETE /orgs/{id}/public-token`, mint = rotate), enforced at both `require_member` and `require_identity` layers
- `_resolve_call` trailing-slash fix: empty named-call path relays the pinned base as-is (Stripe 404s `/v1/charges/`)

## Deploy

Set `TREG_DEMO_STRIPE_KEY` + `TREG_DEMO_STRIPE_WEBHOOK_SECRET` on Render (already declared `sync:false` in render.yaml); Stripe sandbox webhook for `charge.succeeded` → `/stripe/webhook`. Unset = feature fully dark.

## Testing

44 new tests (live-wire fingerprint/tamper/rate-limit, webhook signatures, wordlist gating, receipt allowlist, public-token lockdown); full suite 568 passing. Verified end-to-end locally against the real Stripe sandbox, including live SSE updates in-browser. Code-simplifier pass applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)