### PR TITLE
feat(dashboard): Getting started back to two self-contained tabs, agent instruction first

### DIFF
--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -174,9 +174,12 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   confirmation spelling out that an admin agent can register/delete tools and secrets and manage members.
 - **Tool form** — Add/Edit now carries a **Project** dropdown (default "team-wide"); `loadProjectsIfNeeded`
   fetches the list on demand so it works even if the Team page was never opened.
-- **Getting started** (`view==='start'`, under Help) — the CLI path: install (`{BASE}/install.sh`),
-  `treg login`, `treg onboard`, register-a-tool + no-key call, and links to the interactive tutorial +
-  `/llms.txt`. Per-block copy via `copyStart`.
+- **Getting started** (`view==='start'`, under Help) — two tabs (`startTab`, default `access`), each
+  leading with the agent instruction (`buildAgentPrompt('agent')`) then a manual CLI walkthrough:
+  **"Access 2000+ treg tools"** (install `{BASE}/install.sh` → `treg login` → catalog search/call/
+  `treg balance`) and **"Setup your team's skills & env vault"**, which stacks two sections — set up
+  the vault (install → login → `treg scan`/`treg upload`) then *let the team use it* (`treg skill ls`
+  / `skill install` / URL-passthrough call). Per-block copy via `copyStart`.
 - **Activity** — one time-sorted feed (`activityRows`) merging `GET /calls` (proxy calls) + `GET /runs`
   (CLI executions). Local runs now arrive via `/runs` (tagged `where`), so the calls feed **excludes**
   `local_run` rows to avoid double-counting, and each run row shows a **local/server** chip.

