### PR TITLE
release: v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.5.0"
+version = "0.6.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -553,7 +553,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump only (`pyproject.toml` + `uv.lock`). 757 tests passing.

## What 0.6.0 contains, since 0.5.0

**Marketplace depth (#32)** — the provider catalog grew from 12 to **39** (23 API-key + 15 OAuth +
Slack), covering SEO / Social / Enrichment / Ads, with a paste-a-key connect flow and the dashboard
UI for it.

**The credential + control layer for agents (#32)**
- **Agents** — a machine caller gets its own member identity, with no new table and no migration.
- **Projects** — an optional sub-scope inside an org; a label + ACL scope, not a namespace.
- **Deny rules** — block a host, path or method; a guardrail that applies to every role including
  owner.
- **Frictionless local mode** — `curl …/selfhost.sh | sh` brings up a registry you are already
  signed into, guarded by `single_user_ok` (local sqlite **and** a loopback `public_url`).

**Round-4 security fixes (#32)** — five findings, two of them release blockers. Four were the same
mistake in different places: a write path read an **absent** value as an **unrestricted** one.
Deleting a project widened a member's scope to every project; rotating an agent wiped its tool ACL.
Also: a no-access caller now gets `403` instead of `404` from URL-passthrough, deny rules no longer
outlive the identity they named, and the local bootstrap can no longer claim an existing `personal`
team as owner.

**CLI fix (#29)** — `treg call` stopped dropping an inline `?query` (httpx drops a URL's query
whenever `params=` is passed, so the upstream silently got no query and returned wrong data with no
error), and gained `--upload NAME=@FILE` for real multipart file uploads.

**CI (#24, #25, #27)** — dependabot bumps for `actions/labeler`, `astral-sh/setup-uv`,
`actions/stale`.

## Pre-flight, already done

- `uv sync` + `uv run pytest -q` → **757 passed**
- `uv build` → wheel + sdist; base-only install in a clean 3.13 venv reports `treg 0.6.0` and stays
  **light** (no fastapi / asyncpg / cryptography)
- `twine check` → both PASSED
- gitleaks on the packaged sdist → only the three placeholders already allowlisted in
  `.gitleaks.toml`; no `.env` or `*.db` in either artifact

## Migration note

**(A21)** is guarded and additive: `project` is a new table, so the step only adds
`tool.project_id` plus `project_access` on `membership` and `invite`. All nullable, NULL means
unrestricted, so an existing deployment behaves exactly as before until someone creates a project.
None is a BOOLEAN, so the Postgres integer-default trap does not apply. `DenyRule` needs no step.
