### PR TITLE
fix(billing): one payment can only credit once (UNIQUE on the top-up reference)

### DIFF
--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -7,6 +7,7 @@ per-user token becomes an owner Membership. It is a no-op on a fresh or already-
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 
@@ -277,6 +278,13 @@ def _migrate_to_orgs(conn) -> None:
             if col not in cols:
                 conn.execute(text(f"ALTER TABLE callrecord ADD COLUMN {col} {ddl}"))
 
+    # (A28) corrective: creditblock.stripe_payment_intent must be UNIQUE (the top-up idempotency
+    # key). It sits HERE, above the (B) block, because (B) returns early on a fresh/new-schema DB —
+    # and a fresh DB created between the ledger landing and this fix is precisely the one that has
+    # the table with only a plain index.
+    if "creditblock" in tables:
+        _ensure_payment_ref_unique(conn, insp)
+
     # (B) legacy backfill — guarded
     if "org" not in tables:
         return  # defensive: create_all should have made it
@@ -373,6 +381,36 @@ def _ensure_bool_col(conn, insp, tables, table: str, col: str) -> None:
     if table in tables and col not in {c["name"] for c in insp.get_columns(table)}:
         # DEFAULT false, not 0 — Postgres rejects an integer default on a BOOLEAN column (sqlite accepts both).
         conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {col} BOOLEAN NOT NULL DEFAULT false"))
+
+
+def _ensure_payment_ref_unique(conn, insp) -> None:
+    """`creditblock.stripe_payment_intent` must be UNIQUE — it is the idempotency key for a Stripe
+    top-up, and `ledger.topup` checks it with a SELECT before the INSERT. Without the constraint two
+    concurrent deliveries of one PaymentIntent both credit the org.
+
+    `create_all` gives a NEW database the unique index for free; this is for one created between the
+    ledger landing and this fix. If duplicate refs already exist the index cannot be built — say so
+    loudly and leave the data alone, because deciding which of two credits to void is a money
+    decision, not a migration's call.
+    """
+    idx = insp.get_indexes("creditblock")
+    if any(i.get("unique") and i.get("column_names") == ["stripe_payment_intent"] for i in idx):
+        return
+    dupes = conn.execute(text(
+        "SELECT stripe_payment_intent, COUNT(*) c FROM creditblock "
+        "WHERE stripe_payment_intent IS NOT NULL GROUP BY stripe_payment_intent HAVING COUNT(*) > 1"
+    )).fetchall()
+    if dupes:
+        logging.getLogger("treg.db").error(
+            "creditblock has %d payment reference(s) credited more than once (%s); the UNIQUE index "
+            "was NOT created. Resolve the duplicates by hand — voiding a credit is a money decision.",
+            len(dupes), ", ".join(str(d[0]) for d in dupes[:5]))
+        return
+    for name in ("ix_creditblock_stripe_payment_intent",):   # drop the plain index it replaces
+        if any(i.get("name") == name for i in idx):
+            conn.execute(text(f"DROP INDEX {name}"))
+    conn.execute(text("CREATE UNIQUE INDEX ix_creditblock_stripe_payment_intent "
+                      "ON creditblock (stripe_payment_intent)"))
 
 
 def _fix_tool_uniqueness(conn) -> None:

--- a/src/treg/ledger.py
+++ b/src/treg/ledger.py
@@ -46,6 +46,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -159,19 +160,36 @@ async def topup(
         raise ValueError("topup amount must be positive")
     if not payment_ref:
         raise ValueError("topup requires a payment reference (the idempotency key)")
-    existing = (await db.execute(
-        select(CreditBlock).where(CreditBlock.stripe_payment_intent == payment_ref)
-    )).scalars().first()
+    existing = await _block_for_payment(db, payment_ref)
     if existing is not None:
         return existing  # already credited — a redelivered webhook, not a second purchase
     block = CreditBlock(id=_id(), org_id=org_id, kind="purchased", amount_micro=int(amount_micro),
                         remaining_micro=int(amount_micro), stripe_payment_intent=payment_ref)
     db.add(block)
+    try:
+        # FLUSH before anything else moves. The check above is a SELECT and this is the INSERT, so a
+        # concurrent delivery of the same PaymentIntent can land between them; the UNIQUE index is
+        # what actually stops the second credit. Flushing here means the loser finds out BEFORE the
+        # balance is touched — and losing the race then gives the same answer as the sequential path
+        # instead of a 500 that makes Stripe retry forever.
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        winner = await _block_for_payment(db, payment_ref)
+        if winner is None:  # pragma: no cover — the constraint fired, so a row exists
+            raise
+        return winner
     await _add_balance(db, org_id, int(amount_micro))
     await _entry(db, org_id=org_id, kind="topup", amount_micro=int(amount_micro), block_id=block.id,
                  meta={"payment_ref": payment_ref, **(meta or {})})
     await db.commit()
     return block
+
+
+async def _block_for_payment(db: AsyncSession, payment_ref: str) -> CreditBlock | None:
+    return (await db.execute(
+        select(CreditBlock).where(CreditBlock.stripe_payment_intent == payment_ref)
+    )).scalars().first()
 
 
 # ---- the call path -----------------------------------------------------------------------------

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -434,8 +434,13 @@ class CreditBlock(SQLModel, table=True):
     currency: str = Field(default="USD")
     expires_at: datetime | None = Field(default=None)
     # The already-authorized payment this block was funded by (phase 4). Doubles as the idempotency
-    # key for ledger.topup — a redelivered webhook must not credit twice.
-    stripe_payment_intent: str | None = Field(default=None, index=True)
+    # key for ledger.topup — a redelivered webhook must not credit twice. **UNIQUE**, because the
+    # check in `topup` is a SELECT then an INSERT: two concurrent deliveries of the same PaymentIntent
+    # both find nothing and both credit. Stripe delivers at least once, retries after the 500 the
+    # handler deliberately returns, and prod can run more than one instance — so the database has to
+    # be the one that says no. NULL is exempt from a unique index, so promo blocks are unaffected.
+    stripe_payment_intent: str | None = Field(
+        default=None, index=True, sa_column_kwargs={"unique": True})
     created_at: datetime = Field(default_factory=_now)
 
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -93,6 +93,30 @@ async def test_topup_credits_purchased_and_is_idempotent_on_payment_ref(c: Async
     assert len(topups) == 1  # append-only journal, but only ONE entry for one payment
 
 
+async def test_two_deliveries_of_one_payment_credit_once(c: AsyncClient):
+    """The sequential test above passes even WITHOUT the unique index, because the second call sees
+    the first one's committed row. The dangerous case is two deliveries in flight at the same time —
+    Stripe delivers at least once, retries after the 500 the webhook deliberately returns, and prod
+    runs more than one instance. Both would SELECT nothing and both would credit.
+
+    Each task needs its OWN session: two coroutines sharing one AsyncSession is a different bug.
+    """
+    org_id, _ = await _org(c)
+    promo = get_settings().promo_grant_micro
+
+    async def _deliver():
+        async with session_maker() as db:
+            return await ledger.topup(db, org_id, 5_000_000, "pi_concurrent")
+
+    blocks = await asyncio.gather(_deliver(), _deliver(), _deliver(), return_exceptions=True)
+    assert not [b for b in blocks if isinstance(b, Exception)], blocks   # none may error out
+    assert len({b.id for b in blocks}) == 1                              # all three: the same block
+
+    assert await _assert_invariant(org_id) == promo + 5_000_000          # credited ONCE
+    async with session_maker() as db:
+        assert len([e for e in await ledger.entries_of(db, org_id) if e.kind == "topup"]) == 1
+
+
 @pytest.mark.parametrize("amount,ref", [(0, "pi_x"), (-1, "pi_x"), (1_000, "")])
 async def test_topup_rejects_nonsense(c: AsyncClient, amount, ref):
     org_id, _ = await _org(c)


### PR DESCRIPTION
Found while reviewing #38. Small change, real bug.

## The bug

`ledger.topup` deduplicates a redelivered Stripe webhook like this:

```python
existing = SELECT ... WHERE stripe_payment_intent = ref
if existing: return existing
INSERT ...
```

but the column was **indexed, not unique**. Two deliveries of the same PaymentIntent in flight
together both find nothing and both credit the org — one payment, two credits.

Not theoretical: Stripe delivers at least once, retries after the **500 the handler deliberately
returns**, and production can run more than one instance. The existing test calls `topup` twice in a
row, which passes either way because the second call sees the first one's committed row.

## The fix

1. **`stripe_payment_intent` is UNIQUE.** NULL is exempt, so promotional blocks are untouched. The
   database says no, because an application check between a SELECT and an INSERT cannot.
2. **`topup` flushes before the balance moves**, so the loser of the race rolls back and returns the
   winner's block — the same answer the sequential path gives. Written the other way first (catch at
   commit), the error surfaced *after* `_add_balance` and escaped as a 500 that would make Stripe
   retry forever. The new test caught that.
3. **Migration A28** for a database created between the ledger landing and this fix. Placed above the
   `(B)` legacy block, which returns early on a fresh/new-schema DB — precisely the database that
   needs it. If duplicates already exist it logs which references and leaves the data alone: voiding
   a credit is a money decision, not a migration's call.

## Verified

- New test: three concurrent deliveries, separate sessions → one block, one ledger entry, invariant
  intact. **It fails without the constraint** (checked by reverting just the model line).
- Migration exercised on three real SQLite databases: plain-index upgrade, already-unique (no-op),
  and duplicates present (must log and not crash startup).
- Full suite: **1141 passing**.

The rest of #38 reviewed well — integer micro-USD, the single-statement `reserve` gate, the lazy hold
reaper, margin recorded per entry, a separate webhook secret from the demo feed's, and `_billing_org`
correctly gating on admin+.