--- a/docs/context/interface/onboarding.md
+++ b/docs/context/interface/onboarding.md
@@ -138,5 +138,6 @@ teammate** (`onbInviteTeammate` prefills + invites Alex, then `/onboard/accept-t
 shifted left via `.drawer.onb-shift` so it doesn't overlap the panel). A step tracker shows
 numbered/checked progress; **↺ Restart** (`onbRestart`) and `onbFinish`/**✕** skip (posting
 `/onboard/skip`). Each step's **"Read more"** deep-links to the matching tutorial panel via
-`readMore(onbSection)` → `/tutorial#<concepts|skills|roles|auth>`. **Help → "Guided setup"** replays
-(`replayOnboard`); **"Remove demo"** calls `resetDemo`. A clay **`demo` chip** marks a demo org.
+`readMore(onbSection)` → `/tutorial#<concepts|skills|roles|auth>`. The stepper fires only on first run —
+the Help chooser's "Guided setup" replay card (and its `replayOnboard` method) was removed; **"Remove
+demo"** (`resetDemo`) remains in Help. A clay **`demo` chip** marks a demo org.

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2501,10 +2501,21 @@ a:hover{text-decoration-color:var(--muted)}
           <div style="display:flex;align-items:center;gap:14px;flex-wrap:wrap">
             <h1 style="margin:0">Getting started</h1>
           </div>
-          <!-- SHARED — everyone does these three, whichever half of treg they came for. They used to
-               be duplicated verbatim inside BOTH tabs (install + sign in, twice). -->
-          <div style="max-width:720px">
-            <div class="lbl" style="margin-top:20px">1 · Install the CLI</div>
+          <div class="seg" style="margin-top:8px">
+            <button :class="{on:startTab==='access'}" @click="startTab='access'">Access 2000+ treg tools</button>
+            <button :class="{on:startTab==='setup'}" @click="startTab='setup'">Setup your team's skills &amp; env vault</button>
+          </div>
+
+          <!-- TAB · Access the catalog — agent instruction first, then the manual CLI walkthrough -->
+          <div v-show="startTab==='access'" style="max-width:720px">
+            <p class="sub">~2,600 catalogued endpoints: SEO and backlinks, social and trends, people and company enrichment, ads. Find one by what it <i>does</i>, see its price, call it — no provider signup. Your team's <b>$1.00 free credit</b> covers hundreds of calls.</p>
+
+            <div class="lbl" style="margin-top:16px">▸ Set up with your agent <span class="muted" style="font-weight:400">— paste &amp; go</span></div>
+            <p class="sub">It installs the CLI, signs in as you, reads the treg skill, then finds the catalog tools that fit this project and shows you each price before spending anything.</p>
+            <div class="lc-codewrap" style="margin-top:8px"><button class="lc-cp" @click="copyAgentGuide('agent')">{{agentRowCopied==='agent'?'✓ copied':'copy'}}</button><pre style="max-height:240px;overflow:auto">{{buildAgentPrompt('agent', true)}}</pre></div>
+
+            <div class="lbl" style="margin-top:26px">▸ Or set it up manually</div>
+            <div class="lbl" style="margin-top:14px">1 · Install the CLI</div>
             <p class="sub">Installs the <span class="mono">treg</span> command and points it at this server. Upgrade later with <span class="mono">treg update</span>.</p>
             <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('curl -fsSL '+proxy+'/install.sh | sh','i')">{{startCopied==='i'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">curl</span> -fsSL <span class="hl-str">{{proxy}}/install.sh</span> | sh</pre></div>
 
@@ -2513,49 +2524,43 @@ a:hover{text-decoration-color:var(--muted)}
             <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('treg login','l')">{{startCopied==='l'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">treg</span> login</pre></div>
 
             <div class="lbl" style="margin-top:22px">3 · Call something — no key, nothing to set up</div>
-            <p class="sub">~2,600 catalogued endpoints: SEO and backlinks, social and trends, people and company enrichment, ads. Find one by what it <i>does</i>, see its price, call it. Your team's <b>$1.00 free credit</b> covers hundreds of calls.</p>
+            <p class="sub">Search the catalog by what you need done, check the price, call it, and see exactly what it cost.</p>
             <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('treg catalog search &quot;backlinks for a domain&quot;\ntreg call tikhub.tiktok.user.profile --query uniqueId=tiktok\ntreg balance','cat1')">{{startCopied==='cat1'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">treg</span> catalog search <span class="hl-str">"backlinks for a domain"</span>
 <span class="hl-cmd">treg</span> call tikhub.tiktok.user.profile <span class="hl-flag">--query</span> uniqueId=tiktok
 <span class="hl-cmd">treg</span> balance      <span class="hl-comment"># see exactly what it cost</span></pre></div>
           </div>
 
-          <div style="max-width:720px">
-            <div class="lbl" style="margin-top:26px">▸ Or hand the whole thing to your agent <span class="muted" style="font-weight:400">— one paste, it does 1-3 and keeps going</span></div>
-            <p class="sub">It installs the CLI, signs in as you, reads the treg skill, then finds the catalog tools that fit this project and shows you each price before spending anything.</p>
-            <div class="lc-codewrap" style="margin-top:8px"><button class="lc-cp" @click="copyAgentGuide('agent')">{{agentRowCopied==='agent'?'✓ copied':'copy'}}</button><pre style="max-height:240px;overflow:auto">{{buildAgentPrompt('agent', true)}}</pre></div>
-          </div>
-
-          <h2 style="margin:34px 0 0;font-size:16px">Then — what did you come here for?</h2>
-          <div class="seg" style="margin-top:10px">
-            <button :class="{on:startTab==='connect'}" @click="startTab='connect'">Use my team's tools</button>
-            <button :class="{on:startTab==='setup'}" @click="startTab='setup'">Share my own keys &amp; skills</button>
-          </div>
-
-          <!-- FORK · Share your own — agent instruction first, then the manual CLI walkthrough -->
-          <div v-show="startTab==='setup'">
-          <div v-if="canAdmin" style="max-width:720px">
+          <!-- TAB · Setup the team vault — two sections: set it up, then let the team use it -->
+          <div v-show="startTab==='setup'" style="max-width:720px">
             <p class="sub">Share your skills &amp; API keys with the team — your <span class="mono">.env</span> keys and skill folders become tools every teammate's agent can call, without the key ever leaving the server.</p>
-          </div>
-          <p class="sub">Two ways to give your agents power: share a whole <b>skill</b>, or register a single <b>API endpoint</b>. Everything here works in this dashboard too - this is the CLI path. Grab it as markdown ↑ to paste anywhere.</p>
-          <div style="max-width:720px">
-            <div class="lbl" style="margin-top:20px">4 · Upload your keys &amp; skills</div>
-            <p class="sub">Register your <span class="mono">.env</span> keys and skill folders as shared tools. Preview with <span class="mono">treg scan</span> first. Idempotent — re-run freely.</p>
+
+            <div class="lbl" style="margin-top:16px">▸ Set up with your agent <span class="muted" style="font-weight:400">— paste &amp; go</span></div>
+            <p class="sub">Paste into Claude Code / Codex / Gemini. It installs the CLI, signs in, and registers your local skills + keys as shared tools (with a read-only scan you approve first).</p>
+            <div class="lc-codewrap" style="margin-top:8px"><button class="lc-cp" @click="copyAgentGuide('agent')">{{agentRowCopied==='agent'?'✓ copied':'copy'}}</button><pre style="max-height:240px;overflow:auto">{{buildAgentPrompt('agent', true)}}</pre></div>
+
+            <div class="lbl" style="margin-top:26px">▸ Or set it up manually</div>
+            <div class="lbl" style="margin-top:14px">1 · Install the CLI</div>
+            <p class="sub">Installs the <span class="mono">treg</span> command and points it at this server. Upgrade later with <span class="mono">treg update</span>.</p>
+            <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('curl -fsSL '+proxy+'/install.sh | sh','si')">{{startCopied==='si'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">curl</span> -fsSL <span class="hl-str">{{proxy}}/install.sh</span> | sh</pre></div>
+
+            <div class="lbl" style="margin-top:22px">2 · Sign in</div>
+            <p class="sub">Opens your browser — GitHub, Google, or an email code. Your first sign-in also registers you.</p>
+            <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('treg login','sl')">{{startCopied==='sl'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">treg</span> login</pre></div>
+
+            <div class="lbl" style="margin-top:22px">3 · Upload your keys &amp; skills</div>
+            <p class="sub">Two ways to give your agents power: share a whole <b>skill</b>, or register a single <b>API endpoint</b>. Preview with <span class="mono">treg scan</span> first. Idempotent — re-run freely.</p>
             <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('treg upload                 # both .env + skills in this dir\ntreg upload env --select openai,stripe\ntreg upload skills --dir ~/.claude/skills --all      # register skill from a specific path','im')">{{startCopied==='im'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">treg</span> upload                 <span class="hl-comment"># both .env + skills in this dir</span>
 <span class="hl-cmd">treg</span> upload env <span class="hl-flag">--select</span> openai,stripe
 <span class="hl-cmd">treg</span> upload skills <span class="hl-flag">--dir</span> <span class="hl-str">~/.claude/skills</span> <span class="hl-flag">--all</span>      <span class="hl-comment"># register skill from a specific path</span></pre></div>
-          </div>
-          </div><!-- /manual tab -->
 
-          <!-- TAB · Connect to this tool registry — agent instruction first, then the same CLI flow (path 2) -->
-          <div v-show="startTab==='connect'" style="max-width:720px">
-            <p class="sub">Your team's own tools: pull a shared skill and call any registered API, with no keys on your machine. These are never metered — your team already pays for them.</p>
+            <div class="lbl" style="margin-top:30px">▸ Then — let the team use it</div>
+            <p class="sub">Your team's own tools: a teammate pulls a shared skill and calls any registered API, with no keys on their machine. These are never metered — your team already pays for them.</p>
 
             <div class="lbl" style="margin-top:14px">4 · Use the team's shared tools</div>
             <p class="sub">Browse the shared library, pull a skill, and call a tool — the credential stays on the server, never on your machine.</p>
             <div class="lc-codewrap"><button class="lc-cp" @click="copyStart('treg skill ls\ntreg skill install seo-blog-writer                    # a teammate pulls one (or --all)\ntreg call https://api.stripe.com/v1/charges','cc')">{{startCopied==='cc'?'✓ copied':'copy'}}</button><pre><span class="hl-cmd">treg</span> skill ls
 <span class="hl-cmd">treg</span> skill install seo-blog-writer
 <span class="hl-cmd">treg</span> call <span class="hl-str">https://api.stripe.com/v1/charges</span></pre></div>
-
           </div>
         </template>
 
@@ -2563,11 +2568,8 @@ a:hover{text-decoration-color:var(--muted)}
         <template v-if="view==='help'">
           <!-- chooser -->
           <template v-if="!helpMode">
-            <h1>Tutorial</h1><p class="sub">Five ways to learn treg - pick one.</p>
+            <h1>Tutorial</h1><p class="sub">Four ways to learn treg - pick one.</p>
             <div class="grid" style="max-width:680px">
-              <div class="card" @click="replayOnboard" style="cursor:pointer">
-                <h3>✨ Guided setup</h3><p class="muted" style="font-family:var(--sans);margin:7px 0 0">Seed a demo team - teammates, a working tool, live activity - and walk it in 3 beats. Learn by doing.</p>
-              </div>
               <div class="card" @click="helpMode='cli'" style="cursor:pointer">
                 <h3>▤ CLI tutorial</h3><p class="muted" style="font-family:var(--sans);margin:7px 0 0">The whole registry from your terminal - copy each command and follow along. {{tutSteps.length}} steps.</p>
               </div>
@@ -3295,7 +3297,7 @@ createApp({
       exPath:'<PATH>', exMethod:'GET',
       tryTool:null, tryMethod:'GET', tryPath:'', tryBody:'', trying:false, tryResp:null, tryStatus:0, tryMs:0,
       useMode:'call', runArgsStr:'', running:false, runOut:null,
-      startCopied:'', startTab:'connect', mdMenu:false, llmsCopied:false, myToken:null, tokenCopied:false,
+      startCopied:'', startTab:'access', mdMenu:false, llmsCopied:false, myToken:null, tokenCopied:false,
       agentGuide:null, agentGuideCopied:false, agentInclToken:true, agentRowCopied:null,
       demo:{
         token:null, org_slug:'', ttl:60, busy:false, err:'', copied:'', signin:false,
@@ -4440,7 +4442,6 @@ createApp({
     onbTryEcho(){ const t=(this.tools||[]).find(x=>x.name==='echo'); if(t){ this.go('tools'); this.openTry(t); } },
     async onbFinish(){ this.onb.on=false; this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){} },
     onbRestart(){ this.onb.invited=false; this.onb.tool=false; this.onb.err=''; this.go('tools'); this.onbGoto(0); },
-    replayOnboard(){ this.helpMode=null; this.onb.teamName='Acme Design'; this.onb.on=true; this.onbRestart(); },
     async resetDemo(){ try{ await this.api('/onboard/reset',{method:'POST'}); this.onboarded=true; await this.loadAll(); this.orgMsg='Demo teammates removed.'; }
       catch(e){ this.err='Reset failed: '+(e.detail||e.status); } },
     readMore(section){ try{ window.open('/tutorial'+(section?('#'+section):''),'_blank'); }catch(e){} },


### PR DESCRIPTION
## What

Rebuilds the dashboard's **Getting started** view (`/app#start`) in the original tabbed shape, per Jason's direction:

- **Tabs move back to the top**; the "Then — what did you come here for?" fork heading is removed.
- **Tab 1 — "Access 2000+ treg tools"** (default): the paste-to-your-agent instruction leads, then the manual path — install → sign in → catalog search / call / `treg balance`.
- **Tab 2 — "Setup your team's skills & env vault"**: two sections in sequence — *set up the vault* (agent instruction, install → sign in → `treg scan`/`treg upload`) then *"▸ Then — let the team use it"*, which absorbs the old "Connect to this tool registry" content (`skill ls` / `skill install` / URL-passthrough call).
- **Tutorial chooser drops the "Guided setup" replay card** ("Four ways to learn treg") and its now-dead `replayOnboard` method. The mandatory first-run onboarding stepper is untouched — only the replay entry point goes.

## Docs (same commit, per repo convention)

- `docs/context/interface/dashboard.md` — the Getting-started bullet was already stale (still said `treg onboard`); rewritten for the tab layout.
- `docs/context/interface/onboarding.md` — records that the Help replay card is gone; `resetDemo` stays.

## Verified

Rendered in Chrome against the live local server: both tabs switch correctly, default tab is Access, the Tutorial grid shows four cards, console clean. (The "choose an org" banner visible during testing is the pre-existing machine-token `/orgs` limitation, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxXESp86gzHu5M2yNrkvQf