### PR TITLE
release: v0.7.0 — the local proxy, and a frictionless install

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -189,14 +189,16 @@ key.
 Put `treg` in front of any command:
 
 ```bash
-pip install "tools-registry[proxy]"   # the certificate library; not in the light CLI
-
 treg claude                  # a Claude Code session using the team's shared credentials
 treg codex                   # same for Codex
 treg node server.js          # your app, with the team's keys, without holding any
 treg python train.py
 treg with -- npm test        # the explicit form, for anything that confuses the parser
 ```
+
+The proxy needs one compiled package (`cryptography`) to generate this machine's certificate
+authority. The `install.sh` installer includes it; if you installed with plain `pip` and it is
+missing, treg offers to add it the right way for your install the first time you use the feature.
 
 **This is opt-in per command, and that is the point.** treg is the parent process, so the setting
 applies to that command and its children only. `treg claude` uses the team's shared access; plain
@@ -229,7 +231,6 @@ routed through the registry, which adds the credential **on the server** and ret
 unchanged. Your code needs no key and no treg-specific lines:
 
 ```bash
-pip install "tools-registry[proxy]"      # the certificate library; not in the light CLI
 treg shell start --proxy                 # the banner lists the hosts being captured
 curl https://api.stripe.com/v1/balance   # no key anywhere — treg injected it server-side
 python my_script.py                      # same for anything the script calls

--- a/examples/proxy-demo/README.md
+++ b/examples/proxy-demo/README.md
@@ -9,8 +9,6 @@ parent process.
 ## Run it
 
 ```bash
-pip install "tools-registry[proxy]"     # the certificate library; not part of the light CLI
-
 node server.js          # plain: the call goes out as-is
 treg node server.js     # the same code, credentialed by your team
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.6.0"
+version = "0.7.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import argparse
 import base64
 import contextlib
+import importlib
+import importlib.util
 import itertools
 import getpass
 import json
@@ -2620,12 +2622,93 @@ def cmd_setup_local_run(args, cfg) -> None:
 
 
 # ---- shell mode: transparent CLI interception (`treg shell`) -------------------------------
