### PR TITLE
feat(marketplace): disclose the Crewlet Meta app name before consent

### DIFF
--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -98,6 +98,14 @@ module symbols:
   `CATEGORY_ORDER`, each flagged `configured`, with per-capability scopes already in plain English via
   `scope_label()`/`SCOPE_LABELS` (a lookup keyed by the raw scope string;
   `test_every_requested_scope_has_a_plain_english_label` guards it).
+- `consent_notice` — one line the dashboard shows **before** the consent popup opens, for a provider
+  whose consent screen names something the user has not seen on treg. Only the Meta family carries one:
+  the shared Meta app is registered as **Crewlet**, a sibling product of the same company (Superdesign
+  Dev Inc), and Facebook renders only that bare app name with no parent business, so without the notice
+  a treg user is asked to authorize a stranger. It rides `listing()` like any other provider field, so
+  the UI never hard-codes which services get one; `test_only_the_meta_family_carries_a_consent_notice`
+  derives the set from `auth_uri == _META_AUTH` rather than a service list. Meta Developer Policy 1.6
+  wants the relationship disclosed at the point of consent, which is why this is not a docs link.
 - **Scopes are per CAPABILITY, not per provider** (`scopes: dict[capability -> list[scope]]`). Capabilities
   are cumulative supersets (write ⊇ read); `default_capability` is the **broadest** (an agent product needs
   write eventually, so one honest consent screen beats connecting twice). `scopes_for()` /

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -247,6 +247,15 @@ tool name so an agent can call a specific one), their health/expiry chips, and a
 (`mkGranted` marks which capabilities are already granted; `scope_detail` gives the exact upstream scopes
 on hover).
 
