### PR TITLE
docs(context): sync design fragments to current main

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -16,7 +16,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
-| [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, health.py |
+| [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, ratestore.py |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |
 | [Multi-tenancy — orgs, memberships, invites, per-org scoping](architecture/multi-tenancy.md) | shipped | models.py, api.py, db.py |
@@ -31,7 +31,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [The CLI (treg) + skill scaffolding](interface/cli.md) | shipped | cli.py, convert.py |
 | [The web dashboard (Ledger, served from FastAPI)](interface/dashboard.md) | shipped | index.html, tutorial.js, tutorial.html, tour.js, … |
 | [Import — scan a .env AND/OR a skills dir, auto-register as tools + bundles](interface/env-import.md) | in-progress | providers.py, skills.py |
-| [Landing sandbox studio — anonymous try-it, hosted skills, CLI installer](interface/landing-sandbox.md) | shipped | sandbox.py, api.py, index.html, install.sh |
+| [Landing sandbox studio — anonymous try-it, hosted skills, CLI installer](interface/landing-sandbox.md) | shipped | sandbox.py, pubfeed.py, api.py, index.html, … |
 | [Onboarding — the first-run demo team (dashboard + CLI)](interface/onboarding.md) | shipped | demo.py, cli.py, index.html |
 | [Shell mode (treg shell) — transparent CLI interception](interface/shell.md) | shipped | shell.py, cli.py |
 | [The shippable tools-registry skill (3 personas)](interface/skill.md) | shipped | skill.md |

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -5,6 +5,7 @@ sources:
   - src/treg/injectors.py
   - src/treg/crypto.py
   - src/treg/oauth.py
+  - src/treg/oauth_providers.py
   - src/treg/health.py
 related:
   - architecture/proxy-model.md
@@ -55,10 +56,61 @@ provider that omits `expires_in` doesn't force a refresh on every call), coerces
 and raises a clear error when a 200 body carries no `access_token`; `_expires_at` treats a naive ISO
 `expiry` as UTC.
 
+`refresh()` posts the credential's recorded `client_id_param` dialect (TikTok reads `client_key`, not
+`client_id`), snapshotted onto the blob at mint time so a refresh months later still speaks the dialect
+the grant was minted with.
+
 **Connect flow (mint the first token):** `consent_url(pending)` builds the provider consent URL
-(`access_type=offline` + `prompt=consent` so a refresh token comes back); `exchange_code(pending, code,
-client)` trades the auth code for tokens and returns a self-refreshable blob. Driven by the
-`/oauth/*` endpoints ([interface/api.md](../interface/api.md)).
+(default `access_type=offline` + `prompt=consent` so a refresh token comes back); `exchange_code(pending,
+code, client)` trades the auth code for tokens and returns a self-refreshable blob. Both honor
+per-provider quirks carried on the `PendingOAuth` (snapshotted from the registry entry, below): a provider's
+`auth_params` **replaces** the Google defaults entirely (LinkedIn/X/TikTok/Meta reject `access_type`);
+PKCE (`pkce_challenge()` — X requires a verifier); `token_endpoint_auth_method` = `client_secret_basic`
+(X puts the secret in HTTP Basic, not the body); the `client_id_param`/`scope_separator` dialect; and
+`long_lived_exchange` (`_extend_meta_token()` swaps Meta's ~1-hour code-exchange token for its ~60-day
+one, non-fatal on failure). Driven by the `/oauth/*` endpoints ([interface/api.md](../interface/api.md)).
+
+**Expiry as a separate axis (`expiry_of` / `expiry_state` / `connection_view`).** Health answers "does
+this credential work"; expiry answers "how long will it keep working" — different questions for a
+**non-refreshable** token (a LinkedIn non-partner token reads healthy right up until it silently dies at
+~60 days). `secret_is_refreshable(secret)` decrypts server-side (blob never leaves the function) to tell
+auto from manual; `expiry_state(expires_at, refreshable)` returns `fresh|expiring|expired|unknown` — a
+refreshable credential is **always** `fresh` (treg mints on demand, so the user is never nagged), only an
+unrenewable one earns a warning (`EXPIRING_SOON_DAYS=7`). `connection_view()` is the metadata-only shape
+(no token material) the dashboard/CLI read, with a single actionable `needs_reconnect` flag.
+
+## Curated OAuth provider registry (`oauth_providers.py`)
+Two ways to connect a provider. **Bring-your-own (BYO):** `POST /oauth/start` takes a caller-supplied
+`client_id`/`client_secret`/URIs — works for any OAuth2 provider. **Curated:** for the providers where
+**treg itself holds the approved app** (Google Search Console/Analytics/Business Profile/Ads, YouTube,
+LinkedIn, X, TikTok, Facebook, Instagram, Meta Ads — added PRs #20/#21), the user picks a provider and
+consents, supplying nothing. The asymmetry is the point of a hosted registry: the gating cost on these
+platforms is the *approval* (a Google Ads developer token, Meta App Review), not the OAuth dance — treg
+has already cleared it. treg's own client id/secret load from `Settings` (named by
+`client_id_setting`/`client_secret_setting`, so they come from `.env` like every other setting).
+
+Each entry is a frozen `OAuthProvider` dataclass; `REGISTRY` is the `{service: provider}` map. Key
+module symbols:
+- `get(service)` — look up one provider. `credentials(provider)` — treg's own id/secret (raises if this
+  deployment hasn't set them). `is_configured(provider)` — whether this deployment can offer it (a
+  `token`-kind provider needs nothing from treg, so always offerable).
+- `listing()` — the marketplace payload (`GET /oauth/providers`): every provider, grouped by
+  `CATEGORY_ORDER`, each flagged `configured`, with per-capability scopes already in plain English via
+  `scope_label()`/`SCOPE_LABELS` (a lookup keyed by the raw scope string;
+  `test_every_requested_scope_has_a_plain_english_label` guards it).
+- **Scopes are per CAPABILITY, not per provider** (`scopes: dict[capability -> list[scope]]`). Capabilities
+  are cumulative supersets (write ⊇ read); `default_capability` is the **broadest** (an agent product needs
+  write eventually, so one honest consent screen beats connecting twice). `scopes_for()` /
+  `satisfied_capabilities()` decide when a later capability needs a re-consent.
+- `auth_kind` = `"oauth"` (treg's app) or `"token"` (Slack — a workspace-scoped bot the user creates from a
+  pre-filled manifest and pastes; `is_token_kind`). `can_autoprovision` (has a `base_url` and either needs no
+  second credential or treg holds it) drives auto-building a callable tool on a successful connect;
+  `needs_extra_credential` covers Google Ads' `developer-token` header (a second binding the operator supplies).
+- Post-connect helpers the dashboard/CLI drive: resource **discovery** (`supports_discovery`,
+  `discover_*` — which site/property/account this connection acts on), row **enrichment**
+  (`supports_enrichment`, `enrich_*` — Google Ads returns bare ids, so a per-row lookup fills the human name),
+  and **identity** (`has_identity`, `identity_*` — providers with nothing to pick, like LinkedIn/X/TikTok,
+  capture who consented instead). A `probe_path` gives registry tools a real health check.
 
 ## Credential health (`health.py`)
 `run_all(db, client, org_id=None)` iterates tools (filtered to `org_id` when set, so `/health/run` never
@@ -81,7 +133,13 @@ probe just marked `invalid`), a transport error / `5xx` / `429` maps to `unknown
 + webhook spam), an injection failure maps to `invalid`, and only secrets **evaluated this run** are
 notified/reported. The run also calls `gc_expired_invites(db, org_id)` + `gc_stale_pending_oauth(db,
 org_id)` (abandoned OAuth connects hold an encrypted client_secret + a replayable `state`, so they
-expire after `OAUTH_PENDING_TTL_MIN`).
+expire after `OAUTH_PENDING_TTL_MIN`). Alongside the probe verdicts the run sweeps an **expiring** list
+over **every** oauth secret via `needs_reconnect()` (built on `oauth.expiry_state`) — not just the ones a
+tool probe touched — because an unbound, unprobed, perfectly-healthy credential can still be days from
+silent death (the LinkedIn shape). `_view()` now carries `provider`/`refreshable`/`expiry_state`/`expires_at`
+so the caller sees both axes. `_probe()` merges a binding's query onto the URL with `copy_add_param` rather
+than passing `params=` (httpx would otherwise **replace** a probe path's own query string, e.g. YouTube's
+`?part=snippet&mine=true`, and fail a healthy credential).
 
 ## Storage / security posture (MVP)
 TLS-only in transit (paste/upload over https, like GitHub/Vercel secrets); Fernet at rest. Per-membership

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -19,7 +19,9 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
 
 - **`Org`** — the tenant that owns resources: `id, name, slug` (unique), `suspended` (admin lock),
   `demo` (a sandbox team seeded by [onboarding](../interface/onboarding.md) — labeled + removable),
-  `created_at`.
+  `public_demo` (a team whose member token is PUBLISHED, e.g. on the landing page — non-admin members
+  are locked to `/call` + reads and may never act as a user; gated in `api.require_member` /
+  `require_identity`), `created_at`.
 - **`User`** — a **global identity** only: `email` (unique), `is_superadmin` + `suspended` (platform
   flags, see [super-admin](super-admin.md)), `token_version` (bump to revoke every session cookie +
   identity token this user holds — the signed token carries the `tv` it was minted at; see `sess.make`
@@ -40,7 +42,14 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   (`env` | `secret_file` | `oauth` | `cli_auth` | `param`), `value` (**Fernet-encrypted at rest**, never
   returned), `bundle_id` (FK), and health fields `health_status` (`unknown`|`ok`|`invalid`) /
   `health_detail` / `health_checked_at`. `param` is a non-secret value (project/org id) injected like a
-  secret but never health-checked.
+  secret but never health-checked. **Connection metadata** (set for registry-minted OAuth connects — see
+  the OAuth marketplace / `oauth_providers.py`; empty for uploaded or bring-your-own-app credentials):
+  `provider` (**indexed** — which curated registry provider minted it), `granted_scopes` (space-joined,
+  what the user ACTUALLY consented to), `resource_ref` + `resource_name` (the chosen site/property/account
+  this connection acts on, plus its human label since upstream ids are opaque). **Expiry is a separate
+  axis from `health_status`** — `health` says "does it work", expiry says "how long will it keep working"
+  (a non-refreshable token stays healthy right up until it silently dies): `expires_at`, `last_refresh_at`,
+  `last_error`.
 - **`Tool`** — a callable capability: `org_id` (FK, idx), `name` (**unique per `(org_id, name)`**),
   `owner`, `base_url`, `host` (netloc of base_url, **indexed** for URL-passthrough resolution),
   `bindings` (a **JSON list** — see below), `health_check` (optional JSON), `examples` (optional JSON
@@ -56,7 +65,15 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
 
 - **`PendingOAuth`** — an in-flight connect flow: `org_id` (FK), `state` (unique, the CSRF/lookup key),
   `client_id`, `client_secret` (encrypted), `auth_uri`, `token_uri`, `scopes`, `redirect_uri`, `status`
-  (`pending`|`done`|`error`), `secret_id` (the secret created on success), `detail`.
+  (`pending`|`done`|`error`), `secret_id` (the secret created on success), `detail`. **Marketplace/quirk
+  fields**, all defaulted, carried through the redirect so the callback exchanges the code exactly the way
+  the consent URL was built: `provider` (which curated registry provider this connect is for — `""` for a
+  bring-your-own-app connect), `code_verifier` (PKCE; `""` = unused), `auth_params` (JSON of extra
+  consent-URL query params), `token_endpoint_auth_method` (`client_secret_post` default),
+  `client_id_param` + `scope_separator` (TikTok spells the client id `client_key` and comma-joins scopes),
+  `long_lived_exchange` (Meta only — swap the short-lived token for a ~60-day one before storing), and
+  `replaces_secret_id` (which existing connection this consent REPLACES — null = add a new one, so the
+  callback no longer has to blanket-replace by provider).
 - **`CallRecord`** — the proxied-call audit row: `org_id`, `user_email`, `tool_name`, `method`, `path`,
   `status_code`, `kind` (**`call`** = proxy `/call`, **`local_run`** = `/tools/{name}/grant`), `created_at`.
 - **`RunRecord`** — the **server-side run** audit row (a `treg run --server` CLI execution — the "kind"
@@ -85,8 +102,13 @@ The API builds a single-binding tool from flat fields via `_flat_binding()`; inj
 One async SQLAlchemy engine (`_engine`) + a public `session_maker` (the audit writer opens its own
 session here). `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` —
 see [multi-tenancy](multi-tenancy.md)); that migration also does the small additive `ADD COLUMN` steps for
-columns added after a table shipped (e.g. `tool.examples`, and `tool.cli` for local runs — guarded by a
-column-existence check, so it is idempotent on both SQLite and Postgres). `reset_db()` is test-only (drop +
+columns added after a table shipped (e.g. `tool.examples`, `tool.cli` for local runs, `org.public_demo`
+(A15), the seven `secret` connection-metadata columns (A16), and the eight `pendingoauth` marketplace/quirk
+columns (A17–A20) — guarded by a column-existence check, so it is idempotent on both SQLite and Postgres).
+**Postgres BOOLEAN default fix:** boolean columns added here use `DEFAULT false`, never `DEFAULT 0` —
+Postgres rejects an integer default on a `BOOLEAN` column (SQLite accepts both, so the test suite alone
+cannot catch it), which is why `pendingoauth.long_lived_exchange` is spelled `BOOLEAN NOT NULL DEFAULT
+false`. `reset_db()` is test-only (drop +
 recreate); `get_session()` is the FastAPI dependency. SQLite locally (`aiosqlite`), Postgres on Render, same code. **Timestamps are
 naive UTC:** `_now()` (the `created_at` default) drops tzinfo because the columns are `TIMESTAMP WITHOUT
 TIME ZONE` and asyncpg rejects tz-aware values on Postgres; the app compares naive UTC throughout

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -19,7 +19,10 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
 `docs/MULTI-TENANCY-PLAN.md` (standalone plan).
 
 ## The model (`models.py`)
-- **`Org`** — `id, name, slug (unique), created_at`. The tenant that owns secrets/tools/bundles.
+- **`Org`** — `id, name, slug (unique), suspended, demo, public_demo, created_at`. The tenant that owns
+  secrets/tools/bundles. **`public_demo`** marks a team whose member token is PUBLISHED (e.g. on the
+  landing page): non-admin members are locked to `/call` + reads and may never act as a user — enforced in
+  `require_member` / `require_identity`.
 - **`User`** — identity only: `id, email (unique), created_at`. No token, no role.
 - **`Membership`** — `user_id, org_id, role (owner|admin|member|viewer), token_hash (idx), webhook_url,
   daily_call_cap` (per-user daily usage cap; `-1` = unlimited, admin-set — see the API fragment's
@@ -117,7 +120,16 @@ silently drops them and, because a re-run short-circuits, permanently 500s every
 upgrade. (`"user"` is quoted in the `ALTER` — a reserved word in Postgres, where this runs in-place.)
 (A12) adds `tool_access` (JSON, nullable) + `local_run_enabled` (`BOOLEAN NOT NULL DEFAULT true`) to
 **both** `membership` and `invite`; the legacy owner-backfill INSERT names `local_run_enabled` explicitly
-(create_all builds it NOT NULL with no server default). Verified in-place on Postgres.
+(create_all builds it NOT NULL with no server default). Verified in-place on Postgres. Later additive steps
+follow the same guarded pattern: (A14) `invite.landing`, (A15) `org.public_demo`, (A16) the seven `secret`
+connection-metadata columns (`provider`/`granted_scopes`/`resource_ref`/`resource_name`/`expires_at`/
+`last_refresh_at`/`last_error`), and (A17–A20) the eight `pendingoauth` OAuth-marketplace/quirk columns
+(`provider`/`code_verifier`/`auth_params`/`token_endpoint_auth_method`/`client_id_param`/`scope_separator`/
+`long_lived_exchange`/`replaces_secret_id`). **Postgres BOOLEAN default fix (PR #22):** every boolean added
+in-place uses `DEFAULT false`, never `DEFAULT 0` — Postgres rejects an integer default on a `BOOLEAN`
+column (SQLite accepts both, so the test suite alone cannot catch it); `pendingoauth.long_lived_exchange`
+is spelled `BOOLEAN NOT NULL DEFAULT false`, and the legacy `INSERT INTO org (…)` backfill names
+`public_demo` explicitly with a `false` literal.
 
 > Health (`run_all`) takes an `org_id` filter so `/health/run` never leaks other orgs' credentials, and
 > alerts resolve the owner's per-org membership webhook. See [auth-secrets](auth-secrets.md).

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -47,6 +47,18 @@ Faithfulness mechanics inside `relay()`:
 A request may carry several credentials: `relay()` loops `tool.bindings` and calls
 `injectors.inject(headers, params, binding, crypto.decrypt(secret.value))` per binding.
 
+**Platform bindings — injecting treg's OWN credential.** A binding with a `platform_setting` key (instead
+of a `secret_id`) injects one of treg's own credentials read from `get_settings()` — the Google Ads
+developer token is the case that exists. The value never lives in the org's secret store, so a tenant
+can't read it or extract it through a local run; a missing setting is a clean `502`
+(`this server has no <setting> configured`). Used by the OAuth-marketplace auto-provisioner for a provider
+that needs a second credential treg holds centrally (see [api](../interface/api.md)).
+
+**Accept-Encoding is normalized to `identity`** when the caller sent none. `relay()` streams the upstream
+body raw (`aiter_raw`), so if the caller doesn't ask for compression httpx would otherwise add its own
+`Accept-Encoding: gzip` and hand a plain HTTP client / agent compressed bytes it never requested. Asking
+for `identity` keeps what the caller receives matching what the caller requested.
+
 ## Tool resolution (`_resolve_call` in api.py)
 `* /call/{rest:path}` → `call_tool()` → `_resolve_call(rest, caller.org_id, db)` returns
 `(tool, upstream_url)`. **Both shapes are scoped to the caller's org** (`Tool.org_id == org_id`), so two
@@ -58,7 +70,8 @@ same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the pe
   by **host** (`_host_of()` = `urlsplit(...).netloc`, matched against the indexed `Tool.host`) then the
   **longest `base_url` prefix**; a tie → `409`, no match → `404`.
 - **Named:** `rest = "<tool>/<path>"` (`rest.partition("/")`), looked up by `Tool.name`; upstream URL =
-  `base_url + path`.
+  `base_url + path`. **No path → the base URL itself, without a trailing slash** — a tool pinned to a
+  full resource (`.../v1/charges`) must relay as-is, since Stripe `404`s `/v1/charges/`.
 
 `call_tool()` loads every bound secret (running `oauth.ensure_fresh` on oauth secrets first — see
 [auth-secrets](auth-secrets.md)), calls `relay()`, then fires `audit.record_call(...)` off the response
@@ -67,7 +80,11 @@ path. Methods allowed: GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
 **Resolution + error hardening:** the URL-passthrough prefix match respects a **path-segment boundary**
 (`norm == base` or `base + "/"`), so `.../v1` no longer matches `.../v10/...` and inject the wrong
 credential; the longest-prefix tiebreak compares rstripped lengths (a trailing-slash duplicate is a real
-`409`, not a silent winner). Binding validity is checked at **registration** (`_validate_bindings` rejects
+`409`, not a silent winner). When two same-host tools still tie on prefix length, `_resolve_call`
+**prefers the registry-provider-backed tool** (one whose binding points at a `Secret` with a `provider`)
+over a hand-registered one that often holds a stale credential — a `409` there would break exactly the
+agent-facing URL-passthrough callers who never typed a tool name; only a genuine ambiguity (neither or
+both provider-owned) still `409`s. Binding validity is checked at **registration** (`_validate_bindings` rejects
 an unknown `injector` and a cross-org/dangling `secret_id`; `register_skill` runs the same gate), and
 `call_tool` translates a call-time injector `ValueError` and an upstream `httpx.RequestError` into a
 `502` instead of an unhandled 500 (and audits the failed attempt, not just successes). A binding

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -218,16 +218,46 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `web/llms.txt` as `text/plain` with `{BASE}` templated from `public_url` — the [llms.txt](https://llmstxt.org)
   agent-onboarding file (call protocol + discovery + auth + CLI + skills + doc links). See [dashboard](dashboard.md).
   `install_sh` (`GET /install.sh`, `{BASE}`-templated) serves the CLI installer (`web/install.sh`).
+  `terms_page` (`GET /terms`) + `privacy_page` (`GET /privacy`) serve the hosted registry's legal pages
+  (`_legal_page`, no-cache) with `legal_css` (`GET /legal.css`) as the shared skin — `/privacy` is also
+  the URL given to OAuth providers at app-verification time, so don't rename it. Provider brand marks are
+  mounted at `/logos` (`StaticFiles` over `web/logos/`, resolved by convention `logos/<service>.svg`).
+  `dashboard_marketplace` (`GET /app/marketplace/{service}`) serves the plain SPA (a connect page is only
+  meaningful to a signed-in member, so no OG meta).
   `_serve_md` backs `quickstart_md` (`GET /quickstart.md`) + `tutorial_md` (`GET /tutorial.md`) —
   `{BASE}`-templated markdown served as inline `text/plain` (so "open in new tab" shows it, not a
   download); the docs pages' **Copy markdown** dropdowns (copy / open-in-tab) fetch these.
   Browser-facing auth pages (GitHub callback, OAuth-connect result) render via `_auth_page` (brand card).
 - **Landing sandbox + hosted skills:** `demo_sandbox_mint` (`POST /demo/sandbox`, open, per-IP
-  rate-limited) mints an anonymous throwaway team; `demo_sandbox_skill` (`GET /demo/sandbox/skill`)
-  exports what the visitor built. `skill_samples` (`GET /skills/samples`, open) + `skill_install`
+  rate-limited) mints an anonymous throwaway team (its response now carries `live` = whether the seeded
+  stripe tool is a real wire); `demo_sandbox_skill` (`GET /demo/sandbox/skill`) exports what the visitor
+  built. `skill_samples` (`GET /skills/samples`, open) + `skill_install`
   (`GET /skills/{name}/install.sh?token=`) host sample skills. `call_tool` short-circuits **sandbox**
   orgs to `sandbox.synthesize` (real injection, no network). Caps via `_enforce_sandbox_cap`. Full
   behavior: [landing-sandbox](landing-sandbox.md).
+  - **The one live wire (real Stripe demo).** When `demo_stripe_key` is set, a sandbox call to the exact
+    seeded `stripe` tool (fingerprint-matched by `demo_sandbox.is_live_tool`, GET/POST only) is relayed
+    for real to Stripe's test API via `_relay_live_demo` — a deliberately narrower relay: the auth header
+    is built from the env key (never from a sandbox secret, which doesn't hold it), the body is
+    form-encoded, and `metadata[visitor]` is overridden server-side. Metered per client IP
+    (`_enforce_public_demo_ip_cap`) since the wire is one shared credential. `demo_sandbox_live`
+    (`GET /demo/sandbox/live`) reports `live` + the visitor's feed name for an existing sandbox.
+    `_require_not_live_demo_tool`/`_require_not_live_demo_secret` freeze the seeded `stripe` tool and its
+    `STRIPE_KEY` against edit/delete so a visitor can't break their own live pane. The public payments
+    feed: `stripe_webhook` (`POST /stripe/webhook`, 404 when `demo_stripe_webhook_secret` unset, verifies
+    the signature via `pubfeed.verify_signature`, pushes a `charge.succeeded` into `pubfeed.push_charge`)
+    and `landing_stripe_feed` (`GET /landing/stripe-feed`, unauthenticated SSE via `pubfeed.stream`,
+    server-chosen fields only).
+- **Public demo token (publishable, call-only credential):** `create_public_token`
+  (`POST /orgs/{id}/public-token`, owner-only) flips the org to `public_demo` and mints a **viewer-role**
+  token bound to a dedicated can't-log-in identity (`pub-<slug>@public-demo.treg.local`) — safe to print
+  on a web page. Re-POSTing **rotates** (instant revocation of the old one); `delete_public_token`
+  (`DELETE …`) revokes and lifts the lockdown. **Lockdown is centralized in the auth deps:** when
+  `org.public_demo` and the role is below admin, `require_member` allows only `/call/*` + GET/HEAD/OPTIONS
+  (every mutation is frozen no matter what routes are added later), and `require_identity` refuses the
+  token entirely (it must never act as a user — mint identity tokens, create orgs, accept invites). Its
+  `/call` traffic is metered per client IP (`_enforce_public_demo_ip_cap`, `PUBLIC_DEMO_HIT_NS`,
+  ~10 calls/min/IP) since one token stands in for thousands of strangers.
 - **Skills / bundles:** `register_skill` (`POST /skills`) composes a `Bundle` + its secrets + tools
   atomically, resolving each binding's `secret` local-name to the created secret id; the shared core is
   `_register_skill_bundle` (also used by the folder importer). `list_bundles`, `get_bundle`,
@@ -242,20 +272,62 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   selected ones (`_materialize_skill_files` sandboxes the upload). `list_orgs` now carries `tool_count`.
 - **Audit:** `list_calls` (`GET /calls`, limit clamped 1–500; each row carries its `kind` —
   `call`/`local_run` — for the Activity + Usage views).
-- **OAuth connect:** `oauth_start` (`POST /oauth/start`) creates a `PendingOAuth` and returns
-  `consent_url` + `state` + `redirect_uri`; `oauth_callback` (`GET /oauth/callback`, open) exchanges the
-  code and creates the oauth secret; `oauth_status` polls. See [auth-secrets](../architecture/auth-secrets.md).
-- **Health:** `run_health` (`POST /health/run`) → `health.run_all`; `get_health` (`GET /health`).
+- **OAuth connect + the provider marketplace:** `oauth_start` (`POST /oauth/start`) creates a
+  `PendingOAuth` and returns `consent_url` + `state` + `redirect_uri`; `oauth_callback`
+  (`GET /oauth/callback`, open) exchanges the code and creates/updates the oauth secret; `oauth_status`
+  polls. **Two modes** (`OAuthStartIn`): **BYO** (supply `client_id`/`client_secret`/`auth_uri`/
+  `token_uri`/`scopes`) or **REGISTRY** (supply `provider` + optional `capability`) where treg fills
+  everything from **its own approved OAuth app** — the marketplace. `oauth_providers_list`
+  (`GET /oauth/providers`) lists the providers treg holds an app for, each flagged `configured` (false
+  when this deployment hasn't set that provider's client credentials). In registry mode `oauth_start`
+  reads the provider from `oauth_providers.get`, resolves scopes via `scopes_for(capability)`, and
+  stashes every per-provider auth quirk on the `PendingOAuth` (PKCE `code_verifier`, `auth_params`,
+  `token_endpoint_auth_method`, `client_id_param`, `scope_separator`, `long_lived_exchange`) so the
+  callback exchanges the code exactly the way the consent URL was built. `connection_id` (BYO or
+  registry) targets ONE existing connection to **reconnect/widen** it — scoped to the caller's org and
+  matched to the provider, recorded as `replaces_secret_id` — instead of adding another account.
+  **Callback does the real work:** it either replaces the named connection (`replaces_secret_id`) or
+  adds a new one named by `_free_connection_name` (the first account for a provider keeps the bare
+  service name — `google-search-console` — later ones get `-2`/`-3`), normalizes `granted_scopes` to
+  space-joined, sets `expires_at` (`oauth.expiry_of`), then `_autoprovision_provider_tool` binds the
+  fresh credential to the provider's API as a callable tool (idempotent by (org, name); a token-kind
+  provider gets an `env` header binding, an oauth one gets a `Bearer {access_token}` binding; a provider
+  needing treg's own second credential — Google Ads' developer token — also gets a **platform binding**,
+  see [proxy-model](../architecture/proxy-model.md)) and `_record_connected_identity` best-effort asks
+  the provider who connected. See [auth-secrets](../architecture/auth-secrets.md).
+- **Connections (the marketplace's dashboard surface):** `list_connections` (`GET /connections`) returns
+  every OAuth/registry credential in the org — metadata only, no token material — with health, expiry,
+  and (for a known provider) `capabilities`/`missing_capabilities` + extra-credential notes. The filter
+  is `kind=="oauth" OR provider!=""` so a bring-your-own-token provider (a plain `env` string, e.g.
+  Slack) still lists. `connection_resources` (`GET /connections/{id}/resources`) **live-fetches** what a
+  connection can act on (GSC sites, GA properties, Ads accounts), enriching id-only rows with the
+  upstream's human name concurrently (`_enrich_resource_labels`) and recording the successful upstream
+  call as proof of health; `set_connection_resource` (`POST …/resource`) pins the chosen `resource_ref`
+  + `resource_name`. `connect_with_token` (`POST /connections/token`) connects a bring-your-own-bot-token
+  provider (Slack), **verifying the token against the provider's probe before storing** and then
+  auto-provisioning its tool. `set_extra_credential` (`POST /connections/{id}/extra-credential`) stores
+  the second credential a provider needs when treg does NOT hold it centrally (rare) and finishes the
+  tool with BOTH bindings. `revoke_connection` (`DELETE /connections/{id}`) deletes the credential and
+  cleans up: it removes the tool treg auto-provisioned for the provider and drops the dead binding from
+  any user-built tool, leaving that tool's other bindings intact. All `require_can_register`
+  (member+). Helpers: `_owned_connection`, `_dig` (dotted-path walk).
+- **Health:** `run_health` (`POST /health/run`) → `health.run_all`; `get_health` (`GET /health`) now
+  returns `health._view(s)` plus a `needs_reconnect` flag (`health.needs_reconnect`) so a credential treg
+  can't renew announces itself before it dies.
 - **The proxy:** `call_tool` (`* /call/{rest:path}`) → `_resolve_call` → `_enforce_daily_cap` (the
-  per-user daily cap; 429 when over) → load secrets (+ `ensure_fresh`) → `relay()` → `audit.record_call`.
-  Detail in [proxy-model](../architecture/proxy-model.md).
+  per-user daily cap; 429 when over) → (public-demo token → `_enforce_public_demo_ip_cap`) → load secrets
+  (+ `ensure_fresh`) → `relay()` → `audit.record_call`. A **platform binding** carries no `secret_id`
+  (its value comes from settings at relay time), so secret-loading now skips `secret_id is None`. Detail
+  in [proxy-model](../architecture/proxy-model.md).
 
 ## Schemas
 Pydantic input models: `UserIn`, `OrgIn` / `InviteIn` / `AcceptIn`, `EmailStartIn` / `EmailVerifyIn`,
 `SecretIn` / `SecretUpdate`,
 `ToolIn` (flat single-binding sugar + optional `bindings` + `health_check` + `cli`) / `ToolUpdate` (incl.
 `cli`), `SkillIn` (`SkillSecretIn` + `SkillToolIn`, whose `cli` inject entries reference secrets by
-local_name), `GrantIn` (argv) / `RunReportIn` (audit_id + exit_code + verdict), `OAuthStartIn`. Output
+local_name), `GrantIn` (argv) / `RunReportIn` (audit_id + exit_code + verdict), `OAuthStartIn` (now
+BYO-or-registry: `provider` / `capability` / `connection_id` plus the BYO `client_id`/`secret`/URIs/
+`scopes`), and the connection models `ResourceRefIn`, `TokenConnectIn`, `ExtraCredentialIn`. Output
 helpers `_secret_view` / `_tool_view` / `_bundle_view` never leak secret values — `_tool_view` returns
 `health_check` + `examples` + `cli` (it once omitted `health_check`, so a tool's probe was stored but never
 surfaced by `GET /tools` / `/bundles/{id}`).

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -47,9 +47,13 @@ exits non-zero on HTTP >= 400.
 ## Commands
 - **`config`** (`--base-url`; shows email + active org + logged-in) · **`login`** — three doors in one
   `cmd_login`: default browser handshake — `POST /auth/cli/start` mints the `login_id` **and a short
-  pairing code** (shown only in the terminal), opens the universal `/login?cli=<id>` page (reuses an
-  existing dashboard session via a **team picker**, else offers GitHub / Google / email-code; the browser
-  must echo the pairing code to complete, the anti-phishing guard), then polls `/auth/cli/poll` **with no
+  pairing code**, opens the universal `/login?cli=<id>#code=<code>` page — the code rides in the URL
+  **fragment** (a fragment is never sent to the server, so it stays out of request logs) and the `/login`
+  page **displays** it so the user just confirms it matches the terminal instead of typing it (the
+  anti-phishing guard: a login you didn't start can't be approved into a token, and the server still
+  validates the code at approve time — the guard itself is unchanged). The page reuses an
+  existing dashboard session via a **team picker**, else offers GitHub / Google / email-code, then polls
+  `/auth/cli/poll` **with no
   code**; the poll result may carry `active_org` = the team picked in the browser, which `cmd_login` adopts
   directly, falling back to `_pick_active_org` only against an older server (where `/start` 404s → a
   locally-minted `login_id`, no code)),
@@ -61,11 +65,20 @@ exits non-zero on HTTP >= 400.
   any door also registers you (the user only — no auto personal org) · **`logout`** (clears creds).
   After a first human login, `_maybe_offer_onboarding` prompts `[Y/n]` then shows the 3-path menu (TTY-only).
 - **`onboard`** (`cmd_onboard`, `--path setup|access|demo`/`--source local|global|both`/`--name`/`--yes`/
-  `--reset`; `--mode` hidden, back-compat `quick`→demo) — `_pick_path` offers **Set up** (`_run_setup`,
-  asks "Import from where?" — this project / global agent folders `~/.claude/skills` etc. / both, unless
-  `--source` pins it — then wraps `treg upload` + batched `health --run` + teammate hand-off) · **Access** (`_run_access`, list tools+skills → multi-select
-  `skill install` → a no-key test call) · **Demo** (`_run_demo`, throwaway team → scan+sync probe-able keys → roster → real no-key
-  call → push/pull sync → audit log), with a smart default from the active org. See [onboarding](onboarding.md).
+  `--reset`; `--mode` hidden, back-compat `quick`→demo) — a TTY run opens with a one-second `_splash`
+  decrypt animation (the wordmark reveals behind a ░▒▓ wavefront; any key skips; off-TTY/`NO_COLOR`/dumb
+  terminals never see it), then `_pick_path` presents an **arrow-key menu** (`_menu` — ↑↓/jk move, ↵
+  confirm, 1-9 jump-pick; falls back to questionary where raw-key mode is unavailable). The interactive
+  default is **Set up**; the smart org-based default (team-with-tools → Access, empty admin team → Set up,
+  else Demo) applies only non-interactively. **Set up** (`_run_setup`) asks "Import skill/secret from
+  where?" — this project / global agent folders `~/.claude/skills` etc. / both / an **other project repo**
+  typed inline (a `_menu` type-in row with fish-style folder autosuggestion; "this project" is hidden from
+  a root-ish folder via `_is_rootish` so it can't sweep `$HOME`), unless `--source` pins it — then imports
+  the chosen `.env` + skills and runs a batched `health --run`. **Access** (`_run_access`, list tools+skills
+  → multi-select `skill install` → a no-key test call). **Demo** (`_run_demo`) is now purely
+  **illustrative** — no team is created, nothing is uploaded — showing the loop across four beats (scan
+  preview → roles → a real no-key call if the active team has a callable tool → the audit log). See
+  [onboarding](onboarding.md).
 - **`invites`** (`cmd_invites` → `GET /invites/mine`) lists invites addressed to your proven email;
   **`accept <org-slug>`** (`cmd_accept`) accepts one code-free (finds it in `/invites/mine`, `POST
   /invites/{id}/accept`, sets it active). The code path stays as `org join <code>`.
@@ -112,9 +125,12 @@ exits non-zero on HTTP >= 400.
   catalog (prompts for its key env var + API base_url) and prints a catalog-entry snippet to share; an
   unknown bin isn't server-allow-listed, so it runs locally until an admin allow-lists it. Brains in
   `providers.py` + `skills.py`; see [env-import](env-import.md).
-- **`call`** (`target`, optional `path`; `--method`, `--query K=V` repeatable, `--data`, `--file`) →
-  two shapes: named `call <tool> <path>` or agent-native single URL `call https://host/full/path`
-  (path omitted) → both hit `/call/<rest>` · **`calls`** (`--limit`).
+- **`call`** (`target`, optional `path`; `--method`, `--query K=V` repeatable, `--data`, `--file`,
+  `--content-type`, `--header 'K: V'` repeatable) → two shapes: named `call <tool> <path>` or agent-native
+  single URL `call https://host/full/path` (path omitted) → both hit `/call/<rest>`. **`--header`** adds an
+  extra request header the binding can't know (e.g. Google Ads' per-call `login-customer-id`); an
+  **injected credential always wins**, so a `--header` can never overwrite the secret the proxy injects ·
+  **`calls`** (`--limit`).
 - **`run`** (`treg run <tool> [--local|--server] [--] <cli args…>`, `cmd_run`) — a **dispatcher** that picks
   a tier by flag: `_run_local` (default) or `_run_server`. `args` is an `argparse.REMAINDER`, which silently
   swallows a treg flag typed AFTER the tool name; `cmd_run` guards against that by reading the **real**
@@ -158,8 +174,17 @@ exits non-zero on HTTP >= 400.
   or falls back to the active org token (works for an `is_superadmin` user). See
   [super-admin](../architecture/super-admin.md).
 - **`skill`** (`init --dir`, `add --dir`, `scaffold <dir> [--out]`, `push <file>`, `ls`, `rm`) — see below.
-- **`health`** (`--run`) · **`oauth connect`** (`name`, `--client-secret`, `--scopes`) → drives
-  `/oauth/start`, prints the consent URL, polls `/oauth/status` ~5 min.
+- **`health`** (`--run`).
+- **`oauth`** — **`oauth providers`** (`cmd_oauth_providers` → `GET /oauth/providers`) lists the services
+  treg holds its **own** approved OAuth app for. **`oauth connect`** (`cmd_oauth_connect`) has two modes:
+  **registry** — `--provider <service>` (e.g. `google-search-console`), optional `--capability` to pick a
+  scope set (default read) and optional `name`, so treg's app supplies the client credentials; or
+  **bring-your-own** — `name --client-secret <file> --scopes …` reads your own Google OAuth client JSON
+  (`_byo_body`). Either posts `/oauth/start`, prints the consent URL, and polls `/oauth/status` ~5 min.
+- **`connections`** (`cmd_connections_ls`/`_resources`/`_use`/`_rm`) — your connected accounts: **`ls`**
+  (`GET /connections`, health + expiry), **`resources <id>`** (`GET /connections/{id}/resources` — the
+  sites/properties/accounts it can act on), **`use <id> <resource_ref>`** (`POST /connections/{id}/resource`
+  — select which one), **`rm <id>`** (`DELETE /connections/{id}` — disconnect).
 
 `_parse_bind` defaults every field to a bearer `Authorization` header; only `secret=` is required, so a
 multi-credential tool needs no JSON.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -34,7 +34,8 @@ The **authed** shell is sidebar-first. The **top bar** is just brand + search. T
 stacks: (top) an **org block** — role + team name — that on click opens a switcher **dropdown** where
 each team carries its own **⚙ Settings** (`orgSettings` → switch into it, then open its settings) and
 **Switch** (`switchTo`) button (long names truncate, actions pinned right; the click-outside handler
-keys on `.orgblock`); (middle) the nav — Tools · Activity · **Usage** (admin/owner) · Team · Getting
+keys on `.orgblock`); (middle) the nav — Tools · **Secrets** (member+) · **Marketplace** (member+, the
+OAuth-connect view — `go('connections')`) · Activity · **Usage** (admin/owner) · Team · Getting
 started · Tutorial · Admin; (bottom)
 the **account** block — avatar · email · theme · sign out. The old top-bar org dropdown and top-right
 account controls are gone.
@@ -165,11 +166,81 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   `/tutorial` mirrors it and opens a panel from the URL hash (`/tutorial#auth`, `#skills`); the onboarding
   stepper deep-links each step's "Read more" there via `readMore(onbSection)`. See below.
 
+## Marketplace — the in-browser OAuth-connect UI (`view==='connections'` / `'provider'`)
+The dashboard now runs the whole **hosted connect flow** in the browser, so a member can attach a
+provider account (Google Analytics, Search Console, Google Ads, Slack, Meta/Facebook/Instagram, X,
+TikTok, LinkedIn, YouTube, …) without touching the CLI. `loadConnections` fetches **`GET /oauth/providers`**
+(server route `oauth_providers_list` → `oauth_providers.listing()`, each row carrying `service`,
+`display_name`, `category`, `summary`, `capabilities`, `scope_detail`, `auth_kind`, `supports_discovery`,
+and a **`configured`** flag = whether *this* deployment holds the provider's client credentials) plus
+**`GET /connections`** (`list_connections` — the org's existing grants). The list view groups providers by
+category (`providerGroups` computed → `shownGroups` filtered by the `mkCat` chip row), rendering a card
+grid; the whole card is the click target (`openProvider(service)`). Each card shows a **provider logo**
+served by convention from **`/logos/<service>.svg`** (`.plogo-tile`/`.plogo`, `@error` hides a missing
+file) — the `StaticFiles` mount `_LOGO_DIR` (`src/treg/web/logos/`). `connCount` labels how many accounts
+are already connected.
+
+**One integration** is its own view (`view==='provider'`, `mkProvider`/`mkConns` keyed on `mkService`) at a
+shareable path **`/app/marketplace/<service>`** (server route `dashboard_marketplace` — plain SPA, **no**
+og meta, since the page is only meaningful to a signed-in member; client route `mkFromPath`/`openProvider`
+push `/app/marketplace/<service>` into history). It lists the connected accounts (each account = its own
+tool name so an agent can call a specific one), their health/expiry chips, and a **Permissions** panel
+(`mkGranted` marks which capabilities are already granted; `scope_detail` gives the exact upstream scopes
+on hover).
+
+**Connecting** (`startConnect` picks the shape): a **token** provider (`auth_kind==='token'` — "bring your
+own bot") opens the `tokenAsk` modal → `submitToken` → **`POST /connections/token`** (`connect_with_token`);
+a provider with 2+ capabilities opens the `capAsk` modal (`capLabel`/`capHelp` explain each, e.g. TikTok's
+weaker `draft`) → `chooseCapability`; otherwise it goes straight to `connectProvider`. `connectProvider`
+does **`POST /oauth/start`** then opens the consent screen in a **popup** and **polls** `GET /oauth/status/{state}`
+every 2s (state stays in the dashboard rather than relying on the popup talking back); on `done` it re-reads
+`/connections` + `loadAll`, and if the provider `supports_discovery` and no resource is chosen yet it opens
+the resource picker. **Post-connect setup:** `openResources` (**`GET /connections/{id}/resources`**,
+`connection_resources` — a live upstream round-trip, so the modal opens first with a spinner) → `chooseResource`
+(**`POST /connections/{id}/resource`**) sets the default account/property; `saveExtraCred` (**`POST
+/connections/{id}/extra-credential`**, `set_extra_credential`) supplies a second credential a grant needs to
+be callable (e.g. Google Ads' developer token — surfaced by the `needSecondCred`/`mkNeedsCred` banners);
+`enableCapability`/`reconnect` re-run consent to widen scopes or refresh a `staleConns` credential; `disconnect`
+(inline-confirm → **`DELETE /connections/{id}`**, `revoke_connection`). Server-side, a successful connect
+**auto-provisions the tool** (`_autoprovision_provider_tool`) and records the account identity/resource labels
+(`_record_connected_identity`, `_enrich_resource_labels`). The three post-connect dialogs (`tokenAsk`, `capAsk`,
+`resPick`) live at **app-root level**, not nested in the view — a nested copy failed to render on an integration
+page (Connect looked dead).
+
+## Shareable detail pages (`/app/skills/<name>`, `/app/tools/<name>`)
+A skill or a tool has its own deep-linkable page so a member can **share** the exact thing (`view==='detail'`,
+`detail={kind,name}`). Server routes `dashboard_skill_page` (`/app/skills/{name}`) and `dashboard_tool_page`
+(`/app/tools/{name}`) both call **`_spa_with_og`**, which serves the same SPA but injects per-resource
+`og:`/`twitter:` meta so a pasted link unfurls — the meta echoes **only the URL's own name segment**
+(HTML-escaped via `_esc_html`, **no DB read**, so an unauthenticated crawler learns nothing). The client
+resolves the record by **name** (not id, so the URL is stable): `openDetail`/`loadDetail` fetch
+**`/bundles/by-name/{name}`** (`get_bundle_by_name`) for a skill or **`/tools/by-name/{name}`**
+(`get_tool_by_name`) for a tool. A **skill** page renders a "Use with your agent" copy-prompt (`detailPrompt`
+— no token embedded), a bundled-tools/secrets chip row, and a file browser over the SKILL package
+(`detailTree`/`detailFileContent`, `detailFile`); a **tool** page shows upstream + credential chips
+(`credChips`), examples, and the CLI/guardrails block, linking back to its parent skill (`detailParentSkill`).
+Actions: **⧉ Copy link** (`detailShareUrl`), **▶ Try it** / **⚙ Configure** (`tryDetailTool`/`configureTool`
+via `fullTool`, which resolves the full record from a skill's tool summary), and **Share…** (`canAdmin` only).
+
+The Tools list routes its rows through `rowTarget`/`rowHref`/`rowOpen` — a skill-born tool (has `bundle_id`)
+opens its **skill** page (the shareable thing), a bare endpoint opens its **tool** page. **Share…**
+(`openShare`/`sendShare`) invites someone by email with a **`landing`** field on the invite
+(`POST /orgs/{id}/invites`, server-validated to a `/app/skills|tools/<name>` path) plus optional scoped
+`tool_access` (unchecked "full access" → the skill + its bundled tools only). The emailed one-click link IS
+the consent: on arrival `autoAcceptShare` accepts the matching pending invite silently and enters that team.
+If the link resolves to a team the caller is **already** in but a different one, `findDetailOrg` probes the
+caller's other teams and switches silently on a unique hit; a 404 with no match shows an "ask for an invite"
+message. Boot + `popstate` route these paths (`routeFromPath`); a detail/marketplace path is stashed in
+`localStorage['treg-next']` across an OAuth sign-in hop (the callback always lands on `/app`, which would
+otherwise drop the path).
+
 ## The tutorial (one source, two renderers)
 `src/treg/web/tutorial.js` is the **single source of truth**: `window.TREG_TUTORIAL` (`concepts`, `roles`,
 `personas`, `steps[]` = `{part,who,title,explain,cmd,out,notice}`, plus the two focused arrays
 `importShell[]` and `access[]`, same step shape) + a self-contained `tregHL(text,lang)` shell/json
-highlighter. It's served at `/tutorial.js` and consumed by **both** the dashboard Help view (native Vue
+highlighter. (The `CONCEPTS` proxy analogy was reworded from "a coat check" to **"a bank teller"** — you
+hand over your token, the teller fetches the real secret from the vault and makes the call for you; the key
+never crosses the counter.) It's served at `/tutorial.js` and consumed by **both** the dashboard Help view (native Vue
 render) and the **standalone** `src/treg/web/tutorial.html` (vanilla render, served at `/tutorial`;
 renders `steps` only) — so they can never drift. `docs/tutorial.html` is now a redirect to `/tutorial`;
 the prose walkthrough is `docs/TUTORIAL.md`. Editing steps means editing `tutorial.js` only.
@@ -244,8 +315,9 @@ error banner on success. `+ Skill` (`openAddSkill`/`addSkill`) registers a **bun
 with client-side JSON validation.
 
 ## Not yet
-OAuth-connect in-browser (the hosted consent + poll flow, `/oauth/*`). Everything else in DASHBOARD-PLAN
-(org lifecycle, resource registration incl. multi-binding + edit, skill bundles, super-admin mutations)
-has shipped. Packaging: `src/treg/web` lives inside the `treg` package, so the wheel's `packages`
+OAuth-connect in-browser (the hosted consent + poll flow, `/oauth/*`) **has now shipped** — see the
+Marketplace section above. Everything in DASHBOARD-PLAN (org lifecycle, resource registration incl.
+multi-binding + edit, skill bundles, super-admin mutations, OAuth connect, shareable detail pages) has
+shipped. Packaging: `src/treg/web` lives inside the `treg` package, so the wheel's `packages`
 inclusion ships every asset (incl. `tutorial.js`/`tutorial.html`) — no `force-include` (a redundant
 one double-adds each file and breaks the wheel build).

--- a/docs/context/interface/landing-sandbox.md
+++ b/docs/context/interface/landing-sandbox.md
@@ -3,6 +3,7 @@ title: Landing sandbox studio — anonymous try-it, hosted skills, CLI installer
 status: shipped
 sources:
   - src/treg/sandbox.py
+  - src/treg/pubfeed.py
   - src/treg/api.py
   - src/treg/web/index.html
   - src/treg/web/install.sh
@@ -24,9 +25,12 @@ Vue methods (`sbxInit`/`startSandbox`/`refreshSandbox`/`sbxAddSecret`/`sbxAddToo
 `mint(db)` creates a login-free team: a `visitor-<hex>@sandbox.treg.local` `User` (can never sign in),
 a `demo` `Org` slugged `sbx-<hex>`, a member `Membership` whose **token is returned** (unlike
 onboarding's `demo.py`, which discards it), plus seeded starters from `DEFAULTS` — real-brand names,
-**fake keys**. To keep the story clean the seed leaves **one** live endpoint on arrival:
-`STRIPE_KEY`→`stripe`→api.stripe.com (an `env` `Authorization: Bearer {secret}` binding), which auto-runs
-so the "no key" aha shows immediately. `POSTHOG_KEY` is seeded **vault-only** (an entry with no `tool`
+**fake keys**. To keep the story clean the seed leaves **one** working endpoint on arrival:
+`STRIPE_KEY`→`stripe`, whose base is pinned to the full charges resource
+(`https://api.stripe.com/v1/charges`, host `api.stripe.com`, an `env` `Authorization: Bearer {secret}`
+binding), which auto-runs so the "no key" aha shows immediately. This exact seeded tool is also the
+**live wire** (see below): when the server is configured for it, a call to it is the sandbox's one real
+upstream request. `POSTHOG_KEY` is seeded **vault-only** (an entry with no `tool`
 key, so `mint` creates the secret but no Tool); the front-end prefills the "add your own" row with the
 real PostHog API + that key, so the visitor's first action is a single **Add**. `is_sandbox(org)` =
 `org.demo && _SANDBOX_SLUG_RE.match(org.slug)` — it matches the **exact mint slug format**
@@ -51,7 +55,7 @@ stays **orange** (deliberately complementary, not all-orange). Skippable (✕ / 
 The visitor holds that token and calls the **same product endpoints** the dashboard does —
 `POST /secrets`, `POST /tools`, `/call/*` — so it is a genuine registry, not a mock.
 
-## Safety: sandbox calls never touch the network
+## Safety: sandbox calls never touch the network (except the one live wire)
 `call_tool` in `api.py` checks `demo_sandbox.is_sandbox(caller.org)` and, for a sandbox, short-circuits to
 `sandbox.synthesize(...)` instead of `relay()`. `synthesize` runs the **real** `injectors.inject` to
 compute exactly what treg would send upstream (the injected header/query), then returns a **labelled
@@ -59,6 +63,49 @@ dummy** response — brand-shaped via `SAMPLE_BODIES` (Stripe charge list / Post
 injected credential shown is 100% real, but no outbound request is ever made: no SSRF, no open relay,
 regardless of the (arbitrary) base_url the visitor typed. Org-scoped tool resolution already prevents a
 sandbox token from reaching any tool it didn't register.
+
+## The one live wire (real Stripe test charges)
+There is a single deliberate exception, gated on env `TREG_DEMO_STRIPE_KEY` (`settings.demo_stripe_key`,
+a Stripe **restricted test key** limited to Charges). When it is set, a sandbox call to the exact seeded
+stripe tool relays for real. `call_tool` matches the tool with `demo_sandbox.is_live_tool(tool)` — a strict
+fingerprint (`LIVE_HOST == "api.stripe.com"` and `base_url.rstrip("/") == LIVE_BASE
+== "https://api.stripe.com/v1/charges"`) — and, for `GET`/`POST` only, calls `_relay_live_demo(...)`. That
+helper is intentionally narrower than `relay()`: form-encoded only, the `Authorization: Bearer` header is
+built from the **env key** (never from any sandbox secret), and `metadata[visitor]` in the POST body is
+**stripped and re-set server-side** to `demo_sandbox.visitor_name(org.slug)` so the identity on the public
+feed is always ours. Because the match is exact, editing the tool (base_url, bindings, a lookalike) makes it
+stop matching and **fall through to `synthesize`** — there is no key in the sandbox org to exfiltrate.
+Two guards keep the demo intact: `_require_not_live_demo_tool` / `_require_not_live_demo_secret` refuse edits
+or deletes of the seeded `stripe` tool and its `STRIPE_KEY` while the wire is on (visitor-created tools stay
+fully editable). `visitor_name` and `is_live_tool` live in `sandbox.py`; the wordlists (`ADJECTIVES`/
+`ANIMALS`) are imported from `pubfeed.py` (leaf module, no import cycle). `mint()` returns the visitor name;
+`POST /demo/sandbox` adds `"live"` and `GET /demo/sandbox/live` (`demo_sandbox_live`) reports `{live, visitor}`
+for a reused sandbox (the browser keeps one across reloads via `localStorage`, so it may predate the mint that
+carried these facts). The front-end live pane (`liveSnippets`, the `SBX` state) shows the visitor a copyable
+`curl` that hits their OWN sandbox token.
+
+## The public payments feed (`pubfeed.py`)
+`pubfeed.py` is the landing page's **live payments ticker**: a stranger's live-wire charge appears on the
+page within seconds, no refresh, as skeptic-proof that the proxy really injected a real key. The path:
+visitor `curl` → live wire relays a Stripe test charge → Stripe fires `charge.succeeded` at
+`POST /stripe/webhook` (`stripe_webhook`) → `pubfeed.push_charge(...)` → `GET /landing/stripe-feed`
+(`landing_stripe_feed`) streams it over Server-Sent Events via `pubfeed.stream()`. The webhook verifies the
+`Stripe-Signature` with `pubfeed.verify_signature` (constant-time HMAC-SHA256 over `{t}.{body}`, timestamps
+older than `SIG_TOLERANCE_S` rejected as replays, any of several `v1` signatures accepted during rotation);
+it returns **404 when `TREG_DEMO_STRIPE_WEBHOOK_SECRET` (`settings.demo_stripe_webhook_secret`) is unset**, so
+a deploy without the secret exposes no unauthenticated POST surface. Design points:
+- **In-memory + tiny.** A `deque(maxlen=FEED_MAX)` ring buffer plus a set of per-subscriber `asyncio.Queue`s;
+  it is a marketing surface, not a system of record. A dropped event on restart costs nothing (Stripe retries),
+  and each instance of a multi-instance deploy streams only the deliveries its own webhook received.
+- **No visitor-controlled text can reach the page.** `push_charge` copies **only server-chosen fields**
+  (amount/currency/created, a 6-char `id_suffix`, and a `receipt_url` only if it starts with
+  `https://pay.stripe.com/`) — never `description`. The display **name** (`_display_name`) is accepted only when
+  it passes `_is_wordlist_name` (adjective-animal-nnn, both words from the exact `ADJECTIVES`/`ANIMALS` lists,
+  number ≤ 999); anything else falls back to `_derived_name`, a deterministic wordlist name hashed from the
+  charge id. This is the "graffiti lesson": hand-typed strings can never deface the shared feed.
+- **`stream()`** replays the ring buffer to a fresh subscriber, then live events, with a `: ping` keepalive every
+  `KEEPALIVE_S`; a subscriber that lags past `_MAX_SUBSCRIBER_LAG` is dropped rather than buffered forever. The
+  SSE response sets `X-Accel-Buffering: no` so a reverse proxy does not buffer it. `reset()` is a test hook.
 
 Bounds: `MAX_TOOLS`/`MAX_SECRETS` (3) enforced by `_enforce_sandbox_cap` on `POST /tools|/secrets`;
 `SANDBOX_TTL_MIN` (60) + `gc(db)` reaps expired visitors (their org + all org-scoped rows), run
@@ -89,14 +136,16 @@ files a skill folder is — `SKILL.md` (agent recipe: call the treg proxy, key i
 
 ## CLI installer
 `GET /install.sh` (`install_sh`) serves `src/treg/web/install.sh`, `{BASE}`-templated like `llms.txt`
-(so it targets whatever host is live — a dev box or the real domain). The script installs the
-`treg` CLI via `uv tool install` → `pipx` → `pip3` and runs `treg config --base-url {BASE}`.
-**Caveat:** the repo is private and the package is not on PyPI, so `curl … /install.sh | sh` works today
-for teammates with repo access (git creds); a fully public install needs a PyPI publish (or a
-public repo) — a launch step to fold into the Render deploy. The **Getting started** dashboard view
-(`view==='start'`) surfaces this install command + `treg login`/`onboard`/`add`/`call` and links to the
-tutorial and `/llms.txt`; `llms.txt` gained a matching **Install the CLI** section.
+(so it targets whatever host is live — a dev box or the real domain). The script now installs from
+**PyPI** (`SRC="tools-registry"`, the light CLI package; the FastAPI/DB server stack is the separate
+`tools-registry[server]` extra for self-hosters) via `uv tool install --force` → `pipx install --force` →
+`pip3 install --user --upgrade`, then runs `treg config --base-url {BASE}`. It also installs the official
+**tools-registry skill** into every detected agent via `treg skill bootstrap` (Claude Code, Cursor, Codex,
+Gemini, Copilot, OpenCode, Windsurf …), falling back on older CLIs to a Claude-only drop that curls
+`{BASE}/skill.md` into `~/.claude/skills/tools-registry`. Because the package is public on PyPI,
+`curl … /install.sh | sh` now works for anyone with no repo/git access needed. The **Getting started**
+dashboard view (`view==='start'`) surfaces this install command + `treg login`/`onboard`/`add`/`call` and
+links to the tutorial and `/llms.txt`; `llms.txt` has a matching **Install the CLI** section.
 
 ## Not yet
-Publish `treg` to PyPI (or make the repo public / serve a slim wheel) so the installer is public; wire
-the landing's sign-up CTAs through to the real account flow post-launch.
+Wire the landing's sign-up CTAs through to the real account flow post-launch.

--- a/docs/context/interface/onboarding.md
+++ b/docs/context/interface/onboarding.md
@@ -30,21 +30,29 @@ seeded with teammates, a working tool, and a real audit trail — one backend br
   returns 200 with the injected `Authorization: Bearer sk-demo-…`** — the aha.
 - **Sample activity** (`SAMPLE_CALLS`): a few `CallRecord`s attributed to teammates so Activity is alive.
 
-**CLI onboarding is 3 paths** (`cmd_onboard` → `_pick_path`, `_PATHS = {1:setup, 2:access, 3:demo}`; smart
-default from the active org: a team with tools → **Connect**, an empty team you admin → **Setup**, else
-**Demo**). Menu labels: **Setup** · **Connect existing tool-registry** · **Demo**:
-- **Setup** (`_run_setup`, path `setup`) — first asks **"Import from where?"** (this project / global agent
-  folders / both; `--source local|global|both` skips the question; non-TTY or `--yes` never prompts and
-  keeps the local scan, falling back to global only when the project has nothing to share). Global =
-  `agents.detect_installed()` → each agent's `global_dir()` (`~/.claude/skills`, `~/.codex/skills`, …),
-  kept only when it actually holds skills. Then imports the cwd `.env` (API keys — local scope only; global
-  folders carry no project `.env`) then ALL chosen skill folders in **one deduped pass** (`_import_skills`
-  takes a list of dirs — the cwd's top-level skills + every agent's project dir
-  `.claude/skills`/`.agents/skills`/… from the `agents` registry, plus the chosen global dirs — deduped by
-  skill NAME so a mirror-installed skill isn't prompted twice), with `--no-oauth` (no forced browser consent), a batched
-  `POST /health/run` (surfaces `N healthy · M unchecked (no probe)`), then a **✓ Done** hand-off: the
-  dashboard team URL (`{base}/#orgs`), the invite command, and the teammate's install snippet (framed as
-  *their* machine, "pick Connect"). Missing skill creds are prompted, not skipped.
+**CLI onboarding is 3 paths** (`cmd_onboard` → `_dispatch_onboard`, one of `_run_setup`/`_run_access`/
+`_run_demo`; `_PATHS = {1:setup, 2:access, 3:demo}`). A TTY run opens with a one-second `_splash` decrypt
+animation (the wordmark reveals behind a ░▒▓ wavefront; any key skips; off-TTY / `NO_COLOR` / dumb
+terminals never see it), then `_pick_path` presents an **arrow-key menu** (`_menu` — ↑↓/jk move, ↵ confirm,
+1-9 jump-pick; where raw-key mode is unavailable it falls back to questionary). The **interactive default is
+Setup**; the smart org-based default (a team with tools → **Connect**, an empty team you admin → **Setup**,
+else **Demo**) applies **only non-interactively** (scripted/agent runs stay unchanged). Menu labels:
+**Setup** · **Connect existing tool-registry** · **Demo**:
+- **Setup** (`_run_setup`, path `setup`) — first asks **"Import skill/secret from where?"** via `_menu`:
+  this project / global agent folders / both / an **other project repo** typed inline (a `_menu` type-in row
+  with fish-style folder autosuggestion — → / tab accept the ghost completion). "This project" is hidden
+  when the cwd is root-ish (`_is_rootish` — `/`, `$HOME`, `/Users`) so Setup can't sweep the whole account;
+  a typed path that isn't a directory re-prompts via `questionary.path`. `--source local|global|both` skips
+  the question; non-TTY or `--yes` never prompts and keeps the local scan, falling back to global only when
+  the project has nothing to share. Global = `agents.detect_installed()` → each agent's `global_dir()`
+  (`~/.claude/skills`, `~/.codex/skills`, …), kept only when it actually holds skills. Then imports the cwd
+  `.env` (API keys — local scope only; global folders carry no project `.env`) then ALL chosen skill folders
+  in **one deduped pass** (`_import_skills` takes a list of dirs — the cwd's top-level skills + every
+  agent's project dir `.claude/skills`/`.agents/skills`/… from the `agents` registry, plus the chosen
+  global dirs — deduped by skill NAME so a mirror-installed skill isn't prompted twice), with `--no-oauth`
+  (no forced browser consent) and a batched `POST /health/run` (surfaces `N healthy · M unchecked (no
+  probe)`), then a **✓ Done** hand-off pointing at the team's skills + secret vault (`{base}`). Missing
+  skill creds are prompted, not skipped.
 - **Connect existing tool-registry** (`_run_access`, path `access`) — lists the team's tools + skills,
   multi-selects skills to `skill install` (one call → one summary; kept skills surfaced), then one no-key
   test call (`_onboard_test_call`, prefers a probe/example path so it hits a REAL endpoint). Never pulls keys.
@@ -87,33 +95,35 @@ any demo user left with zero memberships — a clean exit, no litter.
 
 ## CLI face (`treg onboard`)
 
-Colourful (ANSI truecolor, Ledger palette; suppressed off-TTY / under `NO_COLOR`). `_pick_mode` offers
-**both** styles (`--mode` skips the prompt):
-- **`quick`** → `_run_quick`: `POST /onboard/demo` (full auto-seed), then walk ① roster → ② the no-key
-  call → ③ the audit log.
-- **`guided`** → `_run_guided`: a **detailed 11-section tutorial** that *shows and explains the actual
-  command* at each step (helpers `_section` dividers, `_cmd`, `_tip` amber asides; Ledger colours —
-  clay headers/commands, teal values/token, green ✓, amber tips): ① create team (`treg org create`,
-  `org ls`/`use`) → ② roles + invite (`org invite`, `members`, `set-role`) → ③ register a tool
-  (`secret add`, `tool add --base-url --secret`, bindings) → ④ the no-key call + URL-passthrough →
-  ⑤ skills (folder + `treg.json`, `skill init/add`) → ⑥ audit → ⑦ other auth shapes (`oauth connect`,
-  file creds, multi-`--bind`) → ⑧ health (`health --run`) → ⑨ manage (`tool/secret ls/rm/update`) →
-  ⑩ team admin (`org invites/revoke/leave/delete`, `admin`) → ⑪ point an agent at it (URL-passthrough
-  curl). The team + teammate are built for real via `POST /orgs` + `/onboard/accept-teammate`.
+Colourful (ANSI truecolor, Ledger palette; suppressed off-TTY / under `NO_COLOR`). `cmd_onboard` first
+ensures an active org (`_pick_active_org` — the flows need an identity token so requests carry
+`X-Treg-Org`; a per-org agent token is org-bound), plays `_splash` (skipped for scripted `--path`/`--yes`
+runs), then routes through `_pick_path` → `_dispatch_onboard`. Slow steps (team lookup, scans, network
+fetches) show a `_spinner`; `_onboard_active_org` caches its `/orgs` result in `_ORG_CACHE` so a single run
+never re-fetches. Shared drawing helpers: `_section` dividers, `_brand`, `_cmd` (shows the actual command),
+`_kv`, `_tip` amber asides, `_ok`.
 
-After a first **human** `treg login`, `_maybe_offer_onboarding` prompts `[Y/n]` then `_pick_mode` —
-**TTY-only / CI-safe**; a decline posts `/onboard/skip`. `_run_onboarding` sets the active org first so
-requests carry `X-Treg-Org` (the flows need an identity token — a per-org agent token is org-bound).
+The three paths are **Setup / Connect / Demo** (see the path descriptions above): **Setup** and **Connect**
+do real work against the active team; **Demo** (`_run_demo`) is illustrative — no team is created, nothing
+is uploaded — four beats (`_demo_scan_preview` → roles → `_demo_teammate_call` a real no-key call when a
+callable tool exists → `_demo_call_log`), then `_demo_next_steps`.
+
+After a first **human** `treg login`, `_maybe_offer_onboarding` prompts `[Y/n]` then `_pick_path` +
+`_dispatch_onboard` — **TTY-only / CI-safe**; a decline posts `/onboard/skip` so it never re-asks.
 
 ## Dashboard face (`web/index.html`)
 
 A **docked right-side narrative stepper** (`onb.*` state; content pushed left via `.onb-push` so nothing
 overlaps). Boot reads `onboarded` from `/auth/me`; `maybeOnboard()` auto-opens it only for a non-onboarded
-session with **no team yet**. Seven steps (`onbSteps`) tell the story and have the USER do each action:
-Why → Personal space → **Create a team** (`onbCreateTeam` → `POST /orgs`) → Active team → **Add a teammate**
-(`onbInviteTeammate` prefills + invites Alex, then `/onboard/accept-teammate` auto-joins) → **Call with no
-key** (`onbAddTool` → `/onboard/seed-tool`, then `onbTryEcho` opens the Try-it drawer, shifted left via
-`.drawer.onb-shift` so it doesn't overlap the panel) → You're set. A step tracker shows numbered/checked
-progress; **↺ Restart** (`onbRestart`) and the **✕** skip. Each step's **"Read more"** deep-links to the
-matching tutorial panel via `readMore(onbSection)` → `/tutorial#roles|auth|skills`. **Help → "Guided setup"**
-replays (`replayOnboard`); **"Remove demo"** calls `resetDemo`. A clay **`demo` chip** marks a demo org.
+session with **no team yet**. The team itself is created up front by the separate **welcome** flow
+(`welcomeCreate` → `POST /orgs`), which then lands the user on "Getting started" and launches the stepper
+alongside it. **Five steps** (`onbSteps` = Why treg · Set up your vault · Add a teammate · Call without
+keys · You're set) tell the story and have the USER do each action, with `onbGoto`/`onbNext`/`onbBack`
+walking the panel to the matching page (`orgs` for the roster, `tools` for vault + calling): **Add a
+teammate** (`onbInviteTeammate` prefills + invites Alex, then `/onboard/accept-teammate` auto-joins) →
+**Call without keys** (`onbAddTool` → `/onboard/seed-tool`, then `onbTryEcho` opens the Try-it drawer,
+shifted left via `.drawer.onb-shift` so it doesn't overlap the panel). A step tracker shows
+numbered/checked progress; **↺ Restart** (`onbRestart`) and `onbFinish`/**✕** skip (posting
+`/onboard/skip`). Each step's **"Read more"** deep-links to the matching tutorial panel via
+`readMore(onbSection)` → `/tutorial#<concepts|skills|roles|auth>`. **Help → "Guided setup"** replays
+(`replayOnboard`); **"Remove demo"** calls `resetDemo`. A clay **`demo` chip** marks a demo org.

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -41,6 +41,23 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
 - `admin_token` — the cross-tenant **super-admin** bearer (`TREG_ADMIN_TOKEN`); empty disables the env
   path (only `is_superadmin` users reach `/admin`). Keep it long + secret. See
   [super-admin](../architecture/super-admin.md).
+- **Registry OAuth-marketplace apps** — treg's OWN approved OAuth clients, so a member can connect a
+  provider without registering an app themselves. `google_client_id`/`_secret` backs both Google login
+  AND the Google registry connects (Search Console / Analytics / Business Profile) via `/oauth/callback`
+  — register both redirect URIs. Google **Ads** is special: `google_ads_client_id`/`_secret` is a
+  DEDICATED client in its own Cloud project (a developer token is welded to one project), plus
+  `google_ads_developer_token` (treg's token from OUR approved manager account, injected on every Ads
+  call as a **platform binding** — see [proxy-model](../architecture/proxy-model.md)). The other
+  providers each take a `<name>_client_id`/`_secret` pair: `linkedin_*`, `slack_*`, `x_*`, `tiktok_*`
+  (separate sandbox vs prod app), and `meta_*` (ONE Meta app backs both facebook + instagram). Empty for
+  a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
+- **Landing live-wire (optional):** `demo_stripe_key` (`TREG_DEMO_STRIPE_KEY`, a Stripe **sandbox
+  restricted** key) powers the landing sandbox's ONE real upstream call — a sandbox call to the exact
+  seeded `stripe` tool relays for real with this key injected; the key exists in no sandbox org. Empty ⇒
+  every sandbox call synthesizes, exactly as before the wire existed. `demo_stripe_webhook_secret`
+  (`TREG_DEMO_STRIPE_WEBHOOK_SECRET`, `whsec_…`) signs the landing payments feed; empty ⇒ `POST
+  /stripe/webhook` is off (`404`, so a deploy without it exposes no unauthenticated POST surface). See
+  [api](../interface/api.md).
 - `github_client_id` / `github_client_secret` / `session_secret` — GitHub OAuth login for the dashboard
   (`TREG_GITHUB_*`, `TREG_SESSION_SECRET`); empty hides the GitHub button. Callback must be
   `<public_url>/auth/github/callback`. See [dashboard](../interface/dashboard.md).
@@ -96,7 +113,8 @@ its own sqlite DB and email dev mode.
 server deploy needs the `[server]` extra (FastAPI/DB/crypto); the wheel ships every web asset via the package.
 `startCommand: python -m treg`, health check on `/meta`. The DB URL is auto-wired via `fromDatabase`
 (config's validator adds the asyncpg driver). Secrets are **dashboard-managed** (`sync: false` — the
-Fernet key, session/admin tokens, GitHub OAuth pair, Resend key); `TREG_PUBLIC_URL`,
+Fernet key, session/admin tokens, GitHub OAuth pair, Resend key, and the optional landing live-wire pair
+`TREG_DEMO_STRIPE_KEY` + `TREG_DEMO_STRIPE_WEBHOOK_SECRET`); `TREG_PUBLIC_URL`,
 `TREG_EMAIL_DEV_MODE=false`, and `TREG_EMAIL_FROM` are set inline. `asyncpg` is a dependency (Postgres
 async driver, alongside `aiosqlite`).
 
@@ -118,7 +136,15 @@ Also **quote a reserved-word table name**: the `token_version` step is `ALTER TA
 touched by `create_all`, only by the migration). The usage-metering columns (A10 `membership.daily_call_cap
 INTEGER DEFAULT -1`, A11 `callrecord.kind VARCHAR DEFAULT 'call'`) follow the same rules but need no
 quoting (neither table name is reserved); the legacy owner-Membership backfill `INSERT` supplies
-`daily_call_cap` explicitly, since a `create_all` column is NOT NULL with no server default.
+`daily_call_cap` explicitly, since a `create_all` column is NOT NULL with no server default. The later
+additive steps follow the same rules: **A15** `org.public_demo BOOLEAN` (via `_ensure_bool_col`, the
+publishable call-only token; the legacy-org backfill `INSERT` now lists it explicitly); **A16** the
+connection metadata on `secret` (`provider`, `granted_scopes`, `resource_ref`, `resource_name`,
+`expires_at`/`last_refresh_at TIMESTAMP`, `last_error`) so the OAuth marketplace can attribute, scope,
+and expire a credential; **A17–A20** the per-provider auth quirks on `pendingoauth` carried through the
+redirect (`provider`, `code_verifier`, `auth_params`, `token_endpoint_auth_method`, `client_id_param`,
+`scope_separator`, `long_lived_exchange BOOLEAN DEFAULT false`, `replaces_secret_id INTEGER`) so the
+callback exchanges the code exactly as the consent URL was built.
 
 **Audit back-pressure (`audit.py`).** Audit rows are written off the request path (fire-and-forget), and
 each write opens a DB connection from the small pool **shared** with real requests. Two limits keep


### PR DESCRIPTION
Full doc-fragment sync after PRs #19-#28 (OAuth marketplace, live Stripe wire, provider skills, 0.4/0.5 CLI). Adds coverage for new modules oauth_providers.py + pubfeed.py; every cited symbol grep-verified. Docs-only.