### PR TITLE
Marketplace depth (39 providers) + the credential & control layer for agents (agents · projects · deny rules · local mode), with the round-4 security fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ docs/hn-launch-post.md
 # Machine-local symlinks into .agents/skills — they resolve only on the machine that made them.
 /.claude/
 skills-lock.json
+
+# Local planning / handoffs — private, never committed.
+.context/

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -46,7 +46,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
-| [Running & deploying the server](ops/deploy.md) | shipped | __main__.py, config.py, db.py, email.py, … |
+| [Running & deploying the server](ops/deploy.md) | shipped | __main__.py, selfhost.sh, config.py, db.py, … |
 
 ## Reference
 

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -36,6 +36,12 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [Shell mode (treg shell) — transparent CLI interception](interface/shell.md) | shipped | shell.py, cli.py |
 | [The shippable tools-registry skill (3 personas)](interface/skill.md) | shipped | skill.md |
 
+## Guides (how-to)
+
+| Fragment | Status | Covers |
+|---|---|---|
+| [Expanding a marketplace category — the add-a-provider playbook](guides/expanding-a-category.md) | guide | oauth_providers.py, api.py, config.py |
+
 ## Ops (deploy, scale)
 
 | Fragment | Status | Covers |

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -102,8 +102,18 @@ module symbols:
   are cumulative supersets (write ⊇ read); `default_capability` is the **broadest** (an agent product needs
   write eventually, so one honest consent screen beats connecting twice). `scopes_for()` /
   `satisfied_capabilities()` decide when a later capability needs a re-consent.
-- `auth_kind` = `"oauth"` (treg's app) or `"token"` (Slack — a workspace-scoped bot the user creates from a
-  pre-filled manifest and pastes; `is_token_kind`). `can_autoprovision` (has a `base_url` and either needs no
+- `auth_kind` = `"oauth"` (treg's app), `"token"` (Slack — a workspace-scoped bot the user creates and
+  pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
+  Akta, Hunter on a new **Enrichment** shelf, TikHub + Bright Data under Social, Semrush under SEO). A
+  `token` and a `key` share ONE connect/verify/auto-provision path, so `uses_pasted_secret` (`token | key`)
+  gates it while `is_token_kind` stays narrow for Slack's bot-only copy; a key provider needs nothing from
+  treg, so `is_configured` is always true for it. The pasted credential rides in a header
+  (`token_header`/`token_format`, default `Authorization: Bearer {secret}`) or a **query param**
+  (`token_location="query"` + `token_param` — Semrush spells its key `?key=`); the connect probe hits
+  `base_url`+`probe_path`, or an absolute `probe_url` when the cheapest key-check lives on another host
+  (Semrush's balance endpoint on `www.semrush.com`). Validity is read from the HTTP status, a truthy JSON
+  `token_verify_field` (Slack's `ok`, Apollo's `is_logged_in` — both answer 200 even on a **bad** key), or
+  the absence of an `ERROR`-prefixed text body (Semrush). `can_autoprovision` (has a `base_url` and either needs no
   second credential or treg holds it) drives auto-building a callable tool on a successful connect;
   `needs_extra_credential` covers Google Ads' `developer-token` header (a second binding the operator supplies).
 - Post-connect helpers the dashboard/CLI drive: resource **discovery** (`supports_discovery`,

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -104,7 +104,8 @@ module symbols:
   `satisfied_capabilities()` decide when a later capability needs a re-consent.
 - `auth_kind` = `"oauth"` (treg's app), `"token"` (Slack — a workspace-scoped bot the user creates and
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
-  Akta, Hunter on a new **Enrichment** shelf, TikHub + Bright Data under Social, Semrush under SEO). A
+  Akta, Hunter, Crunchbase on a new **Enrichment** shelf, TikHub + Bright Data + Just One API under
+  Social, Semrush under SEO). A
   `token` and a `key` share ONE connect/verify/auto-provision path, so `uses_pasted_secret` (`token | key`)
   gates it while `is_token_kind` stays narrow for Slack's bot-only copy; a key provider needs nothing from
   treg, so `is_configured` is always true for it. The pasted credential rides in a header

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -104,7 +104,8 @@ module symbols:
   `satisfied_capabilities()` decide when a later capability needs a re-consent.
 - `auth_kind` = `"oauth"` (treg's app), `"token"` (Slack — a workspace-scoped bot the user creates and
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
-  Akta, Hunter, Crunchbase on a new **Enrichment** shelf, TikHub + Bright Data + Just One API under
+  Akta, Hunter, Crunchbase, Lusha, Coresignal, Diffbot, The Companies API, LeadMagic on a new
+  **Enrichment** shelf, TikHub + Bright Data + Just One API under
   Social, and under **SEO** Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat). A
   `token` and a `key` share ONE connect/verify/auto-provision path, so `uses_pasted_secret` (`token | key`)
   gates it while `is_token_kind` stays narrow for Slack's bot-only copy; a key provider needs nothing from

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -105,7 +105,7 @@ module symbols:
 - `auth_kind` = `"oauth"` (treg's app), `"token"` (Slack — a workspace-scoped bot the user creates and
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
   Akta, Hunter, Crunchbase on a new **Enrichment** shelf, TikHub + Bright Data + Just One API under
-  Social, Semrush under SEO). A
+  Social, and under **SEO** Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat). A
   `token` and a `key` share ONE connect/verify/auto-provision path, so `uses_pasted_secret` (`token | key`)
   gates it while `is_token_kind` stays narrow for Slack's bot-only copy; a key provider needs nothing from
   treg, so `is_configured` is always true for it. The pasted credential rides in a header
@@ -113,8 +113,11 @@ module symbols:
   (`token_location="query"` + `token_param` — Semrush spells its key `?key=`); the connect probe hits
   `base_url`+`probe_path`, or an absolute `probe_url` when the cheapest key-check lives on another host
   (Semrush's balance endpoint on `www.semrush.com`). Validity is read from the HTTP status, a truthy JSON
-  `token_verify_field` (Slack's `ok`, Apollo's `is_logged_in` — both answer 200 even on a **bad** key), or
-  the absence of an `ERROR`-prefixed text body (Semrush). `can_autoprovision` (has a `base_url` and either needs no
+  `token_verify_field` (Slack's `ok`, Apollo's `is_logged_in` — both answer 200 even on a **bad** key), a
+  `token_ok_field`==`token_ok_value` match (Majestic's `Code`=="OK"), a `token_reject_field` present
+  (Serpstat's `error`), or an `ERROR`-prefixed text body (Semrush). The connect probe may be a POST with a
+  `probe_json` body (Serpstat's JSON-RPC), and `token_encode="base64"` turns a pasted `login:password` into
+  the Basic blob for `Basic {secret}` (DataForSEO, Moz). `can_autoprovision` (has a `base_url` and either needs no
   second credential or treg holds it) drives auto-building a callable tool on a successful connect;
   `needs_extra_credential` covers Google Ads' `developer-token` header (a second binding the operator supplies).
 - Post-connect helpers the dashboard/CLI drive: resource **discovery** (`supports_discovery`,

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -106,7 +106,11 @@ module symbols:
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
   Akta, Hunter, Crunchbase, Lusha, Coresignal, Diffbot, The Companies API, LeadMagic on a new
   **Enrichment** shelf, TikHub + Bright Data + Just One API under
-  Social, and under **SEO** Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat). A
+  Social, under **SEO** Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat, and under
+  **Advertising** the ad-intel keys SpyFu, Apify, Meta Ad Library, SerpApi — alongside the OAuth ad
+  platforms Google Ads + Meta Ads and the **unconfigured** Microsoft Ads, Snapchat Ads, Pinterest Ads
+  (standard OAuth, live once this deployment sets their client credentials) and TikTok Ads (a
+  placeholder: its non-standard app_id/auth_code/Access-Token flow needs oauth.py work before it runs)). A
   `token` and a `key` share ONE connect/verify/auto-provision path, so `uses_pasted_secret` (`token | key`)
   gates it while `is_token_kind` stays narrow for Slack's bot-only copy; a key provider needs nothing from
   treg, so `is_configured` is always true for it. The pasted credential rides in a header

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -91,6 +91,13 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   `ratestore.py` (`kv_put`/`kv_get`/`kv_pop`, `rate_check` sliding-window, `sweep`). NOT the CLI-login
   handshake — that is deliberately still in-process (`api._cli_pending`, short-lived, self-heals on retry).
 
+- **`DenyRule`** — org policy over what may be CALLED: `org_id`, nullable `user_id` (NULL = the whole
+  org, set = one member/agent), `host` / `path_prefix` / `method` (an empty field means **any**, so a
+  rule carrying only `method="DELETE"` blocks every delete), `verdict`, `note`, `created_by`. A new
+  table, so `create_all` makes it — **no migration step**. `verdict` is `deny` today and exists so
+  approval-required actions can land here later without one, mirroring the `verdict` vocabulary
+  `localrun.py` already uses. Enforcement: [proxy-model](proxy-model.md).
+
 ## Bindings (the multi-credential shape)
 `Tool.bindings` is a JSON list; each entry is
 `{secret_id, injector, location, name, format, secret_field}` — one credential injection. A request

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -37,6 +37,14 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   — the code is a shortcut, not a requirement. `email_token_hash` is the inbox-only **second secret** in
   the emailed link — it can sign the invitee in (`GET/POST /auth/invite-signin?t=`, one-time), while the
   admin-visible code never can.
+- **Machine identities** — a `User` on an **unroutable domain**, which is what makes it a machine
+  rather than a person. Two exist: the published demo token (`PUBLIC_DEMO_DOMAIN`) and an **agent**
+  (`AGENT_DOMAIN` = `agents.treg.local`). Both are minted by an admin and act ONLY by their token:
+  `_is_machine_email` gates them out of every login door and out of `require_identity` (below). An
+  agent needs **no new table and no migration** — it is a `Membership`, so it inherits `daily_call_cap`,
+  `tool_access`, `local_run_enabled` and per-identity audit for free, which is exactly what makes those
+  controls *per-agent*. NOTE: "agent" here is an IDENTITY; `agents.py` is the unrelated skill-directory
+  table ("where does each coding agent keep its skills").
 - Resource tables (`Secret`/`Tool`/`Bundle`/`CallRecord`/`PendingOAuth`) carry `org_id`; `owner`
   (creator email) is kept for audit + the member role gate. `Tool.name` is unique **per `(org_id, name)`**
   (`UniqueConstraint("org_id", "name")`), so two orgs may reuse a name.
@@ -60,6 +68,22 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   *customized* member does NOT auto-get a newly-registered tool (the dashboard toasts a reminder). `Invite`
   carries `tool_access`/`local_run_enabled` (validated at `create_invite`) → copied onto the membership at
   both accept doors. `list_members` returns both fields.
+- **Agents (`create_agent` / `list_agents` / `revoke_agent`, `/orgs/{id}/agents`, admin+).** Mints a
+  member identity for a machine caller, reusing the `create_public_token` recipe (re-POST the same name
+  **rotates** — the old token dies there; revoke deletes the membership). Three invariants, each closing
+  a real hole:
+  1. **An agent token can never act as a USER.** `create_org` depends on `require_identity`, so without
+     the `_is_machine_email` refusal there an agent could create a fresh org **in which it is owner** —
+     and owners are exempt from `_require_tool_access` / `_require_local_run`, escaping every limit on it.
+  2. **An agent can never be an owner** — blocked in `create_agent` AND in `set_member_role`, for the
+     same exemption reason.
+  3. **The address is org-scoped** (`agent-{org.slug}-{name}@…`, mirroring `_public_demo_email`): two
+     orgs must each own an agent called `deploy` without sharing one `User` row, or a superadmin
+     suspending one tenant's agent would kill the other's. Agents are always looked up by
+     *(org + domain)*, never by recomputing the address, so an org rename can't orphan them.
+  Every identity door is blocked at the shared choke point `_find_or_create_user`, plus `register_user`
+  (which predates it and creates a `User` directly) and `auth_email_start` (refuse early, mint no code).
+  `list_members` carries `is_agent` so one roster can show people and machines apart.
 - Every list filters by `caller.org_id`; every create stamps `org_id = caller.org_id` +
   `owner = caller.email`; `_resolve_call` scopes **both** the named lookup and the host/longest-prefix
   passthrough to the org; `call_tool` loads only same-org secrets. See [proxy-model](proxy-model.md).

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -91,6 +91,14 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   Every identity door is blocked at the shared choke point `_find_or_create_user`, plus `register_user`
   (which predates it and creates a `User` directly) and `auth_email_start` (refuse early, mint no code).
   `list_members` carries `is_agent` so one roster can show people and machines apart.
+  **A rotate replaces the TOKEN, never the limits.** Because rotate is the same endpoint as create, an
+  absent optional field used to fall back to its permissive default — and the dashboard's Rotate button
+  sends only `{name, role, daily_call_cap}`, so a scoped agent silently became unrestricted
+  (`tool_access=None` = every tool) just by getting a new token: round-4 blocker #2. `create_agent` now
+  writes a field **only when the caller actually sent it** (`body.model_fields_set`, the shape
+  `set_member_access` already used for `project_access`); a brand-new agent, having nothing to keep,
+  still takes the documented defaults. `project_access` is preserved for free — `AgentIn` cannot even
+  express it, so it could previously only ever be lost.
 - **Two ACL axes, composed as AND** (`_tool_usable` = `_tool_allowed` AND `_project_allowed`). The
   project scope is the coarse dial, `tool_access` the fine one; both are NULL-means-everything and the
   owner is exempt from both. `project_access` holds project **IDs**, not slugs, so the hot-path check is
@@ -100,8 +108,13 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   accepts slugs or ids, 422s on an unknown one, and collapses an all-projects selection back to NULL
   (mirroring `_normalize_tool_access`). Endpoints: `create_project` / `list_projects` (a scoped member
   sees only their own) / `delete_project` (admin+) — deleting **frees** its tools back to org-wide rather
-  than hiding them, and drops the id from every member's scope, treating an emptied list as *unscoped*
-  so nobody is locked out of the whole team. Invites carry `project_access` onto the membership at both
+  than hiding them, and drops the id from every member's scope, **storing an emptied list as `[]`, never
+  NULL**. NULL means *every project*, so collapsing `[]` would hand a member scoped to only the deleted
+  project the run of every OTHER project's tools — a privilege escalation fired by an unrelated delete
+  (round-4 blocker #1, `test_security_round4.py`). `[]` already carries the intended meaning (org-wide
+  tools only), and nobody is locked out because the **freed tools** are what they keep: whatever the
+  member could reach before the delete they can still reach after it. That, not a widened scope, is
+  what "never lock anyone out" rests on. Invites carry `project_access` onto the membership at both
   accept doors, exactly as `tool_access` does.
 - Every list filters by `caller.org_id`; every create stamps `org_id = caller.org_id` +
   `owner = caller.email`; `_resolve_call` scopes **both** the named lookup and the host/longest-prefix
@@ -126,6 +139,14 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   `list_members`
   / `remove_member` (`GET`/`DELETE /orgs/{id}/members[/{user}]`, admin+; owners cannot be removed).
   `_require_admin_of(org_id, caller)` gates the admin endpoints (token must be for that org + role ≥ admin).
+- **An identity leaving takes its policy with it (`_drop_member_deny_rules`).** A `DenyRule` aimed at
+  one caller (`user_id` set) is meaningless once that caller is gone, and it lingers in the Policy
+  table naming a user id nobody can resolve. `remove_member`, `leave_org` and `revoke_agent` sweep the
+  rules for that `(user_id, org_id)`; `admin_delete_user` sweeps **every org's** rules for that user,
+  because `DenyRule.user_id` is a foreign key and a surviving row would dangle — Postgres rejects that
+  outright, while SQLite only hides it by not enforcing FKs (so the test suite alone cannot catch it).
+  ORG-wide rules (`user_id` NULL) are never touched: they are about the team, not about one caller.
+  Mirrors how `delete_project` sweeps the id it deletes out of every `project_access`.
 - **Org administration:** `set_member_role` (`PATCH /orgs/{id}/members/{user}`, **owner-only** via
   `_require_owner_of`; a `_count_owners` last-owner guard blocks demoting the sole owner — ownership
   transfer = promote another to owner, then step down), `leave_org` (`POST /orgs/{id}/leave`, self-removal,

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -37,6 +37,13 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   — the code is a shortcut, not a requirement. `email_token_hash` is the inbox-only **second secret** in
   the emailed link — it can sign the invitee in (`GET/POST /auth/invite-signin?t=`, one-time), while the
   admin-visible code never can.
+- **`Project`** — an OPTIONAL sub-scope inside an org (`org_id`, `name`, `slug`, unique `(org_id, slug)`).
+  The org stays the hard isolation boundary; a project is a softer grouping on top. Deliberately a
+  **label + ACL scope, NOT a namespace**: `Tool.name` stays unique per `(org_id, name)`, so no unique
+  constraint had to be rebuilt (`_fix_tool_uniqueness` had to do that once already, and SQLite cannot
+  alter constraints portably). `Tool.project_id` NULL = **org-wide**, which is every tool that predates
+  projects — so this shipped purely additive. Secrets stay org-level on purpose: one shared credential
+  legitimately backs tools in several projects.
 - **Machine identities** — a `User` on an **unroutable domain**, which is what makes it a machine
   rather than a person. Two exist: the published demo token (`PUBLIC_DEMO_DOMAIN`) and an **agent**
   (`AGENT_DOMAIN` = `agents.treg.local`). Both are minted by an admin and act ONLY by their token:
@@ -84,6 +91,18 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   Every identity door is blocked at the shared choke point `_find_or_create_user`, plus `register_user`
   (which predates it and creates a `User` directly) and `auth_email_start` (refuse early, mint no code).
   `list_members` carries `is_agent` so one roster can show people and machines apart.
+- **Two ACL axes, composed as AND** (`_tool_usable` = `_tool_allowed` AND `_project_allowed`). The
+  project scope is the coarse dial, `tool_access` the fine one; both are NULL-means-everything and the
+  owner is exempt from both. `project_access` holds project **IDs**, not slugs, so the hot-path check is
+  a pure set test (no id→slug query per call) and a rename cannot strand an access list.
+  `project_access=[X]` with `tool_access=NULL` means "every tool in project X, **including ones added
+  later**" — the composition that makes the coarse dial useful alone. `_normalize_project_access`
+  accepts slugs or ids, 422s on an unknown one, and collapses an all-projects selection back to NULL
+  (mirroring `_normalize_tool_access`). Endpoints: `create_project` / `list_projects` (a scoped member
+  sees only their own) / `delete_project` (admin+) — deleting **frees** its tools back to org-wide rather
+  than hiding them, and drops the id from every member's scope, treating an emptied list as *unscoped*
+  so nobody is locked out of the whole team. Invites carry `project_access` onto the membership at both
+  accept doors, exactly as `tool_access` does.
 - Every list filters by `caller.org_id`; every create stamps `org_id = caller.org_id` +
   `owner = caller.email`; `_resolve_call` scopes **both** the named lookup and the host/longest-prefix
   passthrough to the org; `call_tool` loads only same-org secrets. See [proxy-model](proxy-model.md).

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -166,13 +166,22 @@ upgrade. (`"user"` is quoted in the `ALTER` — a reserved word in Postgres, whe
 (create_all builds it NOT NULL with no server default). Verified in-place on Postgres. Later additive steps
 follow the same guarded pattern: (A14) `invite.landing`, (A15) `org.public_demo`, (A16) the seven `secret`
 connection-metadata columns (`provider`/`granted_scopes`/`resource_ref`/`resource_name`/`expires_at`/
-`last_refresh_at`/`last_error`), and (A17–A20) the eight `pendingoauth` OAuth-marketplace/quirk columns
+`last_refresh_at`/`last_error`), (A17–A20) the eight `pendingoauth` OAuth-marketplace/quirk columns
 (`provider`/`code_verifier`/`auth_params`/`token_endpoint_auth_method`/`client_id_param`/`scope_separator`/
 `long_lived_exchange`/`replaces_secret_id`). **Postgres BOOLEAN default fix (PR #22):** every boolean added
 in-place uses `DEFAULT false`, never `DEFAULT 0` — Postgres rejects an integer default on a `BOOLEAN`
 column (SQLite accepts both, so the test suite alone cannot catch it); `pendingoauth.long_lived_exchange`
 is spelled `BOOLEAN NOT NULL DEFAULT false`, and the legacy `INSERT INTO org (…)` backfill names
-`public_demo` explicitly with a `false` literal.
+`public_demo` explicitly with a `false` literal. **(A21) PROJECTS** follows the same shape: the `project`
+table itself needs no ALTER (a brand-new table is created by `create_all`), so the step only adds the three
+columns that hang off it — `tool.project_id` (INTEGER, nullable) plus `project_access` (JSON, nullable) on
+**both** `membership` and `invite`. Every one is nullable and NULL means *org-wide / unrestricted*, so an
+existing deployment behaves exactly as before until someone creates a project; and because none of them is a
+BOOLEAN, the Postgres integer-default trap does not apply here. Note what (A21) deliberately does NOT do:
+`Tool.name` keeps its `(org_id, name)` unique constraint, because projects are a **label + ACL scope, not a
+namespace** — making them a namespace would have meant rebuilding that constraint, which `_fix_tool_uniqueness`
+already had to do once and which SQLite cannot express portably. **`DenyRule`** (policy) needs no migration
+step at all for the same new-table reason.
 
 > Health (`run_all`) takes an `org_id` filter so `/health/run` never leaks other orgs' credentials, and
 > alerts resolve the owner's per-org membership webhook. See [auth-secrets](auth-secrets.md).

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -68,7 +68,8 @@ same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the pe
 - **URL-passthrough (agent-native):** `rest` is the real upstream URL (`/call/https://api.intercom.io/me`).
   `_normalize_scheme()` restores the `https://` a path param collapses to `https:/`. The tool is resolved
   by **host** (`_host_of()` = `urlsplit(...).netloc`, matched against the indexed `Tool.host`) then the
-  **longest `base_url` prefix**; a tie → `409`, no match → `404`.
+  **longest `base_url` prefix**; a tie → `409`, no match → `404` (or `403` when the caller's ACL is the
+  only thing that removed the match — see below).
 - **Named:** `rest = "<tool>/<path>"` (`rest.partition("/")`), looked up by `Tool.name`; upstream URL =
   `base_url + path`. **No path → the base URL itself, without a trailing slash** — a tool pinned to a
   full resource (`.../v1/charges`) must relay as-is, since Stripe `404`s `/v1/charges/`.
@@ -79,6 +80,14 @@ tool the caller cannot use must not be able to cause a `409` — or win the tieb
 cannot even see it in `list_tools`. This only NARROWS the candidate set, so it can never grant access:
 whatever resolves still passes `_require_tool_use`. The named shape needs no filter (it resolves one
 tool, then the gate runs).
+
+**"Not yours" is a `403`, not a `404`.** Narrowing the candidate set to empty first read as *nothing is
+registered here*, so a caller with no access was told the tool did not EXIST — which sends an admin
+hunting for a registration that is already there (round-4 finding #3). `_resolve_call` keeps the
+**unfiltered** host matches alongside the filtered ones: if a tool would have matched and only the ACL
+removed it, the answer is `403`, the same verdict the named shape has always given. A host with nothing
+registered is still `404`. The `403` names only the **host the caller typed**, never the tool name the
+ACL is there to hide.
 
 **Policy deny (`_enforce_deny`, `_deny_match`).** After resolution and the tool ACL, the resolved
 upstream is matched against the org's `DenyRule` rows (org-wide + the ones aimed at this caller) →

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -73,6 +73,17 @@ same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the pe
   `base_url + path`. **No path → the base URL itself, without a trailing slash** — a tool pinned to a
   full resource (`.../v1/charges`) must relay as-is, since Stripe `404`s `/v1/charges/`.
 
+**Policy deny (`_enforce_deny`, `_deny_match`).** After resolution and the tool ACL, the resolved
+upstream is matched against the org's `DenyRule` rows (org-wide + the ones aimed at this caller) →
+`403` naming the rule. Evaluating the **resolved** upstream is what makes both call shapes equally
+gated — a caller cannot dodge a rule by switching to URL-passthrough — and the relay does not follow
+redirects, so a blocked host is not reachable via a 3xx bounce. The path match is anchored at a
+segment boundary (`/v1/charges` must not match `/v1/chargesX`), the same trap `_resolve_call` guards.
+It applies to **every role including owner** (a guardrail, not a permission tier) and to both run
+tiers, where the tool's own `base_url` host stands in for the request path. `_deny_match` is pure, so
+it unit-tests without a DB — mirroring `localrun.check_deny`, which is the same idea one layer down
+(argv instead of URL). Zero rules = one indexed query and no behavior change.
+
 `call_tool()` loads every bound secret (running `oauth.ensure_fresh` on oauth secrets first — see
 [auth-secrets](auth-secrets.md)), calls `relay()`, then fires `audit.record_call(...)` off the response
 path. Methods allowed: GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -60,7 +60,7 @@ body raw (`aiter_raw`), so if the caller doesn't ask for compression httpx would
 for `identity` keeps what the caller receives matching what the caller requested.
 
 ## Tool resolution (`_resolve_call` in api.py)
-`* /call/{rest:path}` → `call_tool()` → `_resolve_call(rest, caller.org_id, db)` returns
+`* /call/{rest:path}` → `call_tool()` → `_resolve_call(rest, caller, db)` returns
 `(tool, upstream_url)`. **Both shapes are scoped to the caller's org** (`Tool.org_id == org_id`), so two
 orgs resolve independently and may reuse a tool name or upstream host; `call_tool` then loads only
 same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the per-user daily usage cap —
@@ -72,6 +72,13 @@ same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the pe
 - **Named:** `rest = "<tool>/<path>"` (`rest.partition("/")`), looked up by `Tool.name`; upstream URL =
   `base_url + path`. **No path → the base URL itself, without a trailing slash** — a tool pinned to a
   full resource (`.../v1/charges`) must relay as-is, since Stripe `404`s `/v1/charges/`.
+
+**ACL-filtered candidates.** `_resolve_call` takes the **caller** and filters passthrough candidates by
+`_tool_usable` (project scope AND the per-tool list) **before** the longest-prefix tiebreak. A same-host
+tool the caller cannot use must not be able to cause a `409` — or win the tiebreak — for someone who
+cannot even see it in `list_tools`. This only NARROWS the candidate set, so it can never grant access:
+whatever resolves still passes `_require_tool_use`. The named shape needs no filter (it resolves one
+tool, then the gate runs).
 
 **Policy deny (`_enforce_deny`, `_deny_match`).** After resolution and the tool ACL, the resolved
 upstream is matched against the org's `DenyRule` rows (org-wide + the ones aimed at this caller) →

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -1,0 +1,126 @@
+---
+title: Expanding a marketplace category — the add-a-provider playbook
+status: guide
+sources:
+  - src/treg/oauth_providers.py
+  - src/treg/api.py
+  - src/treg/config.py
+related:
+  - architecture/auth-secrets.md
+  - interface/api.md
+---
+
+# Expanding a marketplace category (adding providers)
+
+How we grew **SEO**, **Enrichment** and **Advertising** from a handful of entries to ten each. This is the
+repeatable process — follow it whenever a category needs more providers.
+
+Everything lives in **`oauth_providers.py`** (the `REGISTRY` of `OAuthProvider` entries). Connecting,
+verifying and auto-provisioning a pasted-key provider is **`connect_with_token`** (`POST /connections/token`)
+in `api.py`. Both are documented in [auth-secrets](../architecture/auth-secrets.md) + [api](../interface/api.md);
+this fragment is the *process*, not the mechanics reference.
+
+## The two kinds of provider
+- **API-key** (`auth_kind="key"`) — the user pastes a key; self-serve; **the fast path** (research → implement
+  → live-test in one session). This is the workhorse and where almost all growth happens.
+- **OAuth** (`auth_kind="oauth"`) — treg holds its own registered app; **heavy** (needs a dev-app registration
+  + client credentials). Add as **unconfigured** entries (they list `configured:false` until this deployment
+  sets the credentials).
+- **token** (Slack) — bring-your-own bot token; shares the pasted-secret path via `uses_pasted_secret`.
+
+## The fast path — adding an API-key provider
+
+1. **Curate.** Pick providers that fill a *gap* vs what the category already has (not near-duplicates). Use
+   the selection heuristics below. A research subagent is the right tool: give it the pool + criteria and have
+   it recommend + reject with reasons.
+2. **Get EXACT specs** per provider — `base_url`, auth (location / name / format), a **cheap or FREE probe
+   endpoint** (a valid key returns 200, an invalid key does NOT), and the **bad-key behavior** (status, or the
+   JSON field that signals invalid). Accuracy of `base_url` + probe path + bad-key behavior matters most,
+   because you validate them **live**. Have the research agent say "unconfirmed" rather than guess a path.
+3. **Add the registry entry** — an `OAuthProvider(auth_kind="key", …)` in `oauth_providers.py`; add it to the
+   `REGISTRY` tuple; add the category to `CATEGORY_ORDER` if it's new. Key providers have `scopes={}` (no
+   consent screen); the marketplace card leans on `summary`.
+4. **Placeholder logo** — `web/logos/<service>.svg` (a lettermark; swap for the official brand SVG later). The
+   guard test `test_every_provider_has_a_logo` fails without one. Do NOT reproduce a real brand mark — a neutral
+   lettermark is the placeholder.
+5. **Tests** — add the id to `test_every_provider_is_registered` (test_oauth_providers_m3) and the offerable
+   loop in test_key_providers.
+6. **LIVE bogus-key test — the load-bearing step.** Start the server and `POST /connections/token` with a
+   *garbage* key against the **real** API:
+   - `422` "rejected …" → correct (bad key rejected). Ship it.
+   - `200` → the probe does **not** validate the key → fix the verify (see the toolbox), or drop the provider.
+   - `404`/`502` in the reason → wrong probe path / host → fix `base_url`/`probe_path`.
+   This one step caught Apollo (`is_logged_in`), Akta (trailing slash), Majestic (`Code`), and ScrapeCreators
+   (accepts any key). **Never ship a key provider you haven't watched reject a bogus key.** Run in a throwaway
+   org and delete it after (test users are `e2e-…@treg.local`).
+7. **Run the suite, [sync docs](../../../.claude/skills/tools-registry-context/MAINTAINING.md), commit + push.**
+
+## The verify toolbox — which `OAuthProvider` field for which bad-key behavior
+
+| Provider behavior | Field(s) to set | Real example |
+|---|---|---|
+| Key in a header | `token_header` + `token_format` (`Bearer {secret}` / `{secret}` / `Token {secret}`) | TikHub, Apollo, SE Ranking |
+| Key in the query string | `token_location="query"` + `token_param` | Semrush, Diffbot, SpyFu |
+| HTTP Basic from `login:password` | `token_format="Basic {secret}"` + `token_encode="base64"` | DataForSEO, Moz |
+| HTTP Basic with a RAW token after `Basic ` | `token_format="Basic {secret}"`, **no** `token_encode` | The Companies API |
+| Cheapest check on a DIFFERENT host | `probe_url` (absolute) | Semrush (balance host), Diffbot (account host) |
+| Probe needs a POST body | `probe_method="POST"` + `probe_json` | Serpstat, Moz, Coresignal |
+| 200 on a bad key; a truthy field = valid | `token_verify_field` | Slack `ok`, Apollo `is_logged_in` |
+| 200 on a bad key; a field == a value = valid | `token_ok_field` + `token_ok_value` | Majestic `Code=="OK"` |
+| 200 on a bad key; an error object present = invalid | `token_reject_field` | Serpstat `error` |
+| 200 on a bad key; an `ERROR …` text body | handled automatically (text-error guard) | Semrush |
+| No free probe; valid key 400s on empty body, invalid 401s | `probe_reject_statuses=(401,403)` | Coresignal |
+| Ongoing tool health check | `probe_path` (a cheap GET on `base_url`) | most |
+
+The connect verify already parses JSON only when the response *is* JSON (so a CSV/text body doesn't error), and
+rejects on HTTP status by default.
+
+## Common traps (RCAs from real providers)
+- **200 for a bad key.** The status lies; read a body field (`token_verify_field` / `token_ok_field`). Apollo,
+  Majestic.
+- **Trailing-slash 307 redirect.** We don't follow redirects with the key attached, so we only see the 307. Put
+  the trailing slash **in `probe_path`** so it hits the clean 401. Akta.
+- **CSV / text response.** Don't JSON-parse; the verify guards on content-type. Semrush.
+- **Key in the URL PATH** (`/v3/{key}/…`). Our injectors only do header/query — **not supported**. Skip the
+  provider (or add a path injector). Adbeat.
+- **No free probe.** POST an empty body; a valid key 400s, an invalid 401s → `probe_reject_statuses=(401,403)`.
+  Coresignal.
+- **API accepts ANY key** (returns success for garbage). You cannot validate at connect — **drop it**; don't
+  ship a provider whose key can't be checked. ScrapeCreators.
+- **Cheapest check is off-host** → `probe_url`. Semrush, Diffbot.
+
+## Selection heuristics (what makes a provider worth adding)
+- **Self-serve API-key first** — sign up, get a key, no sales call. That is the entire speed advantage; anything
+  sales-gated breaks the fast path.
+- **Distinct value** — fill a gap the category lacks (phones, bulk data, knowledge-graph, tech-stack, GDPR
+  email…). Skip near-duplicates.
+- **Reliability / legal.** Reject, decisively and *with a recorded reason*: legal/shutdown risk (Proxycurl —
+  shut down by LinkedIn's suit, Jul 2025), deprecated/absorbed (Clearbit → HubSpot-gated), UI-only with no API
+  (BigSpy/AdSpy), enterprise-sales-gated (SimilarWeb, SensorTower, MediaRadar).
+- **The self-serve field is often THIN** (Ads especially — only ~4 real self-serve ad-intel APIs). When N clean
+  picks don't exist, **say so** and fill the count with an adjacent-but-clean pick (SerpApi for ads) or an
+  unconfigured OAuth platform — don't force a bad-fit provider.
+
+## The heavy path — adding an OAuth provider
+1. treg must register its **own** dev app on the network → `client_id`/`client_secret` → add the two settings
+   to `config.py` (`Settings`) so they load from env; the registry entry names them via
+   `client_id_setting`/`client_secret_setting`.
+2. Add the `OAuthProvider` with `auth_uri`/`token_uri`/`scopes`/`base_url`/`token_endpoint_auth_method`, a
+   **`SCOPE_LABELS` entry for every scope** (guarded by `test_every_requested_scope_has_a_label`), and a logo.
+   `write` must be a superset of `read` (`test_default_capability_is_the_broadest`) — or use a single capability.
+3. Unset credentials → it lists `configured:false`, so it is **safe to add UNCONFIGURED** to reach a target
+   count; it activates when the credentials are set.
+4. **Quirks** (all snapshotted onto `PendingOAuth`): `extra_credential_*` for a second header (Google Ads /
+   Microsoft Ads `DeveloperToken`), `auth_params={}` for non-Google providers that reject `access_type`,
+   `client_id_param` (TikTok's `app_id`/`client_key`), `scope_separator`, `pkce`, `long_lived_exchange`.
+5. **NON-STANDARD OAuth is not free.** TikTok Ads (`app_id`/`auth_code`, JSON-body token exchange, `code==0`
+   envelope, `Access-Token` header instead of `Authorization: Bearer`) does NOT work with the standard
+   `oauth.py` flow or the Bearer auto-provision binding. Add it as a **flagged placeholder** — it needs real
+   `oauth.py` + binding work before it can run.
+
+## The tests that gate every new provider
+- `test_every_provider_is_registered` — add the id.
+- `test_every_provider_has_a_logo` — add `web/logos/<id>.svg`.
+- `test_default_capability_is_the_broadest` — OAuth: `write ⊇ read` (or one capability).
+- `test_every_requested_scope_has_a_label` — a `SCOPE_LABELS` entry per OAuth scope (key providers have none).
+- `test_key_providers` — the offerable + connect-flow coverage for `auth_kind="key"`.

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -303,9 +303,12 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   connection can act on (GSC sites, GA properties, Ads accounts), enriching id-only rows with the
   upstream's human name concurrently (`_enrich_resource_labels`) and recording the successful upstream
   call as proof of health; `set_connection_resource` (`POST …/resource`) pins the chosen `resource_ref`
-  + `resource_name`. `connect_with_token` (`POST /connections/token`) connects a bring-your-own-bot-token
-  provider (Slack), **verifying the token against the provider's probe before storing** and then
-  auto-provisioning its tool. `set_extra_credential` (`POST /connections/{id}/extra-credential`) stores
+  + `resource_name`. `connect_with_token` (`POST /connections/token`) connects any **pasted-secret**
+  provider — a bring-your-own bot token (Slack) or an **API key** (Apollo, Hunter, TikHub, Semrush, …) —
+  **verifying the credential against the provider's probe before storing** (a header- OR query-param probe,
+  an off-host `probe_url`, tolerating a CSV/text body or a 200-with-false-`token_verify_field` reply), then
+  auto-provisioning its tool with a header or query binding. See
+  [auth-secrets](../architecture/auth-secrets.md). `set_extra_credential` (`POST /connections/{id}/extra-credential`) stores
   the second credential a provider needs when treg does NOT hold it centrally (rare) and finishes the
   tool with BOTH bindings. `revoke_connection` (`DELETE /connections/{id}`) deletes the credential and
   cleans up: it removes the tool treg auto-provisioned for the provider and drops the dead binding from

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -59,11 +59,15 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   [multi-tenancy](../architecture/multi-tenancy.md).
 - **Agents (machine identities):** `create_agent` (`POST /orgs/{id}/agents`, admin+) mints/rotates a
   member token for a machine caller — its own `daily_call_cap`, `tool_access` and audit trail, with no
-  new table; `list_agents` (`GET`, never returns a token) and `revoke_agent` (`DELETE …/{user_id}`).
-  An agent token is refused by `require_identity` and can never be an owner. See
+  new table; `list_agents` (`GET`, never returns a token) and `revoke_agent` (`DELETE …/{user_id}`,
+  which also sweeps the deny rules aimed at that agent). An agent token is refused by
+  `require_identity` and can never be an owner. **Re-POSTing the same name ROTATES, and a field the
+  caller omits is left as it is** — a rotate changes the token, never the limits. See
   [multi-tenancy](../architecture/multi-tenancy.md).
 - **Projects (a sub-scope inside the org):** `create_project` / `list_projects` /
-  `delete_project` (`/orgs/{id}/projects`, admin+ to mutate). `POST /tools` and `PATCH /tools/{id}`
+  `delete_project` (`/orgs/{id}/projects`, admin+ to mutate) — deleting frees its tools to org-wide and
+  removes the id from every member's `project_access`, leaving an emptied list as `[]` (NULL would mean
+  *every* project). `POST /tools` and `PATCH /tools/{id}`
   take `project` (slug or id; null = org-wide), and `set_member_access` / `create_invite` take
   `project_access`. See [multi-tenancy](../architecture/multi-tenancy.md).
 - **Deny rules (org policy):** `create_deny_rule` (`POST /orgs/{id}/deny`, admin+) blocks a

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -62,6 +62,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   new table; `list_agents` (`GET`, never returns a token) and `revoke_agent` (`DELETE …/{user_id}`).
   An agent token is refused by `require_identity` and can never be an owner. See
   [multi-tenancy](../architecture/multi-tenancy.md).
+- **Projects (a sub-scope inside the org):** `create_project` / `list_projects` /
+  `delete_project` (`/orgs/{id}/projects`, admin+ to mutate). `POST /tools` and `PATCH /tools/{id}`
+  take `project` (slug or id; null = org-wide), and `set_member_access` / `create_invite` take
+  `project_access`. See [multi-tenancy](../architecture/multi-tenancy.md).
 - **Deny rules (org policy):** `create_deny_rule` (`POST /orgs/{id}/deny`, admin+) blocks a
   host / path_prefix / method for the whole org or one member (`user_id`); an all-empty rule is
   refused (it would freeze the org) and a full URL is reduced to its host. Plus `list_deny_rules`

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -62,6 +62,11 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   new table; `list_agents` (`GET`, never returns a token) and `revoke_agent` (`DELETE …/{user_id}`).
   An agent token is refused by `require_identity` and can never be an owner. See
   [multi-tenancy](../architecture/multi-tenancy.md).
+- **Deny rules (org policy):** `create_deny_rule` (`POST /orgs/{id}/deny`, admin+) blocks a
+  host / path_prefix / method for the whole org or one member (`user_id`); an all-empty rule is
+  refused (it would freeze the org) and a full URL is reduced to its host. Plus `list_deny_rules`
+  (`GET`) and `delete_deny_rule` (`DELETE …/{rule_id}`, 404 across orgs). Enforced on the proxy and
+  both run tiers — see [proxy-model](../architecture/proxy-model.md).
 - **Usage metering + caps** (usage-metering v1, `docs/USAGE-METERING-PLAN.md`): `org_usage`
   (`GET /orgs/{id}/usage?days=`, admin+) rolls up `CallRecord` + `RunRecord` since the window start into
   **by-user** (with a `call`/`local_run`/`server_run` split), **by-tool**, **by-day**, and totals — pure

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -57,6 +57,11 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `_cascade_delete_org`, which now also sweeps each org's `RunRecord` rows);
   `list_invites` / `revoke_invite` (`GET`/`DELETE /orgs/{id}/invites[/{id}]`, admin+). Full behavior:
   [multi-tenancy](../architecture/multi-tenancy.md).
+- **Agents (machine identities):** `create_agent` (`POST /orgs/{id}/agents`, admin+) mints/rotates a
+  member token for a machine caller — its own `daily_call_cap`, `tool_access` and audit trail, with no
+  new table; `list_agents` (`GET`, never returns a token) and `revoke_agent` (`DELETE …/{user_id}`).
+  An agent token is refused by `require_identity` and can never be an owner. See
+  [multi-tenancy](../architecture/multi-tenancy.md).
 - **Usage metering + caps** (usage-metering v1, `docs/USAGE-METERING-PLAN.md`): `org_usage`
   (`GET /orgs/{id}/usage?days=`, admin+) rolls up `CallRecord` + `RunRecord` since the window start into
   **by-user** (with a `call`/`local_run`/`server_run` split), **by-tool**, **by-day**, and totals — pure

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -45,6 +45,21 @@ for a per-org token, and picks the org for an identity token). `_effective_org` 
 exits non-zero on HTTP >= 400.
 
 ## Commands
+- **Team policy + scoping (all under `org`, all admin+):**
+  - **`org agent-new <name>`** (`--role`, `--cap`, `--tools`, `--all-tools`, `--local-run`) mints or
+    **rotates** an agent's token — a member identity for a machine caller (`POST /orgs/{id}/agents`).
+    Re-running the same name rotates: the previous token dies there. **`org agents`** lists them with
+    today's usage; **`org agent-rm <user_id>`** revokes. Nested under `org` on purpose — the top-level
+    **`treg agents`** already means "which coding agents can I install skills for", an unrelated concept
+    (`agents.py`). See [multi-tenancy](../architecture/multi-tenancy.md).
+  - **`org deny`** (`--host`, `--path`, `--method`, `--user`, `--note`) blocks calls for the whole team or
+    one member/agent; **`org deny-ls`** / **`org deny-rm <id>`**. An empty field means *any*, so
+    `--method DELETE` alone blocks every delete. Enforced on the proxy AND both run tiers — see
+    [proxy-model](../architecture/proxy-model.md).
+  - **`org project-new <name>`** / **`org projects`** / **`org project-rm <id>`** manage the optional
+    sub-scope inside a team. `org access` and `org invite` additionally take **`--projects a,b`** /
+    **`--all-projects`**, which ride alongside the existing `--tools` flags (the two ACL axes compose as
+    AND). Deleting a project frees its tools back to team-wide rather than hiding them.
 - **`config`** (`--base-url`; shows email + active org + logged-in) · **`login`** — three doors in one
   `cmd_login`: default browser handshake — `POST /auth/cli/start` mints the `login_id` **and a short
   pairing code**, opens the universal `/login?cli=<id>#code=<code>` page — the code rides in the URL

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -120,10 +120,35 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   balanced quote pair removed). A single-line `NAME=value` splits only in the *name* field — a value
   containing `=` (base64 pad, connection strings) pastes untouched into the value field; multi-line
   splits from either field.
-- **Team settings** (`view==='orgs'`) — the **active** team's settings, not an all-teams list (switching
-  now lives in the sidebar dropdown). Renders `Manage {activeName}` — members / invite / pending / danger
-  zone for admins (`canAdmin`); a **personal** org shows a focused page with the invite + danger blocks
-  hidden. Reached via the sidebar org-dropdown ⚙.
+- **Team** (`view==='orgs'`) — the active team, now split into **tabs** (`orgTab`) because it had grown
+  into one scroll of unrelated things: **Members · My teams · Projects · Policy · Team settings**.
+  Header reads `Team: {activeName} — you are {activeRole}` and points at the sidebar picker for switching.
+  - **Members** — the roster (role, daily cap, today's usage, tool ACL, project scope, local-run toggle).
+    Inviting is no longer a separate section: it sits here behind an **"＋ Add member"** toggle
+    (`showInvite`), which is where people look for it. The inline access editor now carries **project
+    checkboxes** (`projDraft`) beside the tool ones, each collapsing "all checked" back to *all* so future
+    tools/projects are inherited. `list_members` returns `is_agent`, so people and machines are
+    distinguishable in one roster.
+  - **My teams** — the sidebar picker rendered as a real table (name, slug, your role, tool count, which
+    is active) with **Switch to** per row plus **New team** / **Join by code** / **Paste token**. The ONE
+    tab not gated on `canAdmin`: a plain member has teams too and the dropdown was their only way to see
+    them, so `loadOrgAdmin` moves a non-admin onto this tab instead of showing a permission notice.
+  - **Projects** — create / list (with tool counts) / delete, with the delete button stating that its
+    tools become team-wide rather than being deleted.
+  - **Policy** — deny rules (host / path / method / who / note), listed and removable. The "who" select
+    labels agents so a per-agent rule is one click.
+  - **Team settings** — leave / delete (the danger zone), acting on the team you are in.
+- **Agents** (`view==='agents'`, `canAdmin`) — its own sidebar entry rather than a row in Team, because an
+  agent identity is how most people will actually use treg. Create (name / role / daily cap), **Rotate**
+  (re-POSTs the same name, so the old token dies), **Revoke**, and an inline cap editor. A minted token
+  appears in an accented card that says it is shown **once**; under it are three paste-ready snippets
+  (`agentSnip`: Environment / Give it to your agent / Verify) built by the `agentSnippet` computed, mirroring
+  the Tools snippet block. Because a stored token is hashed and unrecoverable, each row also has a **Setup**
+  button (`showAgentSetup`) that reopens those snippets for an existing agent using `$TREG_TOKEN` as a
+  placeholder, telling the user to Rotate if the token was lost. Choosing `role=admin` raises a
+  confirmation spelling out that an admin agent can register/delete tools and secrets and manage members.
+- **Tool form** — Add/Edit now carries a **Project** dropdown (default "team-wide"); `loadProjectsIfNeeded`
+  fetches the list on demand so it works even if the Team page was never opened.
 - **Getting started** (`view==='start'`, under Help) — the CLI path: install (`{BASE}/install.sh`),
   `treg login`, `treg onboard`, register-a-tool + no-key call, and links to the interactive tutorial +
   `/llms.txt`. Per-block copy via `copyStart`.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -140,7 +140,10 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   - **Team settings** — leave / delete (the danger zone), acting on the team you are in.
 - **Agents** (`view==='agents'`, `canAdmin`) — its own sidebar entry rather than a row in Team, because an
   agent identity is how most people will actually use treg. Create (name / role / daily cap), **Rotate**
-  (re-POSTs the same name, so the old token dies), **Revoke**, and an inline cap editor. A minted token
+  (re-POSTs the same name, so the old token dies), **Revoke**, and an inline cap editor. Rotate sends
+  only `{name, role, daily_call_cap}` **on purpose**: `create_agent` leaves every field the client does
+  not send exactly as it was, so the agent's tool ACL and project scope survive the rotate. They used to
+  be silently cleared by this very button — see [multi-tenancy](../architecture/multi-tenancy.md). A minted token
   appears in an accented card that says it is shown **once**; under it are three paste-ready snippets
   (`agentSnip`: Environment / Give it to your agent / Verify) built by the `agentSnippet` computed, mirroring
   the Tools snippet block. Because a stored token is hashed and unrecoverable, each row also has a **Setup**

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -60,6 +60,14 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   (`TREG_DEMO_STRIPE_WEBHOOK_SECRET`, `whsec_…`) signs the landing payments feed; empty ⇒ `POST
   /stripe/webhook` is off (`404`, so a deploy without it exposes no unauthenticated POST surface). See
   [api](../interface/api.md).
+- **Frictionless local mode** (`single_user`, `single_user_token_file`): `curl {BASE}/selfhost.sh | sh`
+  brings up a registry on the caller's own machine that they are **already signed into** — no account,
+  email or password. `lifespan` calls `_bootstrap_single_user()`, which idempotently creates the
+  `you@local.treg` owner + `personal` team and writes the token (0600) for the installer to hand to the
+  CLI; the token is **stable across restarts** (re-minted only if the file is deleted), and `dashboard()`
+  attaches a session when there is none. Gated by **`single_user_ok`**, which mirrors `expose_dev_code`:
+  it demands a **local sqlite** DB **and** a **loopback `public_url`**, so a stray `TREG_SINGLE_USER=true`
+  on a real deploy does nothing. A no-login dashboard on a public host would hand over the whole registry.
 - `github_client_id` / `github_client_secret` / `session_secret` — GitHub OAuth login for the dashboard
   (`TREG_GITHUB_*`, `TREG_SESSION_SECRET`); empty hides the GitHub button. Callback must be
   `<public_url>/auth/github/callback`. See [dashboard](../interface/dashboard.md).

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -3,6 +3,7 @@ title: Running & deploying the server
 status: shipped
 sources:
   - src/treg/__main__.py
+  - src/treg/web/selfhost.sh
   - src/treg/config.py
   - src/treg/db.py
   - src/treg/email.py

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -66,7 +66,12 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   email or password. `lifespan` calls `_bootstrap_single_user()`, which idempotently creates the
   `you@local.treg` owner + `personal` team and writes the token (0600) for the installer to hand to the
   CLI; the token is **stable across restarts** (re-minted only if the file is deleted), and `dashboard()`
-  attaches a session when there is none. Gated by **`single_user_ok`**, which mirrors `expose_dev_code`:
+  attaches a session when there is none. It adopts an org **only through a membership this identity
+  already has** — never by looking one up by the slug `personal`. On a database that is not fresh (a
+  restored dump, a hosted registry run locally) that lookup joined a team belonging to someone else **as
+  owner**, and an owner is exempt from every ACL (round-4 finding #5). A new team therefore takes a free
+  slug via `_unique_slug` (`personal-2`, …) instead of colliding; a fresh box still gets the clean name.
+  Gated by **`single_user_ok`**, which mirrors `expose_dev_code`:
   it demands a **local sqlite** DB **and** a **loopback `public_url`**, so a stray `TREG_SINGLE_USER=true`
   on a real deploy does nothing. A no-login dashboard on a public host would hand over the whole registry.
 - `github_client_id` / `github_client_secret` / `session_secret` — GitHub OAuth login for the dashboard

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -49,8 +49,10 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   `google_ads_developer_token` (treg's token from OUR approved manager account, injected on every Ads
   call as a **platform binding** — see [proxy-model](../architecture/proxy-model.md)). The other
   providers each take a `<name>_client_id`/`_secret` pair: `linkedin_*`, `slack_*`, `x_*`, `tiktok_*`
-  (separate sandbox vs prod app), and `meta_*` (ONE Meta app backs both facebook + instagram). Empty for
-  a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
+  (separate sandbox vs prod app), `meta_*` (ONE Meta app backs both facebook + instagram), and the
+  Advertising OAuth platforms `microsoft_ads_*`, `snapchat_ads_*`, `tiktok_ads_*`, `pinterest_*` (all
+  unset by default, so those providers ship **unconfigured** until a deployment registers a dev app).
+  Empty for a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
 - **Landing live-wire (optional):** `demo_stripe_key` (`TREG_DEMO_STRIPE_KEY`, a Stripe **sandbox
   restricted** key) powers the landing sandbox's ONE real upstream call — a sandbox call to the exact
   seeded `stripe` tool relays for real with this key injected; the key exists in no sandbox org. Empty ⇒

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3943,15 +3943,21 @@ async def connect_with_token(
             payload = resp.json()
         except Exception:  # noqa: BLE001
             payload = {}
-    # Slack answers 200 with {"ok": false, "error": "invalid_auth"}, and Semrush answers 200 with a
-    # text body like "ERROR 120 :: ..." — an HTTP status alone would happily accept a dead key.
+    # Some providers answer HTTP 200 even for a BAD key and signal validity only in the body: a JSON
+    # field (Slack: "ok"; Apollo: "is_logged_in") or an "ERROR ..." text line (Semrush). An HTTP
+    # status alone would happily accept a dead key, so check all three signals.
+    field_bad = bool(provider.token_verify_field) and not payload.get(provider.token_verify_field)
     text_error = (
         resp.status_code < 400
         and not ctype.startswith("application/json")
         and resp.text.lstrip().upper().startswith("ERROR")
     )
-    if resp.status_code >= 400 or payload.get("ok") is False or text_error:
-        why = payload.get("error") or (resp.text.strip()[:80] if text_error else f"HTTP {resp.status_code}")
+    if resp.status_code >= 400 or field_bad or text_error:
+        why = (
+            payload.get("error")
+            or (f"{provider.token_verify_field}=false" if field_bad else None)
+            or (resp.text.strip()[:80] if text_error else f"HTTP {resp.status_code}")
+        )
         raise HTTPException(status_code=422, detail=f"{provider.display_name} rejected that token ({why})")
 
     secret = (await db.execute(

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3456,13 +3456,20 @@ async def _autoprovision_provider_tool(
             select(Tool).where(Tool.org_id == secret.org_id, Tool.name == tool_name)
         )
     ).scalars().first()
-    # A token provider's secret is a plain string, not an oauth blob — injecting it with
-    # secret_field="access_token" would try to read a JSON field that isn't there.
-    if provider.is_token_kind:
-        bindings = [{
-            "secret_id": secret.id, "injector": "env", "location": "header",
-            "name": provider.token_header, "format": provider.token_format,
-        }]
+    # A pasted-secret provider's value is a plain string, not an oauth blob — injecting it with
+    # secret_field="access_token" would try to read a JSON field that isn't there. A key may ride in
+    # a header (default) or a query param (Semrush's ?key=…).
+    if provider.uses_pasted_secret:
+        if provider.token_location == "query":
+            bindings = [{
+                "secret_id": secret.id, "injector": "env", "location": "query",
+                "name": provider.token_param, "format": provider.token_format,
+            }]
+        else:
+            bindings = [{
+                "secret_id": secret.id, "injector": "env", "location": "header",
+                "name": provider.token_header, "format": provider.token_format,
+            }]
     else:
         bindings = [{
             "secret_id": secret.id, "injector": "oauth", "location": "header",
@@ -3797,9 +3804,11 @@ async def connection_resources(
             detail=f"{secret.provider or 'this provider'} has nothing to choose between — it acts on your whole account",
         )
     await oauth.ensure_fresh(secret, db, request.app.state.http)  # no-op for a non-oauth secret
-    # A bring-your-own-token secret is a PLAIN STRING, not an oauth blob — json.loads on it throws.
+    # A pasted-secret (bot token / API key) secret is a PLAIN STRING, not an oauth blob — json.loads
+    # on it throws. (Only header-auth pasted providers reach here; a query-key provider like Semrush
+    # has nothing to discover, so supports_discovery is False and this endpoint 422s earlier.)
     raw = crypto.decrypt(secret.value)
-    if provider.is_token_kind:
+    if provider.uses_pasted_secret:
         disc_headers = {provider.token_header: provider.token_format.format(secret=raw)}
     else:
         blob = json.loads(raw)
@@ -3899,31 +3908,50 @@ async def connect_with_token(
     body: TokenConnectIn, request: Request,
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Connect a provider where the user brings their own bot token (Slack).
+    """Connect a provider the user brings a pasted credential for — a bot token (Slack) or an API
+    key (Apollo, TikHub, Semrush, …).
 
-    The token is VERIFIED against the provider's probe before anything is stored. Saving an
+    The credential is VERIFIED against the provider's probe before anything is stored. Saving an
     unverified credential just moves the failure to the first real call, by which point the user
-    has left the setup screen and has no idea which of the three steps they got wrong."""
+    has left the setup screen and has no idea which of the steps they got wrong."""
     _require_can_register(caller)
     provider = oauth_providers.get(body.provider)
-    if provider is None or not provider.is_token_kind:
+    if provider is None or not provider.uses_pasted_secret:
         raise HTTPException(status_code=422, detail="this provider is connected by consent, not a token")
     token = body.token.strip()
     if not token:
         raise HTTPException(status_code=422, detail=f"{provider.token_label or 'Token'} is required")
 
-    headers = {provider.token_header: provider.token_format.format(secret=token)}
+    # The credential rides in a header (default) or a query param (Semrush: ?key=…). The cheapest
+    # check may also live on a different host than base_url, so honor an absolute probe_url override.
+    rendered = provider.token_format.format(secret=token)
+    if provider.token_location == "query":
+        headers, params = {}, {provider.token_param: rendered}
+    else:
+        headers, params = {provider.token_header: rendered}, {}
+    probe_url = provider.probe_url or f"{provider.base_url.rstrip('/')}{provider.probe_path}"
     try:
-        resp = await request.app.state.http.get(
-            f"{provider.base_url.rstrip('/')}{provider.probe_path}", headers=headers
-        )
-        payload = resp.json() if resp.status_code < 500 else {}
+        resp = await request.app.state.http.get(probe_url, headers=headers, params=params)
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"could not reach {provider.display_name}: {exc}") from None
-    # Slack answers 200 with {"ok": false, "error": "invalid_auth"} — an HTTP status alone would
-    # happily accept a dead token.
-    if resp.status_code >= 400 or payload.get("ok") is False:
-        why = payload.get("error") or f"HTTP {resp.status_code}"
+    # Only parse JSON when the response actually is JSON — a key check may answer in CSV/text
+    # (Semrush's balance endpoint), where resp.json() would throw and mask a valid key as unreachable.
+    ctype = resp.headers.get("content-type", "")
+    payload: dict = {}
+    if resp.status_code < 500 and ctype.startswith("application/json"):
+        try:
+            payload = resp.json()
+        except Exception:  # noqa: BLE001
+            payload = {}
+    # Slack answers 200 with {"ok": false, "error": "invalid_auth"}, and Semrush answers 200 with a
+    # text body like "ERROR 120 :: ..." — an HTTP status alone would happily accept a dead key.
+    text_error = (
+        resp.status_code < 400
+        and not ctype.startswith("application/json")
+        and resp.text.lstrip().upper().startswith("ERROR")
+    )
+    if resp.status_code >= 400 or payload.get("ok") is False or text_error:
+        why = payload.get("error") or (resp.text.strip()[:80] if text_error else f"HTTP {resp.status_code}")
         raise HTTPException(status_code=422, detail=f"{provider.display_name} rejected that token ({why})")
 
     secret = (await db.execute(

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -47,7 +47,7 @@ from . import oauth_providers
 from . import pubfeed, ratestore, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings
 from .db import get_session, init_db
-from .models import ROLE_RANK, Bundle, CallRecord, DenyRule, Invite, Membership, Org, PendingOAuth, RunRecord, Secret, Tool, User
+from .models import ROLE_RANK, Bundle, CallRecord, DenyRule, Invite, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User
 from .proxy import relay
 
 
@@ -1357,7 +1357,7 @@ async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
 
 async def _cascade_delete_org(org: Org, db: AsyncSession) -> None:
     """Delete every org-scoped row then the org. Shared by owner delete_org + admin force-delete."""
-    for model in (Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Membership):
+    for model in (Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project, Membership):
         for r in (await db.execute(select(model).where(model.org_id == org.id))).scalars().all():
             await db.delete(r)
     await db.delete(org)
@@ -1393,6 +1393,35 @@ def _require_tool_access(caller: Caller, tool_name: str) -> None:
         raise HTTPException(status_code=403, detail=(
             f"you don't have access to the tool {tool_name!r} in this team — an admin can grant it "
             "(dashboard → Team, or `treg org access <you> --tools …`)"))
+
+
+def _project_allowed(caller: Caller, tool: Tool) -> bool:
+    """Per-member PROJECT scope, the coarse dial above the per-tool one.
+
+    NULL `project_access` = the whole org (the default, so nothing changed when projects landed), and a
+    tool with NULL `project_id` is ORG-WIDE and always in scope — which is every tool that existed
+    before projects. Owner is never restricted, matching `_tool_allowed`. Pure: `project_access` holds
+    project IDs, so this is a set test with no query, even on the proxy's hot path."""
+    if caller.role == "owner":
+        return True
+    access = caller.membership.project_access
+    return access is None or tool.project_id is None or tool.project_id in access
+
+
+def _tool_usable(caller: Caller, tool: Tool) -> bool:
+    """The two ACL axes compose as AND: the project scope AND the per-tool list must both allow it.
+    `project_access=[X]` with `tool_access=NULL` therefore means "every tool in project X, including
+    ones added later" — the composition that makes the coarse dial useful on its own."""
+    return _tool_allowed(caller, tool.name) and _project_allowed(caller, tool)
+
+
+def _require_tool_use(caller: Caller, tool: Tool) -> None:
+    """Gate any use of a tool (proxy call + both run tiers) on BOTH ACL axes."""
+    _require_tool_access(caller, tool.name)
+    if not _project_allowed(caller, tool):
+        raise HTTPException(status_code=403, detail=(
+            f"the tool {tool.name!r} belongs to a project you're not scoped to — an admin can grant it "
+            "(dashboard → Team, or `treg org access <you> --projects …`)"))
 
 
 def _deny_match(rules: list[DenyRule], host: str, path: str, method: str) -> DenyRule | None:
@@ -1457,7 +1486,7 @@ async def _visible_secret_ids(caller: Caller, db: AsyncSession) -> set[int] | No
     tools = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id))).scalars().all()
     ids: set[int] = set()
     for t in tools:
-        if not _tool_allowed(caller, t.name):
+        if not _tool_usable(caller, t):
             continue
         ids |= {b.get("secret_id") for b in (t.bindings or []) if b.get("secret_id") is not None}
         ids |= {e.get("secret_id") for e in ((t.cli or {}).get("inject") or []) if e.get("secret_id") is not None}
@@ -1489,6 +1518,7 @@ class InviteIn(BaseModel):
     # Access to seed onto the membership on accept: tool_access None = all tools, a list = the allowed
     # tool names; local_run may be turned off. Both default to the unrestricted state.
     tool_access: list[str] | None = None
+    project_access: list[str | int] | None = None  # None = the whole org; slugs/ids = the scoped set
     local_run_enabled: bool = True
     landing: str | None = None  # a shared detail page ("/app/skills/<name>") to land on after sign-in
 
@@ -1514,6 +1544,9 @@ class CapIn(BaseModel):
 class AccessIn(BaseModel):
     # tool_access: None = all tools (clear the restriction); a list = the ONLY tool names allowed.
     tool_access: list[str] | None = None
+    # project_access: None = the whole org; a list of project SLUGS or IDS = the only projects allowed.
+    # Accepts slugs because that's the human handle; stored as ids (see _normalize_project_access).
+    project_access: list[str | int] | None = None
     local_run_enabled: bool = True
 
 
@@ -1546,6 +1579,7 @@ class ToolIn(BaseModel):
     health_check: dict | None = None  # {method, path, expect_status}
     examples: list[dict] | None = None  # [{method, path, note}]
     cli: dict | None = None  # local-run profile for `treg run` (docs/CLI-RUN-PLAN.md)
+    project: str | int | None = None  # project slug or id; None = org-wide (the default)
 
 
 class ToolUpdate(BaseModel):
@@ -1554,6 +1588,7 @@ class ToolUpdate(BaseModel):
     health_check: dict | None = None
     examples: list[dict] | None = None
     cli: dict | None = None  # set/replace the local-run profile; explicit null clears it
+    project: str | int | None = None  # move between projects; explicit null makes it org-wide
 
 
 class GrantIn(BaseModel):
@@ -1870,6 +1905,7 @@ async def create_invite(
     days = max(1, min(body.expires_days, 3650))  # clamp BOTH ends — a huge value overflows datetime → 500
     expires_at = _utcnow_naive() + timedelta(days=days)
     tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
+    project_access = await _normalize_project_access(body.project_access, org_id, db)
     if body.landing is not None and not _LANDING_RE.match(body.landing):
         raise HTTPException(status_code=422, detail="landing must be a detail path like /app/skills/<name>")
     code = crypto.new_token()
@@ -1881,7 +1917,8 @@ async def create_invite(
         org_id=org_id, email=email, role=body.role,
         code_hash=crypto.hash_token(code), email_token_hash=crypto.hash_token(email_token),
         invited_by=caller.email, expires_at=expires_at,
-        tool_access=tool_access, local_run_enabled=body.local_run_enabled, landing=body.landing,
+        tool_access=tool_access, project_access=project_access,
+        local_run_enabled=body.local_run_enabled, landing=body.landing,
     )
     db.add(invite)
     await db.commit()
@@ -1936,7 +1973,8 @@ async def accept_invite(body: AcceptIn, db: AsyncSession = Depends(get_session))
         raise HTTPException(status_code=409, detail="already a member of this org")
     token = crypto.new_token()
     db.add(Membership(user_id=user.id, org_id=invite.org_id, role=invite.role, token_hash=crypto.hash_token(token),
-                      tool_access=invite.tool_access, local_run_enabled=invite.local_run_enabled))
+                      tool_access=invite.tool_access, project_access=invite.project_access,
+                      local_run_enabled=invite.local_run_enabled))
     invite.status = "accepted"
     try:
         await db.commit()  # a concurrent double-accept trips uq_membership_user_org — 409, not 500
@@ -2309,7 +2347,8 @@ async def accept_my_invite(
     token = crypto.new_token()  # return the org-scoped token (was minted-then-discarded → an unusable membership)
     db.add(Membership(
         user_id=user.id, org_id=invite.org_id, role=invite.role, token_hash=crypto.hash_token(token),
-        tool_access=invite.tool_access, local_run_enabled=invite.local_run_enabled,
+        tool_access=invite.tool_access, project_access=invite.project_access,
+        local_run_enabled=invite.local_run_enabled,
     ))
     invite.status = "accepted"
     try:
@@ -2372,7 +2411,8 @@ async def list_members(
         if user is not None:
             out.append({"user_id": user.id, "email": user.email, "role": m.role,
                         "daily_call_cap": m.daily_call_cap, "used_today": used.get(user.email, 0),
-                        "tool_access": m.tool_access, "local_run_enabled": m.local_run_enabled,
+                        "tool_access": m.tool_access, "project_access": m.project_access,
+                        "local_run_enabled": m.local_run_enabled,
                         # so the dashboard can separate people from machines in one roster
                         "is_agent": _is_agent_email(user.email)})
     return out
@@ -2452,9 +2492,11 @@ async def set_member_access(
     if membership.role == "owner":
         raise HTTPException(status_code=403, detail="an owner always has full access; it can't be restricted")
     membership.tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
+    membership.project_access = await _normalize_project_access(body.project_access, org_id, db)
     membership.local_run_enabled = body.local_run_enabled
     await db.commit()
     return {"user_id": user_id, "org_id": org_id, "tool_access": membership.tool_access,
+            "project_access": membership.project_access,
             "local_run_enabled": membership.local_run_enabled}
 
 
@@ -2736,6 +2778,129 @@ async def revoke_agent(
         await db.delete(user)
     await db.commit()
     return {"revoked": True, "email": email}
+
+
+# ---- projects: an optional sub-scope inside an org ------------------------------------------
+class ProjectIn(BaseModel):
+    name: str
+
+
+def _project_view(p: Project, tool_count: int | None = None) -> dict:
+    out = {"id": p.id, "name": p.name, "slug": p.slug, "created_by": p.created_by,
+           "created_at": p.created_at}
+    if tool_count is not None:
+        out["tool_count"] = tool_count
+    return out
+
+
+async def _normalize_project_access(
+    refs: list[str | int] | None, org_id: int, db: AsyncSession
+) -> list[int] | None:
+    """Turn slugs/ids into the stored list of project IDS, mirroring `_normalize_tool_access`:
+    validate against the org's own projects (422 on unknown — never silently ignore a typo) and
+    **collapse an all-projects selection back to NULL**, so a fully-scoped member keeps
+    auto-inheriting projects created later."""
+    if refs is None:
+        return None
+    known = (await db.execute(select(Project).where(Project.org_id == org_id))).scalars().all()
+    by_slug = {p.slug: p.id for p in known}
+    by_id = {p.id for p in known}
+    ids: set[int] = set()
+    for ref in refs:
+        if isinstance(ref, int) or (isinstance(ref, str) and ref.isdigit()):
+            pid = int(ref)
+            if pid not in by_id:
+                raise HTTPException(status_code=422, detail=f"unknown project {ref!r} in this team")
+            ids.add(pid)
+        elif ref in by_slug:
+            ids.add(by_slug[ref])
+        else:
+            raise HTTPException(status_code=422, detail=f"unknown project {ref!r} in this team")
+    if known and ids >= by_id:
+        return None  # every project selected = unrestricted, so store it as such
+    return sorted(ids)
+
+
+async def _resolve_project(ref: str | int | None, org_id: int, db: AsyncSession) -> Project | None:
+    """A project by slug or id, scoped to the org (404 across orgs). None/'' = org-wide."""
+    if ref is None or ref == "":
+        return None
+    q = select(Project).where(Project.org_id == org_id)
+    if isinstance(ref, int) or (isinstance(ref, str) and str(ref).isdigit()):
+        q = q.where(Project.id == int(ref))
+    else:
+        q = q.where(Project.slug == _slugify(str(ref)))
+    project = (await db.execute(q)).scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail=f"no project {ref!r} in this team")
+    return project
+
+
+@app.post("/orgs/{org_id}/projects")
+async def create_project(
+    org_id: int, body: ProjectIn,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Create a project — a sub-scope inside the team (admin+). Tools can then be filed under it and
+    members scoped to it. Creating one changes nothing on its own: existing tools stay org-wide."""
+    _require_admin_of(org_id, caller)
+    name = (body.name or "").strip()
+    slug = _slugify(name)
+    if not name or not slug:
+        raise HTTPException(status_code=422, detail="name is required")
+    if (await db.execute(select(Project).where(
+            Project.org_id == org_id, Project.slug == slug))).scalar_one_or_none():
+        raise HTTPException(status_code=409, detail=f"a project {slug!r} already exists in this team")
+    project = Project(org_id=org_id, name=name, slug=slug, created_by=caller.email)
+    db.add(project)
+    await db.commit()
+    await db.refresh(project)
+    return _project_view(project, tool_count=0)
+
+
+@app.get("/orgs/{org_id}/projects")
+async def list_projects(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> list[dict]:
+    """The team's projects. A member scoped to some of them sees only those (the ACL hides what it
+    gates, matching how `list_tools` behaves)."""
+    if caller.org_id != org_id:
+        raise HTTPException(status_code=403, detail="use this team's token")
+    projects = (await db.execute(select(Project).where(Project.org_id == org_id))).scalars().all()
+    access = caller.membership.project_access
+    if caller.role != "owner" and access is not None:
+        projects = [p for p in projects if p.id in access]
+    counts = dict((await db.execute(
+        select(Tool.project_id, func.count(Tool.id)).where(Tool.org_id == org_id).group_by(Tool.project_id)
+    )).all())
+    return [_project_view(p, tool_count=counts.get(p.id, 0)) for p in projects]
+
+
+@app.delete("/orgs/{org_id}/projects/{project_id}")
+async def delete_project(
+    org_id: int, project_id: int,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Delete a project. Its tools are NOT deleted — they fall back to org-wide, which is the safe
+    direction (a tool that quietly vanished from every listing would be far worse than one that
+    briefly becomes visible to the whole team). Members scoped to it lose that entry."""
+    _require_admin_of(org_id, caller)
+    project = await db.get(Project, project_id)
+    if project is None or project.org_id != org_id:  # 404 across orgs — never confirm another org's ids
+        raise HTTPException(status_code=404, detail="unknown project")
+    freed = 0
+    for tool in (await db.execute(select(Tool).where(Tool.project_id == project_id))).scalars().all():
+        tool.project_id = None
+        freed += 1
+    for m in (await db.execute(select(Membership).where(Membership.org_id == org_id))).scalars().all():
+        if m.project_access and project_id in m.project_access:
+            remaining = [p for p in m.project_access if p != project_id]
+            # An empty list would mean "no projects at all" — treat it as "unscoped" instead of
+            # silently locking the member out of every tool in the team.
+            m.project_access = remaining or None
+    await db.delete(project)
+    await db.commit()
+    return {"deleted": project_id, "tools_made_org_wide": freed}
 
 
 # ---- deny rules: org policy over what may be called ----------------------------------------
@@ -3049,10 +3214,12 @@ async def create_tool(
     await _validate_bundle_id(body.bundle_id, caller.org_id, db)
     _validate_cli_profile(body.cli)
     await _validate_cli_secrets(body.cli, caller, db)
+    project = await _resolve_project(body.project, caller.org_id, db)
     tool = Tool(
         org_id=caller.org_id, name=body.name, owner=caller.email, base_url=body.base_url,
         host=_host_of(body.base_url), bindings=bindings, health_check=body.health_check,
         examples=body.examples or [], cli=body.cli, bundle_id=body.bundle_id,
+        project_id=project.id if project else None,
     )
     db.add(tool)
     try:
@@ -3068,7 +3235,7 @@ async def list_tools(
 ) -> list[dict]:
     rows = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id))).scalars().all()
     # The per-member tool ACL hides what it gates: a restricted member's listing shows only their tools.
-    return [_tool_view(t) for t in rows if _tool_allowed(caller, t.name)]
+    return [_tool_view(t) for t in rows if _tool_usable(caller, t)]
 
 
 @app.get("/tools/by-name/{name}")
@@ -3081,7 +3248,7 @@ async def get_tool_by_name(
     )).scalars().first()
     if tool is None:
         raise HTTPException(status_code=404, detail="tool not found")
-    _require_tool_access(caller, tool.name)  # a 403 names the fix (ask an admin) — clearer than a fake 404
+    _require_tool_use(caller, tool)  # a 403 names the fix (ask an admin) — clearer than a fake 404
     return _tool_view(tool)
 
 
@@ -3114,6 +3281,9 @@ async def update_tool(
     if "cli" in fields:  # explicit null clears the profile (turns local runs off entirely)
         _validate_cli_profile(fields["cli"])
         await _validate_cli_secrets(fields["cli"], caller, db, grandfather)
+    if "project" in fields:  # slug/id in, column out; explicit null = back to org-wide
+        project = await _resolve_project(fields.pop("project"), caller.org_id, db)
+        tool.project_id = project.id if project else None
     for k, v in fields.items():
         setattr(tool, k, v)
     if "base_url" in fields:
@@ -3197,7 +3367,7 @@ async def grant_local_run(
     tool = (await db.execute(select(Tool).where(Tool.org_id == caller.org_id, Tool.name == name))).scalar_one_or_none()
     if tool is None:
         raise HTTPException(status_code=404, detail="tool not found")
-    _require_tool_access(caller, tool.name)  # per-member tool ACL (call + both run tiers)
+    _require_tool_use(caller, tool)  # per-member tool + project ACL (call + both run tiers)
     _require_local_run(caller)               # local tier may be disabled for this member (server-only)
     await _enforce_deny(caller, tool.base_url, "", db)  # host-level policy (see run_tool_server)
     await _enforce_daily_cap(caller, db)  # a local run counts toward the per-user daily cap
@@ -4692,7 +4862,7 @@ async def admin_delete_org(
 
 
 # ---- the proxy: call a tool without holding its credential --------------------------------
-async def _resolve_call(rest: str, org_id: int, db: AsyncSession) -> tuple[Tool, str]:
+async def _resolve_call(rest: str, caller: Caller, db: AsyncSession) -> tuple[Tool, str]:
     """Resolve `/call/<rest>` to (tool, full upstream URL), scoped to the caller's org. Shapes:
 
     - URL-passthrough (agent-facing): rest is the real upstream URL. Resolve the tool by host
@@ -4701,16 +4871,26 @@ async def _resolve_call(rest: str, org_id: int, db: AsyncSession) -> tuple[Tool,
 
     Both lookups are constrained to `org_id`, so two orgs resolve independently (and may reuse
     a tool name or an upstream host without colliding).
+
+    Passthrough candidates are additionally filtered by the caller's ACL (project scope AND the
+    per-tool list) *before* the longest-prefix tiebreak. That ordering matters: a same-host tool the
+    caller cannot use must not be able to cause a 409 — or win the tiebreak — for someone who can't
+    even see it in `list_tools`. This narrows the candidate set, so it can never grant access: whatever
+    resolves still passes `_require_tool_use`. The named shape needs no filter (it resolves one tool).
     """
+    org_id = caller.org_id
     norm = _normalize_scheme(rest)
     if norm.startswith("http://") or norm.startswith("https://"):
         try:
             host = urlsplit(norm).netloc.lower()
         except ValueError:  # malformed passthrough URL (e.g. unbalanced IPv6 brackets) → 400, not 500
             raise HTTPException(status_code=400, detail="malformed upstream URL")
-        candidates = (
-            await db.execute(select(Tool).where(Tool.host == host, Tool.org_id == org_id))
-        ).scalars().all()
+        candidates = [
+            t for t in (await db.execute(
+                select(Tool).where(Tool.host == host, Tool.org_id == org_id)
+            )).scalars().all()
+            if _tool_usable(caller, t)  # a tool the caller can't use can't 409 them either
+        ]
         # Match on a path-segment boundary, not a raw string prefix: base `.../v2` must NOT match
         # request `.../v20/...` (that would inject v2's credential onto an unregistered sibling path).
         def _prefix_match(base: str) -> bool:
@@ -4796,8 +4976,8 @@ async def call_tool(
         _, sep, raw_rest = raw_path.decode("ascii", "replace").partition("/call/")
         if sep:
             rest = raw_rest
-    tool, upstream_url = await _resolve_call(rest, caller.org_id, db)
-    _require_tool_access(caller, tool.name)  # per-member tool ACL (NULL access = all; admins exempt)
+    tool, upstream_url = await _resolve_call(rest, caller, db)
+    _require_tool_use(caller, tool)  # per-member tool + project ACL (NULL access = all; admins exempt)
     # Policy deny — evaluated on the RESOLVED upstream, so it sees the real host/path/method whichever
     # shape the caller used (named or URL-passthrough), and the relay never follows redirects, so a
     # blocked host can't be reached via a 3xx bounce.
@@ -4896,7 +5076,7 @@ async def run_tool_server(
     ).scalar_one_or_none()
     if tool is None:
         raise HTTPException(status_code=404, detail=f"no tool {body.tool!r} in this org")
-    _require_tool_access(caller, tool.name)  # per-member tool ACL
+    _require_tool_use(caller, tool)  # per-member tool + project ACL
     # A run executes a CLI, so there is no request path to match — evaluate the tool's own upstream
     # host, which is what a host-level rule ("nobody may reach api.stripe.com") is really saying.
     await _enforce_deny(caller, tool.base_url, "", db)
@@ -4954,6 +5134,7 @@ def _tool_view(t: Tool) -> dict:
         # every pre-auth_mechanism tool server-runnable as before).
         "server_runnable": (bool(t.cli) and (t.cli.get("bin") or t.name) in _allowed_server_bins()
                             and (t.cli.get("auth_mechanism") or "env") in ("env", "argv")),
+        "project_id": t.project_id,  # None = org-wide
         "bundle_id": t.bundle_id,
     }
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -74,22 +74,29 @@ async def _bootstrap_single_user() -> None:
             user = User(email=LOCAL_USER_EMAIL, onboarded=True)
             db.add(user)
             await db.flush()
-        org = (await db.execute(select(Org).where(Org.slug == LOCAL_ORG_NAME))).scalar_one_or_none()
-        if org is None:
-            org = Org(name=LOCAL_ORG_NAME.title(), slug=LOCAL_ORG_NAME)
+        # Adopt an org ONLY through a membership this identity already has. Looking one up by the
+        # slug `personal` and joining it as owner would, on a database that is not fresh, hand the
+        # password-less local identity ownership of a team that belongs to someone else — and an
+        # owner is exempt from every ACL. A new team therefore takes a FREE slug (`personal-2`, …)
+        # rather than colliding with whatever already holds `personal`.
+        membership = (await db.execute(
+            select(Membership).where(Membership.user_id == user.id).order_by(Membership.id)
+        )).scalars().first()
+        token = ""
+        if membership is None:
+            org = Org(name=LOCAL_ORG_NAME.title(), slug=await _unique_slug(LOCAL_ORG_NAME, db))
             db.add(org)
             await db.flush()
-        membership = (await db.execute(select(Membership).where(
-            Membership.user_id == user.id, Membership.org_id == org.id))).scalar_one_or_none()
-        token = ""
-        if membership is None or not path.exists():
-            token = crypto.new_token()  # first boot, or the token file was removed
-            if membership is None:
-                membership = Membership(user_id=user.id, org_id=org.id, role="owner",
-                                        token_hash=crypto.hash_token(token))
-                db.add(membership)
-            else:
+            token = crypto.new_token()  # first boot
+            membership = Membership(user_id=user.id, org_id=org.id, role="owner",
+                                    token_hash=crypto.hash_token(token))
+            db.add(membership)
+        else:
+            org = await db.get(Org, membership.org_id)
+            if not path.exists():
+                token = crypto.new_token()  # the token file was removed — mint a replacement
                 membership.token_hash = crypto.hash_token(token)
+        team = org.slug if org is not None else LOCAL_ORG_NAME
         await db.commit()
     if token:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -98,7 +105,7 @@ async def _bootstrap_single_user() -> None:
     shown = token or "(unchanged — see " + str(path) + ")"
     print(f"\n  treg is ready — no account needed."
           f"\n  Dashboard  {s.public_url}/app"
-          f"\n  Team       {LOCAL_ORG_NAME}"
+          f"\n  Team       {team}"
           f"\n  Token      {shown}\n", flush=True)
 
 
@@ -2623,6 +2630,7 @@ async def remove_member(
     if membership.role == "owner":  # only an owner manages owners; an admin cannot remove one
         raise HTTPException(status_code=403, detail="owners cannot be removed")
     await db.delete(membership)  # revokes that user's token for this org
+    await _drop_member_deny_rules(db, user_id, org_id)
     await db.commit()
     return {"removed": user_id}
 
@@ -2664,6 +2672,7 @@ async def leave_org(
     if caller.role == "owner" and await _count_owners(org_id, db) <= 1:
         raise HTTPException(status_code=409, detail="you are the last owner — transfer ownership or delete the org")
     await db.delete(caller.membership)  # revokes the caller's token for this org
+    await _drop_member_deny_rules(db, caller.membership.user_id, org_id)  # same sweep as remove_member
     await db.commit()
     return {"left_org": org_id}
 
@@ -2789,7 +2798,13 @@ async def create_agent(
 ) -> dict:
     """Mint (or ROTATE) an agent token: a member identity for a machine caller, with its own cap, tool
     ACL and audit trail. Re-POSTing the same name rotates the token — the previous one dies here, the
-    same instant-revocation idiom as the public token. Admin+; only an owner may mint an admin agent."""
+    same instant-revocation idiom as the public token. Admin+; only an owner may mint an admin agent.
+
+    On a ROTATE, a field the caller did not send is LEFT AS IT IS — a rotate replaces the token, never
+    the agent's limits. Reading an absent field as its default would silently widen a scoped agent to
+    every tool (`tool_access=None`), to unlimited calls (`daily_call_cap=-1`) and back to local runs
+    (`local_run_enabled=True`) — the dashboard's Rotate button sends only {name, role, cap}, so this
+    would fire on the ordinary path. Same shape `set_member_access` already uses for `project_access`."""
     _require_admin_of(org_id, caller)
     name = (body.name or "").strip()
     if not name or not _slugify(name):
@@ -2802,7 +2817,6 @@ async def create_agent(
         raise HTTPException(status_code=403, detail="only an owner can create an admin agent")
     if body.daily_call_cap < -1:
         raise HTTPException(status_code=422, detail="daily_call_cap must be -1 (unlimited) or >= 0")
-    tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
 
     email = _agent_email(caller.org, name)
     user = (await db.execute(select(User).where(User.email == email))).scalar_one_or_none()
@@ -2813,20 +2827,30 @@ async def create_agent(
     token = crypto.new_token()
     membership = (await db.execute(select(Membership).where(
         Membership.user_id == user.id, Membership.org_id == org_id))).scalar_one_or_none()
-    if membership is None:
+    # A brand-new agent takes the defaults; a rotate keeps whatever it already had unless told otherwise.
+    is_new = membership is None
+    sent = body.model_fields_set
+
+    def _keep(field: str, current):
+        return getattr(body, field) if (is_new or field in sent) else current
+
+    if is_new:
         membership = Membership(user_id=user.id, org_id=org_id, role=body.role,
                                 token_hash=crypto.hash_token(token))
         db.add(membership)
     else:
         membership.token_hash = crypto.hash_token(token)  # rotate: the previous token dies here
-        membership.role = body.role
-    membership.daily_call_cap = body.daily_call_cap
-    membership.tool_access = tool_access
-    membership.local_run_enabled = body.local_run_enabled
+        membership.role = _keep("role", membership.role)
+    membership.daily_call_cap = _keep("daily_call_cap", membership.daily_call_cap)
+    if is_new or "tool_access" in sent:  # only re-validate what the caller actually sent
+        membership.tool_access = _normalize_tool_access(
+            body.tool_access, await _known_access_names(org_id, db))
+    membership.local_run_enabled = _keep("local_run_enabled", membership.local_run_enabled)
     await db.commit()
     return {"token": token, "name": name, "email": email, "org": caller.org.slug, "user_id": user.id,
-            "role": body.role, "daily_call_cap": body.daily_call_cap, "tool_access": tool_access,
-            "local_run_enabled": body.local_run_enabled,
+            "role": membership.role, "daily_call_cap": membership.daily_call_cap,
+            "tool_access": membership.tool_access, "project_access": membership.project_access,
+            "local_run_enabled": membership.local_run_enabled,
             "note": "save this token now — it is shown once; POST the same name again to rotate it"}
 
 
@@ -2870,6 +2894,7 @@ async def revoke_agent(
         raise HTTPException(status_code=404, detail="unknown agent")
     email = user.email  # read before the delete — the row is expired after commit
     await db.delete(membership)
+    await _drop_member_deny_rules(db, user_id, org_id)  # a rule aimed at a caller that no longer exists
     await db.flush()
     # The identity is org-scoped, so once its last membership is gone the User row has no purpose.
     if (await db.execute(select(Membership).where(
@@ -2982,7 +3007,11 @@ async def delete_project(
 ) -> dict:
     """Delete a project. Its tools are NOT deleted — they fall back to org-wide, which is the safe
     direction (a tool that quietly vanished from every listing would be far worse than one that
-    briefly becomes visible to the whole team). Members scoped to it lose that entry."""
+    briefly becomes visible to the whole team). Members scoped to it lose that entry.
+
+    The freed tools are what keeps a scoped member from being locked out: they were the member's only
+    tools and they are now org-wide, so the member keeps exactly what they had. The scope list itself
+    must NOT be widened to do that (see below)."""
     _require_admin_of(org_id, caller)
     project = await db.get(Project, project_id)
     if project is None or project.org_id != org_id:  # 404 across orgs — never confirm another org's ids
@@ -2993,10 +3022,11 @@ async def delete_project(
         freed += 1
     for m in (await db.execute(select(Membership).where(Membership.org_id == org_id))).scalars().all():
         if m.project_access and project_id in m.project_access:
-            remaining = [p for p in m.project_access if p != project_id]
-            # An empty list would mean "no projects at all" — treat it as "unscoped" instead of
-            # silently locking the member out of every tool in the team.
-            m.project_access = remaining or None
+            # Store the remaining ids AS THEY ARE, empty list included. Collapsing `[]` to NULL here
+            # would read as "every project" and hand a member scoped to only this project access to
+            # every OTHER project's tools — a privilege escalation triggered by an unrelated delete.
+            # `[]` is already the right meaning: org-wide tools only, which now include the freed ones.
+            m.project_access = [p for p in m.project_access if p != project_id]
     await db.delete(project)
     await db.commit()
     return {"deleted": project_id, "tools_made_org_wide": freed}
@@ -3012,6 +3042,28 @@ class DenyRuleIn(BaseModel):
     method: str = ""
     user_id: int | None = None  # None = the whole org; set = only that member/agent
     note: str = ""
+
+
+async def _drop_member_deny_rules(db: AsyncSession, user_id: int, org_id: int | None = None) -> int:
+    """Delete the member-scoped rules that named a member/agent who is going away — the caller they
+    were written for no longer exists, so the rule can never fire again. Left behind, they show up in
+    the Policy table as a row naming a user id the team can no longer see or clean up. Mirrors how
+    `delete_project` sweeps the id it deletes out of every `project_access`.
+
+    `org_id` set = that org only (the member left THIS team but may still be in others). `org_id`
+    None = every org, for when the USER row itself is deleted — `DenyRule.user_id` is a foreign key,
+    so a surviving rule would dangle, which Postgres rejects outright (SQLite does not enforce it by
+    default, which is why only a real deployment would have shown this).
+
+    ORG-wide rules (`user_id` NULL) are untouched: they are about the team, not about one caller.
+    The caller commits — this only stages the deletes, so it composes with the removal itself."""
+    q = select(DenyRule).where(DenyRule.user_id == user_id)
+    if org_id is not None:
+        q = q.where(DenyRule.org_id == org_id)
+    stale = (await db.execute(q)).scalars().all()
+    for rule in stale:
+        await db.delete(rule)
+    return len(stale)
 
 
 def _deny_view(r: DenyRule) -> dict:
@@ -4931,6 +4983,9 @@ async def admin_delete_user(
             # Deleting the sole owner would leave an ungovernable org (no one can pass _require_owner_of).
             # Promote the earliest-joined survivor so ownership never evaporates.
             survivors[0].role = "owner"
+    # The USER row is about to go, so member-scoped rules must go from EVERY org — `DenyRule.user_id`
+    # is a foreign key, and a surviving row would dangle (a hard error on Postgres).
+    await _drop_member_deny_rules(db, user_id)
     await db.delete(user)
     await db.commit()
     return {"deleted_user": user_id, "deleted_empty_orgs": emptied}
@@ -4984,12 +5039,10 @@ async def _resolve_call(rest: str, caller: Caller, db: AsyncSession) -> tuple[To
             host = urlsplit(norm).netloc.lower()
         except ValueError:  # malformed passthrough URL (e.g. unbalanced IPv6 brackets) → 400, not 500
             raise HTTPException(status_code=400, detail="malformed upstream URL")
-        candidates = [
-            t for t in (await db.execute(
-                select(Tool).where(Tool.host == host, Tool.org_id == org_id)
-            )).scalars().all()
-            if _tool_usable(caller, t)  # a tool the caller can't use can't 409 them either
-        ]
+        on_host = (await db.execute(
+            select(Tool).where(Tool.host == host, Tool.org_id == org_id)
+        )).scalars().all()
+        candidates = [t for t in on_host if _tool_usable(caller, t)]  # can't use it → can't 409 on it
         # Match on a path-segment boundary, not a raw string prefix: base `.../v2` must NOT match
         # request `.../v20/...` (that would inject v2's credential onto an unregistered sibling path).
         def _prefix_match(base: str) -> bool:
@@ -4998,6 +5051,14 @@ async def _resolve_call(rest: str, caller: Caller, db: AsyncSession) -> tuple[To
 
         matches = [t for t in candidates if _prefix_match(t.base_url)]
         if not matches:
+            # Tell "no such tool" and "not yours to use" apart. If the ACL filter above is the ONLY
+            # reason nothing matched, this is a 403 like the named shape would give — a 404 here
+            # would send an admin hunting for a registration that already exists. The message names
+            # the HOST the caller already typed, never the internal tool name the ACL hides.
+            if any(_prefix_match(t.base_url) for t in on_host):
+                raise HTTPException(status_code=403, detail=(
+                    f"you don't have access to the registered tool for {host!r} in this team — an "
+                    "admin can grant it (dashboard → Team, or `treg org access <you> …`)"))
             raise HTTPException(status_code=404, detail=f"no registered tool for upstream {host!r}")
         # Tiebreak on the NORMALIZED length so `.../v1` and `.../v1/` count equal (a real 409), not
         # one silently "longer" than the other.

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3921,9 +3921,15 @@ async def connect_with_token(
     token = body.token.strip()
     if not token:
         raise HTTPException(status_code=422, detail=f"{provider.token_label or 'Token'} is required")
+    # HTTP Basic providers (DataForSEO, Moz) take a pasted `login:password`; store the Base64 blob so
+    # `Basic {secret}` renders the same at connect and on every proxy call.
+    if provider.token_encode == "base64":
+        import base64
+        token = base64.b64encode(token.encode()).decode()
 
     # The credential rides in a header (default) or a query param (Semrush: ?key=…). The cheapest
-    # check may also live on a different host than base_url, so honor an absolute probe_url override.
+    # check may also live on a different host than base_url, so honor an absolute probe_url override,
+    # and a POST probe with a JSON body (Serpstat's JSON-RPC limits call).
     rendered = provider.token_format.format(secret=token)
     if provider.token_location == "query":
         headers, params = {}, {provider.token_param: rendered}
@@ -3931,7 +3937,10 @@ async def connect_with_token(
         headers, params = {provider.token_header: rendered}, {}
     probe_url = provider.probe_url or f"{provider.base_url.rstrip('/')}{provider.probe_path}"
     try:
-        resp = await request.app.state.http.get(probe_url, headers=headers, params=params)
+        resp = await request.app.state.http.request(
+            provider.probe_method or "GET", probe_url,
+            headers=headers, params=params, json=provider.probe_json,
+        )
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"could not reach {provider.display_name}: {exc}") from None
     # Only parse JSON when the response actually is JSON — a key check may answer in CSV/text
@@ -3947,14 +3956,17 @@ async def connect_with_token(
     # field (Slack: "ok"; Apollo: "is_logged_in") or an "ERROR ..." text line (Semrush). An HTTP
     # status alone would happily accept a dead key, so check all three signals.
     field_bad = bool(provider.token_verify_field) and not payload.get(provider.token_verify_field)
+    field_reject = bool(provider.token_reject_field) and bool(payload.get(provider.token_reject_field))
+    equals_bad = bool(provider.token_ok_field) and str(payload.get(provider.token_ok_field)) != provider.token_ok_value
     text_error = (
         resp.status_code < 400
         and not ctype.startswith("application/json")
         and resp.text.lstrip().upper().startswith("ERROR")
     )
-    if resp.status_code >= 400 or field_bad or text_error:
+    if resp.status_code >= 400 or field_bad or field_reject or equals_bad or text_error:
         why = (
             payload.get("error")
+            or (payload.get("ErrorMessage") if equals_bad else None)
             or (f"{provider.token_verify_field}=false" if field_bad else None)
             or (resp.text.strip()[:80] if text_error else f"HTTP {resp.status_code}")
         )

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3958,12 +3958,18 @@ async def connect_with_token(
     field_bad = bool(provider.token_verify_field) and not payload.get(provider.token_verify_field)
     field_reject = bool(provider.token_reject_field) and bool(payload.get(provider.token_reject_field))
     equals_bad = bool(provider.token_ok_field) and str(payload.get(provider.token_ok_field)) != provider.token_ok_value
+    # Usually any >=400 is a bad key; a provider with no free probe (Coresignal) POSTs an empty body so
+    # a VALID key answers 400 — there only 401/403 mean the key itself is bad.
+    status_reject = (
+        resp.status_code in provider.probe_reject_statuses
+        if provider.probe_reject_statuses else resp.status_code >= 400
+    )
     text_error = (
         resp.status_code < 400
         and not ctype.startswith("application/json")
         and resp.text.lstrip().upper().startswith("ERROR")
     )
-    if resp.status_code >= 400 or field_bad or field_reject or equals_bad or text_error:
+    if status_reject or field_bad or field_reject or equals_bad or text_error:
         why = (
             payload.get("error")
             or (payload.get("ErrorMessage") if equals_bad else None)

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -770,6 +770,8 @@ async def auth_email_start(
     email = _norm_email(body.email)
     if email.endswith("@" + demo_seed.DEMO_DOMAIN):  # fake onboarding teammates are roster-only — never a login
         raise HTTPException(status_code=400, detail="that's a demo address — pick a real email")
+    if _is_machine_email(email):  # agents / the public token act by token only — same rule, said early
+        raise HTTPException(status_code=403, detail="this address cannot be used to sign in")
     await ratestore.sweep(db, OTP_START_NS)  # bound the namespace before we add to it
     if not await ratestore.rate_check(
         db, OTP_START_NS,
@@ -1214,6 +1216,13 @@ async def require_identity(
                 raise HTTPException(status_code=403, detail=(
                     "this is a public demo token — it can only call the demo team's tools"))
         user = await db.get(User, m.user_id) if m else await _user_from_identity_token(x_treg_token, db)
+        # A machine token must never act as a USER. `create_org` depends on THIS dependency, so an
+        # agent could otherwise create a fresh org in which it is the OWNER — and owners are exempt
+        # from `_require_tool_access` and `_require_local_run`, escaping every limit set on it.
+        if user is not None and _is_machine_email(user.email):
+            raise HTTPException(status_code=403, detail=(
+                "this token belongs to a machine identity — it can call this team's tools, "
+                "but cannot act as a user"))
         if user is not None and not user.suspended:
             return user
         raise HTTPException(status_code=401, detail="invalid token")
@@ -1637,6 +1646,12 @@ async def _find_or_create_user(db: AsyncSession, email: str) -> User:
     token is user-scoped, so it works before they have any org (org chosen per-request via X-Treg-Org).
     Caller commits."""
     email = _norm_email(email)
+    # Machine identities (agents, the published demo token) are minted by an admin and act ONLY by
+    # their token. This is the single choke point every identity door shares, so blocking here means
+    # no door — GitHub, Google, email OTP, invite sign-in — can hand a human an agent's identity.
+    # (The domains are unroutable, so a code could never be delivered anyway; this makes it explicit.)
+    if _is_machine_email(email):
+        raise HTTPException(status_code=403, detail="this address cannot be used to sign in")
     user = (await db.execute(select(User).where(User.email == email))).scalar_one_or_none()
     if user is None:
         user = User(email=email)
@@ -1653,6 +1668,10 @@ async def _find_or_create_user(db: AsyncSession, email: str) -> User:
 @app.post("/users")
 async def register_user(body: UserIn, db: AsyncSession = Depends(get_session)) -> dict:
     email = _norm_email(body.email)
+    # This door creates a User directly (it predates `_find_or_create_user`), so it needs the same
+    # machine-domain block — otherwise open registration could squat an agent address.
+    if _is_machine_email(email):
+        raise HTTPException(status_code=403, detail="this address cannot be used to sign in")
     if body.webhook_url and not health.safe_webhook_url(body.webhook_url):  # SSRF guard on the alert URL
         raise HTTPException(status_code=422, detail="webhook_url must be a public http(s) URL")
     if (await db.execute(select(User).where(User.email == email))).scalar_one_or_none():
@@ -2300,7 +2319,9 @@ async def list_members(
         if user is not None:
             out.append({"user_id": user.id, "email": user.email, "role": m.role,
                         "daily_call_cap": m.daily_call_cap, "used_today": used.get(user.email, 0),
-                        "tool_access": m.tool_access, "local_run_enabled": m.local_run_enabled})
+                        "tool_access": m.tool_access, "local_run_enabled": m.local_run_enabled,
+                        # so the dashboard can separate people from machines in one roster
+                        "is_agent": _is_agent_email(user.email)})
     return out
 
 
@@ -2428,6 +2449,12 @@ async def set_member_role(
     ).scalar_one_or_none()
     if membership is None:
         raise HTTPException(status_code=404, detail="not a member of this org")
+    if body.role == "owner":
+        # Owners short-circuit `_tool_allowed` and `_require_local_run`, so an owner machine identity
+        # would silently bypass the tool ACL and the local-run gate placed on it.
+        target = await db.get(User, user_id)
+        if target is not None and _is_machine_email(target.email):
+            raise HTTPException(status_code=422, detail="a machine identity cannot be an owner")
     if membership.role == "owner" and body.role != "owner" and await _count_owners(org_id, db) <= 1:
         raise HTTPException(status_code=409, detail="cannot demote the last owner — promote another owner first")
     membership.role = body.role
@@ -2461,12 +2488,42 @@ async def delete_org(
     return {"deleted_org": org_id}
 
 
-# ---- public demo token: a publishable, call-only credential for this org -------------------
+# ---- machine identities: the publishable demo token, and agents ----------------------------
+# Both are Users on an UNROUTABLE domain, which is what makes them machines rather than people: no
+# login door can ever resolve one (guarded in `_find_or_create_user`) and neither may act as a USER
+# (guarded in `require_identity`). Everything else they inherit from Membership for free.
 PUBLIC_DEMO_DOMAIN = "public-demo.treg.local"  # unroutable — the public identity can never log in
+# NOTE: "agent" here is an IDENTITY — a coding agent / automation that calls treg. It is NOT the
+# skill-directory table in `agents.py` (which answers "where does each coding agent keep its skills").
+# The words collide, the concepts don't; kept apart deliberately.
+AGENT_DOMAIN = "agents.treg.local"  # unroutable — an agent acts only by its token
+
+
+def _is_agent_email(email: str) -> bool:
+    return _norm_email(email).endswith(f"@{AGENT_DOMAIN}")
+
+
+def _is_machine_email(email: str) -> bool:
+    """An identity minted by an admin for a machine — never a person who can sign in."""
+    return _is_agent_email(email) or _norm_email(email).endswith(f"@{PUBLIC_DEMO_DOMAIN}")
 
 
 def _public_demo_email(org: Org) -> str:
     return f"pub-{org.slug}@{PUBLIC_DEMO_DOMAIN}"
+
+
+def _agent_email(org: Org, name: str) -> str:
+    """Org-SCOPED on purpose: two orgs must each be able to own an agent called `deploy` without
+    sharing one User row (`User.email` is unique). Sharing would mean a superadmin suspending or
+    deleting one tenant's agent silently killed the other tenant's too."""
+    return f"agent-{org.slug}-{_slugify(name)}@{AGENT_DOMAIN}"
+
+
+def _agent_name(org: Org, email: str) -> str:
+    """The friendly name back out of the address (the name isn't stored — the address IS the id)."""
+    local = email.split("@", 1)[0]
+    prefix = f"agent-{org.slug}-"
+    return local[len(prefix):] if local.startswith(prefix) else local
 
 
 @app.post("/orgs/{org_id}/public-token")
@@ -2516,6 +2573,116 @@ async def delete_public_token(
     org.public_demo = False
     await db.commit()
     return {"public_token_revoked": True, "org": org.slug}
+
+
+# ---- agents: a member identity for a machine caller ----------------------------------------
+# An agent is JUST a Membership whose user lives on AGENT_DOMAIN, which is why this needs no new
+# table and no migration: it inherits every per-member control already in place — `daily_call_cap`
+# (enforced by `_enforce_daily_cap`), `tool_access` (`_require_tool_access`, on the proxy AND both run
+# tiers), `local_run_enabled`, and per-identity audit, since `CallRecord.user_email` already stamps
+# every call. Giving the agent its own identity is what makes all of that per-agent.
+class AgentIn(BaseModel):
+    name: str
+    role: str = "member"  # never "owner" (see below); "admin" is owner-granted only
+    daily_call_cap: int = -1  # -1 = unlimited, mirroring set_member_cap
+    tool_access: list[str] | None = None  # None = every tool, mirroring set_member_access
+    local_run_enabled: bool = True
+
+
+@app.post("/orgs/{org_id}/agents")
+async def create_agent(
+    org_id: int, body: AgentIn,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Mint (or ROTATE) an agent token: a member identity for a machine caller, with its own cap, tool
+    ACL and audit trail. Re-POSTing the same name rotates the token — the previous one dies here, the
+    same instant-revocation idiom as the public token. Admin+; only an owner may mint an admin agent."""
+    _require_admin_of(org_id, caller)
+    name = (body.name or "").strip()
+    if not name or not _slugify(name):
+        raise HTTPException(status_code=422, detail="name is required")
+    if body.role not in ROLE_RANK:
+        raise HTTPException(status_code=422, detail=f"role must be one of {sorted(ROLE_RANK)}")
+    if body.role == "owner":
+        raise HTTPException(status_code=422, detail="an agent cannot be an owner")
+    if body.role == "admin" and caller.role != "owner":
+        raise HTTPException(status_code=403, detail="only an owner can create an admin agent")
+    if body.daily_call_cap < -1:
+        raise HTTPException(status_code=422, detail="daily_call_cap must be -1 (unlimited) or >= 0")
+    tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
+
+    email = _agent_email(caller.org, name)
+    user = (await db.execute(select(User).where(User.email == email))).scalar_one_or_none()
+    if user is None:
+        user = User(email=email)  # NOT demo=True: unlike the public token, agent traffic counts in usage
+        db.add(user)
+        await db.flush()
+    token = crypto.new_token()
+    membership = (await db.execute(select(Membership).where(
+        Membership.user_id == user.id, Membership.org_id == org_id))).scalar_one_or_none()
+    if membership is None:
+        membership = Membership(user_id=user.id, org_id=org_id, role=body.role,
+                                token_hash=crypto.hash_token(token))
+        db.add(membership)
+    else:
+        membership.token_hash = crypto.hash_token(token)  # rotate: the previous token dies here
+        membership.role = body.role
+    membership.daily_call_cap = body.daily_call_cap
+    membership.tool_access = tool_access
+    membership.local_run_enabled = body.local_run_enabled
+    await db.commit()
+    return {"token": token, "name": name, "email": email, "org": caller.org.slug, "user_id": user.id,
+            "role": body.role, "daily_call_cap": body.daily_call_cap, "tool_access": tool_access,
+            "local_run_enabled": body.local_run_enabled,
+            "note": "save this token now — it is shown once; POST the same name again to rotate it"}
+
+
+@app.get("/orgs/{org_id}/agents")
+async def list_agents(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> list[dict]:
+    """Every agent identity in the org, with its limits and today's usage. Never the token."""
+    _require_admin_of(org_id, caller)
+    memberships = (await db.execute(select(Membership).where(Membership.org_id == org_id))).scalars().all()
+    users = {u.id: u for u in (await db.execute(
+        select(User).where(User.id.in_([m.user_id for m in memberships]))
+    )).scalars().all()}
+    used = await _used_today_by_user(db, org_id)
+    out: list[dict] = []
+    for m in memberships:
+        user = users.get(m.user_id)
+        if user is None or not _is_agent_email(user.email):
+            continue
+        out.append({"user_id": user.id, "name": _agent_name(caller.org, user.email),
+                    "email": user.email, "role": m.role, "daily_call_cap": m.daily_call_cap,
+                    "used_today": used.get(user.email, 0), "tool_access": m.tool_access,
+                    "local_run_enabled": m.local_run_enabled, "created_at": m.created_at})
+    return out
+
+
+@app.delete("/orgs/{org_id}/agents/{user_id}")
+async def revoke_agent(
+    org_id: int, user_id: int,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Revoke an agent: delete its membership, which kills its token immediately."""
+    _require_admin_of(org_id, caller)
+    user = await db.get(User, user_id)
+    if user is None or not _is_agent_email(user.email):
+        raise HTTPException(status_code=404, detail="unknown agent")
+    membership = (await db.execute(select(Membership).where(
+        Membership.user_id == user_id, Membership.org_id == org_id))).scalar_one_or_none()
+    if membership is None:
+        raise HTTPException(status_code=404, detail="unknown agent")
+    email = user.email  # read before the delete — the row is expired after commit
+    await db.delete(membership)
+    await db.flush()
+    # The identity is org-scoped, so once its last membership is gone the User row has no purpose.
+    if (await db.execute(select(Membership).where(
+            Membership.user_id == user_id))).scalars().first() is None:
+        await db.delete(user)
+    await db.commit()
+    return {"revoked": True, "email": email}
 
 
 # ---- secrets (values are write-only — never returned) -------------------------------------

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -46,14 +46,73 @@ from . import audit, crypto, demo as demo_seed, email as email_sender, health, i
 from . import oauth_providers
 from . import pubfeed, ratestore, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings
-from .db import get_session, init_db
+from .db import get_session, init_db, session_maker
 from .models import ROLE_RANK, Bundle, CallRecord, DenyRule, Invite, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User
 from .proxy import relay
+
+
+LOCAL_USER_EMAIL = "you@local.treg"   # the single-user identity; a real address is never needed
+LOCAL_ORG_NAME = "personal"
+
+
+async def _bootstrap_single_user() -> None:
+    """Frictionless local mode: make the machine's owner exist, so `curl … | sh` lands on a dashboard
+    that is already signed in — no account, no email, no password.
+
+    Idempotent, and the token is STABLE across restarts (rotating it every boot would break the CLI
+    config the installer just wrote). It is re-minted only when the token file is missing, i.e. the
+    user deleted it and needs a new one. Gated by `single_user_ok`, which refuses anything that isn't
+    a local sqlite box — see config.Settings.
+    """
+    s = get_settings()
+    if not s.single_user_ok:
+        return
+    path = Path(s.single_user_token_file).expanduser()
+    async with session_maker() as db:
+        user = (await db.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one_or_none()
+        if user is None:
+            user = User(email=LOCAL_USER_EMAIL, onboarded=True)
+            db.add(user)
+            await db.flush()
+        org = (await db.execute(select(Org).where(Org.slug == LOCAL_ORG_NAME))).scalar_one_or_none()
+        if org is None:
+            org = Org(name=LOCAL_ORG_NAME.title(), slug=LOCAL_ORG_NAME)
+            db.add(org)
+            await db.flush()
+        membership = (await db.execute(select(Membership).where(
+            Membership.user_id == user.id, Membership.org_id == org.id))).scalar_one_or_none()
+        token = ""
+        if membership is None or not path.exists():
+            token = crypto.new_token()  # first boot, or the token file was removed
+            if membership is None:
+                membership = Membership(user_id=user.id, org_id=org.id, role="owner",
+                                        token_hash=crypto.hash_token(token))
+                db.add(membership)
+            else:
+                membership.token_hash = crypto.hash_token(token)
+        await db.commit()
+    if token:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(token)
+        path.chmod(0o600)  # the installer reads it; nobody else should
+    shown = token or "(unchanged — see " + str(path) + ")"
+    print(f"\n  treg is ready — no account needed."
+          f"\n  Dashboard  {s.public_url}/app"
+          f"\n  Team       {LOCAL_ORG_NAME}"
+          f"\n  Token      {shown}\n", flush=True)
+
+
+async def _local_owner(db: AsyncSession) -> User | None:
+    """The single-user identity, if this deployment is in that mode."""
+    if not get_settings().single_user_ok:
+        return None
+    return (await db.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one_or_none()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
+    await _bootstrap_single_user()
     # One long-lived client for ALL upstream calls (rule 1: keepalive). The pool reuses
     # TCP+TLS connections across requests — the single biggest latency win for a relay.
     limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
@@ -950,16 +1009,33 @@ async def landing(request: Request, treg_session: str = Cookie(default=""),
         if treg_session and await _user_from_session(treg_session, db):
             return RedirectResponse("/app", status_code=302)
         return FileResponse(page, headers={"Cache-Control": "no-cache"})
-    return await dashboard()
+    return await dashboard(request, treg_session, db)
 
 
 @app.get("/app", include_in_schema=False)
-async def dashboard():
-    """Serve the single-file dashboard (same-origin, so it calls this API directly)."""
+async def dashboard(
+    request: Request, treg_session: str = Cookie(default=""),
+    db: AsyncSession = Depends(get_session),
+):
+    """Serve the single-file dashboard (same-origin, so it calls this API directly).
+
+    In frictionless local mode the dashboard opens ALREADY SIGNED IN: with no valid session we
+    attach one for the machine's single user, so `curl … | sh` reaches a working dashboard without
+    an account. Only reachable when `single_user_ok` holds (local sqlite + loopback URL), so this
+    can never hand a session to a stranger on a real deploy.
+    """
     index = _WEB_DIR / "index.html"
     if not index.exists():
         return HTMLResponse("<h3>tools-registry API. Dashboard not bundled.</h3>")
-    return FileResponse(index, headers={"Cache-Control": "no-cache"})
+    resp = FileResponse(index, headers={"Cache-Control": "no-cache"})
+    if not await _user_from_session(treg_session, db):
+        owner = await _local_owner(db)
+        if owner is not None:
+            resp.set_cookie(sess.COOKIE, sess.make(owner.id, token_version=owner.token_version),
+                            httponly=True, samesite="lax",
+                            secure=_is_https(request),
+                            max_age=sess.TTL_SECONDS)
+    return resp
 
 
 def _spa_with_og(kind: str, name: str):
@@ -984,10 +1060,13 @@ def _spa_with_og(kind: str, name: str):
 
 
 @app.get("/app/marketplace/{service}", include_in_schema=False)
-async def dashboard_marketplace(service: str):  # noqa: ARG001 — the SPA reads the path itself
+async def dashboard_marketplace(
+    service: str, request: Request, treg_session: str = Cookie(default=""),  # noqa: ARG001 — the SPA reads the path itself
+    db: AsyncSession = Depends(get_session),
+):
     """One integration's page. Served as the plain SPA: unlike /app/skills/<x> there is no og meta
     to add, because a marketplace page is only meaningful to a signed-in member of the org."""
-    return await dashboard()
+    return await dashboard(request, treg_session, db)
 
 
 @app.get("/app/skills/{name}", include_in_schema=False)
@@ -1022,6 +1101,21 @@ async def install_sh():
         raise HTTPException(status_code=404, detail="install.sh not bundled")
     base = get_settings().public_url.rstrip("/")
     return PlainTextResponse(f.read_text(encoding="utf-8").replace("{BASE}", base), media_type="text/x-shellscript; charset=utf-8")
+
+
+@app.get("/selfhost.sh", include_in_schema=False)
+async def selfhost_sh():
+    """`curl -fsSL {BASE}/selfhost.sh | sh` — run your OWN registry locally, with no account.
+
+    Different from install.sh, which only installs the CLI and points it at THIS server. This one
+    brings up a server on the caller's machine in single-user mode, so they land on a dashboard that
+    is already signed in. Value first, account later."""
+    f = _WEB_DIR / "selfhost.sh"
+    if not f.exists():
+        raise HTTPException(status_code=404, detail="selfhost.sh not bundled")
+    base = get_settings().public_url.rstrip("/")
+    return PlainTextResponse(f.read_text(encoding="utf-8").replace("{BASE}", base),
+                             media_type="text/x-shellscript; charset=utf-8")
 
 
 def _serve_md(name: str) -> PlainTextResponse:

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -2492,7 +2492,11 @@ async def set_member_access(
     if membership.role == "owner":
         raise HTTPException(status_code=403, detail="an owner always has full access; it can't be restricted")
     membership.tool_access = _normalize_tool_access(body.tool_access, await _known_access_names(org_id, db))
-    membership.project_access = await _normalize_project_access(body.project_access, org_id, db)
+    # Only touch the project scope when the caller actually SENT the field. Without this, any client
+    # that PATCHes just tool_access or local_run_enabled (the dashboard's local-run toggle does exactly
+    # that) would silently clear the member's project scoping, because the field defaults to None.
+    if "project_access" in body.model_fields_set:
+        membership.project_access = await _normalize_project_access(body.project_access, org_id, db)
     membership.local_run_enabled = body.local_run_enabled
     await db.commit()
     return {"user_id": user_id, "org_id": org_id, "tool_access": membership.tool_access,
@@ -2751,6 +2755,7 @@ async def list_agents(
         out.append({"user_id": user.id, "name": _agent_name(caller.org, user.email),
                     "email": user.email, "role": m.role, "daily_call_cap": m.daily_call_cap,
                     "used_today": used.get(user.email, 0), "tool_access": m.tool_access,
+                    "project_access": m.project_access,  # the dashboard renders this column
                     "local_run_enabled": m.local_run_enabled, "created_at": m.created_at})
     return out
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -47,7 +47,7 @@ from . import oauth_providers
 from . import pubfeed, ratestore, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings
 from .db import get_session, init_db
-from .models import ROLE_RANK, Bundle, CallRecord, Invite, Membership, Org, PendingOAuth, RunRecord, Secret, Tool, User
+from .models import ROLE_RANK, Bundle, CallRecord, DenyRule, Invite, Membership, Org, PendingOAuth, RunRecord, Secret, Tool, User
 from .proxy import relay
 
 
@@ -1357,7 +1357,7 @@ async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
 
 async def _cascade_delete_org(org: Org, db: AsyncSession) -> None:
     """Delete every org-scoped row then the org. Shared by owner delete_org + admin force-delete."""
-    for model in (Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, Membership):
+    for model in (Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Membership):
         for r in (await db.execute(select(model).where(model.org_id == org.id))).scalars().all():
             await db.delete(r)
     await db.delete(org)
@@ -1393,6 +1393,59 @@ def _require_tool_access(caller: Caller, tool_name: str) -> None:
         raise HTTPException(status_code=403, detail=(
             f"you don't have access to the tool {tool_name!r} in this team — an admin can grant it "
             "(dashboard → Team, or `treg org access <you> --tools …`)"))
+
+
+def _deny_match(rules: list[DenyRule], host: str, path: str, method: str) -> DenyRule | None:
+    """The FIRST rule that matches — pure, so it unit-tests without a DB (like `localrun.check_deny`).
+
+    An empty field on a rule means "any", so `{method: "DELETE"}` blocks every delete and
+    `{host: "api.stripe.com"}` blocks that upstream entirely. Host is compared case-insensitively;
+    the path match is a prefix, anchored at `/` so `/v1/charges` cannot be dodged by `/v1/chargesX`.
+    """
+    host, method = host.lower(), method.upper()
+    path = path or "/"
+    for r in rules:
+        if r.host and r.host.lower() != host:
+            continue
+        if r.method and r.method.upper() != method:
+            continue
+        if r.path_prefix:
+            p = (r.path_prefix if r.path_prefix.startswith("/") else "/" + r.path_prefix).rstrip("/")
+            # Anchored at a segment boundary: `/v1/charges` must NOT match `/v1/chargesX`.
+            if not (path == p or path.startswith(p + "/")):
+                continue
+        return r
+    return None
+
+
+async def _org_deny_rules(caller: Caller, db: AsyncSession) -> list[DenyRule]:
+    """This caller's applicable rules: the org-wide ones plus the ones aimed at them specifically."""
+    return list((await db.execute(select(DenyRule).where(
+        DenyRule.org_id == caller.org_id,
+        or_(DenyRule.user_id.is_(None), DenyRule.user_id == caller.membership.user_id),
+    ))).scalars().all())
+
+
+async def _enforce_deny(caller: Caller, url: str, method: str, db: AsyncSession) -> None:
+    """Block a call the org's policy forbids. Deliberately applies to EVERY role including owner: a
+    deny rule is a guardrail, not a permission tier — an owner who disagrees deletes the rule rather
+    than quietly bypassing it. The refusal names the rule, mirroring `localrun.check_deny`'s
+    "a refusal can name its source"."""
+    rules = await _org_deny_rules(caller, db)
+    if not rules:
+        return  # the common path costs one indexed query and nothing else
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return
+    rule = _deny_match(rules, parts.netloc, parts.path, method)
+    if rule is None:
+        return
+    why = f" ({rule.note})" if rule.note else ""
+    scope = "this team" if rule.user_id is None else "you"
+    raise HTTPException(status_code=403, detail=(
+        f"blocked by a policy rule on {scope}{why} — "
+        f"{rule.method or 'any'} {rule.host or 'any host'}{rule.path_prefix or ''}"))
 
 
 async def _visible_secret_ids(caller: Caller, db: AsyncSession) -> set[int] | None:
@@ -2685,6 +2738,81 @@ async def revoke_agent(
     return {"revoked": True, "email": email}
 
 
+# ---- deny rules: org policy over what may be called ----------------------------------------
+PROXY_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+
+
+class DenyRuleIn(BaseModel):
+    host: str = ""  # a bare netloc or a full URL (we take its host)
+    path_prefix: str = ""
+    method: str = ""
+    user_id: int | None = None  # None = the whole org; set = only that member/agent
+    note: str = ""
+
+
+def _deny_view(r: DenyRule) -> dict:
+    return {"id": r.id, "host": r.host, "path_prefix": r.path_prefix, "method": r.method,
+            "user_id": r.user_id, "scope": "org" if r.user_id is None else "member",
+            "verdict": r.verdict, "note": r.note, "created_by": r.created_by,
+            "created_at": r.created_at}
+
+
+@app.post("/orgs/{org_id}/deny")
+async def create_deny_rule(
+    org_id: int, body: DenyRuleIn,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Block calls to a host / path / method for the whole team, or for one member or agent (admin+).
+
+    Enforced on the proxy AND both run tiers, and it applies to every role including owner — a deny
+    rule is a guardrail, not a permission tier."""
+    _require_admin_of(org_id, caller)
+    host = (body.host or "").strip().lower()
+    if "://" in host:  # pasting a base_url is the obvious thing to try, so accept it
+        host = urlsplit(host).netloc.lower()
+    method = (body.method or "").strip().upper()
+    path_prefix = (body.path_prefix or "").strip()
+    if method and method not in PROXY_METHODS:
+        raise HTTPException(status_code=422, detail=f"method must be one of {list(PROXY_METHODS)}")
+    if not (host or path_prefix or method):
+        # An all-empty rule matches every request — refuse it rather than silently freezing the org.
+        raise HTTPException(status_code=422, detail="give at least one of host, path_prefix or method")
+    if body.user_id is not None:
+        target = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id, Membership.user_id == body.user_id))).scalar_one_or_none()
+        if target is None:
+            raise HTTPException(status_code=404, detail="not a member of this org")
+    rule = DenyRule(org_id=org_id, user_id=body.user_id, host=host, path_prefix=path_prefix,
+                    method=method, note=(body.note or "").strip(), created_by=caller.email)
+    db.add(rule)
+    await db.commit()
+    await db.refresh(rule)
+    return _deny_view(rule)
+
+
+@app.get("/orgs/{org_id}/deny")
+async def list_deny_rules(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> list[dict]:
+    _require_admin_of(org_id, caller)
+    rules = (await db.execute(select(DenyRule).where(DenyRule.org_id == org_id))).scalars().all()
+    return [_deny_view(r) for r in rules]
+
+
+@app.delete("/orgs/{org_id}/deny/{rule_id}")
+async def delete_deny_rule(
+    org_id: int, rule_id: int,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    _require_admin_of(org_id, caller)
+    rule = await db.get(DenyRule, rule_id)
+    if rule is None or rule.org_id != org_id:  # 404 across orgs — never confirm another org's ids
+        raise HTTPException(status_code=404, detail="unknown rule")
+    await db.delete(rule)
+    await db.commit()
+    return {"deleted": rule_id}
+
+
 # ---- secrets (values are write-only — never returned) -------------------------------------
 @app.post("/secrets")
 async def create_secret(
@@ -3071,6 +3199,7 @@ async def grant_local_run(
         raise HTTPException(status_code=404, detail="tool not found")
     _require_tool_access(caller, tool.name)  # per-member tool ACL (call + both run tiers)
     _require_local_run(caller)               # local tier may be disabled for this member (server-only)
+    await _enforce_deny(caller, tool.base_url, "", db)  # host-level policy (see run_tool_server)
     await _enforce_daily_cap(caller, db)  # a local run counts toward the per-user daily cap
     catalog_cli = (prov.match_skill(tool.name) or {}).get("cli")
     profile = localrun.effective_profile(tool, catalog_cli)
@@ -4669,6 +4798,10 @@ async def call_tool(
             rest = raw_rest
     tool, upstream_url = await _resolve_call(rest, caller.org_id, db)
     _require_tool_access(caller, tool.name)  # per-member tool ACL (NULL access = all; admins exempt)
+    # Policy deny — evaluated on the RESOLVED upstream, so it sees the real host/path/method whichever
+    # shape the caller used (named or URL-passthrough), and the relay never follows redirects, so a
+    # blocked host can't be reached via a 3xx bounce.
+    await _enforce_deny(caller, upstream_url, request.method, db)
     await _enforce_daily_cap(caller, db)  # per-user daily cap (skips sandbox + unmetered members)
     if caller.org.public_demo and not _role_at_least(caller.role, "admin"):
         await _enforce_public_demo_ip_cap(request, db)  # shared token → meter by client IP, not user
@@ -4764,6 +4897,9 @@ async def run_tool_server(
     if tool is None:
         raise HTTPException(status_code=404, detail=f"no tool {body.tool!r} in this org")
     _require_tool_access(caller, tool.name)  # per-member tool ACL
+    # A run executes a CLI, so there is no request path to match — evaluate the tool's own upstream
+    # host, which is what a host-level rule ("nobody may reach api.stripe.com") is really saying.
+    await _enforce_deny(caller, tool.base_url, "", db)
     await _enforce_daily_cap(caller, db)  # a server run counts toward the per-user daily cap
     try:
         exec_bin = runner.resolve_exec_bin(tool)  # the SAME resolution run_tool execs — never diverges

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2830,6 +2830,7 @@ def cmd_org_invite(args, cfg) -> None:
             access = None  # full vault access — the dashboard Share modal's default
         body = {"email": args.email, "role": args.role, "expires_days": args.expires_days,
                 "tool_access": access,
+                "project_access": _projects_arg(args),
                 "local_run_enabled": getattr(args, "local_run", "on") != "off",
                 "landing": landing}
         r = c.post(f"/orgs/{org_id}/invites", json=body)
@@ -2862,7 +2863,8 @@ def cmd_org_access(args, cfg) -> None:
         local = cur.get("local_run_enabled", True) if getattr(args, "local_run", None) is None \
             else args.local_run != "off"
         _show(c.patch(f"/orgs/{org_id}/members/{args.user_id}/access",
-                      json={"tool_access": access, "local_run_enabled": local}))
+                      json={"tool_access": access, "project_access": _projects_arg(args),
+                            "local_run_enabled": local}))
 
 
 def cmd_org_invites(args, cfg) -> None:
@@ -2924,6 +2926,39 @@ def cmd_org_agent_rm(args, cfg) -> None:
         if org_id is None:
             sys.exit("no active org")
         _show(c.delete(f"/orgs/{org_id}/agents/{args.user_id}"))
+
+
+def _projects_arg(args) -> list | None:
+    """--projects a,b → the list; --all-projects → None (unrestricted); neither → leave unset."""
+    if getattr(args, "all_projects", False):
+        return None
+    if getattr(args, "projects", None):
+        return [p.strip() for p in args.projects.split(",") if p.strip()]
+    return None
+
+
+def cmd_org_project_new(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.post(f"/orgs/{org_id}/projects", json={"name": args.name}))
+
+
+def cmd_org_projects(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.get(f"/orgs/{org_id}/projects"))
+
+
+def cmd_org_project_rm(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.delete(f"/orgs/{org_id}/projects/{args.project_id}"))
 
 
 def cmd_org_deny(args, cfg) -> None:
@@ -3224,6 +3259,8 @@ def build_parser() -> argparse.ArgumentParser:
     oi.add_argument("--tools", help="comma-separated tool names this member may use (default: prompt / all)")
     oi.add_argument("--all-tools", dest="all_tools", action="store_true", help="grant access to every tool (skip the prompt)")
     oi.add_argument("--local-run", dest="local_run", choices=["on", "off"], help="allow local CLI runs (default: on)")
+    oi.add_argument("--projects", help="comma-separated project slugs to scope them to (default: all)")
+    oi.add_argument("--all-projects", dest="all_projects", action="store_true", help="every project (the default)")
     oi.set_defaults(fn=cmd_org_invite)
     oa = mk(og, "access", "Set which tools a member may use + whether they can run locally (admin+).",
             "treg org access 5 --tools stripe,gh", "treg org access 5 --all-tools", "treg org access 5 --local-run off")
@@ -3231,6 +3268,8 @@ def build_parser() -> argparse.ArgumentParser:
     oa.add_argument("--tools", help="comma-separated tool names to allow (replaces their current list)")
     oa.add_argument("--all-tools", dest="all_tools", action="store_true", help="give access to every tool")
     oa.add_argument("--local-run", dest="local_run", choices=["on", "off"], help="allow/forbid local CLI runs for this member")
+    oa.add_argument("--projects", help="comma-separated project slugs this member may use")
+    oa.add_argument("--all-projects", dest="all_projects", action="store_true", help="give access to every project")
     oa.set_defaults(fn=cmd_org_access)
     mk(og, "invites", "List pending invites for the active team (admin+).", "treg org invites").set_defaults(fn=cmd_org_invites)
     orv = mk(og, "revoke", "Revoke a pending invite before it's used.", "treg org revoke 3")
@@ -3258,6 +3297,15 @@ def build_parser() -> argparse.ArgumentParser:
              "treg org agent-rm 7")
     oar.add_argument("user_id", type=int, help="the agent's user id (from `org agents`)")
     oar.set_defaults(fn=cmd_org_agent_rm)
+    opn = mk(og, "project-new", "Create a project — a sub-scope inside the team (admin+).",
+             'treg org project-new "Apollo"')
+    opn.add_argument("name", help="the project's display name"); opn.set_defaults(fn=cmd_org_project_new)
+    mk(og, "projects", "List the team's projects and how many tools each holds.",
+       "treg org projects").set_defaults(fn=cmd_org_projects)
+    oprm = mk(og, "project-rm", "Delete a project (its tools become org-wide, they are not deleted).",
+              "treg org project-rm 2")
+    oprm.add_argument("project_id", type=int, help="the project id (from `org projects`)")
+    oprm.set_defaults(fn=cmd_org_project_rm)
     od2 = mk(og, "deny", "Block calls to a host / path / method — for the team, or one member (admin+).",
              "treg org deny --method DELETE --note 'no deletes'",
              "treg org deny --host api.stripe.com", "treg org deny --path /admin --user 7")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2897,6 +2897,35 @@ def cmd_org_set_role(args, cfg) -> None:
         _show(c.patch(f"/orgs/{org_id}/members/{args.user_id}", json={"role": args.role}))
 
 
+def cmd_org_agent_new(args, cfg) -> None:
+    """Mint (or rotate) an agent's own token. NOTE: an "agent" here is an IDENTITY that calls treg —
+    unrelated to `treg agents`, which lists the coding agents we can install skills for."""
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.post(f"/orgs/{org_id}/agents", json={
+            "name": args.name, "role": args.role, "daily_call_cap": args.cap,
+            "tool_access": _resolve_tool_access(c, org_id, args),
+            "local_run_enabled": getattr(args, "local_run", "on") != "off"}))
+
+
+def cmd_org_agents(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.get(f"/orgs/{org_id}/agents"))
+
+
+def cmd_org_agent_rm(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.delete(f"/orgs/{org_id}/agents/{args.user_id}"))
+
+
 def cmd_org_join(args, cfg) -> None:
     with _client(cfg, auth=False) as c:
         r = c.post("/invites/accept", json={"code": args.code, "email": args.email})
@@ -3184,6 +3213,25 @@ def build_parser() -> argparse.ArgumentParser:
     osr = mk(og, "set-role", "Change a member's role (owner only).", "treg org set-role 5 admin")
     osr.add_argument("user_id", type=int, help="the member's user id (from `org members`)")
     osr.add_argument("role", choices=["viewer", "member", "admin", "owner"], help="the new role"); osr.set_defaults(fn=cmd_org_set_role)
+    oan = mk(og, "agent-new", "Mint (or rotate) a token so an agent calls treg as ITSELF — its own "
+                              "cap, tool access and audit trail (admin+).",
+             "treg org agent-new ci-bot", "treg org agent-new ci-bot --tools stripe,gh --cap 500",
+             "treg org agent-new ci-bot   # run again to rotate: the old token dies")
+    oan.add_argument("name", help="a short name for the agent, e.g. ci-bot")
+    oan.add_argument("--role", default="member", choices=["viewer", "member", "admin"],
+                     help="role to grant (default: member; an agent can never be an owner)")
+    oan.add_argument("--cap", type=int, default=-1, help="daily call cap (-1 = unlimited, the default)")
+    oan.add_argument("--tools", help="comma-separated tool names this agent may use (default: prompt / all)")
+    oan.add_argument("--all-tools", dest="all_tools", action="store_true", help="allow every tool")
+    oan.add_argument("--local-run", dest="local_run", choices=["on", "off"], help="allow local CLI runs")
+    oan.set_defaults(fn=cmd_org_agent_new)
+    mk(og, "agents", "List this team's agent identities and their limits (admin+). "
+                     "(Different from `treg agents`, which lists coding agents for skill install.)",
+       "treg org agents").set_defaults(fn=cmd_org_agents)
+    oar = mk(og, "agent-rm", "Revoke an agent — its token stops working immediately.",
+             "treg org agent-rm 7")
+    oar.add_argument("user_id", type=int, help="the agent's user id (from `org agents`)")
+    oar.set_defaults(fn=cmd_org_agent_rm)
     oj = mk(og, "join", "Join a team using an invite code.", "treg org join <code> --email you@company.com")
     oj.add_argument("code", help="the one-time invite code"); oj.add_argument("--email", required=True, help="your email (creates you if new)"); oj.set_defaults(fn=cmd_org_join)
     mk(og, "leave", "Remove yourself from the active team.", "treg org leave").set_defaults(fn=cmd_org_leave)

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -2926,6 +2926,32 @@ def cmd_org_agent_rm(args, cfg) -> None:
         _show(c.delete(f"/orgs/{org_id}/agents/{args.user_id}"))
 
 
+def cmd_org_deny(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.post(f"/orgs/{org_id}/deny", json={
+            "host": args.host or "", "path_prefix": args.path or "", "method": args.method or "",
+            "user_id": args.user, "note": args.note or ""}))
+
+
+def cmd_org_deny_ls(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.get(f"/orgs/{org_id}/deny"))
+
+
+def cmd_org_deny_rm(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.delete(f"/orgs/{org_id}/deny/{args.rule_id}"))
+
+
 def cmd_org_join(args, cfg) -> None:
     with _client(cfg, auth=False) as c:
         r = c.post("/invites/accept", json={"code": args.code, "email": args.email})
@@ -3232,6 +3258,19 @@ def build_parser() -> argparse.ArgumentParser:
              "treg org agent-rm 7")
     oar.add_argument("user_id", type=int, help="the agent's user id (from `org agents`)")
     oar.set_defaults(fn=cmd_org_agent_rm)
+    od2 = mk(og, "deny", "Block calls to a host / path / method — for the team, or one member (admin+).",
+             "treg org deny --method DELETE --note 'no deletes'",
+             "treg org deny --host api.stripe.com", "treg org deny --path /admin --user 7")
+    od2.add_argument("--host", help="upstream host to block (a full URL works too); omit = any host")
+    od2.add_argument("--path", help="path prefix to block, e.g. /admin; omit = any path")
+    od2.add_argument("--method", help="HTTP method to block, e.g. DELETE; omit = any method")
+    od2.add_argument("--user", type=int, help="apply to ONE member/agent (from `org members`); omit = whole team")
+    od2.add_argument("--note", help="why — shown in the refusal so it names its source")
+    od2.set_defaults(fn=cmd_org_deny)
+    mk(og, "deny-ls", "List this team's deny rules (admin+).", "treg org deny-ls").set_defaults(fn=cmd_org_deny_ls)
+    odr = mk(og, "deny-rm", "Remove a deny rule.", "treg org deny-rm 3")
+    odr.add_argument("rule_id", type=int, help="the rule id (from `org deny-ls`)")
+    odr.set_defaults(fn=cmd_org_deny_rm)
     oj = mk(og, "join", "Join a team using an invite code.", "treg org join <code> --email you@company.com")
     oj.add_argument("code", help="the one-time invite code"); oj.add_argument("--email", required=True, help="your email (creates you if new)"); oj.set_defaults(fn=cmd_org_join)
     mk(og, "leave", "Remove yourself from the active team.", "treg org leave").set_defaults(fn=cmd_org_leave)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -132,6 +132,16 @@ class Settings(BaseSettings):
     # will reject these credentials outright.
     meta_client_id: str = ""
     meta_client_secret: str = ""
+    # Advertising OAuth platforms — unset by default, so these providers list as "not configured"
+    # until this deployment registers its own developer app on each network.
+    microsoft_ads_client_id: str = ""
+    microsoft_ads_client_secret: str = ""
+    snapchat_ads_client_id: str = ""
+    snapchat_ads_client_secret: str = ""
+    tiktok_ads_client_id: str = ""
+    tiktok_ads_client_secret: str = ""
+    pinterest_client_id: str = ""
+    pinterest_client_secret: str = ""
 
     # Overridable for tests; real Google by default.
     google_authorize_url: str = "https://accounts.google.com/o/oauth2/v2/auth"

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from functools import lru_cache
 
 from pydantic import field_validator
+from urllib.parse import urlsplit
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -152,6 +154,27 @@ class Settings(BaseSettings):
     # response, which is an unauthenticated account-takeover vector in prod — so it defaults OFF and
     # must be explicitly enabled (TREG_EMAIL_DEV_MODE=true) for local testing without a mail sender.
     email_dev_mode: bool = False
+
+    # Frictionless local mode: `curl … | sh` brings up a server you are already signed into, with no
+    # account, email or password. Only takes effect when `single_user_ok` allows it (see below).
+    single_user: bool = False
+    # Where the bootstrapped token is written so the CLI/installer can pick it up (0600).
+    single_user_token_file: str = "~/.treg/local-token"
+
+    @property
+    def single_user_ok(self) -> bool:
+        """No-login mode: ONE person on ONE machine, so the dashboard opens already signed in.
+
+        Guarded exactly like `expose_dev_code`, because a no-login dashboard reachable from the
+        internet would hand the whole registry to anyone who found it. Both must hold:
+          - a LOCAL sqlite database (a Postgres URL means a real deploy), and
+          - a loopback `public_url` (so it is not fronted by a public domain).
+        A stray TREG_SINGLE_USER=true in production therefore does nothing.
+        """
+        if not self.single_user or "sqlite" not in self.database_url:
+            return False
+        host = (urlsplit(self.public_url).hostname or "").lower()
+        return host in ("localhost", "127.0.0.1", "0.0.0.0", "::1", "")
 
     @property
     def expose_dev_code(self) -> bool:

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -192,6 +192,17 @@ def _migrate_to_orgs(conn) -> None:
             if col not in cols:
                 conn.execute(text(f"ALTER TABLE pendingoauth ADD COLUMN {col} {ddl}"))
 
+    # (A21) additive: PROJECTS — an optional sub-scope inside an org. The `project` table itself is made
+    # by create_all (a brand-new table needs no ALTER); these are the three columns that hang off it.
+    # All nullable, and NULL everywhere means "org-wide / unrestricted" — so an existing deployment
+    # behaves exactly as before until someone creates a project. No BOOLEAN here, so the Postgres
+    # integer-default trap (PR #22) doesn't apply. See api._project_allowed / models.Project.
+    if "tool" in tables and "project_id" not in {c["name"] for c in insp.get_columns("tool")}:
+        conn.execute(text("ALTER TABLE tool ADD COLUMN project_id INTEGER"))  # NULL = org-wide tool
+    for tbl in ("membership", "invite"):
+        if tbl in tables and "project_access" not in {c["name"] for c in insp.get_columns(tbl)}:
+            conn.execute(text(f"ALTER TABLE {tbl} ADD COLUMN project_access JSON"))  # NULL = whole org
+
     # (B) legacy backfill — guarded
     if "org" not in tables:
         return  # defensive: create_all should have made it

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -79,6 +79,11 @@ class Membership(SQLModel, table=True):
     # Per-member tool ACL: NULL = ALL tools in the org (the default — no restriction, no regression); a
     # JSON list of tool NAMES = the ONLY tools this member may call or run. See api._require_tool_access.
     tool_access: list | None = Field(default=None, sa_column=Column("tool_access", JSON, nullable=True))
+    # Per-member PROJECT scope: NULL = the whole org (the default); a JSON list of project IDS = the
+    # only projects whose tools this member may use. IDs, not slugs, so the hot-path check stays a pure
+    # set test (no id→slug query per call) and a project rename can't strand an access list.
+    # Composes with tool_access as AND — see api._project_allowed.
+    project_access: list | None = Field(default=None, sa_column=Column("project_access", JSON, nullable=True))
     # May this member use the LOCAL run tier (`treg run --local`, the grant)? False → server runs only.
     local_run_enabled: bool = Field(default=True)
     created_at: datetime = Field(default_factory=_now)
@@ -107,6 +112,8 @@ class Invite(SQLModel, table=True):
     # Access to seed onto the membership when this invite is accepted (requirement: set access at invite
     # time, modify later). NULL tool_access = all tools; a list = the allowed tool names.
     tool_access: list | None = Field(default=None, sa_column=Column("tool_access", JSON, nullable=True))
+    # NULL = the whole org; a list of project IDS = the projects to scope them to (see Membership).
+    project_access: list | None = Field(default=None, sa_column=Column("project_access", JSON, nullable=True))
     local_run_enabled: bool = Field(default=True)
     # Where the invitee lands after sign-in — a shared detail page ("/app/skills/<name>") when the
     # invite was minted from a share, else NULL for the plain dashboard. Path-only, validated on create.
@@ -297,6 +304,10 @@ class Tool(SQLModel, table=True):
     # (disabled until the owner opts in). See docs/CLI-RUN-PLAN.md.
     cli: dict | None = Field(default=None, sa_column=Column("cli", JSON))
     bundle_id: int | None = Field(default=None, foreign_key="bundle.id", index=True)
+    # Optional sub-scope inside the org. NULL = ORG-WIDE — which is every tool that existed before
+    # projects, so adding this changed nothing. A project is a LABEL + ACL scope, never a namespace:
+    # `name` stays unique per (org_id, name), so no unique constraint had to be rebuilt. See models.Project.
+    project_id: int | None = Field(default=None, foreign_key="project.id", index=True)
     created_at: datetime = Field(default_factory=_now)
 
 
@@ -328,4 +339,27 @@ class DenyRule(SQLModel, table=True):
     verdict: str = Field(default="deny")  # deny | approve (approve = reserved, see docstring)
     note: str = Field(default="")  # why this exists — shown in the refusal so it names its source
     created_by: str = Field(default="")  # admin email (audit)
+    created_at: datetime = Field(default_factory=_now)
+
+
+class Project(SQLModel, table=True):
+    """An optional sub-scope INSIDE an org — "one team roster, several projects".
+
+    The org stays the hard isolation boundary (every query is still scoped by `org_id`); a project is
+    a softer grouping on top of it. Deliberately a **label + ACL scope, not a namespace**: `Tool.name`
+    remains unique per `(org_id, name)`, so no unique constraint had to be rebuilt and two projects
+    cannot hold a same-named tool. `Tool.project_id` NULL means org-wide, which is what every tool
+    that predates projects is — so this was purely additive.
+
+    Secrets stay org-level on purpose: one shared credential legitimately backs tools in several
+    projects, so scoping it would pose a question with no good answer.
+    """
+
+    __table_args__ = (UniqueConstraint("org_id", "slug", name="uq_project_org_slug"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    org_id: int | None = Field(default=None, foreign_key="org.id", index=True)
+    name: str
+    slug: str = Field(index=True)  # the human handle inside the org
+    created_by: str = Field(default="")
     created_at: datetime = Field(default_factory=_now)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -298,3 +298,34 @@ class Tool(SQLModel, table=True):
     cli: dict | None = Field(default=None, sa_column=Column("cli", JSON))
     bundle_id: int | None = Field(default=None, foreign_key="bundle.id", index=True)
     created_at: datetime = Field(default_factory=_now)
+
+
+class DenyRule(SQLModel, table=True):
+    """A policy rule evaluated on every proxied call: block this host / path / method.
+
+    treg now denies at three layers, deliberately kept apart because each sees something different:
+      - `egress.py`   — the OS firewall around an isolated LOCAL run (which hosts that uid may reach),
+      - `localrun.check_deny` — the ARGV of a local CLI run (`--live`, `auth token`, …),
+      - **this**      — the HTTP request the PROXY is about to relay (host + path + method).
+
+    Scope: `user_id` NULL = the whole org; set = only that member (so one agent can be held tighter
+    than the rest of the team). An empty `host`/`path_prefix`/`method` means "any" — so a rule with
+    only `method="DELETE"` blocks every delete in the org.
+
+    `verdict` is `deny` today. It exists so approval-required actions ("hold the call, ask a human")
+    can land in this same table later without a migration — mirroring the `verdict` vocabulary
+    `localrun.py` already uses for its argv errors.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    org_id: int | None = Field(default=None, foreign_key="org.id", index=True)
+    # NULL = applies to everyone in the org. Set = only this member/agent (identified the same way
+    # every other member endpoint does, by user id — org_id + user_id IS the membership).
+    user_id: int | None = Field(default=None, foreign_key="user.id", index=True)
+    host: str = Field(default="")  # netloc, case-insensitive; "" = any host
+    path_prefix: str = Field(default="")  # "" = any path
+    method: str = Field(default="")  # "" = any method
+    verdict: str = Field(default="deny")  # deny | approve (approve = reserved, see docstring)
+    note: str = Field(default="")  # why this exists — shown in the refusal so it names its source
+    created_by: str = Field(default="")  # admin email (audit)
+    created_at: datetime = Field(default_factory=_now)

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -88,6 +88,10 @@ class OAuthProvider:
     # www.semrush.com, not the api.semrush.com data host. When empty the connect probe is
     # base_url + probe_path. This does not become the tool's ongoing health probe (that is probe_path).
     probe_url: str = ""
+    # A JSON field in the probe response that must be TRUTHY for the key to be valid — for providers
+    # that answer HTTP 200 even on a BAD key and signal validity only in the body (Slack: "ok";
+    # Apollo: "is_logged_in"). Empty means trust the HTTP status (most providers 401/400 a bad key).
+    token_verify_field: str = ""
 
     # Per-provider auth quirks. Defaults match Google, which is the common case.
     auth_params: dict[str, str] | None = None  # extra ?query on the consent URL
@@ -503,6 +507,7 @@ SLACK = OAuthProvider(
     ),
     setup_note="Public channels work immediately. For a private channel, /invite the bot first.",
     token_scopes_header="x-oauth-scopes",
+    token_verify_field="ok",  # Slack answers 200 with {"ok": false} for a dead token
     auth_uri="", token_uri="",
     scopes={},  # scopes live in the manifest above; there is no consent screen to size
     client_id_setting="", client_secret_setting="",
@@ -745,9 +750,10 @@ APOLLO = OAuthProvider(
     summary="Enrich people and companies and search Apollo's 200M+ B2B contact database.",
     base_url="https://api.apollo.io/api/v1",
     docs_url="https://docs.apollo.io/reference/authentication",
-    # Free auth check. Apollo documents the health probe at the legacy /v1/auth/health (no /api);
-    # /api/v1/auth/health has historically resolved too. Confirm against a real key and adjust if it 404s.
+    # Free auth check. It answers HTTP 200 even for a BAD key ({"healthy":true,"is_logged_in":false});
+    # validity is the is_logged_in field, so the probe must read it, not the status (verified live).
     probe_path="/auth/health",
+    token_verify_field="is_logged_in",
 )
 
 PDL = OAuthProvider(
@@ -799,7 +805,10 @@ AKTA = OAuthProvider(
     # /api/v1/…. Setting base_url to /api/v1 would double the version to /api/v1/v1.
     base_url="https://api.akta.pro/api",
     docs_url="https://docs.akta.pro",
-    probe_path="/v1/company/search?query=canva.com",  # documented free endpoint
+    # Trailing slash matters: /company/search (no slash) 307-redirects to /company/search/, and we
+    # don't follow redirects with the key attached. Hitting the slashed path directly returns a clean
+    # 401 {"detail":"Invalid API key"} for a bad key (verified live).
+    probe_path="/v1/company/search/?query=canva.com",
 )
 
 HUNTER = OAuthProvider(

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -58,6 +58,11 @@ class OAuthProvider:
     token_placeholder: str = ""  # "xoxb-…"
     token_header: str = "Authorization"
     token_format: str = "Bearer {secret}"
+    # Where the pasted credential rides. "header" (default) injects it as token_header; "query"
+    # injects it as the token_param query parameter — Semrush authenticates the classic API with
+    # `?key=…`, not a header. Drives both the connect-time probe and the provisioned tool's binding.
+    token_location: str = "header"  # "header" | "query"
+    token_param: str = ""  # query-param name when token_location == "query" (Semrush: "key")
     setup_url: str = ""  # one-click app creation, pre-filled where the platform supports it
     setup_action_label: str = ""
     setup_steps: tuple[str, ...] = ()
@@ -78,6 +83,11 @@ class OAuthProvider:
     # page forever — health could never say more than "nothing has called this yet". It must live on
     # base_url, NOT discover_base_url: the probe runs against the provisioned tool's own host.
     probe_path: str = ""
+    # An ABSOLUTE URL to verify a pasted key against, used only at connect time when the cheapest
+    # key-check lives on a DIFFERENT host than base_url — Semrush's free unit-balance endpoint is on
+    # www.semrush.com, not the api.semrush.com data host. When empty the connect probe is
+    # base_url + probe_path. This does not become the tool's ongoing health probe (that is probe_path).
+    probe_url: str = ""
 
     # Per-provider auth quirks. Defaults match Google, which is the common case.
     auth_params: dict[str, str] | None = None  # extra ?query on the consent URL
@@ -163,6 +173,15 @@ class OAuthProvider:
     @property
     def is_token_kind(self) -> bool:
         return self.auth_kind == "token"
+
+    @property
+    def uses_pasted_secret(self) -> bool:
+        """A provider the user connects by PASTING a credential — a bring-your-own bot token
+        (Slack, `auth_kind="token"`) or a plain API key (`auth_kind="key"`). Both share one connect
+        path: verify the credential against a probe, store it as an env secret, auto-provision the
+        tool. They differ only in the marketplace copy and, for a key, the header/query it rides in.
+        `is_token_kind` stays narrower — it gates the Slack-only bot-setup wording."""
+        return self.auth_kind in ("token", "key")
 
     @property
     def has_identity(self) -> bool:
@@ -697,11 +716,205 @@ META_ADS = OAuthProvider(
     probe_path="/me?fields=id,name",
 )
 
+# ---- API-key providers (auth_kind="key") ------------------------------------------------------
+# The user pastes an API key instead of consenting through an OAuth app treg owns. Same connect
+# mechanic as Slack's bot token — verify against a probe, store as an env secret, auto-provision the
+# tool — differing only in the header (or query param) the key rides in and the "where do I get a
+# key" copy. A key provider needs nothing from treg, so it is always offerable (is_configured=True).
+# No `scopes`: there is no consent screen to size, so the marketplace card leans on `summary`.
+
+APOLLO = OAuthProvider(
+    service="apollo",
+    display_name="Apollo.io",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Apollo API key",
+    token_header="X-Api-Key",
+    token_format="{secret}",  # raw key, no Bearer prefix
+    setup_url="https://developers.apollo.io/keys",
+    setup_action_label="Get your Apollo API key",
+    setup_steps=(
+        "Sign in to Apollo and open Settings → Integrations → API.",
+        "Create an API key (a master key reaches every endpoint) and copy it.",
+    ),
+    setup_note="Enrichment calls spend Apollo credits; the health check does not.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Enrich people and companies and search Apollo's 200M+ B2B contact database.",
+    base_url="https://api.apollo.io/api/v1",
+    docs_url="https://docs.apollo.io/reference/authentication",
+    # Free auth check. Apollo documents the health probe at the legacy /v1/auth/health (no /api);
+    # /api/v1/auth/health has historically resolved too. Confirm against a real key and adjust if it 404s.
+    probe_path="/auth/health",
+)
+
+PDL = OAuthProvider(
+    service="pdl",
+    display_name="People Data Labs",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your People Data Labs API key",
+    token_header="X-Api-Key",
+    token_format="{secret}",
+    setup_url="https://dashboard.peopledatalabs.com/main/api-keys",
+    setup_action_label="Get your People Data Labs API key",
+    setup_steps=(
+        "Sign in to the People Data Labs dashboard and open API Keys.",
+        "Copy your API key.",
+    ),
+    setup_note="Enrichment and search spend credits; the autocomplete health check is free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Enrich a person or company, or search PDL's people and company datasets.",
+    base_url="https://api.peopledatalabs.com/v5",
+    docs_url="https://docs.peopledatalabs.com/docs/authentication",
+    probe_path="/autocomplete?field=title&text=data",  # Autocomplete API is free (no credits)
+)
+
+AKTA = OAuthProvider(
+    service="akta",
+    display_name="Akta by Wokelo",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Akta API key",
+    token_header="x-api-key",
+    token_format="{secret}",
+    setup_url="https://akta.pro",
+    setup_action_label="Get your Akta API key",
+    setup_steps=(
+        "Request an API key for your Akta account (support@akta.pro).",
+        "Paste it here.",
+    ),
+    setup_note="Company enrichment spends credits; company search is free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Company intelligence — enrichment, industry resolution, reviews and news monitoring.",
+    # base_url is api.akta.pro/api and every path carries its OWN /v1 prefix, so the effective path is
+    # /api/v1/…. Setting base_url to /api/v1 would double the version to /api/v1/v1.
+    base_url="https://api.akta.pro/api",
+    docs_url="https://docs.akta.pro",
+    probe_path="/v1/company/search?query=canva.com",  # documented free endpoint
+)
+
+HUNTER = OAuthProvider(
+    service="hunter",
+    display_name="Hunter",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Hunter API key",
+    # Hunter accepts the key as ?api_key=…, an X-API-KEY header, or a Bearer header. Use the header
+    # so the key never lands in a URL (the proxy records request paths; a query key could leak there).
+    token_header="X-API-KEY",
+    token_format="{secret}",
+    setup_url="https://hunter.io/api-keys",
+    setup_action_label="Get your Hunter API key",
+    setup_steps=(
+        "Sign in to Hunter and open API → API Keys.",
+        "Copy your API key.",
+    ),
+    setup_note="Searches and verifications spend credits; the account check is free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Find and verify professional email addresses, and enrich people and companies.",
+    base_url="https://api.hunter.io/v2",
+    docs_url="https://hunter.io/api-documentation/v2",
+    probe_path="/account",  # free — consumes no search/verification/enrichment credits
+)
+
+TIKHUB = OAuthProvider(
+    service="tikhub",
+    display_name="TikHub",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your TikHub API key",
+    # token_header / token_format default to Authorization: Bearer {secret}
+    setup_url="https://tikhub.io/users/api_keys",
+    setup_action_label="Get your TikHub API key",
+    setup_steps=(
+        "Sign in to TikHub and open the API Keys page.",
+        "Create a key and copy it.",
+    ),
+    setup_note="Data calls are billed per successful request; the account check is not.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Social media",
+    summary="Read TikTok, Instagram, YouTube, X and more social platforms through one unified API.",
+    base_url="https://api.tikhub.io",
+    docs_url="https://docs.tikhub.io/",
+    probe_path="/api/v1/tikhub/user/get_user_info",  # account info — the natural key check
+)
+
+BRIGHTDATA = OAuthProvider(
+    service="brightdata",
+    display_name="Bright Data",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Bright Data API token",
+    # Authorization: Bearer {secret} (defaults)
+    setup_url="https://brightdata.com/cp/setting/users",
+    setup_action_label="Get your Bright Data API token",
+    setup_steps=(
+        "Sign in to Bright Data and open Account settings → API tokens.",
+        "Create a token and copy it.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Social media",
+    summary="Scrape social platforms and the web through Bright Data's Web Scraper API.",
+    # Several product APIs share one host and one Bearer scheme; the social entry is pinned to the
+    # Web Scraper API (/datasets/v3/…).
+    base_url="https://api.brightdata.com",
+    docs_url="https://docs.brightdata.com/api-reference/authentication",
+    # Lightweight dataset listing — inferred (medium confidence). Verify with a real token; adjust if it 404s.
+    probe_path="/datasets/v3/datasets",
+)
+
+SEMRUSH = OAuthProvider(
+    service="semrush",
+    display_name="Semrush",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Semrush API key",
+    token_location="query",  # Semrush authenticates the classic API with ?key=…, not a header
+    token_param="key",
+    token_format="{secret}",
+    setup_url="https://www.semrush.com/accounts/subscription-info/api-units/",
+    setup_action_label="Get your Semrush API key",
+    setup_steps=(
+        "Sign in to Semrush and open Subscription info → API units.",
+        "Copy your API key.",
+    ),
+    setup_note="Reports spend API units; the key check reads your unit balance for free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Domain, keyword and backlink analytics across Semrush's SEO database.",
+    base_url="https://api.semrush.com/",
+    docs_url="https://developer.semrush.com/api/v3/analytics/basic-docs/",
+    # The free unit-balance check lives on a DIFFERENT host than the data API, so verify against it
+    # directly. No probe_path: the classic API is CSV-only with no free GET on api.semrush.com, so the
+    # provisioned tool carries no ongoing health probe (one would spend API units on every run).
+    probe_url="https://www.semrush.com/users/countapiunits.html",
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
         GOOGLE_SEARCH_CONSOLE, GOOGLE_ANALYTICS, GOOGLE_BUSINESS_PROFILE, GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
+        # API-key providers
+        APOLLO, PDL, AKTA, HUNTER, TIKHUB, BRIGHTDATA, SEMRUSH,
     )
 }
 
@@ -709,7 +922,7 @@ DEFAULT_CAPABILITY = "read"
 
 # Shelf order in the marketplace. Anything carrying a category not named here sorts last, so a
 # provider added without one is visible rather than lost between the shelves.
-CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Community", "Other")
+CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Community", "Other")
 
 
 def get(service: str) -> OAuthProvider | None:
@@ -732,9 +945,9 @@ def credentials(provider: OAuthProvider) -> tuple[str, str]:
 
 
 def is_configured(provider: OAuthProvider) -> bool:
-    """Whether THIS deployment can offer the provider. A token provider needs nothing from us —
-    the user brings their own — so it is always offerable."""
-    if provider.is_token_kind:
+    """Whether THIS deployment can offer the provider. A pasted-secret provider (bot token or API
+    key) needs nothing from us — the user brings their own — so it is always offerable."""
+    if provider.uses_pasted_secret:
         return True
     try:
         credentials(provider)

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -107,6 +107,10 @@ class OAuthProvider:
     # string (Majestic: {"Code":"OK"} on success vs {"Code":"FailedRequestViaAPI"} on a bad key).
     token_ok_field: str = ""
     token_ok_value: str = ""
+    # Status codes that mean INVALID KEY specifically (default: any >=400 rejects). Coresignal has no
+    # free probe, so we POST an empty body: a valid key answers 400/422 (bad request, no charge) while
+    # an invalid key answers 401 — so only 401/403 should count as a bad-key rejection there.
+    probe_reject_statuses: tuple[int, ...] = ()
 
     # Per-provider auth quirks. Defaults match Google, which is the common case.
     auth_params: dict[str, str] | None = None  # extra ?query on the consent URL
@@ -1124,6 +1128,122 @@ SERPSTAT = OAuthProvider(
     token_reject_field="error",
 )
 
+# ---- more Enrichment API-key providers -------------------------------------------------------
+
+LUSHA = OAuthProvider(
+    service="lusha",
+    display_name="Lusha",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Lusha API key",
+    token_header="api_key",  # literally "api_key", no scheme prefix
+    token_format="{secret}",
+    setup_url="https://dashboard.lusha.com/api",
+    setup_action_label="Get your Lusha API key",
+    setup_steps=("Sign in to Lusha and open the API settings.", "Copy your API key."),
+    setup_note="API access is generally on paid plans (Pro/Scale).",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Verified direct-dial and mobile phone numbers, plus person and company enrichment.",
+    base_url="https://api.lusha.com",
+    docs_url="https://docs.lusha.com/apis/openapi/section/authentication",
+    probe_path="/v3/account/usage",  # free account snapshot
+)
+
+CORESIGNAL = OAuthProvider(
+    service="coresignal",
+    display_name="Coresignal",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Coresignal API key",
+    token_header="apikey",  # one word, lowercase
+    token_format="{secret}",
+    setup_url="https://dashboard.coresignal.com/",
+    setup_action_label="Get your Coresignal API key",
+    setup_steps=("Sign in to the Coresignal dashboard and open API keys.", "Copy your key."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Large-scale employee, job-posting and company data via search and collect.",
+    base_url="https://api.coresignal.com/cdapi/v2",
+    docs_url="https://docs.coresignal.com/api-introduction/authorization",
+    # No free account endpoint: POST an empty body — a valid key answers 400 (no charge), an invalid
+    # key answers 401 — so only 401/403 count as a bad-key rejection (verified: bad key -> 401).
+    probe_method="POST",
+    probe_path="/company_base/search/es_dsl",
+    probe_json={},
+    probe_reject_statuses=(401, 403),
+)
+
+DIFFBOT = OAuthProvider(
+    service="diffbot",
+    display_name="Diffbot",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Diffbot token",
+    token_location="query",  # token is a query param on every call
+    token_param="token",
+    token_format="{secret}",
+    setup_url="https://app.diffbot.com/get-started/",
+    setup_action_label="Get your Diffbot token",
+    setup_steps=("Sign in to Diffbot and open your account.", "Copy your API token."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Knowledge-graph entities (organizations, people) and AI web extraction.",
+    # Enhance/enrich + DQL live on the KG host; the free account probe lives on the api host, so verify
+    # off-host. The provisioned tool points at the KG host (the enrichment value).
+    base_url="https://kg.diffbot.com/kg/v3",
+    docs_url="https://docs.diffbot.com/reference/authentication",
+    probe_url="https://api.diffbot.com/v4/account",  # token injected as ?token=…
+)
+
+THECOMPANIESAPI = OAuthProvider(
+    service="thecompaniesapi",
+    display_name="The Companies API",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Companies API token",
+    token_header="Authorization",
+    token_format="Basic {secret}",  # the RAW token after "Basic ", NOT base64 (no token_encode)
+    setup_url="https://www.thecompaniesapi.com/",
+    setup_action_label="Get your Companies API token",
+    setup_steps=("Sign up at thecompaniesapi.com.", "Copy your API token from the dashboard."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Firmographics and technology-stack detection across ~50M companies.",
+    base_url="https://api.thecompaniesapi.com/v2",
+    docs_url="https://www.thecompaniesapi.com/api/authentication",
+    probe_path="/companies?simplified=true&size=1",  # free (no credits), auth required
+)
+
+LEADMAGIC = OAuthProvider(
+    service="leadmagic",
+    display_name="LeadMagic",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your LeadMagic API key",
+    token_header="X-API-Key",
+    token_format="{secret}",
+    setup_url="https://app.leadmagic.io/dashboard/api-keys",
+    setup_action_label="Get your LeadMagic API key",
+    setup_steps=("Sign in to LeadMagic and open API keys.", "Copy your key."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Find and verify emails and mobile numbers, and enrich people and companies.",
+    base_url="https://api.leadmagic.io",
+    docs_url="https://leadmagic.io/docs/v1/authentication",
+    probe_path="/v1/credits",  # free — no credits consumed
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
@@ -1133,6 +1253,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
+        # more Enrichment API-key providers
+        LUSHA, CORESIGNAL, DIFFBOT, THECOMPANIESAPI, LEADMAGIC,
     )
 }
 

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -917,13 +917,67 @@ SEMRUSH = OAuthProvider(
     probe_url="https://www.semrush.com/users/countapiunits.html",
 )
 
+CRUNCHBASE = OAuthProvider(
+    service="crunchbase",
+    display_name="Crunchbase",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Crunchbase user key",
+    token_header="X-cb-user-key",
+    token_format="{secret}",
+    setup_url="https://data.crunchbase.com/docs/using-the-api",
+    setup_action_label="Find your Crunchbase API key",
+    setup_steps=(
+        "Crunchbase issues API keys with an Enterprise/Applications license — a Team Owner finds it "
+        "under Integrations settings.",
+        "Paste it here.",
+    ),
+    setup_note="Requires a paid Crunchbase API license; keys are not self-service.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Company, funding, acquisition and people data from Crunchbase.",
+    base_url="https://api.crunchbase.com/v4/data",
+    docs_url="https://data.crunchbase.com/docs/using-the-api",
+    probe_path="/autocompletes?query=google&limit=1",  # rate-limited, no per-call credit
+)
+
+JUSTONEAPI = OAuthProvider(
+    service="justoneapi",
+    display_name="Just One API",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Just One API token",
+    token_location="query",  # token rides as ?token=…, not a header
+    token_param="token",
+    token_format="{secret}",
+    setup_url="https://dashboard.justoneapi.com/en",
+    setup_action_label="Get your Just One API token",
+    setup_steps=(
+        "Sign in to the Just One API dashboard and open Token management.",
+        "Copy your token.",
+    ),
+    setup_note="Data calls are billed only on success (code 0); errors and empty results are free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Social media",
+    summary="A second social-scraping backend — TikTok, Instagram, YouTube, X, Weibo, Xiaohongshu and more.",
+    base_url="https://api.justoneapi.com",
+    docs_url="https://docs.justoneapi.com/en/usage",
+    # A bad token returns HTTP 401 {"code":100,"message":"TOKEN INVALID/UNACTIVATE"} (verified live), so
+    # the standard status check rejects it. A valid token on this endpoint returns code:0 (~1 credit).
+    probe_path="/api/tiktok/get-user-detail/v1?unique_id=tiktok",
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
         GOOGLE_SEARCH_CONSOLE, GOOGLE_ANALYTICS, GOOGLE_BUSINESS_PROFILE, GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, TIKHUB, BRIGHTDATA, SEMRUSH,
+        APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
     )
 }
 

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -92,6 +92,21 @@ class OAuthProvider:
     # that answer HTTP 200 even on a BAD key and signal validity only in the body (Slack: "ok";
     # Apollo: "is_logged_in"). Empty means trust the HTTP status (most providers 401/400 a bad key).
     token_verify_field: str = ""
+    # The INVERSE: reject if this JSON field is present/truthy — for providers that answer 200 with an
+    # error object on a bad key (Serpstat's JSON-RPC `error`).
+    token_reject_field: str = ""
+    # POST-style verify probe, for providers whose key-check needs a request body (Serpstat's JSON-RPC
+    # limits call). `probe_method` defaults to GET; `probe_json` is sent as the JSON body when set.
+    probe_method: str = "GET"
+    probe_json: dict | None = None
+    # Encode the pasted secret before storing: "base64" turns a pasted `login:password` into the Base64
+    # blob HTTP Basic needs (DataForSEO, Moz), so `token_format="Basic {secret}"` renders correctly and
+    # the stored value injects the same way on every proxy call.
+    token_encode: str = ""
+    # Accept only when a JSON field EQUALS a value — for providers that answer 200 with a status
+    # string (Majestic: {"Code":"OK"} on success vs {"Code":"FailedRequestViaAPI"} on a bad key).
+    token_ok_field: str = ""
+    token_ok_value: str = ""
 
     # Per-provider auth quirks. Defaults match Google, which is the common case.
     auth_params: dict[str, str] | None = None  # extra ?query on the consent URL
@@ -971,6 +986,144 @@ JUSTONEAPI = OAuthProvider(
     probe_path="/api/tiktok/get-user-detail/v1?unique_id=tiktok",
 )
 
+# ---- SEO API-key providers -------------------------------------------------------------------
+
+DATAFORSEO = OAuthProvider(
+    service="dataforseo",
+    display_name="DataForSEO",
+    auth_kind="key",
+    token_label="API login:password",
+    token_placeholder="your DataForSEO login:password",
+    token_header="Authorization",
+    token_format="Basic {secret}",
+    token_encode="base64",  # paste "login:password"; we Base64 it for HTTP Basic
+    setup_url="https://app.dataforseo.com/api-access",
+    setup_action_label="Get your DataForSEO API credentials",
+    setup_steps=(
+        "Sign in to DataForSEO and open API access.",
+        "Copy your API login and the SEPARATE API password (not your account password).",
+        "Paste them here as login:password.",
+    ),
+    setup_note="Use the API password from the dashboard, not your account login password.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="SERP, keyword, backlink, on-page and traffic data across search engines.",
+    base_url="https://api.dataforseo.com/v3",
+    docs_url="https://docs.dataforseo.com/v3/auth/",
+    probe_path="/appendix/user_data",  # free account info (no credits)
+)
+
+SERANKING = OAuthProvider(
+    service="seranking",
+    display_name="SE Ranking",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your SE Ranking API key",
+    token_header="Authorization",
+    token_format="Token {secret}",  # the word "Token", not "Bearer"
+    setup_url="https://seranking.com/api/how-to-get-api/",
+    setup_action_label="Get your SE Ranking API key",
+    setup_steps=(
+        "Sign in to SE Ranking and open the API section.",
+        "Create an API key and copy it.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Rank tracking, keyword research, backlinks and competitor data.",
+    base_url="https://api.seranking.com",
+    docs_url="https://seranking.com/api/data/getting-started/",
+    probe_path="/v1/account/subscription",  # free key check + plan
+)
+
+MOZ = OAuthProvider(
+    service="moz",
+    display_name="Moz",
+    auth_kind="key",
+    token_label="AccessID:SecretKey",
+    token_placeholder="your Moz AccessID:SecretKey",
+    token_header="Authorization",
+    token_format="Basic {secret}",
+    token_encode="base64",  # paste "AccessID:SecretKey"; Base64 for HTTP Basic
+    setup_url="https://moz.com/api/dashboard",
+    setup_action_label="Get your Moz API credentials",
+    setup_steps=(
+        "Open the Moz API dashboard.",
+        "Copy your Access ID and Secret Key.",
+        "Paste them here as AccessID:SecretKey.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Domain Authority, Page Authority, backlinks and link metrics.",
+    base_url="https://lsapi.seomoz.com/v2",
+    docs_url="https://moz.com/api/docs",
+    probe_method="POST",
+    probe_path="/quota",
+    probe_json={"path": "api.limits.data.rows"},  # free quota lookup
+)
+
+MAJESTIC = OAuthProvider(
+    service="majestic",
+    display_name="Majestic",
+    auth_kind="key",
+    token_label="OpenApp API key",
+    token_placeholder="your Majestic app_api_key",
+    token_location="query",
+    token_param="app_api_key",
+    token_format="{secret}",
+    setup_url="https://developer-support.majestic.com/openapps/",
+    setup_action_label="Get your Majestic OpenApp key",
+    setup_steps=(
+        "Register an OpenApp in Majestic developer settings.",
+        "Copy the app_api_key.",
+    ),
+    setup_note="Requires a paid Majestic plan and a registered OpenApp.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Backlink metrics — Trust Flow, Citation Flow, referring domains and anchors.",
+    base_url="https://api.majestic.com",
+    docs_url="https://developer-support.majestic.com/api/",
+    probe_path="/api/json?cmd=GetSubscriptionInfo",  # free (0 Analysis Units)
+    # Answers HTTP 200 even on a bad key; validity is {"Code":"OK"} vs {"Code":"FailedRequestViaAPI"}.
+    token_ok_field="Code",
+    token_ok_value="OK",
+)
+
+SERPSTAT = OAuthProvider(
+    service="serpstat",
+    display_name="Serpstat",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Serpstat token",
+    token_location="query",
+    token_param="token",
+    token_format="{secret}",
+    setup_url="https://serpstat.com/api/660-how-to-get-create-token/",
+    setup_action_label="Get your Serpstat API token",
+    setup_steps=(
+        "Sign in to Serpstat and open the API page.",
+        "Create a token and copy it.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Keyword research, backlinks, rank tracking and domain analytics.",
+    base_url="https://api.serpstat.com/v4",
+    docs_url="https://api-docs.serpstat.com/",
+    # JSON-RPC over POST; a bad token answers HTTP 200 with an `error` object, so reject on that field.
+    probe_method="POST",
+    probe_json={"id": "1", "method": "SerpstatLimitsApiProcedure.getStats", "params": {}},
+    token_reject_field="error",
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
@@ -978,6 +1131,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
+        # SEO API-key providers
+        DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
     )
 }
 

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1244,6 +1244,191 @@ LEADMAGIC = OAuthProvider(
     probe_path="/v1/credits",  # free — no credits consumed
 )
 
+# ---- Advertising API-key providers (ad intelligence) -----------------------------------------
+
+SPYFU = OAuthProvider(
+    service="spyfu",
+    display_name="SpyFu",
+    auth_kind="key",
+    token_label="Secret key",
+    token_placeholder="your SpyFu secret key",
+    token_location="query",  # ?api_key=<SecretKey> (the secret alone; API id not needed for this form)
+    token_param="api_key",
+    token_format="{secret}",
+    setup_url="https://www.spyfu.com/account/api",
+    setup_action_label="Get your SpyFu API key",
+    setup_steps=("Open SpyFu Account settings → API.", "Copy your Secret Key."),
+    setup_note="API access is included with paid SpyFu plans; paste the Secret Key.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Advertising",
+    summary="Competitor search-ad keywords, estimated ad spend and PPC history.",
+    base_url="https://api.spyfu.com",
+    docs_url="https://developer.spyfu.com/",
+    probe_path="/apis/domain_stats_api/v2/getAllDomainStats?domain=spyfu.com",
+)
+
+APIFY = OAuthProvider(
+    service="apify",
+    display_name="Apify",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Apify API token",
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://console.apify.com/settings/integrations",
+    setup_action_label="Get your Apify API token",
+    setup_steps=("Open Apify Console → Settings → Integrations.", "Copy your API token."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Advertising",
+    summary="Run Facebook and TikTok ad-library scraper actors for ad creatives and targeting.",
+    base_url="https://api.apify.com/v2",
+    docs_url="https://docs.apify.com/api/v2",
+    probe_path="/users/me",  # free; 401 on bad token
+)
+
+META_AD_LIBRARY = OAuthProvider(
+    service="meta-ad-library",
+    display_name="Meta Ad Library",
+    auth_kind="key",
+    token_label="Access token",
+    token_placeholder="your Meta ad-library access token",
+    token_location="query",
+    token_param="access_token",
+    token_format="{secret}",
+    setup_url="https://www.facebook.com/ads/library/api/",
+    setup_action_label="Set up Meta Ad Library API access",
+    setup_steps=(
+        "Confirm your identity at facebook.com/ID (upload a government ID; 1–3 days).",
+        "Create a Meta app and generate an access token.",
+    ),
+    setup_note="Official free competitive ad data; requires one-time Meta identity verification.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Advertising",
+    summary="Official Meta ad library — anyone's live Facebook/Instagram ads and spend ranges.",
+    base_url="https://graph.facebook.com/v21.0",
+    docs_url="https://www.facebook.com/ads/library/api/",
+    # Required params baked in (ad_reached_countries is a URL-encoded JSON array); access_token injected.
+    probe_path='/ads_archive?search_terms=coffee&ad_reached_countries=%5B%22US%22%5D&limit=1&fields=id',
+)
+
+SERPAPI = OAuthProvider(
+    service="serpapi",
+    display_name="SerpApi",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your SerpApi key",
+    token_location="query",
+    token_param="api_key",
+    token_format="{secret}",
+    setup_url="https://serpapi.com/manage-api-key",
+    setup_action_label="Get your SerpApi key",
+    setup_steps=("Sign in to SerpApi.", "Copy your API key from the dashboard."),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Advertising",
+    summary="Google search, Shopping and paid-ad results from live SERPs.",
+    base_url="https://serpapi.com",
+    docs_url="https://serpapi.com/search-api",
+    probe_path="/account",  # free account/plan snapshot; 401 on bad key
+)
+
+# ---- Advertising OAuth platforms (UNCONFIGURED until this deployment registers a dev app) ------
+# These list as `configured: false` until treg holds each platform's client id/secret. Microsoft +
+# Snapchat fit the existing OAuth machinery (Microsoft additionally needs the user's own developer
+# token, like Google Ads). TikTok Ads is NON-STANDARD OAuth and needs oauth.py + binding work before
+# it can actually run — it is a registry placeholder for now (see the comment on it).
+
+MICROSOFT_ADS = OAuthProvider(
+    service="microsoft-ads",
+    display_name="Microsoft Advertising",
+    auth_uri="https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    token_uri="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    # One combined read+write scope; offline_access buys a refresh token, openid the identity.
+    scopes={"manage": ["https://ads.microsoft.com/msads.manage", "offline_access", "openid"]},
+    client_id_setting="microsoft_ads_client_id",
+    client_secret_setting="microsoft_ads_client_secret",
+    category="Advertising",
+    summary="Run and report on your Microsoft (Bing) search-ad campaigns.",
+    base_url="https://campaign.api.bingads.microsoft.com/CampaignManagement/v13",
+    docs_url="https://learn.microsoft.com/en-us/advertising/guides/get-started",
+    token_endpoint_auth_method="client_secret_post",
+    auth_params={},  # Microsoft identity v2.0; don't send Google's access_type/prompt
+    # Bing REST needs a DeveloperToken header on every call besides the OAuth bearer — issued
+    # instantly for first-party use, so the user supplies it (like Google Ads' developer token).
+    extra_credential_note=(
+        "Microsoft Advertising needs a developer token (issued instantly in the Microsoft Advertising "
+        "Developer Portal). Add it under Secrets and bind it as a DeveloperToken header."
+    ),
+    extra_credential_label="Developer token",
+    extra_credential_header="DeveloperToken",
+)
+
+SNAPCHAT_ADS = OAuthProvider(
+    service="snapchat-ads",
+    display_name="Snapchat Ads",
+    auth_uri="https://accounts.snapchat.com/login/oauth2/authorize",
+    token_uri="https://accounts.snapchat.com/login/oauth2/access_token",
+    scopes={"manage": ["snapchat-marketing-api"]},
+    client_id_setting="snapchat_ads_client_id",
+    client_secret_setting="snapchat_ads_client_secret",
+    category="Advertising",
+    summary="Run and report on your Snapchat ad campaigns.",
+    base_url="https://adsapi.snapchat.com/v1",
+    docs_url="https://developers.snap.com/marketing-api/Ads-API/authentication",
+    token_endpoint_auth_method="client_secret_post",
+    auth_params={},
+    probe_path="/me",  # cheap token check once configured; auto-provisions a Bearer tool
+)
+
+# TikTok Ads is NON-STANDARD OAuth: the token exchange uses app_id/secret + auth_code in a JSON body
+# and returns a {"code":0,"data":{...}} envelope, and API calls authenticate with an `Access-Token`
+# header (NOT `Authorization: Bearer`). oauth.py (standard code/grant_type exchange) and the Bearer
+# auto-provision binding do NOT handle this yet, so this entry cannot be configured to work until that
+# code is added. Kept as a placeholder so the platform is visible on the shelf. See notes.
+TIKTOK_ADS = OAuthProvider(
+    service="tiktok-ads",
+    display_name="TikTok Ads",
+    auth_uri="https://business-api.tiktok.com/portal/auth",
+    token_uri="https://business-api.tiktok.com/open_api/v1.3/oauth2/access_token/",
+    scopes={"manage": ["ads.management"]},  # nominal; TikTok's real scopes are numeric ids set in the portal
+    client_id_setting="tiktok_ads_client_id",
+    client_secret_setting="tiktok_ads_client_secret",
+    category="Advertising",
+    summary="Run and report on your TikTok ad campaigns.",
+    base_url="https://business-api.tiktok.com/open_api/v1.3",
+    docs_url="https://business-api.tiktok.com/portal/docs",
+    token_endpoint_auth_method="client_secret_post",
+    client_id_param="app_id",  # TikTok spells the client id "app_id"
+    auth_params={},
+)
+
+PINTEREST_ADS = OAuthProvider(
+    service="pinterest-ads",
+    display_name="Pinterest Ads",
+    auth_uri="https://www.pinterest.com/oauth/",
+    token_uri="https://api.pinterest.com/v5/oauth/token",
+    scopes={
+        "read": ["ads:read", "user_accounts:read"],
+        "manage": ["ads:read", "ads:write", "user_accounts:read"],
+    },
+    client_id_setting="pinterest_client_id",
+    client_secret_setting="pinterest_client_secret",
+    category="Advertising",
+    summary="Run and report on your Pinterest ad campaigns.",
+    base_url="https://api.pinterest.com/v5",
+    docs_url="https://developers.pinterest.com/docs/api/v5/",
+    token_endpoint_auth_method="client_secret_basic",  # Pinterest posts Basic client auth
+    auth_params={},
+    probe_path="/user_account",  # cheap token check once configured; auto-provisions a Bearer tool
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
@@ -1255,6 +1440,9 @@ REGISTRY: dict[str, OAuthProvider] = {
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
         # more Enrichment API-key providers
         LUSHA, CORESIGNAL, DIFFBOT, THECOMPANIESAPI, LEADMAGIC,
+        # Advertising: API-key ad intelligence + unconfigured OAuth ad platforms
+        SPYFU, APIFY, META_AD_LIBRARY, SERPAPI,
+        MICROSOFT_ADS, SNAPCHAT_ADS, TIKTOK_ADS, PINTEREST_ADS,
     )
 }
 
@@ -1353,6 +1541,17 @@ SCOPE_LABELS: dict[str, str] = {
     "ads_read": "Read your ad accounts, campaigns and performance",
     "business_management": "See the businesses and ad accounts you have access to",
     "ads_management": "Create and change campaigns, ad sets and ads",
+    # Microsoft Advertising
+    "https://ads.microsoft.com/msads.manage": "Manage your Microsoft Advertising campaigns and reports",
+    "offline_access": "Stay connected without asking you to sign in again",
+    # Snapchat Ads
+    "snapchat-marketing-api": "Manage your Snapchat ad campaigns and reporting",
+    # TikTok Ads (nominal — real scopes are numeric ids configured in the TikTok portal)
+    "ads.management": "Manage your TikTok ad campaigns and reporting",
+    # Pinterest Ads
+    "ads:read": "Read your ad accounts, campaigns and performance",
+    "ads:write": "Create and change your ad campaigns",
+    "user_accounts:read": "See which ad accounts you have access to",
 }
 
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -827,7 +827,7 @@ th{background:rgba(0,0,0,.25)}
                   <span v-if="connCount[p.service]" class="chip ok">{{connCount[p.service]}} connected</span>
                   <span v-else-if="!p.configured" class="chip warn" title="This server has no client credentials for the provider">not configured</span>
                   <span v-else class="mk-quiet">Not connected</span>
-                  <span class="mk-auth">{{p.auth_kind==='token'?'your own bot':'one-click'}}</span>
+                  <span class="mk-auth">{{p.auth_kind==='key'?'API key':(p.auth_kind==='token'?'your own bot':'one-click')}}</span>
                 </div>
               </div>
             </div>
@@ -1598,8 +1598,8 @@ th{background:rgba(0,0,0,.25)}
     <div v-if="tokenAsk" class="scrim" role="dialog" aria-modal="true" @click.self="tokenAsk=null">
       <div class="modal" style="padding:16px">
         <h3 style="margin:0 0 6px"><span class="plogo-tile"><img class="plogo" :src="'/logos/'+tokenAsk.provider.service+'.svg'" alt="" aria-hidden="true" @error="$event.target.style.visibility='hidden'"></span>Connect {{tokenAsk.provider.display_name}}</h3>
-        <p class="sub" style="margin:0 0 12px">You bring your own bot, so it stays yours — treg
-          holds the token server-side and injects it on every call.</p>
+        <p class="sub" style="margin:0 0 12px">You bring your own {{tokenAsk.provider.auth_kind==='key'?'API key':'bot'}}, so it stays yours — treg
+          holds it server-side and injects it on every call.</p>
         <a v-if="tokenAsk.provider.setup_url" class="btn sm primary" :href="tokenAsk.provider.setup_url"
            target="_blank" rel="noopener">{{tokenAsk.provider.setup_action_label||'Create the app'}}</a>
         <ol style="margin:12px 0 0;padding-left:20px;color:var(--muted);font-size:12.5px;line-height:1.7">
@@ -2976,8 +2976,9 @@ createApp({
       manage:'Your agent can view and manage everything in the account.',
     }[cap] || 'Requests the '+cap+' scopes.'; },
     startConnect(p, conn){
-      // A token provider has no consent screen — the user brings their own bot, so setup is a form.
-      if(p.auth_kind==='token') return void (this.tokenAsk={provider:p, token:'', err:'', busy:false, conn});
+      // A pasted-secret provider has no consent screen — the user brings their own bot token (Slack)
+      // or API key (Apollo, TikHub, …), so setup is a form, not a redirect.
+      if(p.auth_kind==='token' || p.auth_kind==='key') return void (this.tokenAsk={provider:p, token:'', err:'', busy:false, conn});
       // One capability means there's nothing to ask — don't put a dialog in the way.
       if((p.capabilities||[]).length<2) return this.connectProvider(p, p.default_capability, conn);
       this.capAsk={provider:p, conn};

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1192,13 +1192,44 @@ th{background:rgba(0,0,0,.25)}
           </div>
           <!-- settings for the ACTIVE team (switching lives in the sidebar) -->
           <div v-if="activeOrg" style="margin-top:20px">
-            <p v-if="!canAdmin" class="sub" style="margin-bottom:12px">Members, projects and policy are visible to admins.</p>
-            <div v-if="canAdmin" class="tabs" style="margin:4px 0 16px">
-              <button :class="{active:orgTab==='members'}" @click="orgTab='members'">Members</button>
-              <button :class="{active:orgTab==='projects'}" @click="orgTab='projects'">Projects</button>
-              <button :class="{active:orgTab==='policy'}" @click="orgTab='policy'">Policy</button>
-              <button :class="{active:orgTab==='danger'}" @click="orgTab='danger'">Team settings</button>
+            <div class="tabs" style="margin:4px 0 16px">
+              <button v-if="canAdmin" :class="{active:orgTab==='members'}" @click="orgTab='members'">Members</button>
+              <button :class="{active:orgTab==='teams'}" @click="orgTab='teams'">My teams</button>
+              <button v-if="canAdmin" :class="{active:orgTab==='projects'}" @click="orgTab='projects'">Projects</button>
+              <button v-if="canAdmin" :class="{active:orgTab==='policy'}" @click="orgTab='policy'">Policy</button>
+              <button v-if="canAdmin" :class="{active:orgTab==='danger'}" @click="orgTab='danger'">Team settings</button>
             </div>
+            <p v-if="!canAdmin && orgTab!=='teams'" class="sub" style="margin-bottom:12px">Members, projects and policy are visible to admins.</p>
+
+            <!-- MY TEAMS: the sidebar picker as a real page — every team you belong to, in one table -->
+            <template v-if="orgTab==='teams'">
+              <div class="lbl" style="margin-top:14px;display:flex;align-items:center;gap:10px">Your teams
+                <button v-if="sessionMode" class="btn sm" @click="newOrg=true; newOrgName=''">＋ New team</button>
+                <button v-if="sessionMode" class="btn sm" @click="showJoin=true; joinCode=''; joinErr=''">⤷ Join by code</button>
+                <button v-if="!sessionMode" class="btn sm" @click="addOrg=true">＋ Add team (paste token)</button>
+              </div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">A team owns its own tools, secrets and members. Switching here changes what the whole dashboard shows — the same as the picker at the top of the sidebar.</p>
+              <table>
+                <tr><th>Team</th><th>Your role</th><th style="text-align:right">Tools</th><th></th></tr>
+                <tr v-for="o in myOrgs" :key="o.slug">
+                  <td>
+                    <b>{{o.name}}</b>
+                    <span v-if="o.slug===activeSlugNow" class="chip ok" style="margin-left:8px">active</span>
+                    <span v-if="isPersonal(o)" class="chip" style="margin-left:6px">personal</span>
+                    <span v-if="o.demo" class="chip demo" style="margin-left:6px">demo</span>
+                    <div class="muted" style="font-size:11px;font-family:var(--mono)">{{o.slug}}</div>
+                  </td>
+                  <td><span class="role" :class="o.role">{{o.role}}</span></td>
+                  <td style="text-align:right" class="muted">{{o.tool_count}}</td>
+                  <td style="text-align:right;white-space:nowrap">
+                    <button v-if="o.slug!==activeSlugNow && (sessionMode || connected(o.slug))" class="btn sm" @click="switchTo(o)">Switch to</button>
+                    <button v-else-if="o.slug!==activeSlugNow" class="btn sm" @click="addOrg=true">Paste token</button>
+                    <button v-else class="btn sm" @click="orgTab='danger'">Settings</button>
+                  </td>
+                </tr>
+              </table>
+              <p class="sub" style="margin-top:10px;font-size:12px">To leave or delete a team, switch to it and open <b>Team settings</b>.</p>
+            </template>
             <p v-if="myUsage && myUsage.cap>=0" class="sub" style="margin:-6px 0 12px">Your usage today: <b>{{myUsage.used_today}} / {{myUsage.cap}}</b> calls.</p>
             <div v-if="orgErr" class="banner">{{orgErr}}</div>
 
@@ -2226,7 +2257,7 @@ createApp({
       orgMembers:[], orgInvites:[], inviteEmail:'', inviteRole:'member', lastInvite:null,
       editAccess:null, accessDraft:{}, inviteCustomize:false, inviteLocalRun:true, inviteToolSel:{}, accessNote:'',
       // agents (machine identities), projects (sub-scope) and deny rules (policy)
-      orgTab:'members', showInvite:false,   // Team page tabs; invites live inside Members
+      orgTab:'members', showInvite:false,   // Team page tabs; invites live inside Members (a non-admin is moved to 'teams' on open)
       agentSnip:'env',   // which paste-ready snippet the new-agent card shows
       agents:[], agentName:'', agentRole:'member', agentCap:-1, agentBusy:false, agentErr:'',
       newAgent:null, confirmAgent:null,
@@ -2691,6 +2722,7 @@ createApp({
         this.newOrg=false; this.newOrgName=''; await this.loadAll(); this.switchOrg({slug:o.org}); }
       catch(e){ this.orgErr='Could not create: '+(e.detail||e.status); } finally{ this.orgBusy=false; } },
     async loadOrgAdmin(){ this.orgMembers=[]; this.orgInvites=[]; this.lastInvite=null;
+      if(!this.canAdmin) this.orgTab='teams';  // the only tab a plain member can act on
       this.orgErr=''; this.confirmDel=''; this.confirmLeave=false; this.confirmRemove=null;
       if(!this.canAdmin || !this.activeOrgId) return; const id=this.activeOrgId;
       try{ this.orgMembers=await this.api('/orgs/'+id+'/members'); this.orgInvites=await this.api('/orgs/'+id+'/invites');

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1187,16 +1187,22 @@ th{background:rgba(0,0,0,.25)}
         <!-- ORGS -->
         <template v-if="view==='orgs'">
           <div class="tut-head">
-            <div><h1>{{activeName}} <span class="role" :class="activeRole">{{activeRole}}</span><span v-if="isPersonal(activeOrg)" class="chip" style="margin-left:8px;vertical-align:middle">personal</span></h1>
-              <p class="sub" style="margin:0">Team settings<span v-if="isPersonal(activeOrg)"> · your personal space</span>. <span class="muted">Switch, create, or join teams from the sidebar.</span></p></div>
+            <div><h1>Team: {{activeName}}<span v-if="isPersonal(activeOrg)" class="chip" style="margin-left:8px;vertical-align:middle">personal</span></h1>
+              <p class="sub" style="margin:0">You are <b>{{activeRole}}</b> here. <span class="muted">Switch, create or join a team from the picker at the top of the sidebar.</span></p></div>
           </div>
           <!-- settings for the ACTIVE team (switching lives in the sidebar) -->
           <div v-if="activeOrg" style="margin-top:20px">
-            <p class="sub" style="margin-bottom:12px">You're <b>{{activeRole}}</b> in <b>{{activeName}}</b>.<span v-if="!canAdmin"> Members &amp; invites are visible to admins.</span></p>
+            <p v-if="!canAdmin" class="sub" style="margin-bottom:12px">Members, projects and policy are visible to admins.</p>
+            <div v-if="canAdmin" class="tabs" style="margin:4px 0 16px">
+              <button :class="{active:orgTab==='members'}" @click="orgTab='members'">Members</button>
+              <button :class="{active:orgTab==='projects'}" @click="orgTab='projects'">Projects</button>
+              <button :class="{active:orgTab==='policy'}" @click="orgTab='policy'">Policy</button>
+              <button :class="{active:orgTab==='danger'}" @click="orgTab='danger'">Team settings</button>
+            </div>
             <p v-if="myUsage && myUsage.cap>=0" class="sub" style="margin:-6px 0 12px">Your usage today: <b>{{myUsage.used_today}} / {{myUsage.cap}}</b> calls.</p>
             <div v-if="orgErr" class="banner">{{orgErr}}</div>
 
-            <template v-if="canAdmin">
+            <template v-if="canAdmin && orgTab==='members'">
               <div class="lbl" style="margin-top:14px">Members</div>
               <p class="sub" style="margin:-2px 0 8px;font-size:12px">Daily cap = how many calls + runs a member may make per day. <b>-1</b> = unlimited.</p>
               <p class="sub" style="margin:-2px 0 8px;font-size:12px"><b>Tools</b> = which endpoints/CLIs a member may call or run. <b>Local run</b> = may run CLIs on their own machine (off = server only). The owner always has full access.</p>
@@ -1257,55 +1263,11 @@ th{background:rgba(0,0,0,.25)}
                 </template>
               </table>
 
-              <!-- PROJECTS: an optional sub-scope inside the team -->
-              <div class="lbl" style="margin-top:22px">Projects</div>
-              <p class="sub" style="margin:-2px 0 8px;font-size:12px">A project groups tools inside this team, so a member or agent can be scoped to just part of it. A tool with no project stays visible to everyone.</p>
-              <div class="field" style="max-width:560px">
-                <input v-model="projectName" placeholder="Apollo" @keyup.enter="createProject"/>
-                <button class="btn primary" @click="createProject" :disabled="projBusy">{{projBusy?'…':'Add project'}}</button>
-              </div>
-              <p v-if="!projects.length" class="muted" style="font-size:12px;margin-top:8px">No projects yet — every tool is team-wide.</p>
-              <table v-else style="margin-top:8px">
-                <tr><th>Project</th><th>Slug</th><th style="text-align:right">Tools</th><th></th></tr>
-                <tr v-for="p in projects" :key="p.id">
-                  <td><b>{{p.name}}</b></td>
-                  <td class="muted" style="font-family:var(--mono);font-size:12px">{{p.slug}}</td>
-                  <td style="text-align:right">{{p.tool_count}}</td>
-                  <td style="text-align:right">
-                    <button class="btn sm" :class="{danger:confirmProj===p.id}" @click="deleteProject(p)" :title="'its '+p.tool_count+' tool(s) become team-wide — they are not deleted'">{{confirmProj===p.id?'Confirm delete':'Delete'}}</button>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- POLICY: deny rules -->
-              <div class="lbl" style="margin-top:22px">Policy</div>
-              <p class="sub" style="margin:-2px 0 8px;font-size:12px">Block calls to a host, a path, or a method. Leave a field empty to mean <b>any</b>. Applies to the proxy and to runs — and to everyone, including owners.</p>
-              <div class="field" style="max-width:720px;flex-wrap:wrap">
-                <input v-model="denyForm.host" placeholder="host (e.g. api.stripe.com)" style="min-width:190px"/>
-                <input v-model="denyForm.path_prefix" placeholder="path (e.g. /admin)" style="min-width:140px"/>
-                <select v-model="denyForm.method" class="msel"><option value="">any method</option><option>GET</option><option>POST</option><option>PUT</option><option>PATCH</option><option>DELETE</option></select>
-                <select v-model="denyForm.user_id" class="msel" title="who it applies to">
-                  <option :value="null">whole team</option>
-                  <option v-for="m in orgMembers" :key="m.user_id" :value="m.user_id">{{m.is_agent?'agent: ':''}}{{m.email}}</option>
-                </select>
-                <input v-model="denyForm.note" placeholder="why (shown in the refusal)" style="min-width:170px"/>
-                <button class="btn primary" @click="addDeny" :disabled="denyBusy">{{denyBusy?'…':'Block'}}</button>
-              </div>
-              <p v-if="!denyRules.length" class="muted" style="font-size:12px;margin-top:8px">No rules — nothing is blocked.</p>
-              <table v-else style="margin-top:8px">
-                <tr><th>Method</th><th>Host</th><th>Path</th><th>Applies to</th><th>Note</th><th></th></tr>
-                <tr v-for="r in denyRules" :key="r.id">
-                  <td><span class="chip">{{r.method||'any'}}</span></td>
-                  <td style="font-family:var(--mono);font-size:12px">{{r.host||'any'}}</td>
-                  <td style="font-family:var(--mono);font-size:12px">{{r.path_prefix||'any'}}</td>
-                  <td>{{r.scope==='org'?'whole team':(denyWho(r.user_id))}}</td>
-                  <td class="muted" style="font-size:12px">{{r.note}}</td>
-                  <td style="text-align:right"><button class="btn sm" :class="{danger:confirmDeny===r.id}" @click="removeDeny(r)">{{confirmDeny===r.id?'Confirm remove':'Remove'}}</button></td>
-                </tr>
-              </table>
-
               <template v-if="!isPersonal(activeOrg)">
-              <div class="lbl" style="margin-top:22px">Invite a teammate</div>
+              <div class="lbl" style="margin-top:22px;display:flex;align-items:center;gap:10px">Add a member
+                <button class="btn sm" @click="showInvite=!showInvite">{{showInvite?'Close':'＋ Add member'}}</button></div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">Members join the whole team. Scope what they can reach with <b>Tools</b> and <b>Projects</b> above.</p>
+              <div v-show="showInvite">
               <div class="field" style="max-width:560px">
                 <input v-model="inviteEmail" type="email" placeholder="teammate@email.com" @keyup.enter="sendInvite"/>
                 <select v-model="inviteRole" class="msel"><option>viewer</option><option>member</option><option v-if="isOwner">admin</option></select>
@@ -1338,11 +1300,64 @@ th{background:rgba(0,0,0,.25)}
                 </tr>
               </table>
               <p v-else class="sub">No pending invites.</p>
+              </div>
               </template>
             </template>
 
-            <template v-if="!isPersonal(activeOrg)">
-            <div class="lbl" style="margin-top:24px;color:var(--red)">Danger zone</div>
+            <!-- PROJECTS tab -->
+            <template v-if="canAdmin && orgTab==='projects'">
+              <div class="lbl" style="margin-top:14px">Projects</div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">A project groups tools inside this team, so a member or agent can be scoped to just part of it. A tool with no project stays visible to everyone.</p>
+              <div class="field" style="max-width:560px">
+                <input v-model="projectName" placeholder="Apollo" @keyup.enter="createProject"/>
+                <button class="btn primary" @click="createProject" :disabled="projBusy">{{projBusy?'…':'Add project'}}</button>
+              </div>
+              <p v-if="!projects.length" class="muted" style="font-size:12px;margin-top:8px">No projects yet — every tool is team-wide.</p>
+              <table v-else style="margin-top:8px">
+                <tr><th>Project</th><th>Slug</th><th style="text-align:right">Tools</th><th></th></tr>
+                <tr v-for="p in projects" :key="p.id">
+                  <td><b>{{p.name}}</b></td>
+                  <td class="muted" style="font-family:var(--mono);font-size:12px">{{p.slug}}</td>
+                  <td style="text-align:right">{{p.tool_count}}</td>
+                  <td style="text-align:right">
+                    <button class="btn sm" :class="{danger:confirmProj===p.id}" @click="deleteProject(p)" :title="'its '+p.tool_count+' tool(s) become team-wide — they are not deleted'">{{confirmProj===p.id?'Confirm delete':'Delete'}}</button>
+                  </td>
+                </tr>
+              </table>
+
+            </template>
+
+            <!-- POLICY tab -->
+            <template v-if="canAdmin && orgTab==='policy'">
+              <div class="lbl" style="margin-top:14px">Policy</div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">Block calls to a host, a path, or a method. Leave a field empty to mean <b>any</b>. Applies to the proxy and to runs — and to everyone, including owners.</p>
+              <div class="field" style="max-width:720px;flex-wrap:wrap">
+                <input v-model="denyForm.host" placeholder="host (e.g. api.stripe.com)" style="min-width:190px"/>
+                <input v-model="denyForm.path_prefix" placeholder="path (e.g. /admin)" style="min-width:140px"/>
+                <select v-model="denyForm.method" class="msel"><option value="">any method</option><option>GET</option><option>POST</option><option>PUT</option><option>PATCH</option><option>DELETE</option></select>
+                <select v-model="denyForm.user_id" class="msel" title="who it applies to">
+                  <option :value="null">whole team</option>
+                  <option v-for="m in orgMembers" :key="m.user_id" :value="m.user_id">{{m.is_agent?'agent: ':''}}{{m.email}}</option>
+                </select>
+                <input v-model="denyForm.note" placeholder="why (shown in the refusal)" style="min-width:170px"/>
+                <button class="btn primary" @click="addDeny" :disabled="denyBusy">{{denyBusy?'…':'Block'}}</button>
+              </div>
+              <p v-if="!denyRules.length" class="muted" style="font-size:12px;margin-top:8px">No rules — nothing is blocked.</p>
+              <table v-else style="margin-top:8px">
+                <tr><th>Method</th><th>Host</th><th>Path</th><th>Applies to</th><th>Note</th><th></th></tr>
+                <tr v-for="r in denyRules" :key="r.id">
+                  <td><span class="chip">{{r.method||'any'}}</span></td>
+                  <td style="font-family:var(--mono);font-size:12px">{{r.host||'any'}}</td>
+                  <td style="font-family:var(--mono);font-size:12px">{{r.path_prefix||'any'}}</td>
+                  <td>{{r.scope==='org'?'whole team':(denyWho(r.user_id))}}</td>
+                  <td class="muted" style="font-size:12px">{{r.note}}</td>
+                  <td style="text-align:right"><button class="btn sm" :class="{danger:confirmDeny===r.id}" @click="removeDeny(r)">{{confirmDeny===r.id?'Confirm remove':'Remove'}}</button></td>
+                </tr>
+              </table>
+            </template>
+
+            <template v-if="canAdmin && orgTab==='danger' && !isPersonal(activeOrg)">
+            <div class="lbl" style="margin-top:14px;color:var(--red)">Danger zone</div>
             <div style="display:flex;gap:22px;flex-wrap:wrap;align-items:flex-start">
               <div>
                 <button class="btn sm" :class="{danger:confirmLeave}" @click="leaveOrg">{{confirmLeave?'Confirm leave':'Leave org'}}</button>
@@ -1376,6 +1391,17 @@ th{background:rgba(0,0,0,.25)}
               <button class="btn primary" @click="copy(newAgent.token,'agenttok')">{{copied==='agenttok'?'Copied':'Copy'}}</button>
               <button class="btn" @click="newAgent=null">Done</button>
             </div>
+            <!-- a bare token is a dead end: hand over the paste-ready thing, like the Tools snippets do -->
+            <div class="tabs" style="margin:14px 0 8px">
+              <button :class="{active:agentSnip==='env'}" @click="agentSnip='env'">Environment</button>
+              <button :class="{active:agentSnip==='prompt'}" @click="agentSnip='prompt'">Give it to your agent</button>
+              <button :class="{active:agentSnip==='verify'}" @click="agentSnip='verify'">Verify</button>
+            </div>
+            <div class="lc-codewrap">
+              <button class="lc-cp" @click="copy(agentSnippet,'agentsnip')">{{copied==='agentsnip'?'✓ copied':'copy'}}</button>
+              <pre style="max-height:220px;overflow:auto">{{agentSnippet}}</pre>
+            </div>
+            <p class="sub" style="margin:6px 0 0;font-size:11.5px">Put this wherever the agent runs — a <span class="mono">.env</span>, a CI secret, or its config.</p>
           </div>
 
           <div class="lbl" style="margin-top:18px">New agent</div>
@@ -1844,6 +1870,12 @@ th{background:rgba(0,0,0,.25)}
               <button v-if="tForm.bindings.length>1" class="btn sm" @click="removeBinding(i)" aria-label="Remove binding">✕</button>
             </div>
             <p class="sub" style="font-size:11px"><span class="mono">{secret}</span> becomes the credential - e.g. header <span class="mono">Authorization: Bearer {secret}</span>, or query <span class="mono">api_key={secret}</span>. Every binding applies on each call (multi-credential upstreams).</p>
+            <div class="frow" v-if="projects.length"><label>Project</label>
+              <select v-model="tForm.project" class="msel">
+                <option :value="null">— team-wide (everyone) —</option>
+                <option v-for="p in projects" :key="p.id" :value="p.slug">{{p.name}}</option>
+              </select></div>
+            <p v-if="projects.length" class="sub" style="font-size:11px;margin-top:-4px">Optional. Team-wide is the default. A project only narrows things for members you have scoped to it.</p>
           </template>
           <template v-else>
             <p class="explain">Members run <span class="mono">treg run {{tForm.cli.bin||'&lt;cli&gt;'}} -- &lt;args&gt;</span> — treg injects the key into that run's environment only; it never lands on their machine.</p>
@@ -1858,6 +1890,12 @@ th{background:rgba(0,0,0,.25)}
               </select>
               <input v-model="inj.name" placeholder="env var, e.g. GH_TOKEN" class="bindinput" style="font-family:var(--mono)"/>
               <button v-if="tForm.cli.inject.length>1" class="btn sm" @click="tForm.cli.inject.splice(i,1)" aria-label="Remove env var">✕</button>
+            </div>
+            <div class="frow" v-if="projects.length"><label>Project</label>
+              <select v-model="tForm.project" class="msel">
+                <option :value="null">— team-wide (everyone) —</option>
+                <option v-for="p in projects" :key="p.id" :value="p.slug">{{p.name}}</option>
+              </select>
             </div>
             <label class="cliopt"><span class="tswitch"><input type="checkbox" v-model="tForm.cli.enabled"/><span class="knob"></span></span><span style="flex:1;min-width:0"><b>Local runs</b><span class="sub" style="display:block;margin-top:2px">{{tForm.cli.enabled?'on — members can treg run '+(tForm.cli.bin||'it')+' with the key injected':'off — every run is refused'}}</span></span></label>
             <div class="lbl" style="margin-top:14px;display:flex;align-items:center">Deny list - matching runs are refused before the key is injected <button class="btn sm" @click="tForm.cli.deny.push('')" style="margin-left:auto">＋ pattern</button></div>
@@ -2188,6 +2226,8 @@ createApp({
       orgMembers:[], orgInvites:[], inviteEmail:'', inviteRole:'member', lastInvite:null,
       editAccess:null, accessDraft:{}, inviteCustomize:false, inviteLocalRun:true, inviteToolSel:{}, accessNote:'',
       // agents (machine identities), projects (sub-scope) and deny rules (policy)
+      orgTab:'members', showInvite:false,   // Team page tabs; invites live inside Members
+      agentSnip:'env',   // which paste-ready snippet the new-agent card shows
       agents:[], agentName:'', agentRole:'member', agentCap:-1, agentBusy:false, agentErr:'',
       newAgent:null, confirmAgent:null,
       projects:[], projectName:'', projBusy:false, confirmProj:null, projDraft:{},
@@ -2379,6 +2419,20 @@ createApp({
     activeOrgId(){ return this.activeOrg ? this.activeOrg.org_id : null; },
     canAdmin(){ return ['admin','owner'].includes(this.activeRole); },
     agentPromptText(){ return this.buildAgentPrompt(this.agentGuide, this.agentInclToken); },
+    // What to actually DO with a freshly minted agent token, in the three shapes people need.
+    agentSnippet(){ const a=this.newAgent; if(!a) return '';
+      const base=this.proxy||location.origin, org=a.org||this.activeSlugNow;
+      if(this.agentSnip==='env'){
+        return 'export TREG_TOKEN='+a.token+'\nexport TREG_ORG='+org+'\nexport TREG_URL='+base; }
+      if(this.agentSnip==='verify'){
+        return 'curl -s '+base+'/tools \\\n  -H "X-Treg-Token: '+a.token+'" \\\n  -H "X-Treg-Org: '+org+'"'; }
+      return 'You have your own tools-registry identity in the team "'+org+'" (you are "'+a.name+'").\n\n'
+        +'Use THIS token for every treg call — not the machine owner\'s:\n'
+        +'  X-Treg-Token: '+a.token+'\n  X-Treg-Org: '+org+'\n\n'
+        +'Call any tool the team has registered, without holding its key:\n'
+        +'  curl '+base+'/call/<tool>/<path> -H "X-Treg-Token: $TREG_TOKEN" -H "X-Treg-Org: '+org+'"\n\n'
+        +'List what you may use:  GET '+base+'/tools\n'
+        +'Your calls are capped and logged as "'+a.name+'", so keep them purposeful.'; },
     isOwner(){ return this.activeRole==='owner'; },
     canRegister(){ return this.activeRole!=='viewer'; },  // members+ may create secrets/tools
     secretRowsReady(){ return this.secretRows.filter(r=>(r.name||'').trim()&&r.value).length; },
@@ -2651,6 +2705,12 @@ createApp({
       catch(e){ this.agentErr='Load agents failed: '+(e.detail||e.status); } },
     async createAgent(){ const name=(this.agentName||'').trim();
       if(!name){ this.agentErr='Give the agent a name, e.g. ci-bot.'; return; }
+      // An admin agent can manage this team's tools, secrets and members. That is a real step up from
+      // 'can call things', so make it a deliberate choice rather than a dropdown you skimmed past.
+      if(this.agentRole==='admin' && !confirm(
+          'Create "'+name+'" as an ADMIN agent?\n\nAn admin agent can register and delete tools and '
+          +'secrets, invite members, and set access for this team — not just call tools.\n\n'
+          +'Most agents only need "member".')) return;
       this.agentBusy=true; this.agentErr='';
       try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
              body:JSON.stringify({name, role:this.agentRole, daily_call_cap:this.agentCap})});
@@ -2799,15 +2859,19 @@ createApp({
       try{ await this.api('/secrets/'+s.id,{method:'DELETE'}); await this.loadSecrets(); }
       catch(e){ this.secretErr='Delete secret failed: '+(e.detail||e.status); } },
     defaultBinding(){ return {secret_id:(this.secrets[0]?this.secrets[0].id:null), injector:'env', location:'header', name:'Authorization', format:'Bearer {secret}', secret_field:'access_token'}; },
-    openAddTool(mode){ this.addToolMenu=false; this.loadSecrets().then(()=>{
+    async loadProjectsIfNeeded(){ if(this.projects.length || !this.activeOrgId || !this.canAdmin) return;
+      this.projects = await this.api('/orgs/'+this.activeOrgId+'/projects').catch(()=>[]); },
+    openAddTool(mode){ this.addToolMenu=false; this.loadProjectsIfNeeded(); this.loadSecrets().then(()=>{
       this.tForm = mode==='cli'
         ? {id:null, mode:'cli', name:'', base_url:'', bindings:[],
            cli:{bin:'', package:'', enabled:true, auth_mechanism:'env', deny:[], deny_defaults:true,
                 inject:[{via:'env', name:'', secret_id:(this.secrets[0]?this.secrets[0].id:null)}]}}
-        : {id:null, mode:'endpoint', name:'', base_url:'', bindings:[this.defaultBinding()]};
+        : {id:null, mode:'endpoint', name:'', base_url:'', bindings:[this.defaultBinding()], project:null};
+      if(mode==='cli') this.tForm.project=null;
       if(mode==='cli') this.loadCatalogClis();
       this.toolErr=''; this.newTool=true; }); },
-    openEditTool(t){ this.loadSecrets().then(()=>{ this.tForm={ id:t.id, mode:(t.cli?'cli':'endpoint'), name:t.name, base_url:t.base_url,
+    openEditTool(t){ this.loadProjectsIfNeeded(); this.loadSecrets().then(()=>{ const cur=(this.projects||[]).find(p=>p.id===t.project_id);
+      this.tForm={ id:t.id, mode:(t.cli?'cli':'endpoint'), name:t.name, base_url:t.base_url, project:(cur?cur.slug:null),
         bindings:(t.bindings||[]).map(b=>({secret_id:b.secret_id, injector:b.injector||'env', location:b.location||'header', name:b.name||'Authorization', format:b.format||'Bearer {secret}', secret_field:b.secret_field||'access_token'})),
         // deep-copy the cli profile — the PATCH replaces it wholesale, so every field must round-trip
         cli: t.cli ? Object.assign(JSON.parse(JSON.stringify(t.cli)), {package:t.cli.package||'', deny:(t.cli.deny||[]).slice(), deny_defaults:t.cli.deny_defaults!==false,
@@ -2838,14 +2902,14 @@ createApp({
         const cli=Object.assign({},f.cli,{bin, inject, deny, deny_defaults:!!f.cli.deny_defaults, enabled:!!f.cli.enabled});
         if(!(cli.package||'').trim()) delete cli.package; else cli.package=cli.package.trim();
         // PATCH omits `bindings` on purpose: editing the CLI must not clobber any HTTP bindings the tool also has
-        body = f.id ? {base_url:f.base_url.trim(), cli} : {name:bin.replace(/_/g,'-'), base_url:f.base_url.trim(), bindings:[], cli};
+        body = f.id ? {base_url:f.base_url.trim(), cli, project:f.project||null} : {name:bin.replace(/_/g,'-'), base_url:f.base_url.trim(), bindings:[], cli, project:f.project||null};
       } else {
         if(!f.id && !f.name.trim()){ this.toolErr='Name and base URL are required.'; return; }
         if(!f.bindings.length || f.bindings.some(b=>!b.secret_id)){ this.toolErr='Every binding needs a secret.'; return; }
         const hdr=f.bindings.filter(b=>(b.location||'header')==='header').map(b=>(b.name||'Authorization').toLowerCase());
         if(new Set(hdr).size!==hdr.length){ this.toolErr='Two bindings target the same header - give each a distinct name.'; return; }  // catch the collision inline, clearly
         const bindings=f.bindings.map(b=>({secret_id:b.secret_id, injector:b.injector, location:b.location, name:b.name, format:b.format, secret_field:b.secret_field}));
-        body = f.id ? {base_url:f.base_url.trim(), bindings} : {name:f.name.trim(), base_url:f.base_url.trim(), bindings};
+        body = f.id ? {base_url:f.base_url.trim(), bindings, project:f.project||null} : {name:f.name.trim(), base_url:f.base_url.trim(), bindings, project:f.project||null};
       }
       this.toolBusy=true; this.toolErr='';
       try{

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -745,6 +745,7 @@ th{background:rgba(0,0,0,.25)}
           <button class="nav" :class="{active:view==='activity'}" @click="go('activity')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>Activity</button>
           <button v-if="canAdmin" class="nav" :class="{active:view==='usage'}" @click="go('usage')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>Usage</button>
           <button class="nav" :class="{active:view==='orgs'}" @click="go('orgs')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>Team</button>
+          <button v-if="canAdmin" class="nav" :class="{active:view==='agents'}" @click="go('agents')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="7" width="16" height="12" rx="2"/><path d="M12 7V4"/><circle cx="9" cy="13" r="1"/><circle cx="15" cy="13" r="1"/></svg>Agents</button>
           <div v-if="isAdmin"><div class="grp">Platform</div><button class="nav" :class="{active:view==='admin'}" @click="go('admin')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>Admin</button></div>
           <div class="grp">For your agents</div>
           <div v-if="canAdmin" class="agent-copy"><span class="ac-label ac-link" @click="agentGuide='admin'" title="Preview / customize">Setup instruction</span><button class="ac-btn" :class="{done:agentRowCopied==='admin'}" @click="copyAgentGuide('admin')" title="Copy the agent instruction (installs the CLI + registers your skills & keys)">{{agentRowCopied==='admin'?'✓':'⧉'}}</button></div>
@@ -1236,6 +1237,14 @@ th{background:rgba(0,0,0,.25)}
                           <input type="checkbox" v-model="accessDraft[n]"/><span>{{n}}</span>
                         </label>
                       </div>
+                      <template v-if="projects.length">
+                        <div class="sub" style="margin:12px 0 6px">Projects <b>{{m.email}}</b> may use — all checked = every project (and new ones apply automatically). Tools with no project stay visible to everyone.</div>
+                        <div style="display:flex;flex-wrap:wrap;gap:6px 16px">
+                          <label v-for="p in projects" :key="p.id" class="tgl" style="min-width:150px">
+                            <input type="checkbox" v-model="projDraft[p.id]"/><span>{{p.name}}</span>
+                          </label>
+                        </div>
+                      </template>
                       <div style="margin-top:10px;display:flex;gap:8px">
                         <button class="btn sm primary" @click="saveAccess(m)">Save access</button>
                         <button class="btn sm" @click="editAccess=null">Cancel</button>
@@ -1248,8 +1257,55 @@ th{background:rgba(0,0,0,.25)}
                 </template>
               </table>
 
+              <!-- PROJECTS: an optional sub-scope inside the team -->
+              <div class="lbl" style="margin-top:22px">Projects</div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">A project groups tools inside this team, so a member or agent can be scoped to just part of it. A tool with no project stays visible to everyone.</p>
+              <div class="field" style="max-width:560px">
+                <input v-model="projectName" placeholder="Apollo" @keyup.enter="createProject"/>
+                <button class="btn primary" @click="createProject" :disabled="projBusy">{{projBusy?'…':'Add project'}}</button>
+              </div>
+              <p v-if="!projects.length" class="muted" style="font-size:12px;margin-top:8px">No projects yet — every tool is team-wide.</p>
+              <table v-else style="margin-top:8px">
+                <tr><th>Project</th><th>Slug</th><th style="text-align:right">Tools</th><th></th></tr>
+                <tr v-for="p in projects" :key="p.id">
+                  <td><b>{{p.name}}</b></td>
+                  <td class="muted" style="font-family:var(--mono);font-size:12px">{{p.slug}}</td>
+                  <td style="text-align:right">{{p.tool_count}}</td>
+                  <td style="text-align:right">
+                    <button class="btn sm" :class="{danger:confirmProj===p.id}" @click="deleteProject(p)" :title="'its '+p.tool_count+' tool(s) become team-wide — they are not deleted'">{{confirmProj===p.id?'Confirm delete':'Delete'}}</button>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- POLICY: deny rules -->
+              <div class="lbl" style="margin-top:22px">Policy</div>
+              <p class="sub" style="margin:-2px 0 8px;font-size:12px">Block calls to a host, a path, or a method. Leave a field empty to mean <b>any</b>. Applies to the proxy and to runs — and to everyone, including owners.</p>
+              <div class="field" style="max-width:720px;flex-wrap:wrap">
+                <input v-model="denyForm.host" placeholder="host (e.g. api.stripe.com)" style="min-width:190px"/>
+                <input v-model="denyForm.path_prefix" placeholder="path (e.g. /admin)" style="min-width:140px"/>
+                <select v-model="denyForm.method" class="msel"><option value="">any method</option><option>GET</option><option>POST</option><option>PUT</option><option>PATCH</option><option>DELETE</option></select>
+                <select v-model="denyForm.user_id" class="msel" title="who it applies to">
+                  <option :value="null">whole team</option>
+                  <option v-for="m in orgMembers" :key="m.user_id" :value="m.user_id">{{m.is_agent?'agent: ':''}}{{m.email}}</option>
+                </select>
+                <input v-model="denyForm.note" placeholder="why (shown in the refusal)" style="min-width:170px"/>
+                <button class="btn primary" @click="addDeny" :disabled="denyBusy">{{denyBusy?'…':'Block'}}</button>
+              </div>
+              <p v-if="!denyRules.length" class="muted" style="font-size:12px;margin-top:8px">No rules — nothing is blocked.</p>
+              <table v-else style="margin-top:8px">
+                <tr><th>Method</th><th>Host</th><th>Path</th><th>Applies to</th><th>Note</th><th></th></tr>
+                <tr v-for="r in denyRules" :key="r.id">
+                  <td><span class="chip">{{r.method||'any'}}</span></td>
+                  <td style="font-family:var(--mono);font-size:12px">{{r.host||'any'}}</td>
+                  <td style="font-family:var(--mono);font-size:12px">{{r.path_prefix||'any'}}</td>
+                  <td>{{r.scope==='org'?'whole team':(denyWho(r.user_id))}}</td>
+                  <td class="muted" style="font-size:12px">{{r.note}}</td>
+                  <td style="text-align:right"><button class="btn sm" :class="{danger:confirmDeny===r.id}" @click="removeDeny(r)">{{confirmDeny===r.id?'Confirm remove':'Remove'}}</button></td>
+                </tr>
+              </table>
+
               <template v-if="!isPersonal(activeOrg)">
-              <div class="lbl" style="margin-top:18px">Invite a teammate</div>
+              <div class="lbl" style="margin-top:22px">Invite a teammate</div>
               <div class="field" style="max-width:560px">
                 <input v-model="inviteEmail" type="email" placeholder="teammate@email.com" @keyup.enter="sendInvite"/>
                 <select v-model="inviteRole" class="msel"><option>viewer</option><option>member</option><option v-if="isOwner">admin</option></select>
@@ -1302,6 +1358,55 @@ th{background:rgba(0,0,0,.25)}
         </template>
 
         <!-- ACTIVITY -->
+        <!-- AGENTS: machine identities. Same machinery as a member, its own screen because an
+             agent is how most people will actually use treg. -->
+        <template v-if="view==='agents'">
+          <div class="tut-head">
+            <div><h1>Agents</h1>
+              <p class="sub" style="margin:0">Give an agent its own token, so every call it makes is capped, scoped and logged as <b>itself</b> — not as you.</p></div>
+          </div>
+          <div v-if="agentErr" class="banner" style="margin-top:14px">{{agentErr}}</div>
+
+          <!-- the token is shown ONCE: make that unmissable -->
+          <div v-if="newAgent" class="card" style="margin-top:16px;border-color:var(--accent)">
+            <div class="lbl" style="margin-top:0">Token for {{newAgent.name}} — copy it now</div>
+            <p class="sub" style="margin:2px 0 10px">This is the only time it is shown. Put it in the agent's <code>TREG_TOKEN</code>.</p>
+            <div class="field">
+              <input :value="newAgent.token" readonly style="font-family:var(--mono)" @focus="$event.target.select()"/>
+              <button class="btn primary" @click="copy(newAgent.token,'agenttok')">{{copied==='agenttok'?'Copied':'Copy'}}</button>
+              <button class="btn" @click="newAgent=null">Done</button>
+            </div>
+          </div>
+
+          <div class="lbl" style="margin-top:18px">New agent</div>
+          <div class="field" style="max-width:620px">
+            <input v-model="agentName" placeholder="ci-bot" @keyup.enter="createAgent"/>
+            <select v-model="agentRole" class="msel"><option>viewer</option><option>member</option><option v-if="isOwner">admin</option></select>
+            <input v-model.number="agentCap" type="number" min="-1" step="1" class="msel" style="width:96px" title="daily call cap (-1 = unlimited)"/>
+            <button class="btn primary" @click="createAgent" :disabled="agentBusy">{{agentBusy?'…':'Create'}}</button>
+          </div>
+          <p class="sub" style="margin:-2px 0 0;font-size:12px">Cap <b>-1</b> = unlimited. An agent can never be an owner, and can never sign in — its token is the only way to act as it.</p>
+
+          <div class="lbl" style="margin-top:20px">This team's agents</div>
+          <p v-if="!agents.length" class="muted" style="font-size:13px">No agents yet. Create one above, then put its token in your agent's environment.</p>
+          <table v-else>
+            <tr><th>Name</th><th>Role</th><th style="text-align:right">Today</th><th>Daily cap</th><th>Tools</th><th>Projects</th><th></th></tr>
+            <tr v-for="a in agents" :key="a.user_id">
+              <td><b>{{a.name}}</b><div class="muted" style="font-size:11px;font-family:var(--mono)">{{a.email}}</div></td>
+              <td><span class="role" :class="a.role">{{a.role}}</span></td>
+              <td style="text-align:right" class="muted">{{a.used_today}}</td>
+              <td><input class="msel" type="number" min="-1" step="1" style="width:78px" :value="a.daily_call_cap" @change="setAgentCap(a,$event.target.value)" title="-1 = unlimited"/></td>
+              <td><span class="chip">{{a.tool_access===null?'All':a.tool_access.length+' tools'}}</span></td>
+              <td><span class="chip">{{a.project_access===null?'All':a.project_access.length+' projects'}}</span></td>
+              <td style="text-align:right;white-space:nowrap">
+                <button class="btn sm" @click="rotateAgent(a)" title="issue a new token — the old one stops working immediately">Rotate</button>
+                <button class="btn sm" :class="{danger:confirmAgent===a.user_id}" @click="revokeAgent(a)">{{confirmAgent===a.user_id?'Confirm revoke':'Revoke'}}</button>
+              </td>
+            </tr>
+          </table>
+          <p class="sub" style="margin-top:10px;font-size:12px">Scope an agent's tools and projects from <a href="#" @click.prevent="go('orgs')">Team</a> — it appears in the roster like any member.</p>
+        </template>
+
         <template v-if="view==='activity'">
           <h1>Activity - {{activeName}}</h1>
           <p class="sub">Every proxy call and server CLI run in this org.</p>
@@ -2082,6 +2187,11 @@ createApp({
       newOrg:false, newOrgName:'', orgBusy:false, orgErr:'', orgMsg:'',
       orgMembers:[], orgInvites:[], inviteEmail:'', inviteRole:'member', lastInvite:null,
       editAccess:null, accessDraft:{}, inviteCustomize:false, inviteLocalRun:true, inviteToolSel:{}, accessNote:'',
+      // agents (machine identities), projects (sub-scope) and deny rules (policy)
+      agents:[], agentName:'', agentRole:'member', agentCap:-1, agentBusy:false, agentErr:'',
+      newAgent:null, confirmAgent:null,
+      projects:[], projectName:'', projBusy:false, confirmProj:null, projDraft:{},
+      denyRules:[], denyForm:{host:'',path_prefix:'',method:'',user_id:null,note:''}, denyBusy:false, confirmDeny:null,
       bootVersion:'', newVersion:false,
       usage:null, usageDays:30, myUsage:null,  // usage-metering: rollups + the member's own used/cap
       confirmDel:'', confirmLeave:false, confirmRemove:null,
@@ -2529,8 +2639,68 @@ createApp({
     async loadOrgAdmin(){ this.orgMembers=[]; this.orgInvites=[]; this.lastInvite=null;
       this.orgErr=''; this.confirmDel=''; this.confirmLeave=false; this.confirmRemove=null;
       if(!this.canAdmin || !this.activeOrgId) return; const id=this.activeOrgId;
-      try{ this.orgMembers=await this.api('/orgs/'+id+'/members'); this.orgInvites=await this.api('/orgs/'+id+'/invites'); }
+      try{ this.orgMembers=await this.api('/orgs/'+id+'/members'); this.orgInvites=await this.api('/orgs/'+id+'/invites');
+           this.projects=await this.api('/orgs/'+id+'/projects'); this.denyRules=await this.api('/orgs/'+id+'/deny'); }
       catch(e){ this.orgErr='Load team failed: '+(e.detail||e.status); } },
+
+    // ---- agents: a member identity for a machine caller ----
+    async loadAgents(){ this.agentErr=''; this.confirmAgent=null;
+      if(!this.canAdmin || !this.activeOrgId){ this.agents=[]; return; }
+      try{ this.agents=await this.api('/orgs/'+this.activeOrgId+'/agents');
+           this.projects=await this.api('/orgs/'+this.activeOrgId+'/projects'); }
+      catch(e){ this.agentErr='Load agents failed: '+(e.detail||e.status); } },
+    async createAgent(){ const name=(this.agentName||'').trim();
+      if(!name){ this.agentErr='Give the agent a name, e.g. ci-bot.'; return; }
+      this.agentBusy=true; this.agentErr='';
+      try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
+             body:JSON.stringify({name, role:this.agentRole, daily_call_cap:this.agentCap})});
+           this.newAgent=r; this.agentName=''; await this.loadAgents(); }
+      catch(e){ this.agentErr='Create failed: '+(e.detail||e.status); }
+      this.agentBusy=false; },
+    // Rotate = create with the SAME name: the server replaces the token hash, so the old one dies.
+    async rotateAgent(a){ this.agentBusy=true; this.agentErr='';
+      try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
+             body:JSON.stringify({name:a.name, role:a.role, daily_call_cap:a.daily_call_cap})});
+           this.newAgent=r; await this.loadAgents(); }
+      catch(e){ this.agentErr='Rotate failed: '+(e.detail||e.status); }
+      this.agentBusy=false; },
+    async revokeAgent(a){ if(this.confirmAgent!==a.user_id){ this.confirmAgent=a.user_id; return; }
+      try{ await this.api('/orgs/'+this.activeOrgId+'/agents/'+a.user_id,{method:'DELETE'}); }
+      catch(e){ this.agentErr='Revoke failed: '+(e.detail||e.status); }
+      this.confirmAgent=null; await this.loadAgents(); },
+    async setAgentCap(a, val){ const cap=parseInt(val,10);
+      if(isNaN(cap)||cap<-1){ this.agentErr='Daily cap must be -1 (unlimited) or 0 and above.'; await this.loadAgents(); return; }
+      if(cap===a.daily_call_cap) return;
+      try{ await this.api('/orgs/'+this.activeOrgId+'/members/'+a.user_id+'/cap',{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({daily_call_cap:cap})}); }
+      catch(e){ this.agentErr='Set cap failed: '+(e.detail||e.status); }
+      await this.loadAgents(); },
+
+    // ---- projects ----
+    async createProject(){ const name=(this.projectName||'').trim();
+      if(!name){ this.orgErr='Give the project a name.'; return; }
+      this.projBusy=true; this.orgErr='';
+      try{ await this.api('/orgs/'+this.activeOrgId+'/projects',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({name})});
+           this.projectName=''; }
+      catch(e){ this.orgErr='Add project failed: '+(e.detail||e.status); }
+      this.projBusy=false; await this.loadOrgAdmin(); },
+    async deleteProject(p){ if(this.confirmProj!==p.id){ this.confirmProj=p.id; return; }
+      try{ await this.api('/orgs/'+this.activeOrgId+'/projects/'+p.id,{method:'DELETE'}); }
+      catch(e){ this.orgErr='Delete project failed: '+(e.detail||e.status); }
+      this.confirmProj=null; await this.loadOrgAdmin(); },
+
+    // ---- deny rules ----
+    denyWho(uid){ const m=(this.orgMembers||[]).find(x=>x.user_id===uid); return m?m.email:('user '+uid); },
+    async addDeny(){ const f=this.denyForm;
+      if(!f.host && !f.path_prefix && !f.method){ this.orgErr='Give at least a host, a path, or a method.'; return; }
+      this.denyBusy=true; this.orgErr='';
+      try{ await this.api('/orgs/'+this.activeOrgId+'/deny',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(f)});
+           this.denyForm={host:'',path_prefix:'',method:'',user_id:null,note:''}; }
+      catch(e){ this.orgErr='Add rule failed: '+(e.detail||e.status); }
+      this.denyBusy=false; await this.loadOrgAdmin(); },
+    async removeDeny(r){ if(this.confirmDeny!==r.id){ this.confirmDeny=r.id; return; }
+      try{ await this.api('/orgs/'+this.activeOrgId+'/deny/'+r.id,{method:'DELETE'}); }
+      catch(e){ this.orgErr='Remove rule failed: '+(e.detail||e.status); }
+      this.confirmDeny=null; await this.loadOrgAdmin(); },
     async loadUsage(){ if(!this.canAdmin || !this.activeOrgId) return; this.usage=null;
       try{ this.usage=await this.api('/orgs/'+this.activeOrgId+'/usage?days='+this.usageDays); }
       catch(e){ this.err='Failed to load usage: '+(e.detail||e.status); } },
@@ -2555,11 +2725,14 @@ createApp({
     openInviteCustomize(){ this.inviteCustomize=true; const d={}; this.accessNames.forEach(n=>d[n]=true); this.inviteToolSel=d; },
     openAccess(m){ if(m.role==='owner') return;
       if(this.editAccess===m.user_id){ this.editAccess=null; return; }
-      this.editAccess=m.user_id; const d={}; this.accessNames.forEach(n=>{ d[n]=(m.tool_access===null || m.tool_access.includes(n)); }); this.accessDraft=d; },
+      this.editAccess=m.user_id; const d={}; this.accessNames.forEach(n=>{ d[n]=(m.tool_access===null || m.tool_access.includes(n)); }); this.accessDraft=d;
+      const pd={}; this.projects.forEach(p=>{ pd[p.id]=(m.project_access===null || m.project_access.includes(p.id)); }); this.projDraft=pd; },
     setAllAccess(v){ const d={}; this.accessNames.forEach(n=>d[n]=v); this.accessDraft=d; },
     async saveAccess(m){ const names=this.accessNames.filter(n=>this.accessDraft[n]);
       const tool_access = (names.length===this.accessNames.length) ? null : names;  // all checked → 'all' (NULL)
-      try{ await this.api('/orgs/'+this.activeOrgId+'/members/'+m.user_id+'/access',{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({tool_access, local_run_enabled:m.local_run_enabled})}); this.editAccess=null; }
+      const picked=this.projects.filter(p=>this.projDraft[p.id]).map(p=>p.id);
+      const project_access = (!this.projects.length || picked.length===this.projects.length) ? null : picked;  // all checked → 'all'
+      try{ await this.api('/orgs/'+this.activeOrgId+'/members/'+m.user_id+'/access',{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({tool_access, project_access, local_run_enabled:m.local_run_enabled})}); this.editAccess=null; }
       catch(e){ this.orgErr='Set access failed: '+(e.detail||e.status); }
       await this.loadOrgAdmin(); },
     async setLocalRun(m, val){
@@ -3108,7 +3281,7 @@ createApp({
       this.go('orgs'); },
     resetConfirms(){ this.confirmDelTool=null; this.confirmDelSecret=null; this.confirmDelBundle=null; this.confirmRemove=null; this.confirmLeave=false; this.confirmDel=''; this.confirmAdmUser=null; this.confirmAdmOrg=null; },
     go(v, fromPop){ this.resetConfirms();  // stale inline "Confirm" states must not survive a view switch (accidental-delete risk)
-      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage();} if(v==='usage')this.loadUsage(); if(v==='secrets')this.loadSecrets(); if(v==='connections')this.loadConnections();
+      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage();} if(v==='agents')this.loadAgents(); if(v==='usage')this.loadUsage(); if(v==='secrets')this.loadSecrets(); if(v==='connections')this.loadConnections();
       // push history so browser Back navigates BETWEEN views instead of leaving the app; the '/app'
       // pathname also walks back from a /app/skills/<x> detail URL so reload doesn't reopen the detail
       if(!fromPop) history.pushState({view:v}, '', '/app#'+v); },

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2758,6 +2758,8 @@ createApp({
       catch(e){ this.agentErr='Create failed: '+(e.detail||e.status); }
       this.agentBusy=false; },
     // Rotate = create with the SAME name: the server replaces the token hash, so the old one dies.
+    // We deliberately send only name/role/cap — the server leaves every field we DON'T send as it is,
+    // so the agent's tool ACL and project scope survive a rotate (they used to be silently cleared).
     async rotateAgent(a){ this.agentBusy=true; this.agentErr='';
       try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
              body:JSON.stringify({name:a.name, role:a.role, daily_call_cap:a.daily_call_cap})});

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1414,10 +1414,15 @@ th{background:rgba(0,0,0,.25)}
           <div v-if="agentErr" class="banner" style="margin-top:14px">{{agentErr}}</div>
 
           <!-- the token is shown ONCE: make that unmissable -->
-          <div v-if="newAgent" class="card" style="margin-top:16px;border-color:var(--accent)">
-            <div class="lbl" style="margin-top:0">Token for {{newAgent.name}} — copy it now</div>
-            <p class="sub" style="margin:2px 0 10px">This is the only time it is shown. Put it in the agent's <code>TREG_TOKEN</code>.</p>
-            <div class="field">
+          <div v-if="newAgent || snipAgent" class="card" style="margin-top:16px" :style="newAgent?'border-color:var(--accent)':''">
+            <div class="lbl" style="margin-top:0;display:flex;align-items:center;gap:10px">
+              <template v-if="newAgent">Token for {{newAgent.name}} — copy it now</template>
+              <template v-else>How to use {{snipAgent.name}}</template>
+              <button v-if="!newAgent" class="btn sm" style="margin-left:auto" @click="snipAgent=null">Close</button>
+            </div>
+            <p v-if="newAgent" class="sub" style="margin:2px 0 10px">This is the only time it is shown. Put it in the agent's <code>TREG_TOKEN</code>.</p>
+            <p v-else class="sub" style="margin:2px 0 10px">A stored token can never be shown again — these use <span class="mono">$TREG_TOKEN</span>. Lost it? Press <b>Rotate</b> for a fresh one.</p>
+            <div v-if="newAgent" class="field">
               <input :value="newAgent.token" readonly style="font-family:var(--mono)" @focus="$event.target.select()"/>
               <button class="btn primary" @click="copy(newAgent.token,'agenttok')">{{copied==='agenttok'?'Copied':'Copy'}}</button>
               <button class="btn" @click="newAgent=null">Done</button>
@@ -1456,6 +1461,7 @@ th{background:rgba(0,0,0,.25)}
               <td><span class="chip">{{a.tool_access===null?'All':a.tool_access.length+' tools'}}</span></td>
               <td><span class="chip">{{a.project_access===null?'All':a.project_access.length+' projects'}}</span></td>
               <td style="text-align:right;white-space:nowrap">
+                <button class="btn sm" @click="showAgentSetup(a)" title="how to give this agent its identity">Setup</button>
                 <button class="btn sm" @click="rotateAgent(a)" title="issue a new token — the old one stops working immediately">Rotate</button>
                 <button class="btn sm" :class="{danger:confirmAgent===a.user_id}" @click="revokeAgent(a)">{{confirmAgent===a.user_id?'Confirm revoke':'Revoke'}}</button>
               </td>
@@ -2258,7 +2264,8 @@ createApp({
       editAccess:null, accessDraft:{}, inviteCustomize:false, inviteLocalRun:true, inviteToolSel:{}, accessNote:'',
       // agents (machine identities), projects (sub-scope) and deny rules (policy)
       orgTab:'members', showInvite:false,   // Team page tabs; invites live inside Members (a non-admin is moved to 'teams' on open)
-      agentSnip:'env',   // which paste-ready snippet the new-agent card shows
+      agentSnip:'env',   // which paste-ready snippet the agent card shows
+      snipAgent:null,    // an EXISTING agent whose setup snippets are open (no token — placeholder)
       agents:[], agentName:'', agentRole:'member', agentCap:-1, agentBusy:false, agentErr:'',
       newAgent:null, confirmAgent:null,
       projects:[], projectName:'', projBusy:false, confirmProj:null, projDraft:{},
@@ -2451,15 +2458,16 @@ createApp({
     canAdmin(){ return ['admin','owner'].includes(this.activeRole); },
     agentPromptText(){ return this.buildAgentPrompt(this.agentGuide, this.agentInclToken); },
     // What to actually DO with a freshly minted agent token, in the three shapes people need.
-    agentSnippet(){ const a=this.newAgent; if(!a) return '';
+    agentSnippet(){ const a=this.newAgent||this.snipAgent; if(!a) return '';
       const base=this.proxy||location.origin, org=a.org||this.activeSlugNow;
+      const tok=a.token||'$TREG_TOKEN';  // a stored token is hashed — never recoverable
       if(this.agentSnip==='env'){
-        return 'export TREG_TOKEN='+a.token+'\nexport TREG_ORG='+org+'\nexport TREG_URL='+base; }
+        return 'export TREG_TOKEN='+tok+'\nexport TREG_ORG='+org+'\nexport TREG_URL='+base; }
       if(this.agentSnip==='verify'){
-        return 'curl -s '+base+'/tools \\\n  -H "X-Treg-Token: '+a.token+'" \\\n  -H "X-Treg-Org: '+org+'"'; }
+        return 'curl -s '+base+'/tools \\\n  -H "X-Treg-Token: '+tok+'" \\\n  -H "X-Treg-Org: '+org+'"'; }
       return 'You have your own tools-registry identity in the team "'+org+'" (you are "'+a.name+'").\n\n'
         +'Use THIS token for every treg call — not the machine owner\'s:\n'
-        +'  X-Treg-Token: '+a.token+'\n  X-Treg-Org: '+org+'\n\n'
+        +'  X-Treg-Token: '+tok+'\n  X-Treg-Org: '+org+'\n\n'
         +'Call any tool the team has registered, without holding its key:\n'
         +'  curl '+base+'/call/<tool>/<path> -H "X-Treg-Token: $TREG_TOKEN" -H "X-Treg-Org: '+org+'"\n\n'
         +'List what you may use:  GET '+base+'/tools\n'
@@ -2746,16 +2754,18 @@ createApp({
       this.agentBusy=true; this.agentErr='';
       try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
              body:JSON.stringify({name, role:this.agentRole, daily_call_cap:this.agentCap})});
-           this.newAgent=r; this.agentName=''; await this.loadAgents(); }
+           this.newAgent=r; this.snipAgent=null; this.agentName=''; await this.loadAgents(); }
       catch(e){ this.agentErr='Create failed: '+(e.detail||e.status); }
       this.agentBusy=false; },
     // Rotate = create with the SAME name: the server replaces the token hash, so the old one dies.
     async rotateAgent(a){ this.agentBusy=true; this.agentErr='';
       try{ const r=await this.api('/orgs/'+this.activeOrgId+'/agents',{method:'POST',headers:{'content-type':'application/json'},
              body:JSON.stringify({name:a.name, role:a.role, daily_call_cap:a.daily_call_cap})});
-           this.newAgent=r; await this.loadAgents(); }
+           this.newAgent=r; this.snipAgent=null; await this.loadAgents(); }
       catch(e){ this.agentErr='Rotate failed: '+(e.detail||e.status); }
       this.agentBusy=false; },
+    showAgentSetup(a){ this.newAgent=null; this.agentSnip='env';
+      this.snipAgent=(this.snipAgent && this.snipAgent.user_id===a.user_id) ? null : a; },
     async revokeAgent(a){ if(this.confirmAgent!==a.user_id){ this.confirmAgent=a.user_id; return; }
       try{ await this.api('/orgs/'+this.activeOrgId+'/agents/'+a.user_id,{method:'DELETE'}); }
       catch(e){ this.agentErr='Revoke failed: '+(e.detail||e.status); }

--- a/src/treg/web/logos/akta.svg
+++ b/src/treg/web/logos/akta.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="akta">
+  <!-- Placeholder lettermark. Replace with the official akta brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#7C3AED"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Ak</text>
+</svg>

--- a/src/treg/web/logos/apify.svg
+++ b/src/treg/web/logos/apify.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="apify">
+  <!-- Placeholder lettermark. Replace with the official apify brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0F7B6C"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Ap</text>
+</svg>

--- a/src/treg/web/logos/apollo.svg
+++ b/src/treg/web/logos/apollo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="apollo">
+  <!-- Placeholder lettermark. Replace with the official apollo brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#4A3AFF"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">A</text>
+</svg>

--- a/src/treg/web/logos/brightdata.svg
+++ b/src/treg/web/logos/brightdata.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="brightdata">
+  <!-- Placeholder lettermark. Replace with the official brightdata brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#2B44FF"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">BD</text>
+</svg>

--- a/src/treg/web/logos/coresignal.svg
+++ b/src/treg/web/logos/coresignal.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coresignal">
+  <!-- Placeholder lettermark. Replace with the official coresignal brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#5B4EE9"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Cs</text>
+</svg>

--- a/src/treg/web/logos/crunchbase.svg
+++ b/src/treg/web/logos/crunchbase.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="crunchbase">
+  <!-- Placeholder lettermark. Replace with the official crunchbase brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#146AFF"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Cb</text>
+</svg>

--- a/src/treg/web/logos/dataforseo.svg
+++ b/src/treg/web/logos/dataforseo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="dataforseo">
+  <!-- Placeholder lettermark. Replace with the official dataforseo brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#1D6BF3"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">D4</text>
+</svg>

--- a/src/treg/web/logos/diffbot.svg
+++ b/src/treg/web/logos/diffbot.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="diffbot">
+  <!-- Placeholder lettermark. Replace with the official diffbot brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#00C2A8"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Db</text>
+</svg>

--- a/src/treg/web/logos/hunter.svg
+++ b/src/treg/web/logos/hunter.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="hunter">
+  <!-- Placeholder lettermark. Replace with the official hunter brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#FF5100"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">H</text>
+</svg>

--- a/src/treg/web/logos/justoneapi.svg
+++ b/src/treg/web/logos/justoneapi.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="justoneapi">
+  <!-- Placeholder lettermark. Replace with the official justoneapi brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">J1</text>
+</svg>

--- a/src/treg/web/logos/leadmagic.svg
+++ b/src/treg/web/logos/leadmagic.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="leadmagic">
+  <!-- Placeholder lettermark. Replace with the official leadmagic brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#7C3AED"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">LM</text>
+</svg>

--- a/src/treg/web/logos/lusha.svg
+++ b/src/treg/web/logos/lusha.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="lusha">
+  <!-- Placeholder lettermark. Replace with the official lusha brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0A0F45"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Lu</text>
+</svg>

--- a/src/treg/web/logos/majestic.svg
+++ b/src/treg/web/logos/majestic.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="majestic">
+  <!-- Placeholder lettermark. Replace with the official majestic brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#005C9E"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Mj</text>
+</svg>

--- a/src/treg/web/logos/meta-ad-library.svg
+++ b/src/treg/web/logos/meta-ad-library.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="meta-ad-library">
+  <!-- Placeholder lettermark. Replace with the official meta-ad-library brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0866FF"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Ad</text>
+</svg>

--- a/src/treg/web/logos/microsoft-ads.svg
+++ b/src/treg/web/logos/microsoft-ads.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="microsoft-ads">
+  <!-- Placeholder lettermark. Replace with the official microsoft-ads brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0078D4"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">MA</text>
+</svg>

--- a/src/treg/web/logos/moz.svg
+++ b/src/treg/web/logos/moz.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="moz">
+  <!-- Placeholder lettermark. Replace with the official moz brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#2C9AC9"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="8" font-weight="700" text-anchor="middle" dominant-baseline="central">Moz</text>
+</svg>

--- a/src/treg/web/logos/pdl.svg
+++ b/src/treg/web/logos/pdl.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="pdl">
+  <!-- Placeholder lettermark. Replace with the official pdl brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0E8A86"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="7" font-weight="700" text-anchor="middle" dominant-baseline="central">PDL</text>
+</svg>

--- a/src/treg/web/logos/pinterest-ads.svg
+++ b/src/treg/web/logos/pinterest-ads.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="pinterest-ads">
+  <!-- Placeholder lettermark. Replace with the official pinterest-ads brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#E60023"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">PA</text>
+</svg>

--- a/src/treg/web/logos/semrush.svg
+++ b/src/treg/web/logos/semrush.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="semrush">
+  <!-- Placeholder lettermark. Replace with the official semrush brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#FF642D"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Se</text>
+</svg>

--- a/src/treg/web/logos/seranking.svg
+++ b/src/treg/web/logos/seranking.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="seranking">
+  <!-- Placeholder lettermark. Replace with the official seranking brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#5D3BE0"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">SE</text>
+</svg>

--- a/src/treg/web/logos/serpapi.svg
+++ b/src/treg/web/logos/serpapi.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="serpapi">
+  <!-- Placeholder lettermark. Replace with the official serpapi brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#5B21B6"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Sp</text>
+</svg>

--- a/src/treg/web/logos/serpstat.svg
+++ b/src/treg/web/logos/serpstat.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="serpstat">
+  <!-- Placeholder lettermark. Replace with the official serpstat brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#F26D5B"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Ss</text>
+</svg>

--- a/src/treg/web/logos/snapchat-ads.svg
+++ b/src/treg/web/logos/snapchat-ads.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="snapchat-ads">
+  <!-- Placeholder lettermark. Replace with the official snapchat-ads brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#FFFC00" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Sn</text>
+</svg>

--- a/src/treg/web/logos/spyfu.svg
+++ b/src/treg/web/logos/spyfu.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="spyfu">
+  <!-- Placeholder lettermark. Replace with the official spyfu brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#1F9E57"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Sf</text>
+</svg>

--- a/src/treg/web/logos/thecompaniesapi.svg
+++ b/src/treg/web/logos/thecompaniesapi.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="thecompaniesapi">
+  <!-- Placeholder lettermark. Replace with the official thecompaniesapi brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Co</text>
+</svg>

--- a/src/treg/web/logos/tikhub.svg
+++ b/src/treg/web/logos/tikhub.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tikhub">
+  <!-- Placeholder lettermark. Replace with the official tikhub brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">T</text>
+</svg>

--- a/src/treg/web/logos/tiktok-ads.svg
+++ b/src/treg/web/logos/tiktok-ads.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tiktok-ads">
+  <!-- Placeholder lettermark. Replace with the official tiktok-ads brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">TA</text>
+</svg>

--- a/src/treg/web/selfhost.sh
+++ b/src/treg/web/selfhost.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# treg — run your own registry locally, with no account.
+#   curl -fsSL {BASE}/selfhost.sh | sh
+#
+# Brings up a server you are ALREADY SIGNED INTO: no signup, no email, no password. Everything
+# stays on this machine (sqlite under ~/.treg), bound to loopback only. When you want the team
+# version later, `treg cloud join` moves it to a hosted registry.
+set -e
+
+PORT="${TREG_PORT:-18790}"
+HOME_DIR="${TREG_HOME:-$HOME/.treg}"
+URL="http://localhost:$PORT"
+
+say() { printf '  %s\n' "$1"; }
+printf '\n\033[38;5;173m▚ tools-registry\033[0m - starting your local registry…\n\n'
+
+# ---- 1. python (the server needs it; the CLI alone would not) -------------------------------
+PY="$(command -v python3 || true)"
+[ -n "$PY" ] || { echo "  python3 is required (brew install python / apt install python3)"; exit 1; }
+
+# ---- 2. install the server + CLI into an isolated venv --------------------------------------
+mkdir -p "$HOME_DIR"
+VENV="$HOME_DIR/venv"
+if [ ! -x "$VENV/bin/treg" ]; then
+  say "installing treg (server + CLI) into $VENV"
+  "$PY" -m venv "$VENV" >/dev/null
+  "$VENV/bin/pip" install --quiet --upgrade pip >/dev/null
+  "$VENV/bin/pip" install --quiet "tools-registry[server]" >/dev/null
+else
+  say "treg already installed — reusing $VENV"
+fi
+
+# ---- 3. a key so secrets survive a restart --------------------------------------------------
+ENV_FILE="$HOME_DIR/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  KEY="$("$VENV/bin/python" -m treg keygen)"
+  cat > "$ENV_FILE" <<EOF
+# treg local mode — this machine only. Never point TREG_PUBLIC_URL at a public domain while
+# TREG_SINGLE_USER is true: the no-login dashboard refuses to run anywhere but loopback + sqlite.
+TREG_SINGLE_USER=true
+TREG_DATABASE_URL=sqlite+aiosqlite:///$HOME_DIR/treg.db
+TREG_PUBLIC_URL=$URL
+TREG_SECRET_KEY=$KEY
+EOF
+  chmod 600 "$ENV_FILE"
+  say "created $ENV_FILE (your encryption key lives here — keep it)"
+fi
+
+# ---- 4. run it ------------------------------------------------------------------------------
+if curl -fsS "$URL/meta" >/dev/null 2>&1; then
+  say "a treg server is already running on $PORT"
+else
+  say "starting the server on $PORT"
+  ( cd "$HOME_DIR" && PORT="$PORT" nohup "$VENV/bin/python" -m treg > "$HOME_DIR/server.log" 2>&1 & )
+  i=0
+  while [ $i -lt 40 ]; do
+    curl -fsS "$URL/meta" >/dev/null 2>&1 && break
+    i=$((i+1)); sleep 0.5
+  done
+  curl -fsS "$URL/meta" >/dev/null 2>&1 || { echo "  server did not start — see $HOME_DIR/server.log"; exit 1; }
+fi
+
+# ---- 5. point the CLI at it, with the token the server just minted --------------------------
+TOKEN_FILE="$HOME_DIR/local-token"
+if [ -f "$TOKEN_FILE" ]; then
+  "$VENV/bin/treg" login --url "$URL" --token "$(cat "$TOKEN_FILE")" >/dev/null 2>&1 || true
+fi
+
+# ---- 6. put `treg` on the PATH --------------------------------------------------------------
+BIN="$HOME/.local/bin"
+mkdir -p "$BIN"
+ln -sf "$VENV/bin/treg" "$BIN/treg"
+case ":$PATH:" in *":$BIN:"*) ;; *) say "add to your shell: export PATH=\"\$HOME/.local/bin:\$PATH\"" ;; esac
+
+printf '\n\033[32m  ✓ your registry is running\033[0m\n\n'
+say "Dashboard   $URL/app   (already signed in — no account needed)"
+say "CLI         treg tool ls"
+say "Next        treg connect stripe    # paste a key once, then call it with no key"
+printf '\n'

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -120,6 +120,19 @@ treg org invite bob@company.com --role member  # admin+; emails the invite (a on
 treg org members                               # admin+; who's in the active org
 treg org ls / treg org switch <slug>           # your orgs / switch active
 ```
+**Give an agent its own identity** (admin+). An agent doesn't have to borrow the human's token — mint
+it one, and every call it makes is capped, scoped and logged as *itself*:
+```bash
+treg org agent-new ci-bot                        # prints the token ONCE (run again to rotate)
+treg org agent-new ci-bot --tools stripe,gh --cap 500   # only these tools, 500 calls/day
+treg org agents                                  # who the team's agents are + today's usage
+treg org agent-rm <user_id>                      # revoke instantly
+```
+Put that token in the agent's `TREG_TOKEN` env var. An agent token can **call this team's tools and
+read** — it can never sign in, create a team, or be an owner. If you are an agent and you were given
+your own token, use it instead of the machine owner's: your work then shows up under your own name in
+`treg calls`.
+
 The invitee signs in with the invited email and runs `treg accept` — no code handling needed
 (the code path still works: `treg org join <code>`). A brand-new invitee also gets their own
 **personal org** (no empty state), so removing them from a team never locks them out. Give a tool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,13 @@ def make_upstream(hook_hits: list | None = None) -> FastAPI:
         from fastapi.responses import PlainTextResponse
         return PlainTextResponse("ERROR 120 :: wrong key")
 
+    @up.get("/verify-field")
+    async def verify_field(request: Request):
+        # Emulates Apollo: HTTP 200 even for a BAD key, validity signalled only by a body field
+        # (is_logged_in). A key containing "good" is valid. The probe must read the field, not status.
+        ok = "good" in request.headers.get("x-api-key", "")
+        return {"healthy": True, "is_logged_in": ok}
+
     @up.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
     async def echo(request: Request) -> dict:
         body = (await request.body()).decode()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,20 @@ def make_upstream(hook_hits: list | None = None) -> FastAPI:
             hook_hits.append(await request.json())
         return {"ok": True}
 
+    @up.get("/units")
+    async def semrush_units():
+        # Semrush's free unit-balance check answers HTTP 200 with a PLAIN-TEXT body, not JSON — the
+        # key-connect probe must not try to JSON-parse it, or a valid key reads as "unreachable".
+        from fastapi.responses import PlainTextResponse
+        return PlainTextResponse("API units balance: 1200")
+
+    @up.get("/units-bad")
+    async def semrush_units_bad():
+        # Semrush signals a bad key with HTTP 200 and a text body like "ERROR 120 :: ...", so the
+        # probe must read the body, not the status, to reject it.
+        from fastapi.responses import PlainTextResponse
+        return PlainTextResponse("ERROR 120 :: wrong key")
+
     @up.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
     async def echo(request: Request) -> dict:
         body = (await request.body()).decode()

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -1,0 +1,223 @@
+"""Agent identity — a member token for a machine caller.
+
+NOTE: "agent" here is an IDENTITY, not the skill-directory registry in `treg/agents.py`
+(covered by test_agents.py). Same word, different concept.
+
+Proves the invariants that make an agent safe to hand out:
+  - it can CALL, but can never act as a USER (no org creation → no self-promotion to owner),
+  - no login door can resolve an agent address,
+  - it can never be an owner (owners bypass the tool ACL),
+  - two orgs can own the same agent name without sharing one User row,
+  - rotate/revoke kill the old token immediately,
+  - it inherits the per-member cap, tool ACL and audit trail for free.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from conftest import make_upstream
+
+from treg import crypto
+from treg.api import app
+from treg.db import reset_db, session_maker
+from treg.models import Membership, Org, User
+
+
+def _h(t: str) -> dict:
+    return {"X-Treg-Token": t}
+
+
+async def _mint(email: str, org_id: int, role: str) -> str:
+    token = crypto.new_token()
+    async with session_maker() as s:
+        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+        if u is None:
+            u = User(email=email); s.add(u); await s.flush()
+        s.add(Membership(user_id=u.id, org_id=org_id, role=role, token_hash=crypto.hash_token(token)))
+        await s.commit()
+    return token
+
+
+@pytest.fixture
+async def env():
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        async with session_maker() as s:
+            org = Org(name="Team", slug="team"); s.add(org)
+            other = Org(name="Other", slug="other"); s.add(other)
+            await s.commit(); await s.refresh(org); await s.refresh(other)
+            org_id, other_id = org.id, other.id
+        owner = await _mint("owner@x.dev", org_id, "owner")
+        admin = await _mint("adm@x.dev", org_id, "admin")
+        other_owner = await _mint("owner2@x.dev", other_id, "owner")
+        # two callable tools, so tool_access has something to discriminate between
+        sid = (await c.post("/secrets", headers=_h(owner), json={"name": "k", "value": "v"})).json()["id"]
+        for name in ("alpha", "beta"):
+            await c.post("/tools", headers=_h(owner),
+                         json={"name": name, "base_url": "http://upstream", "secret_id": sid})
+        yield SimpleNamespace(c=c, org_id=org_id, other_id=other_id,
+                              owner=owner, admin=admin, other_owner=other_owner)
+    await app.state.http.aclose()
+
+
+async def _agent(env, name="deploy", **kw) -> dict:
+    r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner), json={"name": name, **kw})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ---- the security invariants ---------------------------------------------------------------
+async def test_agent_can_call_but_cannot_act_as_a_user(env):
+    """The load-bearing one. `create_org` runs on require_identity — if an agent could reach it, it
+    would make itself OWNER of a fresh org, and owners bypass the tool ACL and local-run gate."""
+    tok = (await _agent(env))["token"]
+    assert (await env.c.get("/tools", headers=_h(tok))).status_code == 200  # it CAN work in its org
+
+    blocked = await env.c.post("/orgs", headers=_h(tok), json={"name": "escape"})
+    assert blocked.status_code == 403, "an agent must never create an org (it would own it)"
+    assert "machine identity" in blocked.text
+    # and it must not be able to mint a user-scoped identity token, nor accept invites as a user
+    assert (await env.c.get("/auth/cli-token", headers=_h(tok))).status_code == 403
+    assert (await env.c.get("/invites/mine", headers=_h(tok))).status_code == 403
+
+
+async def test_no_login_door_can_resolve_an_agent_address(env):
+    """The address is unroutable, but the block is explicit so no door can hand a human the identity."""
+    email = (await _agent(env))["email"]
+    # open registration must not squat/reuse the address
+    r = await env.c.post("/users", json={"email": email})
+    assert r.status_code == 403 and "cannot be used to sign in" in r.text
+    # nor the email one-time-code door: refused up front, so no code is ever minted for it
+    r = await env.c.post("/auth/email/start", json={"email": email})
+    assert r.status_code == 403 and "cannot be used to sign in" in r.text
+
+
+async def test_the_verify_door_is_blocked_even_if_a_code_were_obtained(env):
+    """Belt and braces: `_find_or_create_user` is the choke point EVERY door shares, so even handed a
+    valid code (dev mode returns one for a real address) an agent address cannot be signed in."""
+    email = (await _agent(env, name="sneak"))["email"]
+    # mint a real code for a REAL address, then try to redeem it against the agent address
+    started = await env.c.post("/auth/email/start", json={"email": "human@x.dev"})
+    code = started.json().get("dev_code")
+    assert code, "dev mode should return the code in the test env"
+    r = await env.c.post("/auth/email/verify", json={"email": email, "code": code})
+    assert r.status_code != 200, r.text
+    async with session_maker() as s:
+        rows = (await s.execute(select(User).where(User.email == email))).scalars().all()
+    assert len(rows) == 1, "no second identity may be created for an agent address"
+
+
+async def test_an_agent_can_never_be_an_owner(env):
+    """Owners short-circuit _tool_allowed and _require_local_run — an owner agent bypasses everything."""
+    r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner),
+                         json={"name": "root", "role": "owner"})
+    assert r.status_code == 422 and "cannot be an owner" in r.text
+
+    a = await _agent(env, name="promote-me")
+    r = await env.c.patch(f"/orgs/{env.org_id}/members/{a['user_id']}", headers=_h(env.owner),
+                          json={"role": "owner"})
+    assert r.status_code == 422, "promoting an agent to owner must be refused too"
+    assert "machine identity" in r.text
+
+
+async def test_only_an_owner_can_mint_an_admin_agent(env):
+    r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.admin),
+                         json={"name": "power", "role": "admin"})
+    assert r.status_code == 403
+    r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner),
+                         json={"name": "power", "role": "admin"})
+    assert r.status_code == 200, r.text
+
+
+async def test_two_orgs_own_the_same_agent_name_without_sharing_a_user(env):
+    """Without the org in the address both orgs would collide on User.email (unique) and share one
+    row — a superadmin suspending one tenant's agent would kill the other tenant's too."""
+    mine = await _agent(env, name="deploy")
+    theirs = await env.c.post(f"/orgs/{env.other_id}/agents", headers=_h(env.other_owner),
+                              json={"name": "deploy"})
+    assert theirs.status_code == 200, theirs.text
+    assert mine["email"] != theirs.json()["email"]
+    assert mine["user_id"] != theirs.json()["user_id"]
+    # and each token only reaches its own org
+    assert (await env.c.get("/tools", headers=_h(mine["token"]))).status_code == 200
+    assert (await env.c.get("/tools", headers=_h(theirs.json()["token"]))).json() == []
+
+
+# ---- lifecycle -----------------------------------------------------------------------------
+async def test_rotate_kills_the_previous_token(env):
+    first = await _agent(env, name="ci")
+    second = await _agent(env, name="ci")  # same name → rotate
+    assert first["token"] != second["token"]
+    assert first["user_id"] == second["user_id"], "rotate must reuse the identity, not duplicate it"
+    assert (await env.c.get("/tools", headers=_h(first["token"]))).status_code == 401
+    assert (await env.c.get("/tools", headers=_h(second["token"]))).status_code == 200
+
+
+async def test_revoke_kills_the_token(env):
+    a = await _agent(env, name="temp")
+    r = await env.c.delete(f"/orgs/{env.org_id}/agents/{a['user_id']}", headers=_h(env.owner))
+    assert r.status_code == 200, r.text
+    assert (await env.c.get("/tools", headers=_h(a["token"]))).status_code == 401
+    assert (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(env.owner))).json() == []
+
+
+async def test_agents_are_listed_and_flagged_apart_from_people(env):
+    await _agent(env, name="worker")
+    agents = (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(env.owner))).json()
+    assert [a["name"] for a in agents] == ["worker"]
+    assert "token" not in agents[0], "the token is shown once at mint time, never listed"
+
+    members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
+    by_email = {m["email"]: m for m in members}
+    assert by_email[agents[0]["email"]]["is_agent"] is True
+    assert by_email["owner@x.dev"]["is_agent"] is False
+
+
+# ---- it inherits the per-member controls for free -------------------------------------------
+async def test_agent_inherits_the_tool_acl(env):
+    """tool_access is enforced by _require_tool_access — the agent gets it with no new code."""
+    tok = (await _agent(env, name="scoped", tool_access=["alpha"]))["token"]
+    assert (await env.c.get("/call/alpha/ok", headers=_h(tok))).status_code == 200
+    assert (await env.c.get("/call/beta/ok", headers=_h(tok))).status_code == 403
+    # and the restricted agent only SEES what it may use
+    assert [t["name"] for t in (await env.c.get("/tools", headers=_h(tok))).json()] == ["alpha"]
+
+
+async def test_agent_inherits_its_own_daily_cap(env):
+    """A cap of 0 proves the cap is read from the agent's own membership, not the creator's."""
+    tok = (await _agent(env, name="capped", daily_call_cap=0))["token"]
+    assert (await env.c.get("/call/alpha/ok", headers=_h(tok))).status_code == 429
+    assert (await env.c.get("/call/alpha/ok", headers=_h(env.owner))).status_code == 200
+
+
+async def test_agent_traffic_is_attributed_to_the_agent(env):
+    """Per-agent logging falls out of identity: CallRecord already stamps user_email."""
+    a = await _agent(env, name="logger")
+    assert (await env.c.get("/call/alpha/ok", headers=_h(a["token"]))).status_code == 200
+    calls = (await env.c.get("/calls", headers=_h(env.owner))).json()
+    assert any(c["user_email"] == a["email"] and c["tool_name"] == "alpha" for c in calls), calls
+
+    usage = (await env.c.get(f"/orgs/{env.org_id}/usage", headers=_h(env.owner))).json()
+    assert any(row["user_email"] == a["email"] for row in usage["by_user"]), usage["by_user"]
+
+
+async def test_bad_input_is_refused_cleanly(env):
+    for payload, code in (({"name": ""}, 422), ({"name": "  "}, 422),
+                          ({"name": "x", "role": "wizard"}, 422),
+                          ({"name": "x", "daily_call_cap": -5}, 422),
+                          ({"name": "x", "tool_access": ["nope"]}, 422)):
+        r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner), json=payload)
+        assert r.status_code == code, f"{payload} → {r.status_code} {r.text}"
+
+
+async def test_a_plain_member_cannot_mint_or_list_agents(env):
+    member = await _mint("plain@x.dev", env.org_id, "member")
+    assert (await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(member),
+                             json={"name": "sneaky"})).status_code == 403
+    assert (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(member))).status_code == 403

--- a/tests/test_agent_identity.py
+++ b/tests/test_agent_identity.py
@@ -221,3 +221,13 @@ async def test_a_plain_member_cannot_mint_or_list_agents(env):
     assert (await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(member),
                              json={"name": "sneaky"})).status_code == 403
     assert (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(member))).status_code == 403
+
+
+async def test_the_agent_listing_carries_everything_the_dashboard_renders(env):
+    """The Agents screen renders role, cap, usage and BOTH access axes — a missing field would show
+    as a blank column, so pin the shape here."""
+    await _agent(env, name="ui-bot")
+    row = (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(env.owner))).json()[0]
+    for field in ("user_id", "name", "email", "role", "daily_call_cap", "used_today",
+                  "tool_access", "project_access", "local_run_enabled"):
+        assert field in row, f"{field} missing from the agent listing"

--- a/tests/test_deny_rules.py
+++ b/tests/test_deny_rules.py
@@ -1,0 +1,204 @@
+"""Deny rules — org policy over what may be called.
+
+The third deny layer (the other two: `egress.py` = the OS firewall around an isolated local run,
+`localrun.check_deny` = a local run's argv). This one sees the HTTP request the proxy is about to
+relay: host + path + method.
+
+Proves: an empty field means "any"; the path match can't be dodged by a lookalike prefix; a rule
+aimed at one member leaves the rest of the team alone; it applies to the OWNER too (a guardrail, not
+a permission tier); both run tiers are gated; and no rules = byte-for-byte the previous behavior.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from conftest import make_upstream
+
+from treg import crypto
+from treg.api import _deny_match, app
+from treg.db import reset_db, session_maker
+from treg.models import DenyRule, Membership, Org, User
+
+
+def _h(t: str) -> dict:
+    return {"X-Treg-Token": t}
+
+
+async def _mint(email: str, org_id: int, role: str) -> tuple[str, int]:
+    token = crypto.new_token()
+    async with session_maker() as s:
+        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+        if u is None:
+            u = User(email=email); s.add(u); await s.flush()
+        s.add(Membership(user_id=u.id, org_id=org_id, role=role, token_hash=crypto.hash_token(token)))
+        await s.commit()
+        uid = u.id
+    return token, uid
+
+
+@pytest.fixture
+async def env():
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        async with session_maker() as s:
+            org = Org(name="Team", slug="team"); s.add(org); await s.commit(); await s.refresh(org)
+            org_id = org.id
+        owner, owner_uid = await _mint("owner@x.dev", org_id, "owner")
+        member, member_uid = await _mint("m@x.dev", org_id, "member")
+        sid = (await c.post("/secrets", headers=_h(owner), json={"name": "k", "value": "v"})).json()["id"]
+        await c.post("/tools", headers=_h(owner),
+                     json={"name": "alpha", "base_url": "http://upstream", "secret_id": sid})
+        yield SimpleNamespace(c=c, org_id=org_id, owner=owner, owner_uid=owner_uid,
+                              member=member, member_uid=member_uid)
+    await app.state.http.aclose()
+
+
+async def _rule(env, **body) -> dict:
+    r = await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner), json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ---- the pure matcher (no DB, like localrun.check_deny) -------------------------------------
+def _r(**kw) -> DenyRule:
+    return DenyRule(host=kw.get("host", ""), path_prefix=kw.get("path_prefix", ""),
+                    method=kw.get("method", ""))
+
+
+def test_an_empty_field_means_any():
+    assert _deny_match([_r(method="DELETE")], "any.host", "/x", "DELETE") is not None
+    assert _deny_match([_r(method="DELETE")], "any.host", "/x", "GET") is None
+    assert _deny_match([_r(host="api.stripe.com")], "api.stripe.com", "/anything", "GET") is not None
+    assert _deny_match([_r(host="api.stripe.com")], "api.other.com", "/anything", "GET") is None
+
+
+def test_host_matching_is_case_insensitive():
+    assert _deny_match([_r(host="API.Stripe.com")], "api.stripe.com", "/", "GET") is not None
+
+
+def test_the_path_prefix_is_anchored_not_a_raw_string_prefix():
+    """`/v1/charges` must not be dodged by `/v1/chargesX`, the same trap `_resolve_call` guards."""
+    rule = [_r(path_prefix="/v1/charges")]
+    assert _deny_match(rule, "h", "/v1/charges", "GET") is not None
+    assert _deny_match(rule, "h", "/v1/charges/evt_1", "GET") is not None
+    assert _deny_match(rule, "h", "/v1/chargesX", "GET") is None
+
+
+def test_all_three_fields_must_match_together():
+    rule = [_r(host="h", path_prefix="/admin", method="DELETE")]
+    assert _deny_match(rule, "h", "/admin/users", "DELETE") is not None
+    assert _deny_match(rule, "h", "/admin/users", "GET") is None
+    assert _deny_match(rule, "other", "/admin/users", "DELETE") is None
+
+
+# ---- enforcement on the proxy ---------------------------------------------------------------
+async def test_no_rules_changes_nothing(env):
+    assert (await env.c.get("/call/alpha/ok", headers=_h(env.member))).status_code == 200
+
+
+async def test_a_method_rule_blocks_that_method_only(env):
+    await _rule(env, method="DELETE", note="no deletes from agents")
+    blocked = await env.c.delete("/call/alpha/thing", headers=_h(env.member))
+    assert blocked.status_code == 403, blocked.text
+    assert "blocked by a policy rule" in blocked.text and "no deletes from agents" in blocked.text
+    assert (await env.c.get("/call/alpha/thing", headers=_h(env.member))).status_code == 200
+
+
+async def test_a_path_rule_blocks_that_path_only(env):
+    await _rule(env, path_prefix="/admin")
+    assert (await env.c.get("/call/alpha/admin/users", headers=_h(env.member))).status_code == 403
+    assert (await env.c.get("/call/alpha/public", headers=_h(env.member))).status_code == 200
+
+
+async def test_a_host_rule_blocks_the_whole_upstream(env):
+    await _rule(env, host="upstream")
+    assert (await env.c.get("/call/alpha/anything", headers=_h(env.member))).status_code == 403
+
+
+async def test_a_rule_aimed_at_one_member_leaves_the_team_alone(env):
+    await _rule(env, method="DELETE", user_id=env.member_uid)
+    assert (await env.c.delete("/call/alpha/x", headers=_h(env.member))).status_code == 403
+    assert (await env.c.delete("/call/alpha/x", headers=_h(env.owner))).status_code == 200
+
+
+async def test_an_org_rule_applies_to_the_owner_too(env):
+    """A deny rule is a guardrail, not a permission tier — an owner who disagrees deletes the rule."""
+    await _rule(env, method="DELETE")
+    assert (await env.c.delete("/call/alpha/x", headers=_h(env.owner))).status_code == 403
+
+
+async def test_the_url_passthrough_shape_is_gated_the_same(env):
+    """The check runs on the RESOLVED upstream, so the caller can't dodge it by using the other shape."""
+    await _rule(env, path_prefix="/admin")
+    r = await env.c.get("/call/http://upstream/admin/users", headers=_h(env.member))
+    assert r.status_code == 403, r.text
+
+
+async def test_deleting_the_rule_restores_the_call(env):
+    rule = await _rule(env, method="DELETE")
+    assert (await env.c.delete("/call/alpha/x", headers=_h(env.member))).status_code == 403
+    assert (await env.c.delete(f"/orgs/{env.org_id}/deny/{rule['id']}",
+                               headers=_h(env.owner))).status_code == 200
+    assert (await env.c.delete("/call/alpha/x", headers=_h(env.member))).status_code == 200
+
+
+# ---- the run tiers are gated too -------------------------------------------------------------
+async def test_a_host_rule_blocks_the_server_run_tier(env):
+    await env.c.post("/skills", headers=_h(env.owner), json={
+        "name": "beta", "recipe": "# beta",
+        "secrets": [{"local_name": "k", "kind": "env", "value": "s"}],
+        "tools": [{"name": "beta", "base_url": "http://upstream",
+                   "cli": {"bin": "sh", "inject": [{"secret": "k", "via": "env", "name": "K"}],
+                           "enabled": True}}]})
+    await _rule(env, host="upstream")
+    r = await env.c.post("/run", headers=_h(env.owner), json={"tool": "beta", "args": ["-c", "true"]})
+    assert r.status_code == 403 and "blocked by a policy rule" in r.text
+
+
+async def test_a_host_rule_blocks_the_local_grant(env):
+    await _rule(env, host="upstream")
+    r = await env.c.post("/tools/alpha/grant", headers=_h(env.owner), json={"argv": ["alpha"]})
+    assert r.status_code == 403 and "blocked by a policy rule" in r.text
+
+
+# ---- the admin surface ------------------------------------------------------------------------
+async def test_rules_are_listed_and_scoped_to_the_org(env):
+    await _rule(env, method="DELETE")
+    await _rule(env, host="https://api.stripe.com/v1", user_id=env.member_uid)
+    rules = (await env.c.get(f"/orgs/{env.org_id}/deny", headers=_h(env.owner))).json()
+    assert len(rules) == 2
+    assert {r["scope"] for r in rules} == {"org", "member"}
+    # a full URL is accepted and reduced to its host, since pasting a base_url is the obvious try
+    assert any(r["host"] == "api.stripe.com" for r in rules), rules
+    assert all(r["verdict"] == "deny" for r in rules)
+
+
+async def test_bad_input_is_refused(env):
+    for payload in ({}, {"note": "nothing to match on"}, {"method": "TELEPORT"}):
+        r = await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner), json=payload)
+        assert r.status_code == 422, f"{payload} → {r.status_code}"
+    r = await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                         json={"method": "GET", "user_id": 9999})
+    assert r.status_code == 404, "a rule can't target someone who isn't a member"
+
+
+async def test_only_admins_manage_rules(env):
+    assert (await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.member),
+                             json={"method": "DELETE"})).status_code == 403
+    assert (await env.c.get(f"/orgs/{env.org_id}/deny", headers=_h(env.member))).status_code == 403
+
+
+async def test_another_orgs_rule_is_never_reachable(env):
+    rule = await _rule(env, method="DELETE")
+    async with session_maker() as s:
+        other = Org(name="Other", slug="other"); s.add(other); await s.commit(); await s.refresh(other)
+        other_id = other.id
+    tok, _ = await _mint("o@x.dev", other_id, "owner")
+    r = await env.c.delete(f"/orgs/{other_id}/deny/{rule['id']}", headers=_h(tok))
+    assert r.status_code == 404, "never confirm another org's ids"

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -1,0 +1,100 @@
+"""API-key providers (auth_kind="key") — the marketplace's paste-a-key connect flow.
+
+These share Slack's bring-your-own-credential path (verify → store → auto-provision), differing only
+in the header or query param the key rides in. The upstream is the shared in-process ASGI app from
+conftest (`/whoami` echoes; `/units` and `/units-bad` model Semrush's plain-text balance responses).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from httpx import AsyncClient
+
+from treg import oauth_providers as P
+
+
+# ---- registry shape ----------------------------------------------------------------------
+def test_key_providers_are_offerable_without_deployment_credentials():
+    """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
+    not shown as 'not configured' the way an unset OAuth provider is."""
+    for svc in ("apollo", "pdl", "akta", "hunter", "tikhub", "brightdata", "semrush"):
+        p = P.get(svc)
+        assert p is not None, svc
+        assert p.auth_kind == "key", svc
+        assert p.uses_pasted_secret is True, svc
+        assert p.is_token_kind is False, f"{svc}: an API key is not a Slack bot token"
+        assert P.is_configured(p) is True, svc
+
+
+def test_key_providers_appear_in_the_marketplace_listing():
+    listing = {row["service"]: row for row in P.listing()}
+    assert listing["apollo"]["category"] == "Enrichment"
+    assert listing["apollo"]["auth_kind"] == "key"
+    assert listing["semrush"]["category"] == "SEO"
+    assert listing["tikhub"]["category"] == "Social media"
+    assert "Enrichment" in P.CATEGORY_ORDER
+
+
+# ---- connect-by-key ----------------------------------------------------------------------
+async def test_key_connect_provisions_a_header_binding(clients: AsyncClient, monkeypatch):
+    """A header key (Apollo's X-Api-Key) is a plain string injected as an env header — never an
+    oauth blob with an access_token field that isn't there."""
+    monkeypatch.setitem(P.REGISTRY, "apollo", dataclasses.replace(
+        P.REGISTRY["apollo"], base_url="http://upstream", probe_path="/whoami"))
+    r = await clients.post("/connections/token", json={"provider": "apollo", "token": "sk-apollo"})
+    assert r.status_code == 200, r.text
+    assert r.json()["health"] == "ok", "a verified key is known-good, not 'unknown'"
+
+    tool = next(t for t in (await clients.get("/tools")).json() if t["name"] == "apollo")
+    b = tool["bindings"][0]
+    assert b["injector"] == "env" and b["location"] == "header"
+    assert b["name"] == "X-Api-Key" and b["format"] == "{secret}"
+    assert "secret_field" not in b or b.get("secret_field") in (None, "")
+
+
+async def test_key_connect_supports_a_query_param_key(clients: AsyncClient, monkeypatch):
+    """Semrush authenticates the classic API with ?key=… and answers the balance check in PLAIN
+    TEXT — the probe must not JSON-parse it, and the tool must bind the key as a query param."""
+    monkeypatch.setitem(P.REGISTRY, "semrush", dataclasses.replace(
+        P.REGISTRY["semrush"], base_url="http://upstream", probe_url="", probe_path="/units"))
+    r = await clients.post("/connections/token", json={"provider": "semrush", "token": "sr-key"})
+    assert r.status_code == 200, r.text
+
+    tool = next(t for t in (await clients.get("/tools")).json() if t["name"] == "semrush")
+    b = tool["bindings"][0]
+    assert b["injector"] == "env" and b["location"] == "query"
+    assert b["name"] == "key" and b["format"] == "{secret}"
+
+
+async def test_a_plain_text_error_body_is_rejected(clients: AsyncClient, monkeypatch):
+    """Semrush signals a bad key with HTTP 200 + an "ERROR ..." text body. Storing it anyway just
+    moves the failure to the first real report call, after the user has left the setup screen."""
+    monkeypatch.setitem(P.REGISTRY, "semrush", dataclasses.replace(
+        P.REGISTRY["semrush"], base_url="http://upstream", probe_url="", probe_path="/units-bad"))
+    r = await clients.post("/connections/token", json={"provider": "semrush", "token": "sr-bad"})
+    assert r.status_code == 422, r.text
+    assert "ERROR" in r.text
+    assert not [c for c in (await clients.get("/connections")).json() if c["provider"] == "semrush"]
+
+
+async def test_probe_url_overrides_base_url_for_verification(clients: AsyncClient, monkeypatch):
+    """The cheapest key-check can live on a different host than the data API (Semrush's balance is on
+    www.semrush.com). probe_url must win: point it at a passing endpoint while probe_path would fail."""
+    monkeypatch.setitem(P.REGISTRY, "semrush", dataclasses.replace(
+        P.REGISTRY["semrush"], base_url="http://upstream",
+        probe_url="http://upstream/units", probe_path="/units-bad"))
+    r = await clients.post("/connections/token", json={"provider": "semrush", "token": "sr-key"})
+    assert r.status_code == 200, "probe_url must be used, not base_url + probe_path"
+
+
+async def test_key_connection_lists_and_revokes(clients: AsyncClient, monkeypatch):
+    """A key connection is a real connection — it must be visible in the list and revocable by id."""
+    monkeypatch.setitem(P.REGISTRY, "tikhub", dataclasses.replace(
+        P.REGISTRY["tikhub"], base_url="http://upstream", probe_path="/whoami"))
+    r = await clients.post("/connections/token", json={"provider": "tikhub", "token": "th-key"})
+    assert r.status_code == 200, r.text
+
+    listed = [c for c in (await clients.get("/connections")).json() if c["provider"] == "tikhub"]
+    assert len(listed) == 1 and listed[0]["kind"] == "env"
+    assert (await clients.delete(f"/connections/{listed[0]['id']}")).status_code == 200

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -40,8 +40,10 @@ def test_key_providers_appear_in_the_marketplace_listing():
 async def test_key_connect_provisions_a_header_binding(clients: AsyncClient, monkeypatch):
     """A header key (Apollo's X-Api-Key) is a plain string injected as an env header — never an
     oauth blob with an access_token field that isn't there."""
+    # token_verify_field cleared: the generic echo stub doesn't model Apollo's is_logged_in body;
+    # this test is about the binding shape, not Apollo's body check (covered separately below).
     monkeypatch.setitem(P.REGISTRY, "apollo", dataclasses.replace(
-        P.REGISTRY["apollo"], base_url="http://upstream", probe_path="/whoami"))
+        P.REGISTRY["apollo"], base_url="http://upstream", probe_path="/whoami", token_verify_field=""))
     r = await clients.post("/connections/token", json={"provider": "apollo", "token": "sk-apollo"})
     assert r.status_code == 200, r.text
     assert r.json()["health"] == "ok", "a verified key is known-good, not 'unknown'"
@@ -76,6 +78,22 @@ async def test_a_plain_text_error_body_is_rejected(clients: AsyncClient, monkeyp
     assert r.status_code == 422, r.text
     assert "ERROR" in r.text
     assert not [c for c in (await clients.get("/connections")).json() if c["provider"] == "semrush"]
+
+
+async def test_a_200_with_a_false_verify_field_is_rejected(clients: AsyncClient, monkeypatch):
+    """Apollo answers HTTP 200 even for a bad key and signals validity in is_logged_in. token_verify_field
+    makes us read that field: a false one is rejected, a true one connects. Verified live against Apollo."""
+    apollo = dataclasses.replace(
+        P.REGISTRY["apollo"], base_url="http://upstream", probe_path="/verify-field",
+        token_verify_field="is_logged_in")
+    monkeypatch.setitem(P.REGISTRY, "apollo", apollo)
+
+    bad = await clients.post("/connections/token", json={"provider": "apollo", "token": "sk-bad"})
+    assert bad.status_code == 422 and "is_logged_in" in bad.text
+    assert not [c for c in (await clients.get("/connections")).json() if c["provider"] == "apollo"]
+
+    ok = await clients.post("/connections/token", json={"provider": "apollo", "token": "sk-good"})
+    assert ok.status_code == 200, ok.text
 
 
 async def test_probe_url_overrides_base_url_for_verification(clients: AsyncClient, monkeypatch):

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -19,7 +19,8 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
-                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat"):
+                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
+                "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "tikhub", "brightdata", "semrush"):
+    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,8 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi"):
+    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
+                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -20,7 +20,8 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
-                "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic"):
+                "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
+                "spyfu", "apify", "meta-ad-library", "serpapi"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -42,6 +42,8 @@ def test_every_provider_is_registered():
         "google-search-console", "google-analytics", "google-business-profile",
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
+        # API-key providers (auth_kind="key")
+        "apollo", "pdl", "akta", "hunter", "tikhub", "brightdata", "semrush",
     }
 
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -44,6 +44,7 @@ def test_every_provider_is_registered():
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "dataforseo", "seranking", "moz", "majestic", "serpstat",
     }
 
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -46,6 +46,8 @@ def test_every_provider_is_registered():
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
+        "spyfu", "apify", "meta-ad-library", "serpapi",
+        "microsoft-ads", "snapchat-ads", "tiktok-ads", "pinterest-ads",
     }
 
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -45,6 +45,7 @@ def test_every_provider_is_registered():
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
+        "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
     }
 
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -43,7 +43,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "tikhub", "brightdata", "semrush",
+        "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
     }
 
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,225 @@
+"""Projects — an optional sub-scope inside an org.
+
+The org stays the hard isolation boundary; a project is a softer grouping on top of it, and a
+deliberate LABEL + ACL scope rather than a namespace (tool names stay unique per org, so no unique
+constraint had to be rebuilt).
+
+Proves: NULL everywhere reproduces the old behavior exactly; project scope AND tool_access compose;
+`project_access=[X]` + `tool_access=NULL` auto-inherits tools added later; a tool in an out-of-scope
+project can't cause a 409 for a caller who can't even use it (the reason `_resolve_call` filters
+before the tiebreak); and deleting a project frees its tools instead of hiding them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from conftest import make_upstream
+
+from treg import crypto
+from treg.api import app
+from treg.db import reset_db, session_maker
+from treg.models import Membership, Org, Tool, User
+
+
+def _h(t: str) -> dict:
+    return {"X-Treg-Token": t}
+
+
+async def _mint(email: str, org_id: int, role: str) -> tuple[str, int]:
+    token = crypto.new_token()
+    async with session_maker() as s:
+        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+        if u is None:
+            u = User(email=email); s.add(u); await s.flush()
+        s.add(Membership(user_id=u.id, org_id=org_id, role=role, token_hash=crypto.hash_token(token)))
+        await s.commit()
+        uid = u.id
+    return token, uid
+
+
+@pytest.fixture
+async def env():
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        async with session_maker() as s:
+            org = Org(name="Team", slug="team"); s.add(org); await s.commit(); await s.refresh(org)
+            org_id = org.id
+        owner, _ = await _mint("owner@x.dev", org_id, "owner")
+        member, member_uid = await _mint("m@x.dev", org_id, "member")
+        sid = (await c.post("/secrets", headers=_h(owner), json={"name": "k", "value": "v"})).json()["id"]
+        apollo = (await c.post(f"/orgs/{org_id}/projects", headers=_h(owner),
+                               json={"name": "Apollo"})).json()
+        gemini = (await c.post(f"/orgs/{org_id}/projects", headers=_h(owner),
+                               json={"name": "Gemini"})).json()
+        # one tool per project, plus one left org-wide
+        for name, proj in (("a-tool", apollo["slug"]), ("g-tool", gemini["slug"]), ("shared", None)):
+            await c.post("/tools", headers=_h(owner), json={
+                "name": name, "base_url": "http://upstream", "secret_id": sid, "project": proj})
+        yield SimpleNamespace(c=c, org_id=org_id, owner=owner, member=member, member_uid=member_uid,
+                              apollo=apollo, gemini=gemini, sid=sid)
+    await app.state.http.aclose()
+
+
+async def _scope(env, projects, tools=None) -> None:
+    r = await env.c.patch(f"/orgs/{env.org_id}/members/{env.member_uid}/access", headers=_h(env.owner),
+                          json={"project_access": projects, "tool_access": tools})
+    assert r.status_code == 200, r.text
+
+
+# ---- nothing changes until you use it --------------------------------------------------------
+async def test_unscoped_members_see_and_call_everything(env):
+    """NULL project_access = the whole org. This is the regression guard for every existing org."""
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(env.member))).json()}
+    assert names == {"a-tool", "g-tool", "shared"}
+    for n in names:
+        assert (await env.c.get(f"/call/{n}/ok", headers=_h(env.member))).status_code == 200
+
+
+async def test_a_tool_with_no_project_is_org_wide(env):
+    """Every tool that predates projects has project_id NULL — it must stay visible to everyone."""
+    await _scope(env, [env.apollo["slug"]])
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(env.member))).json()}
+    assert "shared" in names, "an org-wide tool must remain in scope for a project-scoped member"
+    assert (await env.c.get("/call/shared/ok", headers=_h(env.member))).status_code == 200
+
+
+# ---- the scope itself -------------------------------------------------------------------------
+async def test_project_scope_gates_listing_and_calling(env):
+    await _scope(env, [env.apollo["slug"]])
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(env.member))).json()}
+    assert names == {"a-tool", "shared"}, "the ACL hides what it gates"
+    assert (await env.c.get("/call/a-tool/ok", headers=_h(env.member))).status_code == 200
+    blocked = await env.c.get("/call/g-tool/ok", headers=_h(env.member))
+    assert blocked.status_code == 403 and "project" in blocked.text
+
+
+async def test_the_owner_is_never_scoped(env):
+    await _scope(env, [env.apollo["slug"]])
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(env.owner))).status_code == 200
+
+
+async def test_project_and_tool_access_compose_as_and(env):
+    """Both axes must allow it: in-project but not in tool_access is still refused."""
+    await _scope(env, [env.apollo["slug"]], tools=["shared"])
+    assert (await env.c.get("/call/shared/ok", headers=_h(env.member))).status_code == 200
+    assert (await env.c.get("/call/a-tool/ok", headers=_h(env.member))).status_code == 403
+
+
+async def test_a_scoped_member_auto_inherits_new_tools_in_their_project(env):
+    """project_access=[X] + tool_access=NULL is the composition that makes the coarse dial useful."""
+    await _scope(env, [env.apollo["slug"]])
+    await env.c.post("/tools", headers=_h(env.owner), json={
+        "name": "a-later", "base_url": "http://upstream", "secret_id": env.sid,
+        "project": env.apollo["slug"]})
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(env.member))).json()}
+    assert "a-later" in names
+    assert (await env.c.get("/call/a-later/ok", headers=_h(env.member))).status_code == 200
+
+
+async def test_selecting_every_project_collapses_to_unrestricted(env):
+    """Mirrors _normalize_tool_access: 'all checked' is stored as NULL so later projects are inherited."""
+    await _scope(env, [env.apollo["slug"], env.gemini["slug"]])
+    members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
+    me = next(m for m in members if m["user_id"] == env.member_uid)
+    assert me["project_access"] is None
+
+
+# ---- the reason _resolve_call filters BEFORE the tiebreak -------------------------------------
+async def test_an_out_of_scope_tool_cannot_409_the_passthrough(env):
+    """Two same-host tools in different projects would tie on prefix length. A caller scoped to one
+    of them must resolve cleanly — the other is invisible to them, so it must not cause a 409."""
+    await env.c.post("/tools", headers=_h(env.owner), json={
+        "name": "g-same-host", "base_url": "http://upstream", "secret_id": env.sid,
+        "project": env.gemini["slug"]})
+    await _scope(env, [env.apollo["slug"]])
+    # org-wide + apollo tools still share the host, so narrow the member to exactly one usable tool
+    await _scope(env, [env.apollo["slug"]], tools=["a-tool"])
+    r = await env.c.get("/call/http://upstream/x", headers=_h(env.member))
+    assert r.status_code == 200, f"expected a clean resolve, got {r.status_code}: {r.text[:200]}"
+
+
+# ---- lifecycle ---------------------------------------------------------------------------------
+async def test_projects_are_listed_with_their_tool_counts(env):
+    projects = (await env.c.get(f"/orgs/{env.org_id}/projects", headers=_h(env.owner))).json()
+    counts = {p["slug"]: p["tool_count"] for p in projects}
+    assert counts == {"apollo": 1, "gemini": 1}
+
+
+async def test_a_scoped_member_only_sees_their_projects(env):
+    await _scope(env, [env.apollo["slug"]])
+    projects = (await env.c.get(f"/orgs/{env.org_id}/projects", headers=_h(env.member))).json()
+    assert [p["slug"] for p in projects] == ["apollo"]
+
+
+async def test_deleting_a_project_frees_its_tools_rather_than_hiding_them(env):
+    r = await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}", headers=_h(env.owner))
+    assert r.status_code == 200 and r.json()["tools_made_org_wide"] == 1
+    async with session_maker() as s:
+        tool = (await s.execute(select(Tool).where(Tool.name == "a-tool"))).scalar_one()
+        assert tool.project_id is None, "the tool survives as org-wide; it must not vanish"
+    assert (await env.c.get("/call/a-tool/ok", headers=_h(env.member))).status_code == 200
+
+
+async def test_deleting_a_project_never_locks_a_member_out_of_everything(env):
+    """Dropping the last entry must read as 'unscoped', not 'no projects at all'."""
+    await _scope(env, [env.apollo["slug"]])
+    await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}", headers=_h(env.owner))
+    members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
+    assert next(m for m in members if m["user_id"] == env.member_uid)["project_access"] is None
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(env.member))).status_code == 200
+
+
+async def test_a_tool_can_be_moved_between_projects_and_back(env):
+    tools = (await env.c.get("/tools", headers=_h(env.owner))).json()
+    tid = next(t["id"] for t in tools if t["name"] == "a-tool")
+    r = await env.c.patch(f"/tools/{tid}", headers=_h(env.owner), json={"project": env.gemini["slug"]})
+    assert r.status_code == 200 and r.json()["project_id"] == env.gemini["id"]
+    r = await env.c.patch(f"/tools/{tid}", headers=_h(env.owner), json={"project": None})
+    assert r.status_code == 200 and r.json()["project_id"] is None
+
+
+# ---- guards --------------------------------------------------------------------------------------
+async def test_bad_input_is_refused(env):
+    assert (await env.c.post(f"/orgs/{env.org_id}/projects", headers=_h(env.owner),
+                             json={"name": " "})).status_code == 422
+    assert (await env.c.post(f"/orgs/{env.org_id}/projects", headers=_h(env.owner),
+                             json={"name": "Apollo"})).status_code == 409, "slug must be unique per org"
+    assert (await env.c.post("/tools", headers=_h(env.owner), json={
+        "name": "bad", "base_url": "http://upstream", "project": "nope"})).status_code == 404
+    r = await env.c.patch(f"/orgs/{env.org_id}/members/{env.member_uid}/access", headers=_h(env.owner),
+                          json={"project_access": ["nope"]})
+    assert r.status_code == 422, "an unknown project must not be silently ignored"
+
+
+async def test_only_admins_manage_projects(env):
+    assert (await env.c.post(f"/orgs/{env.org_id}/projects", headers=_h(env.member),
+                             json={"name": "Sneaky"})).status_code == 403
+    assert (await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}",
+                               headers=_h(env.member))).status_code == 403
+
+
+async def test_another_orgs_project_is_never_reachable(env):
+    async with session_maker() as s:
+        other = Org(name="Other", slug="other"); s.add(other); await s.commit(); await s.refresh(other)
+        other_id = other.id
+    tok, _ = await _mint("o@x.dev", other_id, "owner")
+    assert (await env.c.delete(f"/orgs/{other_id}/projects/{env.apollo['id']}",
+                               headers=_h(tok))).status_code == 404
+    assert (await env.c.get(f"/orgs/{other_id}/projects", headers=_h(tok))).json() == []
+
+
+async def test_an_invite_carries_the_project_scope_onto_the_membership(env):
+    r = await env.c.post(f"/orgs/{env.org_id}/invites", headers=_h(env.owner), json={
+        "email": "new@x.dev", "project_access": [env.apollo["slug"]]})
+    assert r.status_code == 200, r.text
+    code = r.json()["code"]
+    joined = await env.c.post("/invites/accept", json={"code": code, "email": "new@x.dev"})
+    assert joined.status_code == 200, joined.text
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(joined.json()["token"]))).json()}
+    assert names == {"a-tool", "shared"}

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -223,3 +223,16 @@ async def test_an_invite_carries_the_project_scope_onto_the_membership(env):
     assert joined.status_code == 200, joined.text
     names = {t["name"] for t in (await env.c.get("/tools", headers=_h(joined.json()["token"]))).json()}
     assert names == {"a-tool", "shared"}
+
+
+async def test_an_access_patch_without_projects_keeps_the_scope(env):
+    """The dashboard's local-run toggle PATCHes only tool_access + local_run_enabled. That must not
+    silently clear the member's project scoping (the field defaults to None on the way in)."""
+    await _scope(env, [env.apollo["slug"]])
+    r = await env.c.patch(f"/orgs/{env.org_id}/members/{env.member_uid}/access", headers=_h(env.owner),
+                          json={"tool_access": None, "local_run_enabled": False})
+    assert r.status_code == 200, r.text
+    members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
+    me = next(m for m in members if m["user_id"] == env.member_uid)
+    assert me["project_access"] == [env.apollo["id"]], "project scope must survive an unrelated PATCH"
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(env.member))).status_code == 403

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -166,13 +166,25 @@ async def test_deleting_a_project_frees_its_tools_rather_than_hiding_them(env):
     assert (await env.c.get("/call/a-tool/ok", headers=_h(env.member))).status_code == 200
 
 
-async def test_deleting_a_project_never_locks_a_member_out_of_everything(env):
-    """Dropping the last entry must read as 'unscoped', not 'no projects at all'."""
+async def test_deleting_a_project_neither_locks_a_member_out_nor_widens_them(env):
+    """Dropping the LAST entry must leave an empty scope, never NULL.
+
+    NULL reads as "every project", so collapsing `[]` to NULL would hand a member scoped to only
+    Apollo the run of Gemini's tools — a privilege escalation fired by an unrelated delete. The
+    member is still not locked out, because the freed tools became org-wide: what they could reach
+    before the delete they can still reach after it. That is the invariant, not the NULL.
+    """
     await _scope(env, [env.apollo["slug"]])
     await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}", headers=_h(env.owner))
     members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
-    assert next(m for m in members if m["user_id"] == env.member_uid)["project_access"] is None
-    assert (await env.c.get("/call/g-tool/ok", headers=_h(env.member))).status_code == 200
+    assert next(m for m in members if m["user_id"] == env.member_uid)["project_access"] == [], \
+        "an emptied scope must stay empty — NULL would mean 'every project'"
+    # kept: the tools they already had (a-tool was freed to org-wide, shared always was)
+    assert (await env.c.get("/call/a-tool/ok", headers=_h(env.member))).status_code == 200
+    assert (await env.c.get("/call/shared/ok", headers=_h(env.member))).status_code == 200
+    # NOT gained: a project they were deliberately kept out of
+    blocked = await env.c.get("/call/g-tool/ok", headers=_h(env.member))
+    assert blocked.status_code == 403, "deleting Apollo must not grant Gemini"
 
 
 async def test_a_tool_can_be_moved_between_projects_and_back(env):

--- a/tests/test_security_round4.py
+++ b/tests/test_security_round4.py
@@ -1,0 +1,351 @@
+"""Round-4 fixes — the bug hunt that closed the agents / projects / deny / local-mode arc.
+
+Four of the five findings are ONE mistake wearing different clothes: **a write path read an ABSENT
+value as an UNRESTRICTED one.** An emptied project scope became "every project"; a rotate that sent
+no `tool_access` became "every tool". Both are privilege escalations reachable from the ordinary
+dashboard, which is why they were release blockers. `test_the_principle_absent_is_never_unrestricted`
+pins the rule itself, so the next field added to one of these bodies inherits the guard.
+
+The other two are smaller: a caller with no access to a tool was told the tool did not EXIST (404
+instead of 403), and rows outlived the identity they named — a deny rule pointing at a revoked agent,
+and a local bootstrap that adopted a team it never created.
+
+Covers: `delete_project` · `create_agent` (rotate) · `_resolve_call` · `_drop_member_deny_rules` ·
+`_bootstrap_single_user`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from conftest import make_upstream
+
+from treg import api, crypto
+from treg.api import LOCAL_ORG_NAME, LOCAL_USER_EMAIL, app
+from treg.config import Settings
+from treg.db import reset_db, session_maker
+from treg.models import DenyRule, Membership, Org, Tool, User
+
+
+def _h(t: str) -> dict:
+    return {"X-Treg-Token": t}
+
+
+async def _mint(email: str, org_id: int, role: str) -> tuple[str, int]:
+    token = crypto.new_token()
+    async with session_maker() as s:
+        u = (await s.execute(select(User).where(User.email == email))).scalar_one_or_none()
+        if u is None:
+            u = User(email=email); s.add(u); await s.flush()
+        s.add(Membership(user_id=u.id, org_id=org_id, role=role, token_hash=crypto.hash_token(token)))
+        await s.commit()
+        uid = u.id
+    return token, uid
+
+
+@pytest.fixture
+async def env():
+    """One org, an owner and a member, and:
+
+    - THREE projects, so scoping to two of them is a real partial scope — `_normalize_project_access`
+      collapses an all-projects selection back to NULL, which would hide the very bug under test.
+    - three tools on `upstream` (one per project + one org-wide) and one on a SECOND host, so a
+      passthrough URL can be made to match only a tool the caller may not use.
+    """
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        async with session_maker() as s:
+            org = Org(name="Team", slug="team"); s.add(org); await s.commit(); await s.refresh(org)
+            org_id = org.id
+        owner, owner_uid = await _mint("owner@x.dev", org_id, "owner")
+        member, member_uid = await _mint("m@x.dev", org_id, "member")
+        sid = (await c.post("/secrets", headers=_h(owner), json={"name": "k", "value": "v"})).json()["id"]
+        apollo, gemini, orion = [
+            (await c.post(f"/orgs/{org_id}/projects", headers=_h(owner), json={"name": n})).json()
+            for n in ("Apollo", "Gemini", "Orion")
+        ]
+        for name, url, proj in (("a-tool", "http://upstream", apollo["slug"]),
+                                ("g-tool", "http://upstream", gemini["slug"]),
+                                ("shared", "http://upstream", None),
+                                ("hidden", "http://solo-host", None)):
+            r = await c.post("/tools", headers=_h(owner), json={
+                "name": name, "base_url": url, "secret_id": sid, "project": proj})
+            assert r.status_code == 200, r.text
+        yield SimpleNamespace(c=c, org_id=org_id, owner=owner, owner_uid=owner_uid,
+                              member=member, member_uid=member_uid,
+                              apollo=apollo, gemini=gemini, orion=orion)
+    await app.state.http.aclose()
+
+
+async def _agent(env, name="deploy", **kw) -> dict:
+    r = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner), json={"name": name, **kw})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+async def _access(env, user_id: int, **fields) -> dict:
+    r = await env.c.patch(f"/orgs/{env.org_id}/members/{user_id}/access", headers=_h(env.owner),
+                          json=fields)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+# ---- #1 deleting a project must not widen a scope ---------------------------------------------
+async def test_deleting_a_project_does_not_widen_an_agents_scope(env):
+    """The same bug as the member case in test_projects, but through an AGENT — the identity most
+    likely to be tightly scoped, and the one whose credential is handed to a machine."""
+    agent = await _agent(env)
+    await _access(env, agent["user_id"], project_access=[env.apollo["slug"]])
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(agent["token"]))).status_code == 403
+
+    r = await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}", headers=_h(env.owner))
+    assert r.status_code == 200
+
+    blocked = await env.c.get("/call/g-tool/ok", headers=_h(agent["token"]))
+    assert blocked.status_code == 403, \
+        "deleting one project must never grant an agent the tools of another"
+    names = {t["name"] for t in (await env.c.get("/tools", headers=_h(agent["token"]))).json()}
+    assert names == {"a-tool", "shared", "hidden"}, \
+        "it keeps what it had (a-tool freed to org-wide) and gains no other project's tools"
+
+
+async def test_deleting_a_project_leaves_other_scoped_entries_alone(env):
+    """A member scoped to two of the three projects loses only the deleted id, not the whole list."""
+    await _access(env, env.member_uid, project_access=[env.apollo["slug"], env.gemini["slug"]])
+    await env.c.delete(f"/orgs/{env.org_id}/projects/{env.apollo['id']}", headers=_h(env.owner))
+    members = (await env.c.get(f"/orgs/{env.org_id}/members", headers=_h(env.owner))).json()
+    remaining = next(m for m in members if m["user_id"] == env.member_uid)["project_access"]
+    assert remaining == [env.gemini["id"]]
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(env.member))).status_code == 200
+
+
+# ---- #2 rotating an agent must not widen it ----------------------------------------------------
+async def test_rotating_an_agent_keeps_its_tool_acl(env):
+    """The dashboard's Rotate button sends {name, role, daily_call_cap} and nothing else. With
+    `tool_access` defaulting to None ("all tools"), a scoped agent became unrestricted just by
+    getting a new token — no admin ever asked for that."""
+    agent = await _agent(env, tool_access=["a-tool"])
+    assert agent["tool_access"] == ["a-tool"]
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(agent["token"]))).status_code == 403
+
+    rotated = await _agent(env, role="member", daily_call_cap=-1)  # exactly what the dashboard sends
+    assert rotated["token"] != agent["token"], "a rotate must still replace the token"
+    assert rotated["tool_access"] == ["a-tool"], "an absent field must leave the ACL untouched"
+    assert (await env.c.get("/call/g-tool/ok", headers=_h(rotated["token"]))).status_code == 403
+
+
+async def test_rotating_an_agent_keeps_its_cap_project_scope_and_local_run(env):
+    """Every other 'absent = unrestricted' field on the same body, including the project scope,
+    which `AgentIn` cannot even express and so could only ever be lost."""
+    agent = await _agent(env, daily_call_cap=5, local_run_enabled=False)
+    await _access(env, agent["user_id"], project_access=[env.apollo["slug"]],
+                  local_run_enabled=False)
+
+    rotated = await _agent(env)  # name only — the most minimal rotate there is
+    assert rotated["daily_call_cap"] == 5, "an absent cap must not become unlimited"
+    assert rotated["local_run_enabled"] is False, "an absent flag must not re-enable local runs"
+    assert rotated["project_access"] == [env.apollo["id"]], "a rotate must not clear the project scope"
+
+
+async def test_rotating_can_still_change_the_limits_when_asked(env):
+    """The guard must not freeze the fields: SENT is still authoritative, in both directions."""
+    agent = await _agent(env, tool_access=["a-tool"], daily_call_cap=5)
+    widened = await _agent(env, tool_access=["a-tool", "g-tool", "shared", "hidden"],
+                           daily_call_cap=-1)
+    assert widened["tool_access"] is None, "everything selected collapses to NULL, as elsewhere"
+    assert widened["daily_call_cap"] == -1
+    narrowed = await _agent(env, tool_access=["shared"])
+    assert narrowed["tool_access"] == ["shared"]
+
+
+async def test_a_new_agent_still_takes_the_documented_defaults(env):
+    """The 'keep what it had' rule applies to a ROTATE only — a first mint has nothing to keep."""
+    fresh = await _agent(env, name="brand-new")
+    assert fresh["tool_access"] is None and fresh["daily_call_cap"] == -1
+    assert fresh["local_run_enabled"] is True and fresh["role"] == "member"
+
+
+# ---- the principle behind #1 and #2 ------------------------------------------------------------
+async def test_the_principle_absent_is_never_unrestricted(env):
+    """The shared rule, stated once: on a path that UPDATES an existing identity, a field the caller
+    did not send must leave that field alone. It must never be read as its permissive default.
+
+    Both blockers this round were this rule broken in a different place, so pin it directly: any new
+    field added to one of these bodies has to keep passing here."""
+    agent = await _agent(env, tool_access=["a-tool"], daily_call_cap=3, local_run_enabled=False)
+    await _access(env, agent["user_id"], tool_access=["a-tool"],
+                  project_access=[env.apollo["slug"]], local_run_enabled=False)
+
+    async def _limits() -> dict:
+        agents = (await env.c.get(f"/orgs/{env.org_id}/agents", headers=_h(env.owner))).json()
+        m = next(a for a in agents if a["name"] == "deploy")
+        return {k: m[k] for k in ("tool_access", "project_access", "daily_call_cap",
+                                  "local_run_enabled")}
+
+    before = await _limits()
+    # every write path that can touch this identity without naming its limits
+    await _agent(env)                                               # rotate: name only
+    await _access(env, agent["user_id"], tool_access=["a-tool"], local_run_enabled=False)
+    await env.c.delete(f"/orgs/{env.org_id}/projects/{env.gemini['id']}", headers=_h(env.owner))
+
+    after = await _limits()
+    assert after["tool_access"] == before["tool_access"]
+    assert after["daily_call_cap"] == before["daily_call_cap"]
+    assert after["local_run_enabled"] == before["local_run_enabled"]
+    assert after["project_access"] == before["project_access"], \
+        "deleting an unrelated project must not touch a scope that never named it"
+
+
+# ---- #3 no access is a 403, not a 404 ----------------------------------------------------------
+async def test_passthrough_without_access_says_403_not_404(env):
+    """The ACL filter in `_resolve_call` emptied the candidate set, so the caller was told the tool
+    did not EXIST. That sends an admin hunting for a registration that is already there. The named
+    shape has always answered 403; the passthrough shape must agree."""
+    await _access(env, env.member_uid, tool_access=["shared"])  # everything on solo-host is off-limits
+    r = await env.c.get("/call/http://solo-host/ok", headers=_h(env.member))
+    assert r.status_code == 403, r.text
+    assert "access" in r.text.lower()
+    assert "hidden" not in r.text, "the 403 must name only the host the caller typed, not the tool"
+
+
+async def test_an_unregistered_host_is_still_a_404(env):
+    """The other half: 403 must not swallow the genuine 'nothing is registered here' case."""
+    r = await env.c.get("/call/http://nowhere.example/ok", headers=_h(env.member))
+    assert r.status_code == 404 and "no registered tool" in r.text
+
+
+async def test_an_out_of_scope_tool_still_cannot_cause_a_409(env):
+    """The reason the ACL filter runs BEFORE the tiebreak in the first place — guard it while
+    changing the code around it. Three tools share `upstream` with the same base_url, so they would
+    all tie; with only ONE of them usable the caller must still get a clean resolve, not a 409."""
+    await _access(env, env.member_uid, project_access=[env.apollo["slug"]], tool_access=["a-tool"])
+    r = await env.c.get("/call/http://upstream/ok", headers=_h(env.member))
+    assert r.status_code == 200, \
+        f"exactly one usable tool on the host must resolve, not 409 on the ones it can't see: {r.text}"
+
+
+# ---- #4 a deny rule must not outlive the identity it named -------------------------------------
+async def _rules(env) -> list[dict]:
+    return (await env.c.get(f"/orgs/{env.org_id}/deny", headers=_h(env.owner))).json()
+
+
+async def test_revoking_an_agent_takes_its_deny_rules_with_it(env):
+    agent = await _agent(env)
+    r = await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                         json={"host": "upstream", "user_id": agent["user_id"]})
+    assert r.status_code == 200, r.text
+    assert len(await _rules(env)) == 1
+
+    await env.c.delete(f"/orgs/{env.org_id}/agents/{agent['user_id']}", headers=_h(env.owner))
+    assert await _rules(env) == [], \
+        "a rule naming a caller that no longer exists can never fire — it is only clutter"
+
+
+async def test_removing_a_member_takes_their_deny_rules_with_them(env):
+    await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                     json={"host": "upstream", "user_id": env.member_uid})
+    await env.c.delete(f"/orgs/{env.org_id}/members/{env.member_uid}", headers=_h(env.owner))
+    assert await _rules(env) == []
+
+
+async def test_the_sweep_leaves_org_wide_rules_and_other_members_alone(env):
+    """It removes rules ABOUT one caller, never the team's own policy."""
+    agent = await _agent(env)
+    await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner), json={"method": "DELETE"})
+    await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                     json={"host": "upstream", "user_id": env.member_uid})
+    await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                     json={"host": "upstream", "user_id": agent["user_id"]})
+
+    await env.c.delete(f"/orgs/{env.org_id}/agents/{agent['user_id']}", headers=_h(env.owner))
+    left = await _rules(env)
+    assert len(left) == 2
+    assert {r["scope"] for r in left} == {"org", "member"}
+    assert all(r["user_id"] != agent["user_id"] for r in left)
+    # and the org-wide rule still bites
+    assert (await env.c.delete("/call/shared/ok", headers=_h(env.owner))).status_code == 403
+
+
+async def test_deleting_a_user_clears_their_rules_in_every_org(env, monkeypatch):
+    """`DenyRule.user_id` is a FOREIGN KEY. A super-admin delete that left one behind would dangle —
+    Postgres refuses that outright, and SQLite only hides it because it does not enforce FKs."""
+    monkeypatch.setenv("TREG_ADMIN_TOKEN", "sa-token")
+    from treg.config import get_settings
+    get_settings.cache_clear()
+    try:
+        await env.c.post(f"/orgs/{env.org_id}/deny", headers=_h(env.owner),
+                         json={"host": "upstream", "user_id": env.member_uid})
+        r = await env.c.delete(f"/admin/users/{env.member_uid}", headers=_h("sa-token"))
+        assert r.status_code == 200, r.text
+        async with session_maker() as s:
+            left = (await s.execute(select(DenyRule).where(
+                DenyRule.user_id == env.member_uid))).scalars().all()
+        assert left == [], "no rule may survive the user row it points at"
+    finally:
+        get_settings.cache_clear()
+
+
+# ---- #5 local bootstrap must not adopt someone else's team -------------------------------------
+def _settings(**kw) -> Settings:
+    base = dict(single_user=True, database_url="sqlite+aiosqlite:///./x.db",
+                public_url="http://localhost:18790")
+    base.update(kw)
+    return Settings(**base)
+
+
+async def test_local_bootstrap_never_claims_an_existing_personal_team(tmp_path, monkeypatch):
+    """It used to look the org up by SLUG and join it as owner. On a database that is not fresh —
+    a hosted registry someone ran locally, a restored dump — that hands the password-less local
+    identity ownership of a real team, and an owner is exempt from every ACL."""
+    await reset_db()
+    async with session_maker() as s:
+        theirs = Org(name="Personal", slug=LOCAL_ORG_NAME); s.add(theirs)
+        real = User(email="someone@x.dev"); s.add(real)
+        await s.flush()
+        s.add(Membership(user_id=real.id, org_id=theirs.id, role="owner",
+                         token_hash=crypto.hash_token(crypto.new_token())))
+        await s.commit()
+        theirs_id = theirs.id
+
+    monkeypatch.setattr(api, "get_settings",
+                        lambda: _settings(single_user_token_file=str(tmp_path / "tok")))
+    await api._bootstrap_single_user()
+
+    async with session_maker() as s:
+        local_user = (await s.execute(
+            select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one()
+        mems = (await s.execute(select(Membership).where(
+            Membership.user_id == local_user.id))).scalars().all()
+        orgs = {o.id: o.slug for o in (await s.execute(select(Org))).scalars().all()}
+    assert len(mems) == 1
+    assert mems[0].org_id != theirs_id, "the local identity must never join a team it did not create"
+    assert orgs[mems[0].org_id] != LOCAL_ORG_NAME, "it takes a free slug instead of colliding"
+    assert orgs[mems[0].org_id].startswith(LOCAL_ORG_NAME)
+
+
+async def test_local_bootstrap_is_still_idempotent_on_its_own_team(tmp_path, monkeypatch):
+    """The fix must not cost the property the feature is built on: re-running makes no second team
+    and does not rotate the token the installer already wrote into the CLI config."""
+    await reset_db()
+    token_file = tmp_path / "tok"
+    monkeypatch.setattr(api, "get_settings",
+                        lambda: _settings(single_user_token_file=str(token_file)))
+    await api._bootstrap_single_user()
+    first = token_file.read_text()
+    await api._bootstrap_single_user()
+    await api._bootstrap_single_user()
+
+    assert token_file.read_text() == first
+    async with session_maker() as s:
+        local_user = (await s.execute(
+            select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one()
+        mems = (await s.execute(select(Membership).where(
+            Membership.user_id == local_user.id))).scalars().all()
+        orgs = (await s.execute(select(Org))).scalars().all()
+    assert len(mems) == 1 and len(orgs) == 1
+    assert orgs[0].slug == LOCAL_ORG_NAME, "on a FRESH box it still gets the clean name"

--- a/tests/test_single_user.py
+++ b/tests/test_single_user.py
@@ -1,0 +1,122 @@
+"""Frictionless local mode — `curl … | sh` lands on a dashboard you are already signed into.
+
+The whole point is that there is no account, so the ONLY thing standing between this and handing a
+stranger the registry is the guard. These tests are mostly about the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from treg import api, session as sess
+from treg.api import LOCAL_ORG_NAME, LOCAL_USER_EMAIL, app
+from treg.config import Settings, get_settings
+from treg.db import reset_db, session_maker
+from treg.models import Membership, Org, User
+
+
+def _settings(**kw) -> Settings:
+    base = dict(single_user=True, database_url="sqlite+aiosqlite:///./x.db",
+                public_url="http://localhost:18790")
+    base.update(kw)
+    return Settings(**base)
+
+
+# ---- the guard: this is the security of the whole feature -------------------------------------
+def test_local_mode_needs_sqlite_and_a_loopback_url():
+    assert _settings().single_user_ok is True
+    assert _settings(public_url="http://127.0.0.1:18790").single_user_ok is True
+
+    # a real deploy — either half is enough to refuse
+    assert _settings(database_url="postgresql+asyncpg://u@h/db").single_user_ok is False, \
+        "a Postgres URL means a real deploy: no-login must be off"
+    assert _settings(public_url="https://treg.superdesign.dev").single_user_ok is False, \
+        "a public domain must never serve a no-login dashboard"
+    assert _settings(database_url="postgresql+asyncpg://u@h/db",
+                     public_url="https://treg.superdesign.dev").single_user_ok is False
+
+
+def test_it_is_off_unless_explicitly_asked_for():
+    assert _settings(single_user=False).single_user_ok is False
+    assert get_settings().single_user_ok is False, "the default deployment must never be no-login"
+
+
+# ---- the bootstrap ----------------------------------------------------------------------------
+@pytest.fixture
+async def local(tmp_path, monkeypatch):
+    """A server in single-user mode, with the token file in a temp dir."""
+    await reset_db()
+    token_file = tmp_path / "local-token"
+    monkeypatch.setattr(api, "get_settings", lambda: _settings(single_user_token_file=str(token_file)))
+    await api._bootstrap_single_user()
+    yield token_file
+
+
+async def test_bootstrap_creates_the_owner_and_writes_the_token(local):
+    assert local.exists(), "the installer reads this file to point the CLI at the server"
+    assert local.read_text().strip(), "a token must actually be written"
+    assert oct(local.stat().st_mode)[-3:] == "600", "the token file must not be world-readable"
+    async with session_maker() as s:
+        user = (await s.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one()
+        org = (await s.execute(select(Org).where(Org.slug == LOCAL_ORG_NAME))).scalar_one()
+        m = (await s.execute(select(Membership).where(
+            Membership.user_id == user.id, Membership.org_id == org.id))).scalar_one()
+    assert m.role == "owner"
+
+
+async def test_the_token_is_stable_across_restarts(local):
+    """Rotating on every boot would break the CLI config the installer just wrote."""
+    first = local.read_text()
+    await api._bootstrap_single_user()
+    await api._bootstrap_single_user()
+    assert local.read_text() == first
+
+
+async def test_a_deleted_token_file_is_re_minted(local):
+    """The one case where rotating is right: the user lost the file and needs a way back in."""
+    first = local.read_text()
+    local.unlink()
+    await api._bootstrap_single_user()
+    assert local.exists() and local.read_text() != first
+
+
+async def test_the_minted_token_actually_works(local):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.get("/tools", headers={"X-Treg-Token": local.read_text().strip()})
+    assert r.status_code == 200, r.text
+
+
+async def test_the_dashboard_opens_already_signed_in(local):
+    """The feeling we are selling: no signup, no email, no password."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.get("/app")
+    assert r.status_code == 200
+    cookie = r.cookies.get(sess.COOKIE)
+    assert cookie, "local mode must attach a session so there is no login screen"
+    async with session_maker() as s:
+        user = (await s.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one()
+    assert sess.read_claims(cookie)["uid"] == user.id
+
+
+# ---- and the same routes must stay closed on a normal deployment ------------------------------
+async def test_a_normal_deployment_bootstraps_nothing_and_signs_nobody_in():
+    await reset_db()
+    await api._bootstrap_single_user()  # default settings → guard refuses
+    async with session_maker() as s:
+        assert (await s.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one_or_none() is None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.get("/app")
+    assert r.status_code == 200
+    assert not r.cookies.get(sess.COOKIE), "a real deploy must never hand out a session"
+
+
+# ---- the installer is served ------------------------------------------------------------------
+async def test_selfhost_script_is_served_and_templated():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.get("/selfhost.sh")
+    assert r.status_code == 200
+    assert "{BASE}" not in r.text, "the serving domain must be templated in"
+    assert "TREG_SINGLE_USER=true" in r.text
+    assert r.headers["content-type"].startswith("text/x-shellscript")


### PR DESCRIPTION
Two arcs, plus the bug hunt that closed them. 20 commits, 753 tests passing.

## 1. Marketplace depth — 12 providers to 39

23 API-key + 15 OAuth + Slack, covering SEO / Social / Enrichment / Ads, with a
paste-a-key connect flow and the dashboard UI for it.

Bad-key detection is not uniform across vendors, so `OAuthProvider` grew a small
verify toolbox — each field exists because a real provider needed it:
`token_verify_field` (Apollo 200s with `is_logged_in:false`), `token_ok_field/value`
(Majestic `Code=="OK"`), `token_reject_field` (Serpstat `error`),
`probe_reject_statuses` (Coresignal has no free probe), `token_encode="base64"`
(DataForSEO/Moz Basic), `probe_url` (Semrush's check is off-host). Full table and
the add-a-provider playbook: `docs/context/guides/expanding-a-category.md`.

Deliberately **not** added, with reasons recorded: Adbeat (key in the URL path —
our injectors do header/query only), ScrapeCreators (its API returns success for
any key, so a key cannot be validated), Proxycurl (shut down), Clearbit
(HubSpot-gated), FullContact (enterprise-only). Reddit OAuth is deferred: it still
works technically, but self-service closed in Nov 2025 and commercial use needs a
contract.

## 2. The credential + control layer for agents

- **Agents** — a machine caller gets its own member identity. An agent is a `User`
  on an unroutable domain (`agents.treg.local`) plus a normal `Membership`, so it
  needed **no new table and no migration**, and inherited `daily_call_cap`,
  `tool_access`, `local_run_enabled` and per-identity audit for free. Three
  invariants close real holes: an agent token is refused by `require_identity` (else
  it could create an org **in which it is owner**, and owners are exempt from every
  ACL); an agent can never be an owner; the address is org-scoped so two teams can
  each own an agent called `deploy`.
- **Projects** — an optional sub-scope inside an org, deliberately a **label + ACL
  scope, not a namespace**. `Tool.name` keeps its `(org_id, name)` unique constraint,
  which removed all migration risk (SQLite cannot rebuild that constraint portably).
  `Tool.project_id` NULL = org-wide, so every pre-existing tool is untouched. The two
  ACL axes compose as AND.
- **Deny rules** — block a host, path or method. A guardrail, not a permission tier:
  they apply to **every role including owner**. treg now denies at three layers, kept
  apart because each sees something different: `egress.py` (OS firewall around an
  isolated local run), `localrun.check_deny` (argv), `_enforce_deny` (the HTTP request
  being relayed).
- **Frictionless local mode** — `curl …/selfhost.sh | sh` brings up a registry you are
  already signed into. Guarded exactly like `expose_dev_code`: `single_user_ok` demands
  local sqlite **and** a loopback `public_url`, so a stray `TREG_SINGLE_USER=true` in
  production does nothing.
- Dashboard screens for all of it, plus a "My teams" tab.

## 3. Round-4 security fixes

Four of the five findings are one mistake in different places: **a write path read an
ABSENT value as an UNRESTRICTED one.** Two were release blockers, both reachable from
the ordinary dashboard.

| | Finding | Fix |
|---|---|---|
| 🔴 | `delete_project` widened a scope — `remaining or None` turned an emptied `project_access` into NULL, which means *every project* | store the remaining ids as they are, `[]` included; nobody is locked out because the freed tools become org-wide |
| 🔴 | Rotating an agent wiped its ACL — rotate is the same endpoint as create, and the dashboard's Rotate sends only `{name, role, cap}` | write a field only when the caller sent it (`model_fields_set`) |
| 🟠 | A caller with no access got `404` instead of `403` from URL-passthrough | keep the unfiltered host matches; if only the ACL removed the match, answer `403` |
| 🟡 | Deny rules outlived the identity they named | `_drop_member_deny_rules` on revoke / remove / leave / admin-delete |
| 🟡 | Local bootstrap could claim an existing `personal` team as **owner** | adopt only through a membership it already has, else a free slug |

The admin-delete case is more than clutter: `DenyRule.user_id` is a foreign key, so a
surviving row dangles. Postgres rejects that outright while SQLite hides it by not
enforcing FKs — which is why the test suite alone could never have caught it.

`tests/test_security_round4.py` adds 16 tests, including
`test_the_principle_absent_is_never_unrestricted`, which pins the shared rule so a new
field on these bodies inherits the guard. `test_projects.py`'s delete-a-project test
asserted the buggy behavior and is corrected.

## Migration

**(A21)** follows the established guarded, additive pattern: `project` is a brand-new
table (no ALTER needed), so the step only adds `tool.project_id` plus `project_access`
on both `membership` and `invite`. Every one is nullable and NULL means
*unrestricted*, so an existing deployment behaves exactly as before until someone
creates a project. None is a BOOLEAN, so the Postgres integer-default trap does not
apply. `DenyRule` needs no step at all, for the same new-table reason.

## Known follow-ups (not blockers)

- The Ads OAuth platforms (Microsoft / Snapchat / Pinterest) need treg's own dev app
  registered. **TikTok Ads is a placeholder** — its OAuth is non-standard and needs
  real `oauth.py` work.
- The 23 key providers ship lettermark placeholder SVGs; swap for official brand marks.
- Only Apollo + Hunter were tested with live keys. The other 21 were verified by
  bogus-key rejection against the real API, which proves base URL, auth shape and probe
  path — but not a successful call.
- `curl …/selfhost.sh | sh` becomes real on `treg.superdesign.dev` only after deploy.
  The script templates its own URL from `public_url`, so no code change is needed.