+**Consent disclosure.** A provider row may carry a **`consent_notice`**, rendered as a `.mk-notice` panel
+in two places: under the summary on the integration page (beside Connect) and inside the `capAsk` modal,
+i.e. everywhere the popup can be triggered from. It is a plain surface, not `.banner` — `.banner` is red
+and would read as a failure rather than something to read before consenting. Today only the Meta family
+(`facebook`, `instagram`, `meta-ads`) sets one: their shared Meta app is registered as **Crewlet**, so
+Facebook's consent screen shows a name the user never saw on treg. The template is `v-if`'d on the field,
+so nothing here names those three services; adding a notice is a registry edit (see
+`architecture/auth-secrets.md`), not a dashboard edit.
+
 **Connecting** (`startConnect` picks the shape): a **token** provider (`auth_kind==='token'` — "bring your
 own bot") opens the `tokenAsk` modal → `submitToken` → **`POST /connections/token`** (`connect_with_token`);
 a provider with 2+ capabilities opens the `capAsk` modal (`capLabel`/`capHelp` explain each, e.g. TikTok's

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -63,6 +63,12 @@ class OAuthProvider:
     # `?key=…`, not a header. Drives both the connect-time probe and the provisioned tool's binding.
     token_location: str = "header"  # "header" | "query"
     token_param: str = ""  # query-param name when token_location == "query" (Semrush: "key")
+    # Shown on the provider page and in the capability modal, i.e. everywhere Connect can be
+    # clicked, BEFORE the consent popup opens. For providers whose consent screen names something
+    # the user has not seen on treg: the Meta app is registered as "Crewlet", a sibling product, so
+    # without this the popup asks them to authorize a stranger. Meta Developer Policy 1.6 wants the
+    # relationship disclosed at the point of consent, not in a docs link.
+    consent_notice: str = ""
     setup_url: str = ""  # one-click app creation, pre-filled where the platform supports it
     setup_action_label: str = ""
     setup_steps: tuple[str, ...] = ()
@@ -630,6 +636,15 @@ _META_AUTH = "https://www.facebook.com/v25.0/dialog/oauth"
 _META_TOKEN = "https://graph.facebook.com/v25.0/oauth/access_token"
 _META_BASE = "https://graph.facebook.com/v25.0"
 
+# The Meta app behind all three providers is registered as "Crewlet" — a sibling product from the
+# same company — and Facebook's consent screen renders only that bare app name, with no parent
+# business. Someone who came here for treg would be asked to authorize a product they have never
+# heard of. Say so before they click Connect, not after.
+_META_CONSENT_NOTICE = (
+    "You'll be taken to Facebook and see Crewlet, our Meta app by Superdesign Dev Inc. "
+    "treg and Crewlet share one Meta integration."
+)
+
 # pages_show_list is the floor for BOTH providers: it is what returns the Page list, and an
 # Instagram professional account is only reachable *through* the Page it is linked to.
 _FB_READ = ["pages_show_list", "pages_read_engagement", "read_insights"]
@@ -654,6 +669,7 @@ FACEBOOK = OAuthProvider(
     ),
     base_url=_META_BASE,
     docs_url="https://developers.facebook.com/docs/pages-api",
+    consent_notice=_META_CONSENT_NOTICE,
     auth_params={},  # Meta ignores Google's access_type/prompt; sending them just noises the URL
     long_lived_exchange=True,
     resource_label="Page",
@@ -691,6 +707,7 @@ INSTAGRAM = OAuthProvider(
     ),
     base_url=_META_BASE,
     docs_url="https://developers.facebook.com/docs/instagram-platform/instagram-graph-api",
+    consent_notice=_META_CONSENT_NOTICE,
     auth_params={},
     long_lived_exchange=True,
     resource_label="account",
@@ -726,6 +743,7 @@ META_ADS = OAuthProvider(
     ),
     base_url=_META_BASE,
     docs_url="https://developers.facebook.com/docs/marketing-apis",
+    consent_notice=_META_CONSENT_NOTICE,
     auth_params={},
     long_lived_exchange=True,
     resource_label="ad account",
@@ -1630,6 +1648,7 @@ def listing() -> list[dict]:
             "needs_extra_credential": p.needs_extra_credential,
             "base_url": p.base_url,
             "docs_url": p.docs_url,
+            "consent_notice": p.consent_notice,
             "configured": is_configured(p),
         }
         # Grouped first, alphabetical within a shelf — so the dashboard can render the shelves by

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -68,6 +68,10 @@
   .mk-chip.on{background:var(--ink);color:var(--bg);border-color:var(--ink)}
   .mk-chip.on span{color:var(--bg);opacity:.65}
   .mk-empty{border:1px dashed var(--line);border-radius:var(--r);padding:16px;color:var(--muted);font-size:13px}
+  /* A disclosure the user has to read before consenting, not a failure — so it borrows the panel
+     surface rather than .banner, which is red and would read as "something went wrong". */
+  .mk-notice{margin:12px 0 0;max-width:64ch;background:var(--panel2);border:1px solid var(--line2);
+    border-radius:8px;padding:9px 12px;color:var(--muted);font-size:12.5px;line-height:1.5}
   .mk-perms{display:grid;grid-template-columns:repeat(auto-fill,minmax(min(100%,300px),1fr));gap:12px}
   .mk-perm{background:var(--panel);border:1px solid var(--line);border-radius:var(--r);padding:13px}
   .mk-perm-h{display:flex;align-items:center;gap:8px;margin-bottom:9px;font-size:12px}
@@ -1452,6 +1456,9 @@ a:hover{text-decoration-color:var(--muted)}
                 </div>
               </div>
               <p class="sub" style="margin:12px 0 0;max-width:64ch">{{mkProvider.summary}}</p>
+              <!-- Sits next to Connect, not in a tooltip or a docs link: it only does its job if
+                   it is read BEFORE the consent popup names an app the user doesn't recognise. -->
+              <p v-if="mkProvider.consent_notice" class="mk-notice">{{mkProvider.consent_notice}}</p>
             </div>
             <div class="tut-actions">
               <a v-if="mkProvider.docs_url" class="btn sm" :href="mkProvider.docs_url" target="_blank" rel="noopener">API docs ↗</a>
@@ -2653,6 +2660,7 @@ a:hover{text-decoration-color:var(--muted)}
         <h3 style="margin:0 0 6px">Connect {{capAsk.provider.display_name}}</h3>
         <p class="sub" style="margin:0 0 14px">What should your agent be allowed to do with this account?
           Widening it later means going through Google's consent screen again.</p>
+        <p v-if="capAsk.provider.consent_notice" class="mk-notice" style="margin:0 0 14px">{{capAsk.provider.consent_notice}}</p>
         <div class="ttable-wrap"><table class="ttable">
           <tr v-for="cap in capAsk.provider.capabilities" :key="cap">
             <!-- Deliberately NOT .tn: that class is nowrap, which is right for a name column

--- a/tests/test_oauth_registry.py
+++ b/tests/test_oauth_registry.py
@@ -165,3 +165,31 @@ def test_scope_label_falls_back_rather_than_raising():
     whole connection page over unfamiliar copy."""
     from treg import oauth_providers as P
     assert P.scope_label("some:unknown:scope") == "some:unknown:scope"
+
+
+# ---- consent-time disclosure -----------------------------------------------------------------
+# The Meta app all three Meta providers share is registered as "Crewlet", a sibling product, and
+# Facebook's consent screen shows only that bare app name. Without a notice on the treg side, the
+# popup asks the user to authorize a product they have never heard of.
+
+META_SERVICES = ["facebook", "instagram", "meta-ads"]
+
+
+def test_meta_providers_disclose_the_crewlet_app_name():
+    from treg import oauth_providers as P
+
+    rows = {row["service"]: row for row in P.listing()}
+    for service in META_SERVICES:
+        notice = rows[service]["consent_notice"]
+        assert "Crewlet" in notice, service
+        assert "Superdesign Dev Inc" in notice, service
+
+
+def test_only_the_meta_family_carries_a_consent_notice():
+    """Driven by provider data, so the check is "who shares the Meta app", not a hand-kept list."""
+    from treg import oauth_providers as P
+
+    meta_auth = {p.service for p in P.REGISTRY.values() if p.auth_uri == P._META_AUTH}
+    assert meta_auth == set(META_SERVICES)
+    with_notice = {row["service"] for row in P.listing() if row["consent_notice"]}
+    assert with_notice == meta_auth


### PR DESCRIPTION
## Why

treg's three Meta providers (`facebook`, `instagram`, `meta-ads`) share one Meta app that is registered and named **Crewlet** — a different product from the same company. The live Facebook consent screen renders only that bare app name, with no parent business. So a user on treg.superdesign.dev clicks **Connect** and gets a Facebook popup asking them to authorize an app they have never heard of.

That is the identity mismatch Meta Developer Policy 1.6 ("Build a Trustworthy Product") exists to catch, and disclosing it is a required mitigation ahead of the Pages/Instagram App Review resubmit.

Hierarchy for the record: **Superdesign Dev Inc** is the company, **Crewlet** is the marketing/ads product the Meta app is registered under, **treg** is the newer product. One Meta integration between them.

## Mechanism

A generic `OAuthProvider.consent_notice: str` field rather than a Meta special case in the view layer:

- `src/treg/oauth_providers.py` — new field, set on the three Meta providers from one shared `_META_CONSENT_NOTICE` constant, and exposed by `listing()` alongside every other provider field.
- `src/treg/web/index.html` — rendered as a `.mk-notice` panel, `v-if`'d on the field, in **both** places the consent popup can be triggered from:
  1. the integration page (`view==='provider'`), directly under the summary and beside the Connect button;
  2. the `capAsk` capability modal, which is the actual last gate for Meta (all three providers have 2 capabilities, so Connect always opens this modal first).

The dashboard names no services — adding a notice to another provider is a registry edit, not a UI edit. `.mk-notice` uses the panel surface rather than `.banner`, which is red and would read as an error rather than something to read before consenting.

## Exact copy

> You'll be taken to Facebook and see Crewlet, our Meta app by Superdesign Dev Inc. treg and Crewlet share one Meta integration.

## Verification

Ran the branch locally (`python -m treg` on :18795, fresh sqlite DB, dev OTP login, Meta client credentials stubbed so the providers report `configured`), driven with Playwright.

`GET /oauth/providers` — notice present on exactly the three Meta rows, empty on `google-ads` and `slack`.

Rendered DOM, `.mk-notice` element count and visibility per page:

| page | `.mk-notice` | visible |
|---|---|---|
| `/app/marketplace/facebook` | 1 | yes |
| `/app/marketplace/instagram` | 1 | yes |
| `/app/marketplace/meta-ads` | 1 | yes |
| `/app/marketplace/google-ads` | 0 | — |
| `/app/marketplace/slack` | 0 | — |
| Instagram `capAsk` modal | 1 | yes |

Also checked in dark theme (`data-theme="dark"`): the panel picks up the dark tokens correctly. No console errors on any page.

Screenshots are attached to the release below.

## Tests

`uv run pytest -q` → **1006 passed**, 1 pre-existing `DeprecationWarning` (aiosqlite datetime adapter, unrelated). No failures before or after.

Two new tests in `tests/test_oauth_registry.py`:
- `test_meta_providers_disclose_the_crewlet_app_name` — the notice names both Crewlet and Superdesign Dev Inc.
- `test_only_the_meta_family_carries_a_consent_notice` — derives the Meta set from `auth_uri == _META_AUTH` and asserts it equals the set of providers carrying a notice, so a fourth Meta provider added later fails the test until it is disclosed too.

## Fragments updated

- `docs/context/architecture/auth-secrets.md` — the `consent_notice` field on the registry.
- `docs/context/interface/dashboard.md` — where the marketplace renders it and why it is not `.banner`.

## Noted, not fixed (pre-existing, out of scope)

The `capAsk` modal's subhead is hard-coded to "Widening it later means going through **Google's** consent screen again" — wrong for Instagram, TikTok, LinkedIn and every other non-Google provider. Visible in the screenshot. Left alone to keep this change scoped.
