### PR TITLE
feat(landing): category-first hero — 'OpenRouter for agent tools'

### DIFF
--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -82,6 +82,8 @@ a{color:var(--teal);text-decoration:none}
 .kicker a{color:var(--teal)}
 .hero-h1{font-family:var(--display);font-weight:400;letter-spacing:0;margin:28px 0 0;
   font-size:clamp(30px,4.6vw,60px);line-height:1.16;position:relative;z-index:2}
+.hero-h1 .l2{font-size:.58em;display:inline-block;margin-top:.42em;color:var(--muted)}
+.hero-h1 .l2 .grad{color:var(--muted)}
 .grad{color:var(--ink)}
 .grad2{color:var(--teal)}
 p.sub{font-size:15px;line-height:1.65;color:var(--muted);max-width:620px;margin:22px auto 0}
@@ -485,10 +487,11 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
     <span class="kicker rv">2,617 endpoints · 42 providers · <a href="https://github.com/superdesigndev/tools-registry" target="_blank" rel="noopener">open source ↗</a></span>
 
     <h1 class="hero-h1 rv">
-      <span class="grad">Turn</span>
+      <span class="grad">OpenRouter for agent tools</span><br>
+      <span class="l2"><span class="grad">Turn</span>
       <span class="agentslot" id="agentslot"></span>
-      <span class="grad">into</span><br>
-      <span class="roleslot" id="roleslot"><span class="rw" id="rolewheel"></span></span><span class="h1cursor"></span>
+      <span class="grad">into</span>
+      <span class="roleslot" id="roleslot"><span class="rw" id="rolewheel"></span></span><span class="h1cursor"></span></span>
     </h1>
 
     <!-- the story for the active role: agent → treg → toolbelt -->


### PR DESCRIPTION
## What

Follow-up to #44, from team feedback on the merged landing:

> "I couldn't get instantly what treg does — the rotating text shows what agents can *become*, but not what treg *is*. I only understood after the diagram."

The hero now leads with the category and demotes the outcome to the example it was meant to be:

- **Line 1 (display size, ink):** `OpenRouter for agent tools`
- **Line 2 (0.58×, muted):** `Turn (agent icons) into` + the rotating role wheel (roles stay teal)

The agent → treg → toolbelt scene below becomes confirmation instead of the explanation.

## Notes

- One-file, 6-line diff (`src/treg/web/landing.html`), cherry-picked onto current main.
- Verified on the dev stack (`scripts/dev-local.sh`, :18790): page serves at `/`, wheel + scenes run, sign-in door works.
- Positioning note for review: this name-drops **OpenRouter** as an "X for Y" comparison. Common practice, but it's a positioning commitment — fallback copy if anyone objects: "The tool router for AI agents".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uosvuq1hnJBDuu2quJUUod