### PR TITLE
fix(cli): treg call — stop dropping inline ?query, add --upload for file uploads

### DIFF
--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -33,7 +33,7 @@ import time
 import webbrowser
 from collections import deque
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import parse_qsl, quote
 
 import httpx
 
@@ -1975,6 +1975,14 @@ def cmd_call(args, cfg) -> None:
     rest = args.target.rstrip("/")
     if args.path:
         rest += "/" + args.path.lstrip("/")
+    # httpx DROPS a URL's existing query string whenever params= is passed (even an empty list), so
+    # an inline `?a=b` written into the path/target would silently vanish — the upstream gets no
+    # query and returns default/wrong data with NO error (Meta's Graph API reads params from the
+    # query string, so `me/adaccounts?fields=…` came back with only ids). Pull any inline query out
+    # and merge it into params so inline and --query compose identically.
+    if "?" in rest:
+        rest, _, inline = rest.partition("?")
+        params = list(parse_qsl(inline, keep_blank_values=True)) + params
     with _client(cfg) as c:
         _show(c.request(args.method, f"/call/{rest}", params=params, content=content, headers=headers))
 

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -1949,10 +1949,36 @@ def cmd_call(args, cfg) -> None:
     # A LIST of pairs (not a dict) so repeated --query keys (?tag=a&tag=b) survive to the upstream —
     # httpx serializes a list of tuples preserving duplicates; a dict would drop all but the last.
     params = [tuple(kv.split("=", 1)) for kv in args.query]
+    # --upload builds a multipart/form-data body. Meta (adimages/advideos), S3, and most upload APIs
+    # require multipart with a real file PART — `--file` sends a single raw body, which they reject,
+    # and cramming a file into a base64 query param dies on argv/URL length for any real asset. httpx
+    # sets the multipart content-type + boundary; the proxy streams the body raw and injects
+    # credentials into headers, so the part travels through untouched.
+    upload_files: list[tuple[str, tuple]] = []
+    for kv in args.upload:
+        if "=" not in kv:
+            sys.exit(f"--upload expects NAME=@/path (or NAME=value), got: {kv!r}")
+        name, _, val = kv.partition("=")
+        if val.startswith("@"):
+            p = Path(val[1:]).expanduser()
+            if not p.is_file():
+                sys.exit(f"--upload file not found: {p}")
+            upload_files.append((name, (p.name, p.read_bytes())))
+        else:
+            upload_files.append((name, (None, val.encode())))  # a plain (non-file) form field
     content = Path(args.file).read_bytes() if args.file else (args.data.encode() if args.data else None)
-    # Content-Type: explicit flag wins; otherwise sniff JSON so `--data '{...}'` / `--file doc.json`
-    # reach upstreams that require `application/json` (e.g. npm publish) without extra flags.
-    ctype = args.content_type
+    upload_ctype = None
+    if upload_files:
+        # Encode the multipart body EAGERLY (not httpx's streaming files=): _RegistryClient's
+        # WAF-retry reads request.content, which a streaming request can't provide (RequestNotRead).
+        # A materialised body is a normal read request and carries the boundary in its content-type.
+        _enc = httpx.Request("POST", "http://local/", files=upload_files)
+        _enc.read()
+        content = _enc.content
+        upload_ctype = _enc.headers["content-type"]  # multipart/form-data; boundary=…
+    # Content-Type: --upload's multipart type wins; else explicit flag; else sniff JSON so
+    # `--data '{...}'` / `--file doc.json` reach upstreams that require `application/json`.
+    ctype = upload_ctype or args.content_type
     if ctype is None and content:
         try:
             json.loads(content)
@@ -3273,6 +3299,10 @@ def build_parser() -> argparse.ArgumentParser:
     cl.add_argument("--header", action="append", default=[], metavar="'K: V'",
                     help="an extra request header (repeatable), e.g. --header 'login-customer-id: 1234567890'. "
                          "Injected credentials always win.")
+    cl.add_argument("--upload", action="append", default=[], metavar="NAME=@FILE",
+                    help="a multipart/form-data part (repeatable): NAME=@/path/to/file for a file, or "
+                         "NAME=value for a plain field. Use for real file uploads (e.g. Meta adimages) — "
+                         "--file sends a single raw body that most upload APIs reject.")
     cl.set_defaults(fn=cmd_call)
 
     ca = mk(sub, "calls", "Show the audit log: who called what, when, and the result.", "treg calls --limit 20")

--- a/tests/test_cli_call_query.py
+++ b/tests/test_cli_call_query.py
@@ -24,7 +24,8 @@ def _capture(monkeypatch):
 
         def request(self, method, url, params=None, content=None, headers=None):
             # Build the same way httpx.Client would, so the query-merge behaviour is exercised.
-            req = httpx.Request(method, httpx.URL("http://t").join(url), params=params)
+            req = httpx.Request(method, httpx.URL("http://t").join(url), params=params,
+                                content=content, headers=headers)
             seen.append(req)
             return httpx.Response(200, json={})
 