+_PROXY_PKG = "cryptography>=43"
+
+
+def _proxy_install_hint() -> tuple[str, list[str]]:
+    """How to add the certificate library to **this** copy of treg: `(human label, argv)`.
+
+    `pip install "tools-registry[proxy]"` is the right answer for exactly one of the four ways people
+    install treg, and the installer's own way is not it: a uv-tool or Homebrew venv is not on the
+    ambient `pip`'s path, so that advice silently does nothing and the user is left with a working
+    install and a broken feature.
+
+    This **probes** instead of guessing from the path, because guessing was wrong: a `uv venv` has no
+    `pip` at all, so `python -m pip install` there fails with "No module named pip". Order: the
+    environment's own pip when it has one (works for pip, venv, Homebrew), then `uv` (which installs
+    into any environment by path), then pipx. An empty argv means we found no way to do it."""
+    prefix = sys.prefix
+    if "/pipx/venvs/" in prefix and shutil.which("pipx"):
+        return "pipx", ["pipx", "inject", "tools-registry", _PROXY_PKG]
+    if importlib.util.find_spec("pip") is not None:
+        label = "Homebrew" if ("/Cellar/" in prefix or "/homebrew/" in prefix) else "pip"
+        return label, [sys.executable, "-m", "pip", "install", _PROXY_PKG]
+    if shutil.which("uv"):
+        # uv tool / uv venv environments ship without pip; uv itself installs into them by path.
+        label = "uv tool" if "/uv/tools/" in prefix else "uv"
+        return label, ["uv", "pip", "install", "--python", sys.executable, _PROXY_PKG]
+    return "this", []
+
+
+def ensure_proxy_dependency(assume_yes: bool = False) -> None:
+    """Make sure the certificate library is importable, offering to install it if it is not.
+
+    The proxy is the one feature that needs a compiled dependency, and it is deliberately not in the
+    base install. Telling someone to run a command that does not work for their install method is
+    worse than not shipping the feature — so treg works out how it was installed and offers to do it,
+    in the right way, on the spot."""
+    try:
+        import cryptography  # noqa: F401
+        return
+    except ModuleNotFoundError:
+        pass
+
+    label, argv = _proxy_install_hint()
+    if not argv:
+        sys.exit("treg: the local proxy needs the `cryptography` package, and this environment has no "
+                 "installer (no pip, no uv, no pipx) to add it with. Install it however you manage "
+                 "this Python, or reinstall treg with:  pip install \"tools-registry[proxy]\"")
+    printable = " ".join(shlex.quote(a) for a in argv)
+    print(f"\n{_A}▚ treg{_R} {_M}— the local proxy needs one more piece: the certificate library that "
+          f"generates{_R}", file=sys.stderr)
+    print(f"  {_M}this machine's certificate authority. It is not in the base install because it is{_R}",
+          file=sys.stderr)
+    print(f"  {_M}compiled, and `pip install tools-registry` is meant to stay light.{_R}\n", file=sys.stderr)
+    if not assume_yes and not sys.stdin.isatty():
+        sys.exit(f"treg: install it for this {label} install with:\n  {printable}")
+    if not assume_yes:
+        try:
+            answer = input(f"  Install it now for this {label} install? [Y/n] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            sys.exit("\ntreg: cancelled.")
+        if answer not in ("", "y", "yes"):
+            sys.exit(f"treg: no problem. When you want it:\n  {printable}")
+
+    print(f"  {_M}{printable}{_R}", file=sys.stderr)
+    try:
+        code = subprocess.call(argv)  # noqa: S603 — argv list, no shell
+    except FileNotFoundError:
+        sys.exit(f"treg: {argv[0]!r} is not on your PATH. Install it by hand with:\n  {printable}")
+    if code != 0:
+        sys.exit(f"treg: that did not work (exit {code}). Try it by hand:\n  {printable}")
+
+    # The package landed in THIS interpreter's environment, so it is importable now — but only after
+    # the import system is told to look again.
+    importlib.invalidate_caches()
+    try:
+        import cryptography  # noqa: F401
+    except ModuleNotFoundError:
+        sys.exit("treg: installed, but still not importable here. Try the command again in a new shell.")
+    print(f"  {_G}✓{_R} {_M}ready.{_R}\n", file=sys.stderr)
+
+
 def _start_proxy_handle(cfg, tools: list[dict], *, port: int | None = None, renew_ca: bool = False):
     """Bring up the local proxy and return `(handle, hosts, treg_host)`. Shared by both front doors:
     `treg shell start --proxy` (dies with the subshell) and `treg serve` (a daemon other terminals
     point at). The allow-list is seeded from the tool listing the caller already fetched, so turning
     the proxy on costs no extra request."""
     from . import localproxy as lpx
+    ensure_proxy_dependency()          # offers to install it rather than printing advice that fails
     try:
         ca = lpx.ensure_ca(renew=renew_ca)
     except lpx.ProxyDependencyError as exc:
@@ -2665,8 +2748,15 @@ def _start_local_proxy(args, cfg, tools: list[dict]):
 
 
 def _proxy_tools(cfg) -> list[dict]:
-    with _client(cfg) as c:
-        r = c.get("/tools")
+    """The tools whose hosts the proxy should capture. A registry we cannot reach is a plain sentence,
+    not a traceback: the user has done nothing wrong and there is an obvious thing to check."""
+    base = os.environ.get("TREG_URL") or cfg.get("base_url", "")
+    try:
+        with _client(cfg) as c:
+            r = c.get("/tools")
+    except httpx.HTTPError as exc:
+        sys.exit(f"treg: cannot reach the registry at {base} ({type(exc).__name__}). "
+                 f"Check it is up, or `treg config --base-url <url>`.")
     if r.status_code >= 400:
         _show(r)  # exits non-zero
     return r.json()
@@ -2690,6 +2780,7 @@ def _serve_daemon(args, cfg) -> None:
     told to stop. On the way out the state file goes with it, so `status` can never claim a proxy
     that is not there."""
     from . import localproxy as lpx
+    ensure_proxy_dependency()
     handle, hosts, treg_host = _start_proxy_handle(
         cfg, _proxy_tools(cfg), port=args.port, renew_ca=args.renew_ca)
     base = os.environ.get("TREG_URL") or cfg["base_url"]
@@ -2812,6 +2903,7 @@ def cmd_with(args, cfg) -> None:
     from . import localproxy as lpx
     from . import shell as sh
 
+    ensure_proxy_dependency()          # local + instant; ask before we go near the network
     cmd = [args.command, *args.args]
     exe = shutil.which(cmd[0])
     if not exe:

--- a/src/treg/localproxy.py
+++ b/src/treg/localproxy.py
@@ -98,7 +98,8 @@ def _require_cryptography():
     except ModuleNotFoundError as exc:  # pragma: no cover - exercised by hand, not in CI
         raise ProxyDependencyError(
             "the local proxy needs the certificate library, which is not part of the light CLI.\n"
-            '  Install it with:  pip install "tools-registry[proxy]"'
+            "  Run this from a terminal and treg offers to install it the right way for your install,\n"
+            '  or add it by hand:  pip install "tools-registry[proxy]"'
         ) from exc
     return x509, hashes, serialization, ec, NameOID
 

--- a/src/treg/web/install.sh
+++ b/src/treg/web/install.sh
@@ -6,7 +6,13 @@ set -e
 BASE="{BASE}"
 # Install from PyPI (fast, public, no git clone). The base package is the light CLI; the FastAPI/DB
 # server stack is the `tools-registry[server]` extra, which people who self-host install separately.
-SRC="tools-registry"
+#
+# `[proxy]` is included here on purpose. It adds only `cryptography`, which is what `treg <command>`
+# needs to generate this machine's certificate authority — and it ships as a prebuilt wheel, so there
+# is no compiler and no meaningful wait. Without it the headline feature (`treg claude`) stops on its
+# first run asking to be installed, which is a bad first minute. `pip install tools-registry` stays
+# light for anyone who wants only the plain CLI.
+SRC="tools-registry[proxy]"
 
 printf '\n\033[38;5;173m▚ tools-registry\033[0m - installing the treg CLI…\n\n'
 

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -68,7 +68,8 @@ automatically: `treg shell start`, then use `stripe`, `gh`, … normally (no `tr
 with the team's credentials. treg is the parent process, so only that command and its children are
 affected: `treg claude` uses shared team access, plain `claude` is untouched and uses your own local
 keys. Nothing is written to any config file. A registered host is credentialed by the server; every
-other address goes straight out unread. Needs `pip install "tools-registry[proxy]"`.
+other address goes straight out unread. It needs the `cryptography` package: the installer includes
+it, and if it is missing treg offers to add it (the right way for how treg was installed) on first use.
 **If you are writing Node:** the built-in `fetch` ignores proxy settings before **Node 24**, so a plain
 `fetch()` on older Node is NOT captured and your call goes out with no credential. Use a client that
 reads the environment (axios, got, undici `ProxyAgent`) or upgrade to Node 24+. curl, git, python
@@ -80,7 +81,7 @@ treg code; the call goes through the registry, which injects the credential **on
 answer comes back unchanged. Only registered hosts are touched — every other address (including
 `api.anthropic.com` / `api.openai.com`) goes straight out and cannot be read. It works by setting
 `HTTPS_PROXY` and a trust bundle for that shell only; the system trust store is never modified, and no
-vendor key ever reaches the machine. Needs `pip install "tools-registry[proxy]"`. `--proxy-port N` moves
+vendor key ever reaches the machine. `--proxy-port N` moves
 the listener off 18791, `--renew-ca` regenerates the machine's local certificate authority. A
 certificate-pinned client will refuse the interception and must use `treg run` or `treg call` instead.
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -581,3 +581,92 @@ def test_with_runs_the_program_for_real_and_passes_args_and_exit_code(monkeypatc
     body = out.read_text()
     assert "a b\n--flag\n" in body                    # spaces survive; no re-splitting
     assert "127.0.0.1:18800" in body                  # the child really saw the proxy
+
+
+# ---- the certificate library: offered, not just described ----------------------------------
+def test_the_install_hint_matches_how_treg_was_installed(monkeypatch):
+    """`pip install "tools-registry[proxy]"` is right for exactly ONE of the four ways people install
+    treg — and the installer's own way is not it. A uv-tool or Homebrew venv is not on the ambient
+    pip's path, so that advice silently does nothing."""
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda n: object() if n == "pip" else None)
+    for prefix, label in {"/opt/homebrew/Cellar/treg/0.6.0/libexec": "Homebrew",
+                          "/Users/x/venv": "pip"}.items():
+        monkeypatch.setattr(cli.sys, "prefix", prefix)
+        got, argv = cli._proxy_install_hint()
+        assert got == label and argv[:3] == [cli.sys.executable, "-m", "pip"]
+        assert argv[-1] == "cryptography>=43"
+
+
+def test_a_pip_less_environment_uses_uv_instead(monkeypatch):
+    """Found by running it: a `uv venv` has NO pip, so the obvious `python -m pip install` fails with
+    'No module named pip'. Probing beats guessing from the path."""
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda n: None)
+    monkeypatch.setattr(cli.shutil, "which", lambda n: "/usr/bin/uv" if n == "uv" else None)
+    monkeypatch.setattr(cli.sys, "prefix", "/Users/x/.local/share/uv/tools/tools-registry")
+    label, argv = cli._proxy_install_hint()
+    assert label == "uv tool"
+    assert argv[:2] == ["uv", "pip"] and cli.sys.executable in argv
+
+
+def test_pipx_is_injected_not_pip_installed(monkeypatch):
+    monkeypatch.setattr(cli.sys, "prefix", "/Users/x/.local/pipx/venvs/tools-registry")
+    monkeypatch.setattr(cli.shutil, "which", lambda n: f"/usr/bin/{n}" if n == "pipx" else None)
+    label, argv = cli._proxy_install_hint()
+    assert label == "pipx" and argv[:2] == ["pipx", "inject"]
+
+
+def test_an_environment_with_no_installer_says_so(monkeypatch):
+    """Nothing to install with: say that plainly instead of running a command that cannot exist."""
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda n: None)
+    monkeypatch.setattr(cli.shutil, "which", lambda n: None)
+    monkeypatch.setattr(cli.sys, "prefix", "/opt/weird")
+    assert cli._proxy_install_hint()[1] == []
+    _hide_cryptography(monkeypatch)
+    with pytest.raises(SystemExit) as exc:
+        cli.ensure_proxy_dependency(assume_yes=True)
+    assert "no installer" in str(exc.value)
+
+
+def test_nothing_happens_when_the_library_is_already_there():
+    cli.ensure_proxy_dependency()          # cryptography is installed in the test env — must be silent
+
+
+def _hide_cryptography(monkeypatch):
+    """Pretend the certificate library is not installed, without uninstalling it."""
+    import builtins
+    real = builtins.__import__
+
+    def _fake(name, *a, **k):
+        if name == "cryptography":
+            raise ModuleNotFoundError(name)
+        return real(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _fake)
+
+
+def test_a_non_interactive_run_prints_the_command_instead_of_prompting(monkeypatch):
+    """In CI or a pipe there is nobody to answer, so it must exit saying exactly what to run — never
+    hang on a prompt nobody can see."""
+    _hide_cryptography(monkeypatch)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+    with pytest.raises(SystemExit) as exc:
+        cli.ensure_proxy_dependency()
+    assert "cryptography>=43" in str(exc.value)
+
+
+def test_declining_leaves_the_command_behind(monkeypatch):
+    _hide_cryptography(monkeypatch)
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _p: "n")
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: pytest.fail("must not install"))
+    with pytest.raises(SystemExit) as exc:
+        cli.ensure_proxy_dependency()
+    assert "cryptography>=43" in str(exc.value)
+
+
+def test_a_failed_install_says_so_rather_than_carrying_on(monkeypatch):
+    _hide_cryptography(monkeypatch)
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 1)
+    with pytest.raises(SystemExit) as exc:
+        cli.ensure_proxy_dependency(assume_yes=True)
+    assert "did not work" in str(exc.value)

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts **0.7.0** for PyPI + Homebrew. Contents: the local proxy (`treg claude`, `treg shell --proxy`,
`treg serve`) merged in #39, plus everything since 0.6.0 — the endpoint catalog, agent identity and
project-scoped policy (#34, #35, #36).

## The part that is not just a version bump

Releasing as-is would have made the headline feature unreachable for most users. The proxy needs
`cryptography`, deliberately kept out of the light base install, and the error said:

```
pip install "tools-registry[proxy]"
```

That works for exactly **one** of the four ways treg is installed — and `install.sh`'s own way is not
it. A uv-tool or Homebrew venv is not on the ambient pip's path, so the advice silently does nothing.

1. **`install.sh` now installs `tools-registry[proxy]`.** The primary path never meets the problem.
   `cryptography` ships prebuilt wheels, so no compiler and no meaningful wait; `pip install
   tools-registry` stays light for anyone who wants only the plain CLI.
2. **When it is missing, treg offers to install it** — correctly for that install — and carries on:
   `Install it now for this uv tool install? [Y/n]`.

Building (2) caught its own bug, only because it was run for real: **a `uv venv` has no pip**, so
`python -m pip install` fails with "No module named pip" — exactly the case for the uv-tool installs
`install.sh` creates. It now probes for what exists (the environment's own pip → uv → pipx) rather
than guessing from the path, and says so plainly when an environment has no installer at all.

Two more found while testing:
- `treg <command>` crashed with a raw httpx traceback when the registry was unreachable; now one
  sentence naming the URL.
- The dependency check runs **before** the registry is contacted, so problems surface in a sensible
  order.

## Release checks already done

- `uv build` → wheel + sdist; **light install verified**: no fastapi/uvicorn/sqlmodel/asyncpg/
  cryptography in a fresh base install, `treg --version` → `treg 0.7.0`.
- `twine check` PASSED on both artifacts.
- sdist carries no `.env`, no database, no `.claude`.
- **1012 tests pass.**
- Base dependencies unchanged, so the Homebrew formula needs only a new `url` + `sha256` — no
  resource regeneration.

After merge: publish to PyPI, update the tap, redeploy prod so the live commit matches `main`.