@@ -33,10 +34,10 @@ def _capture(monkeypatch):
     return seen
 
 
-def _args(target, path="", query=None):
+def _args(target, path="", query=None, upload=None, method="GET"):
     return SimpleNamespace(
-        target=target, path=path, method="GET", query=query or [],
-        data=None, file=None, content_type=None, header=[],
+        target=target, path=path, method=method, query=query or [],
+        data=None, file=None, content_type=None, header=[], upload=upload or [],
     )
 
 
@@ -57,3 +58,15 @@ def test_no_query_still_clean(monkeypatch):
     seen = _capture(monkeypatch)
     cli.cmd_call(_args("meta-ads", "act_1/campaigns"), {})
     assert not seen[0].url.params and seen[0].url.path == "/call/meta-ads/act_1/campaigns"
+
+
+def test_upload_builds_multipart_body(monkeypatch, tmp_path):
+    img = tmp_path / "ad.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"FAKEIMAGEDATA" * 100)
+    seen = _capture(monkeypatch)
+    cli.cmd_call(_args("meta-ads", "act_1/adimages", upload=[f"filename=@{img}"], method="POST"), {})
+    req = seen[0]
+    ct = req.headers.get("content-type", "")
+    assert ct.startswith("multipart/form-data; boundary=")
+    body = req.content
+    assert b"FAKEIMAGEDATA" in body and b'name="filename"' in body and b'filename="ad.png"' in body

--- a/tests/test_cli_call_query.py
+++ b/tests/test_cli_call_query.py
@@ -1,0 +1,59 @@
+"""cmd_call must not lose an inline `?query` written into the path.
+
+httpx drops a URL's existing query string whenever params= is passed (even []), so before the fix
+`treg call meta-ads "act_1?fields=name"` reached the proxy with NO query — the upstream returned
+default/wrong data with no error. These tests capture the request cmd_call actually builds.
+"""
+from types import SimpleNamespace
+
+import httpx
+
+from treg import cli
+
+
+def _capture(monkeypatch):
+    """Swap cmd_call's client + output sink for captures; return the list the URL lands in."""
+    seen: list[httpx.Request] = []
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def request(self, method, url, params=None, content=None, headers=None):
+            # Build the same way httpx.Client would, so the query-merge behaviour is exercised.
+            req = httpx.Request(method, httpx.URL("http://t").join(url), params=params)
+            seen.append(req)
+            return httpx.Response(200, json={})
+
+    monkeypatch.setattr(cli, "_client", lambda cfg, **k: FakeClient())
+    monkeypatch.setattr(cli, "_show", lambda resp: None)
+    return seen
+
+
+def _args(target, path="", query=None):
+    return SimpleNamespace(
+        target=target, path=path, method="GET", query=query or [],
+        data=None, file=None, content_type=None, header=[],
+    )
+
+
+def test_inline_query_is_not_dropped(monkeypatch):
+    seen = _capture(monkeypatch)
+    cli.cmd_call(_args("meta-ads", "act_1?fields=name,currency"), {})
+    assert seen[0].url.params.get("fields") == "name,currency"
+
+
+def test_inline_query_composes_with_query_flag(monkeypatch):
+    seen = _capture(monkeypatch)
+    cli.cmd_call(_args("meta-ads", "act_1/campaigns?fields=name,status", query=["limit=2"]), {})
+    p = seen[0].url.params
+    assert p.get("fields") == "name,status" and p.get("limit") == "2"
+
+
+def test_no_query_still_clean(monkeypatch):
+    seen = _capture(monkeypatch)
+    cli.cmd_call(_args("meta-ads", "act_1/campaigns"), {})
+    assert not seen[0].url.params and seen[0].url.path == "/call/meta-ads/act_1/campaigns"


### PR DESCRIPTION
Two `treg call` fixes surfaced by Meta Ads testing — both in the request path, both verified live against production.

## 1. Inline `?query` silently dropped (bug)
`httpx` discards a URL's query string whenever `params=` is passed (even `[]`), so `treg call meta-ads "act_.../adaccounts?fields=name"` reached the proxy with **no query** and got default/wrong data with **no error** — the worst failure class. Affects every provider (`treg call posthog "api/events?limit=5"` dropped `limit=5` too). Fix: pull inline `?query` out of the path and merge into `params`.

## 2. No file-upload support (missing feature) — "not great at uploading assets"
`treg call` could not upload real ad creative. `--file` sends a single raw body Meta rejects; a base64 blob in `--query` dies on argv/URL length above a few KB; video was impossible. **New `--upload NAME=@/path`** builds a proper multipart/form-data part. The proxy already streams the body raw and injects credentials into headers, so the fix is CLI-only.

## Verified live against production
- Inline: `act_.../?fields=name,currency` → was `{account_id,id}`, now `{name,currency,id}`; composes with `--query`.
- Upload: an **885 KB** image that failed `--file`, `--data`, and `--query bytes` uploaded cleanly via `--upload` and returned an image hash.

## Tests
`tests/test_cli_call_query.py` — inline survives / composes / no-query clean / multipart body built. 673 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)