### PR TITLE
Capability choice: the agent picks, treg publishes the facts — plus 5 bugs from a debugging pass

### DIFF
--- a/docs/CAPABILITY-CHOICE-PLAN.md
+++ b/docs/CAPABILITY-CHOICE-PLAN.md
@@ -1,0 +1,127 @@
+# Capability choice — the agent decides, treg makes the decision factual
+
+**Status:** planned (2026-08). Supersedes the "treg routes for you" reading of landing pillar 2.
+
+## The promise, and what it actually needs
+
+The landing says: *"Your agent asks for the task, not the tool… treg knows the ladder for each
+scenario and routes every call to the best one that's up"* — with *failover built in*, *compared
+live*, *pin a vendor any time*.
+
+Read one way, that means **treg** picks the vendor and silently switches on failure. We measured what
+that would cost:
+
+| | |
+|---|---|
+| capabilities served by 2+ distinct providers treg holds keys for | **171** |
+| ...where the request shape is already identical across providers | **5** |
+| price spread within one capability | up to **261×** (`companies.enrich`: $0.0015 → $0.39) |
+
+So 166 of 171 would need a **translation layer** — a canonical input schema per capability, plus a
+per-endpoint mapping — before treg could re-send a call elsewhere. `capabilities.yaml` is a taxonomy
+(`id: description`), so none of that data exists.
+
+And translation is not the real problem. **These endpoints ask different questions:**
+
+| Endpoint | Needs |
+|---|---|
+| `hunter.people.email.find` | `domain` + `first_name`/`last_name` (GET, query) |
+| `leadmagic.people.email.find` | `first_name`, `company_name`, … (POST, body) |
+| `leadmagic.x.b2b-profile-email` | a **`profile_url`** — different information entirely |
+
+A router choosing on price would pick the third for a caller holding a name and a domain, and fail.
+
+## The decision: the agent chooses; treg publishes the facts
+
+The agent knows **which inputs it actually has** — treg cannot. It also needs no translation layer,
+because it reads the chosen endpoint's own parameters from the catalog and builds that request. So
+the hard part disappears by giving the job to the party that already has the context.
+
+This also keeps the founding rule intact: treg **relays, never models**. A router would have been the
+first feature to break it.
+
+What treg owes in exchange is the part **only treg can do**: it sees every call, from every tenant,
+so it can say which endpoints actually work, how fast, and what they really charge. That is what
+turns "compared live" from copy into fact.
+
+## Three pieces
+
+### 1. Publish observed reality per endpoint
+
+**The cold start is the hard part, and money is not what solves it.** On day one `CallRecord` is
+empty for these endpoints, so every cell would read `—`. Three sources fill it, and they must stay
+visually distinct — the value of a measurement is destroyed by averaging it with a claim:
+
+| Source | Covers | Cost | What it honestly says |
+|---|---|---|---|
+| the catalog's own `verified:` stamp | **1,380 of 1,810** eligible endpoints (76%), all stamped within the last month | **free, today** | "we ran it by hand and it answered, N days ago" |
+| a vendor status page | ~40 providers (3/3 of the ones we pay have one; ScrapeCreators publishes it **per endpoint**) | free, one-off research | "the vendor says it is up right now" |
+| our own `CallRecord` | grows with real use | see below | **"here is what actually happened"** |
+
+Only the third is measurement. So the `LAST OK` column prints a bare age when a real call produced
+it and a **`✓` age** when it came from the stamp — one glance separates evidence from a dated claim.
+
+**The seeding sweep is bounded by ACCOUNTS, not by dollars.** `scripts/catalog_verify.py` already
+sends each endpoint's `test_request` and checks the status; it just discards the timing. But it can
+only call providers we hold a key for, and production holds **three**:
+
+| | endpoints callable | 5 calls each | capabilities we could actually COMPARE |
+|---|---|---|---|
+| keys we have today (tikhub, dataforseo, scrapecreators) | 351 | **$7.50** | **68 of 157** |
+| if all 16 key slots were filled | 526 | $26.90 | 157 of 157 |
+
+$7.50 is nothing; the constraint is that comparing nine email-lookup providers needs a paid account
+with nine of them. And a comparison needs two sides: for the 89 capabilities where we hold exactly
+one provider's key, a sweep produces one number beside two dashes — an advert for the only vendor we
+pay, not a choice. **Which providers treg buys accounts with is therefore a business decision, and it
+is the same list that decides what treg can serve keylessly at all.**
+
+`CallRecord` **already records** everything needed and has since the marketplace shipped:
+`endpoint_id`, `status_code`, `duration_ms`, `response_bytes`, `cost_observed_micro`,
+`cost_estimated_micro`, `params_hash`, `created_at`. Nothing new to collect — only to aggregate.
+
+Per endpoint, over a rolling window: **success rate**, **p50/p95 latency**, **observed-vs-estimated
+cost drift**, **last time it answered**, and **sample size**. Sample size is not decoration: a 100%
+success rate over two calls must not outrank 97% over four hundred, and a reader has to be able to
+see that.
+
+Surfaced where the choice is already made — `treg catalog get <id>` lists a capability's alternatives
+today, so the numbers belong on those rows — and over the API for agents.
+
+Follows `reconcile.py`'s precedent: query-time, read-only, admin-scale windows, aggregation in Python
+where the provenance lives in a JSON column.
+
+### 2. Teach the decision procedure
+
+In `skill.md` and `/llms.txt`, as an ordered rule an agent can follow:
+
+1. **Match the inputs you have.** An endpoint wanting a `profile_url` is not a substitute when you
+   hold a name and a domain, whatever it costs.
+2. Then prefer **verified** over unverified, then **success rate** (with sample size in view), then
+   **price**.
+3. On **429 / 5xx / timeout**, try the next provider — you know its parameters, so you can build its
+   request.
+4. **Never retry a 4xx you caused.** Fixing the parameter is the fix; retrying elsewhere burns money
+   on N providers for one mistake.
+5. **Tell the human the price before spending** the team's balance.
+
+### 3. Bound it with team policy
+
+An org can **pin** a provider for a capability, or **deny** one, so an agent's freedom stops where
+the team's decision starts. Pinning is also what makes the choice deterministic for CI. Reuses the
+existing deny-rule machinery rather than inventing a second policy engine.
+
+## Deliberately later
+
+**Automatic selection (`--auto`)** for callers that are not agents — a `curl`, a CI job, a human.
+Once (3) exists, a pin already does this for the common case. Cross-provider *translation* stays out
+of scope until a capability's canonical schema is worth writing by hand, and even then only for the
+handful with the widest price spreads.
+
+## Copy this changes
+
+The landing's *"✓ your agent never picked a vendor — treg routed it"* becomes false under this
+design. The truthful line is closer to *"your agent picked from live data — price, success rate,
+latency — instead of guessing."* Until (1) and (2) ship, the wording already in `llms.txt`,
+`skill.md` and the charter stands: **treg compares, choosing is the caller's, there is no automatic
+failover.**

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -17,7 +17,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
-| [catalog](architecture/catalog.md) | ? | — |
+| [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog_store.py, endpoint_stats.py |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, ratestore.py |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -682,6 +682,12 @@ Four rules worth keeping:
 Team policy sits on top: `CapabilityPin` (see [data-model](data-model.md)) lets an org fix a
 capability to one provider, enforced in `_resolve_marketplace_call` before anything is reserved.
 
+Its boundary, verified rather than assumed: a pin gates the **catalog id**, which is the only route
+to treg's own key — so it cannot be side-stepped to spend our money (a URL-passthrough call resolves
+against the org's OWN tools and 404s without one). A team holding its own key for another provider
+can still call that provider by URL; that is their credential and their bill, and `DenyRule` —
+host-scoped, applied to every shape of call — is the tool for blocking it.
+
 ## Security
 
 PII IS THE HARD RULE. This repo is public, and every captured example ships in it. Three checks

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1,3 +1,15 @@
+---
+title: Endpoint catalog — what you can DO with a connected key, and which provider should do it
+status: shipped
+sources:
+  - src/treg/catalog_store.py
+  - src/treg/endpoint_stats.py
+related:
+  - architecture/money.md
+  - architecture/proxy-model.md
+  - interface/cli.md
+---
+
 # Endpoint catalog — platform-grouped operations per provider
 
 ## Why
@@ -632,6 +644,43 @@ the core file's paths are relative to it (`/serp/google/organic/live/regular`). 
 **the ingester's core-wins dedup silently misses**, because it compares `(method, path)` across the
 two spellings — every DataForSEO route curated in core is also present in the extended file under
 a different id. Fixing that belongs in `catalog_ingest.py` and needs a regeneration.
+
+## Choosing between providers (`endpoint_stats.py`)
+
+307 capabilities are served by more than one provider, and prices inside one capability differ by up
+to **261×**. So "which provider" is a real decision, made on every call.
+
+**The agent makes it, not treg** — see `docs/CAPABILITY-CHOICE-PLAN.md` for the measurement behind
+that. Two reasons, and the second is the load-bearing one. Providers of the same capability take
+*different requests* (only 5 of 171 match exactly), so a router would need a canonical schema treg
+does not have; and they sometimes ask a different QUESTION entirely — `hunter.people.email.find`
+wants a domain and a name, `leadmagic.x.b2b-profile-email` wants a LinkedIn URL. **Only the caller
+knows which inputs it holds.** A router picking on price would choose the second for someone holding
+a name, and fail. Routing would also have been the first feature to break the founding rule that treg
+relays rather than models.
+
+What treg owes instead is the half only treg can supply, because only treg sees every call from every
+tenant: `endpoint_stats.observed()` aggregates **success rate, p50/p95 latency, last-answered and
+sample size** per endpoint from `CallRecord` — which has recorded `endpoint_id`, `status_code` and
+`duration_ms` since the marketplace shipped and was never read. It rides on
+`/catalog/endpoints/{id}`, attached to the endpoint **and every sibling**, because the choice is made
+on that page and an agent will not make a second round-trip to compare reliability.
+
+Four rules worth keeping:
+
+- **A 4xx never counts against the provider.** It usually means the caller sent bad parameters;
+  counting it would let one agent's mistake make a healthy endpoint look broken to everyone. Only
+  2xx versus 5xx decides the rate.
+- **Below `MIN_SAMPLES` we publish the count and nothing else.** "100% from two calls" is noise
+  dressed as evidence, and on a quiet endpoint a rate could expose one org's activity.
+- **Sample size is always visible**, so `100% (8)` cannot beat `99% (121)` by looking rounder.
+- **A claim never wears a measurement's badge.** The `LAST OK` column prints a bare age when a real
+  call produced it and a **`✓` age** when it came from the catalog's `verified:` stamp — the same
+  discipline `confidence:` already applies to price. The stamp is the cold-start answer: it covers
+  1,380 of 1,810 eligible endpoints for free, which is why the column is useful on day one.
+
+Team policy sits on top: `CapabilityPin` (see [data-model](data-model.md)) lets an org fix a
+capability to one provider, enforced in `_resolve_marketplace_call` before anything is reserved.
 
 ## Security
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -147,3 +147,15 @@ no `TREG_SECRET_KEY` on a real DB (an ephemeral key would lose every stored secr
 
 > **Tenant isolation shipped:** resources are scoped by `org_id` and a token = a `(user, org)` membership.
 > See [multi-tenancy](multi-tenancy.md). `owner` (creator email) is retained for audit + the role gate.
+
+## `CapabilityPin` — "for this job, our team uses this provider"
+
+One row per `(org, capability)`. Deliberately **not** a `DenyRule`: a deny is negative and closed, so
+blocking eight of nine providers leaves the ninth allowed the day a tenth joins the catalog. A pin is
+positive and stays correct as the catalog grows.
+
+It is a gate, not a hint — a catalog call to a different provider of a pinned capability is refused
+in `_resolve_marketplace_call`, before anything is reserved, and the 403 carries `use_endpoint` so
+the caller is told what to use instead rather than just "no". Both halves are validated against the
+catalog when the pin is set, because a typo would otherwise block a job the team really uses and
+surface at 3am in an agent's log. See [catalog](catalog.md) and `docs/CAPABILITY-CHOICE-PLAN.md`.

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -109,6 +109,10 @@ Bare **`treg connections`** now lists (the subparser is `required=False` with a 
     today's usage; **`org agent-rm <user_id>`** revokes. Nested under `org` on purpose — the top-level
     **`treg agents`** already means "which coding agents can I install skills for", an unrelated concept
     (`agents.py`). See [multi-tenancy](../architecture/multi-tenancy.md).
+  - **`org pin <capability> --provider <p>`** / **`org pins`** / **`org unpin <capability>`** —
+    the team's provider choice per job, enforced server-side (a gate, not a hint). `catalog get`
+    shows the pin and lists only that provider's endpoints, so an agent does not learn the policy by
+    being refused. See [catalog](../architecture/catalog.md).
   - **`org deny`** (`--host`, `--path`, `--method`, `--user`, `--project <slug|id>`, `--note`) blocks
     calls for the whole team, one member/agent, and/or one project's tools;
     **`org deny-ls`** / **`org deny-rm <id>`**. An empty field means *any*, so

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3687,16 +3687,33 @@ async def set_capability_pin(
         raise HTTPException(status_code=422, detail=(
             f"{body.provider!r} does not serve {body.capability!r} — "
             f"these do: {', '.join(providers)}"))
+    # Read the caller's email NOW, as a plain string. A rollback below expires every ORM instance
+    # behind `caller`, and touching one afterwards lazy-loads outside the async context —
+    # MissingGreenlet, which is how this first failed under concurrency.
+    who = caller.email
     row = (await db.execute(select(CapabilityPin).where(
         CapabilityPin.org_id == org_id,
-        CapabilityPin.capability == body.capability))).scalar_one_or_none()
+        CapabilityPin.capability == body.capability))).scalars().first()
     if row is None:
         row = CapabilityPin(org_id=org_id, capability=body.capability, provider=body.provider,
-                            created_by=caller.email)
+                            created_by=who)
         db.add(row)
     else:
-        row.provider, row.created_by = body.provider, caller.email
-    await db.commit()
+        row.provider, row.created_by = body.provider, who
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Lost the race to another admin (or another web worker). The UNIQUE index is what actually
+        # prevents the duplicate; this makes losing look like the sequential path — re-apply onto
+        # the winner's row rather than handing back a 500 for a pin that plainly succeeded.
+        await db.rollback()
+        row = (await db.execute(select(CapabilityPin).where(
+            CapabilityPin.org_id == org_id,
+            CapabilityPin.capability == body.capability))).scalars().first()
+        if row is None:
+            raise
+        row.provider, row.created_by = body.provider, who
+        await db.commit()
     return {"capability": body.capability, "provider": body.provider,
             "alternatives": [p for p in providers if p != body.provider]}
 
@@ -3715,11 +3732,12 @@ async def clear_capability_pin(
     did destroy an org in testing. Server-side validation cannot defend against it, because the
     rewrite happens in the client; taking the value out of the path removes the class entirely."""
     _require_admin_of(org_id, caller)
-    row = (await db.execute(select(CapabilityPin).where(
-        CapabilityPin.org_id == org_id, CapabilityPin.capability == capability))).scalar_one_or_none()
-    if row is None:
+    rows = (await db.execute(select(CapabilityPin).where(
+        CapabilityPin.org_id == org_id, CapabilityPin.capability == capability))).scalars().all()
+    if not rows:
         raise HTTPException(status_code=404, detail=f"no pin for {capability!r}")
-    await db.delete(row)
+    for row in rows:      # all of them, in case a duplicate predates the unique index
+        await db.delete(row)
     await db.commit()
     return {"capability": capability, "pinned": False}
 
@@ -6099,7 +6117,8 @@ async def _enforce_capability_pin(ep: dict, caller: Caller, db: AsyncSession) ->
     if not cap or caller.org_id is None:
         return
     pin = (await db.execute(select(CapabilityPin).where(
-        CapabilityPin.org_id == caller.org_id, CapabilityPin.capability == cap))).scalar_one_or_none()
+        CapabilityPin.org_id == caller.org_id,
+        CapabilityPin.capability == cap).order_by(CapabilityPin.id))).scalars().first()
     if pin is None or pin.provider == ep["provider"]:
         return
     cat = catalog_store.load()

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -46,7 +46,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from . import audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, health, injectors, ledger, localrun, oauth
+from . import audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
 from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings, platform_setting_name
@@ -416,7 +416,7 @@ async def catalog_search(q: str = "", limit: int = 25) -> dict:
 
 
 @app.get("/catalog/endpoints/{endpoint_id}", include_in_schema=False)
-async def catalog_endpoint(endpoint_id: str) -> dict:
+async def catalog_endpoint(endpoint_id: str, db: AsyncSession = Depends(get_session)) -> dict:
     """Open: everything about ONE endpoint — the INSPECT half of the loop.
 
     Deliberately one round-trip: params, cost, the sibling providers offering the same capability
@@ -441,6 +441,18 @@ async def catalog_endpoint(endpoint_id: str) -> dict:
             example = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
             example = None
+    # What the calls we have already served say about this endpoint and its alternatives — the half
+    # of "compare providers" that only treg can answer (see endpoint_stats + CAPABILITY-CHOICE-PLAN).
+    # Attached to the SAME response because the choice is made here; a second round-trip to compare
+    # reliability is a round-trip an agent will skip.
+    try:
+        stats = await endpoint_stats.observed(db, [endpoint_id] + [s["id"] for s in siblings])
+    except Exception:  # noqa: BLE001 — telemetry must never take the catalog down
+        logging.getLogger("treg.catalog").warning("endpoint stats unavailable", exc_info=True)
+        stats = {}
+    view = view | {"observed": stats.get(endpoint_id)}
+    siblings = [s | {"observed": stats.get(s["id"])} for s in siblings]
+
     return {
         "endpoint": view,
         "provider": {"service": ep["provider"], "display_name": _provider_display(ep["provider"]),

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -995,8 +995,10 @@ async def auth_me(
     """Who is the caller? Drives the dashboard's identity display in BOTH session mode (cookie) and
     token mode (X-Treg-Token) — the token door otherwise had no way to learn its own email, which
     broke `isPersonal` and join-by-code."""
+    membership = None
     if x_treg_token:
         m = await _membership_by_token(x_treg_token, db)
+        membership = m
         user = await db.get(User, m.user_id) if m else await _user_from_identity_token(x_treg_token, db)
         if user is not None and user.suspended:
             user = None
@@ -1004,8 +1006,17 @@ async def auth_me(
         user = await _user_from_session(treg_session, db)
     if user is None:
         raise HTTPException(status_code=401, detail="no session")
-    return {"email": user.email, "is_superadmin": user.is_superadmin, "onboarded": user.onboarded,
-            "github": bool(get_settings().github_client_id)}
+    out = {"email": user.email, "is_superadmin": user.is_superadmin, "onboarded": user.onboarded,
+           "github": bool(get_settings().github_client_id)}
+    if membership is not None:
+        # The org this token IS. A machine identity cannot call GET /orgs — `require_identity`
+        # refuses it on purpose, since `create_org` hangs off that dependency and an agent could
+        # otherwise mint an org it owns. But it still has to learn its OWN org id to reach any
+        # /orgs/{id}/... route, and being unable to told `treg balance` there was "no active org".
+        org = await db.get(Org, membership.org_id)
+        out |= {"org_id": membership.org_id, "org": org.slug if org else None,
+                "role": membership.role}
+    return out
 
 
 @app.post("/auth/logout")
@@ -2814,11 +2825,18 @@ async def org_balance(
     org_id: int, limit: int = 20, offset: int = 0,
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
 ) -> dict:
-    """The org's prepaid balance (admin/owner — same gate as /usage, since spend is billing data):
-    the materialized balance, the credit blocks it is made of, any in-flight holds, and a page of the
-    append-only ledger. Amounts are integer micro-USD (`*_micro`) with a display-only USD twin —
-    never compute against the USD field (see ledger.py on why money is integers here)."""
-    _require_admin_of(org_id, caller)
+    """The org's prepaid balance. Amounts are integer micro-USD (`*_micro`) with a display-only USD
+    twin — never compute against the USD field (see ledger.py on why money is integers here).
+
+    **Two audiences, one route.** Any MEMBER sees the figure and the in-flight holds: they are the
+    ones spending it, every agent is told to run `treg balance` after a call, and a 402 already hands
+    them `balance_micro` anyway — refusing the same number here while shipping it in an error was
+    incoherent. The FUNDING DETAIL is admin+: the credit blocks (what was bought, when, what is left
+    of each) and the ledger, which together are the org's purchase history, not its wallet.
+    """
+    if caller.org_id != org_id:
+        raise HTTPException(status_code=403, detail="not a member of this org")
+    detailed = _role_at_least(caller.role, "admin")
     limit = max(1, min(limit, 200))
     offset = max(0, offset)
     balance = await ledger.balance_of(db, org_id)
@@ -2834,7 +2852,8 @@ async def org_balance(
         "balance_micro": balance,
         "balance_usd": ledger.usd(balance),
         "promo_grant_micro": get_settings().promo_grant_micro,
-        "blocks": [
+        # admin+ only — see the docstring: the wallet is everyone's, the purchase history is not
+        "blocks": [] if not detailed else [
             {"id": b.id, "kind": b.kind, "amount_micro": b.amount_micro,
              "remaining_micro": b.remaining_micro, "remaining_usd": ledger.usd(b.remaining_micro),
              "currency": b.currency, "expires_at": b.expires_at.isoformat() if b.expires_at else None,
@@ -2848,7 +2867,7 @@ async def org_balance(
         ],
         "entries": {
             "limit": limit, "offset": offset,
-            "items": [
+            "items": [] if not detailed else [
                 {"id": e.id, "kind": e.kind, "amount_micro": e.amount_micro,
                  "amount_usd": ledger.usd(e.amount_micro), "block_id": e.block_id,
                  "call_id": e.call_id, "endpoint_id": e.endpoint_id, "meta": e.meta,

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -51,7 +51,7 @@ from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
-from .models import ROLE_RANK, Bundle, CallRecord, DenyRule, Invite, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User
+from .models import ROLE_RANK, Bundle, CallRecord, CapabilityPin, DenyRule, Invite, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User
 from .proxy import relay
 
 
@@ -3618,6 +3618,75 @@ def _deny_view(r: DenyRule) -> dict:
             "created_at": r.created_at}
 
 
+class CapabilityPinIn(BaseModel):
+    capability: str
+    provider: str
+
+
+@app.get("/orgs/{org_id}/pins")
+async def list_capability_pins(
+    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> list[dict]:
+    """The team's provider choices, per capability. Readable by any member — an agent has to know
+    what it is allowed to call, and finding out by being refused is a wasted round-trip."""
+    if caller.org_id != org_id:      # the token IS the membership (same rule as every org route)
+        raise HTTPException(status_code=403, detail="not a member of this org")
+    rows = (await db.execute(select(CapabilityPin).where(CapabilityPin.org_id == org_id)
+                             .order_by(CapabilityPin.capability))).scalars().all()
+    return [{"id": r.id, "capability": r.capability, "provider": r.provider,
+             "created_by": r.created_by, "created_at": r.created_at} for r in rows]
+
+
+@app.post("/orgs/{org_id}/pins")
+async def set_capability_pin(
+    org_id: int, body: CapabilityPinIn,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Pin a capability to one provider for the whole team (admin+). Re-pinning replaces.
+
+    Both halves are validated against the catalog: an unknown capability, or a provider that does
+    not actually serve it, would be a rule that silently blocks every call to a job the team
+    genuinely uses — a typo must fail here, loudly, not at 3am in an agent's log."""
+    _require_admin_of(org_id, caller)
+    cat = catalog_store.load()
+    serving = cat.for_capability(body.capability)
+    if not serving:
+        raise HTTPException(status_code=422, detail=f"unknown capability {body.capability!r}")
+    providers = sorted({e["provider"] for e in serving})
+    if body.provider not in providers:
+        raise HTTPException(status_code=422, detail=(
+            f"{body.provider!r} does not serve {body.capability!r} — "
+            f"these do: {', '.join(providers)}"))
+    row = (await db.execute(select(CapabilityPin).where(
+        CapabilityPin.org_id == org_id,
+        CapabilityPin.capability == body.capability))).scalar_one_or_none()
+    if row is None:
+        row = CapabilityPin(org_id=org_id, capability=body.capability, provider=body.provider,
+                            created_by=caller.email)
+        db.add(row)
+    else:
+        row.provider, row.created_by = body.provider, caller.email
+    await db.commit()
+    return {"capability": body.capability, "provider": body.provider,
+            "alternatives": [p for p in providers if p != body.provider]}
+
+
+@app.delete("/orgs/{org_id}/pins/{capability}")
+async def clear_capability_pin(
+    org_id: int, capability: str,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Remove a pin (admin+) — the capability goes back to the caller's choice."""
+    _require_admin_of(org_id, caller)
+    row = (await db.execute(select(CapabilityPin).where(
+        CapabilityPin.org_id == org_id, CapabilityPin.capability == capability))).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"no pin for {capability!r}")
+    await db.delete(row)
+    await db.commit()
+    return {"capability": capability, "pinned": False}
+
+
 @app.post("/orgs/{org_id}/deny")
 async def create_deny_rule(
     org_id: int, body: DenyRuleIn,
@@ -5980,6 +6049,39 @@ def _marketplace_upstream(ep: dict, provider, query_params) -> tuple[str, set[st
     return provider.base_url.rstrip("/") + "/" + path.lstrip("/"), consumed
 
 
+async def _enforce_capability_pin(ep: dict, caller: Caller, db: AsyncSession) -> None:
+    """Refuse a catalog call that goes around the team's pin for that capability.
+
+    A pin is a decision the team already made ("for finding work emails we use Hunter"), so the
+    answer names the endpoint they DO use — an agent that gets told "no" without being told "use
+    this instead" will simply try the next provider and be refused again.
+
+    Enforced here rather than in the client so it does not depend on the caller's goodwill, and
+    before anything is reserved, so a refusal never has to un-hold money."""
+    cap = ep.get("capability")
+    if not cap or caller.org_id is None:
+        return
+    pin = (await db.execute(select(CapabilityPin).where(
+        CapabilityPin.org_id == caller.org_id, CapabilityPin.capability == cap))).scalar_one_or_none()
+    if pin is None or pin.provider == ep["provider"]:
+        return
+    cat = catalog_store.load()
+    # Suggest the OBVIOUS endpoint, not merely the first one in file order: `core` is the curated
+    # route for a job, `extended` is the bulk-ingested long tail. Suggesting
+    # `tikhub.x.tiktok-analytics-fetch-creator-info-and-milestones` when `tikhub.tiktok.user.profile`
+    # exists reads as a broken suggestion and sends the caller somewhere they did not ask to go.
+    mine = [e for e in cat.for_capability(cap) if e["provider"] == pin.provider]
+    mine.sort(key=lambda e: ((e.get("tier") or "") != "core", not cat.platform_eligible(e), e["id"]))
+    alt = mine[0]["id"] if mine else None
+    raise HTTPException(status_code=403, detail={
+        "error": "capability_pinned",
+        "message": (f"this team uses {pin.provider!r} for {cap!r}"
+                    + (f" — call {alt} instead" if alt else "")
+                    + f". An admin can change it: treg org unpin {cap}"),
+        "capability": cap, "pinned_provider": pin.provider, "use_endpoint": alt,
+    })
+
+
 async def _resolve_marketplace_call(
     ep: dict, request: Request, caller: Caller, db: AsyncSession
 ) -> MarketplaceCall:
@@ -5993,6 +6095,7 @@ async def _resolve_marketplace_call(
 
     NOTHING is reserved here. Resolution only PRICES the call; `call_tool` reserves after the deny
     rules and caps have had their say, so a refused call never has to un-hold money."""
+    await _enforce_capability_pin(ep, caller, db)
     service = ep["provider"]
     provider = oauth_providers.get(service)
     if provider is None or not provider.base_url:

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -36,7 +36,7 @@ INVITE_TTL_DAYS = 7  # invite codes are one-time AND expire after this many days
 import httpx
 from pathlib import Path
 
-from fastapi import Cookie, Depends, FastAPI, Header, HTTPException, Request
+from fastapi import Cookie, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -3153,12 +3153,23 @@ async def leave_org(
 
 @app.delete("/orgs/{org_id}")
 async def delete_org(
-    org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+    org_id: int, confirm: str = Query(..., min_length=1),
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
 ) -> dict:
+    """Delete a team and everything in it (owner only). `?confirm=<slug>` must match.
+
+    The confirmation is REQUIRED by the API, not just collected by the clients that already ask for
+    it. This route is irreversible and sits one path segment above every other org route, so any
+    client that normalizes `..` turns `DELETE /orgs/{id}/<anything>/..` into this call — that is how
+    `treg org unpin ..` deleted a team during testing. A request arriving without the slug it is
+    about to destroy is not a request anyone meant to send."""
     _require_owner_of(org_id, caller)
     org = await db.get(Org, org_id)
     if org is None:
         raise HTTPException(status_code=404, detail="org not found")
+    if confirm != org.slug:
+        raise HTTPException(status_code=422, detail=(
+            f"to delete this team, confirm with its slug: ?confirm={org.slug}"))
     await _cascade_delete_org(org, db)
     await db.commit()
     return {"deleted_org": org_id}
@@ -3690,12 +3701,19 @@ async def set_capability_pin(
             "alternatives": [p for p in providers if p != body.provider]}
 
 
-@app.delete("/orgs/{org_id}/pins/{capability}")
+@app.delete("/orgs/{org_id}/pins")
 async def clear_capability_pin(
-    org_id: int, capability: str,
+    org_id: int, capability: str = Query(..., min_length=1, max_length=200),
     caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Remove a pin (admin+) — the capability goes back to the caller's choice."""
+    """Remove a pin (admin+) — the capability goes back to the caller's choice.
+
+    The capability is a QUERY parameter, not a path segment, and that is a safety decision rather
+    than a style one. As `/orgs/{id}/pins/{capability}` it was one keystroke from a catastrophe:
+    every normalizing HTTP client (httpx included) rewrites `/orgs/1/pins/..` to `/orgs/1` BEFORE
+    sending it — which is DELETE /orgs/{id}, the delete-the-team route. `treg org unpin ..` really
+    did destroy an org in testing. Server-side validation cannot defend against it, because the
+    rewrite happens in the client; taking the value out of the path removes the class entirely."""
     _require_admin_of(org_id, caller)
     row = (await db.execute(select(CapabilityPin).where(
         CapabilityPin.org_id == org_id, CapabilityPin.capability == capability))).scalar_one_or_none()

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -887,7 +887,10 @@ def _run_setup(cfg: dict, args) -> None:
         _dim('You\'re not in a team yet. Create one:  treg org create "Your Team"')
         return
     _kv("team", org.get("name") or org.get("slug"))
-    print("  You pick what to share; values are read internally, never on the command line.")
+    print("  This is the OTHER half of treg: turning keys and skills you already have into tools")
+    print("  your teammates' agents can call. Nothing is uploaded until you pick it from a preview,")
+    print("  and values are read internally — never on the command line.")
+    _dim("  (Only want to USE treg? Ctrl-C and run `treg onboard` — the catalog needs none of this.)")
     from . import skills as sk
     cwd = Path(os.getcwd())
 
@@ -1112,35 +1115,23 @@ def _onboard_test_call(cfg: dict, tools: list) -> None:
         _dim(f"  (call failed: {exc})")
 
 
-def _demo_scan_preview(cfg: dict) -> None:
-    """Read-only: show what treg WOULD detect to share (API keys + skills). A DEMO — nothing is uploaded."""
-    from . import providers as prov, skills as sk
-    cwd = Path(os.getcwd())
-    env_path = cwd / ".env"
-    keys: list[str] = []
-    skill_names: set[str] = set()
-    with _spinner("scanning this folder for keys & skills"):
-        if env_path.is_file():
-            try:
-                keys = [a.tool_name for a in prov.plan_actions(prov.scan_env(str(env_path), _load_catalog(cfg))) if a.supported]
-            except Exception:  # noqa: BLE001
-                pass
-        for cand in [cwd, cwd / ".claude" / "skills", cwd / ".agents" / "skills"]:
-            try:
-                if cand.is_dir():
-                    for det in sk.scan_skills(str(cand)):
-                        skill_names.add(det.name)
-            except Exception:  # noqa: BLE001
-                pass
-    if keys:
-        print(f"  {_M}API keys in your .env treg could share:{_R} {', '.join(keys[:8])}"
-              + (f" +{len(keys)-8} more" if len(keys) > 8 else ""))
-    if skill_names:
-        print(f"  {_M}skills in this project:{_R} {len(skill_names)}")
-    if not keys and not skill_names:
-        _dim("  (no .env or skills here — in a real project treg detects your keys + skill folders)")
-    print()
-    _dim("  This is just a DEMO — nothing is uploaded. The 'Upload' path is where you actually share.")
+def _demo_catalog_peek(cfg: dict) -> None:
+    """Read-only: what the catalog can already do for this team, with nothing registered and no key.
+    Costs nothing — a search is free; only a call spends the balance."""
+    print("  ~2,600 endpoints across ~40 providers. Ask for the JOB, not the vendor:")
+    _cmd('treg catalog search "backlinks for a domain"')
+    try:
+        with _client(cfg) as c:
+            r = c.get("/catalog/search", params={"q": "backlinks for a domain", "limit": 3})
+        rows = (r.json() or {}).get("results") or [] if r.status_code == 200 else []
+    except Exception:  # noqa: BLE001 — a walkthrough must survive an unreachable registry
+        rows = []
+    for e in rows:
+        cost = _cost_usd(e.get("cost")) or "—"
+        print(f"    {_A}{_clip(e.get('id', ''), 44):<44}{_R} {_M}{cost}{_R}")
+    if not rows:
+        _dim("    (the registry didn't answer — the catalog is still there, try `treg catalog`)")
+    _arrow("treg holds the key; you pay fractions of a cent per call, from $1.00 of free credit.")
 
 
 def _demo_teammate_call(cfg: dict) -> str | None:
@@ -1203,8 +1194,11 @@ def _run_demo(cfg: dict, args) -> None:
     yes = getattr(args, "yes", False)
     _brand("demo — the whole loop (a walkthrough; nothing is changed)")
 
-    _section("① Auto-discover local skills & env")
-    _demo_scan_preview(cfg)
+    # Was: a read-only scan of the user's folder. Jason found it confusing, and rightly — a demo that
+    # opens by reading your disk shows you your OWN files before it has shown you anything treg does.
+    # The catalog is the shorter answer to "what is this?": it needs nothing of yours at all.
+    _section("① Call a tool you don't have a key for")
+    _demo_catalog_peek(cfg)
     _pause(yes)
 
     _section("② Share credentials & skills with your team")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3891,6 +3891,55 @@ def _native_amount(value, currency: str, meter: str = "") -> str:
 
 
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _pad(text: str, width: int) -> str:
+    """Left-justify by VISIBLE width. `f"{s:<7}"` counts ANSI escape bytes as characters, so any
+    coloured cell silently shifts every column to its right."""
+    pad = width - len(_ANSI_RE.sub("", text))
+    return text + " " * max(0, pad)
+
+
+def _observed_cell(obs: dict | None) -> str:
+    """The success rate, or an honest blank. `—` means nobody has called it enough to say (the
+    server refuses to publish a rate below its sample floor); a rate with a tiny sample is worse
+    than no rate, because it reads as evidence."""
+    if not obs or obs.get("ok_rate") is None:
+        n = (obs or {}).get("samples") or 0
+        return f"{_M}— ({n}){_R}" if n else f"{_M}—{_R}"
+    pct = obs["ok_rate"] * 100
+    colour = _G if pct >= 99 else (_AM if pct >= 90 else _A)
+    return f"{colour}{pct:.0f}%{_R} {_M}({obs['samples']}){_R}"
+
+
+def _speed_cell(obs: dict | None) -> str:
+    ms = (obs or {}).get("p50_ms")
+    return f"{_M}—{_R}" if ms is None else (f"{ms}ms" if ms < 1000 else f"{ms/1000:.1f}s")
+
+
+def _last_ok_cell(row: dict) -> str:
+    """When this endpoint last answered. Two different facts, never merged into one badge:
+
+    a plain age is MEASURED — the last time a real call through treg came back 2xx. A `✓` age is
+    the catalog's `verified:` stamp: somebody ran it by hand on that date and it worked. The stamp
+    is the honest fallback while an endpoint has no traffic yet (76% of eligible endpoints carry
+    one), but it is a dated claim, not live evidence, so it must not read as though it were.
+    """
+    days = (row.get("observed") or {}).get("last_ok_days")
+    if days is not None:
+        return "today" if days == 0 else f"{days}d"
+    v = row.get("verified")
+    if not v:
+        return f"{_M}—{_R}"
+    try:
+        from datetime import date
+        d = v if isinstance(v, date) else date.fromisoformat(str(v)[:10])
+        return f"{_M}✓{(date.today() - d).days}d{_R}"
+    except (ValueError, TypeError):
+        return f"{_M}✓{_R}"
+
+
 def _connected_providers(cfg) -> set:
     """Provider services this org holds a working credential for — best-effort, silent on failure.
 
@@ -4082,11 +4131,20 @@ def _catalog_get(endpoint_id: str, cfg) -> None:
     sibs = body.get("siblings") or []
     if sibs:
         connected = _connected_providers(cfg)
-        print(f"  {'PROVIDER':<12} {'ENDPOINT':<46} {'COST':<16} ●")
-        for s in sibs:
-            print(f"  {_clip(s['provider'], 12):<12} {_clip(s['id'], 46):<46} {_clip(_cost_usd(s.get('cost')), 16):<16} "
+        # This endpoint sits in the table too: comparing alternatives against each other while the
+        # one you asked about is somewhere above is how you pick the wrong row.
+        rows = [dict(e, id=e["id"], provider=e["provider"], observed=e.get("observed"), _me=True)] + \
+               [dict(x, _me=False) for x in sibs]
+        print(f"  {'PROVIDER':<12} {'ENDPOINT':<38} {'COST':<15} {'WORKS':<11} {'SPEED':<7} {'LAST OK':<8} ●")
+        for s in rows:
+            mark = f"{_A}▸{_R}" if s.get("_me") else " "
+            print(f" {mark}{_clip(s['provider'], 12):<12} {_clip(s['id'], 38):<38} "
+                  f"{_clip(_cost_usd(s.get('cost')), 15):<15} {_pad(_observed_cell(s.get('observed')), 11)} "
+                  f"{_pad(_speed_cell(s.get('observed')), 7)} {_pad(_last_ok_cell(s), 8)} "
                   f"{'●' if s['provider'] in connected else ' '}")
-        _dim("  the same job from another provider — compare price and verification before you call")
+        _dim("  the same job from another provider. WORKS/SPEED are what treg has actually observed;")
+        _dim("  a ✓ age is the catalog's own verification stamp, not live traffic. Pick the one whose")
+        _dim("  inputs match what you HAVE, then weigh reliability against price.")
     elif e.get("capability"):
         _dim("  the only provider offering this capability")
 

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3717,6 +3717,50 @@ def cmd_org_project_rm(args, cfg) -> None:
         _show(c.delete(f"/orgs/{org_id}/projects/{args.project_id}"))
 
 
+def cmd_org_pin(args, cfg) -> None:
+    """Pin a capability to one provider for the whole team (admin+)."""
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        r = c.post(f"/orgs/{org_id}/pins",
+                   json={"capability": args.capability, "provider": args.provider})
+        if r.status_code >= 400:
+            _show(r)
+            return
+        out = r.json()
+        _ok(f"{out['capability']} → {_B}{out['provider']}{_R}")
+        if out.get("alternatives"):
+            _dim(f"  calls to {', '.join(out['alternatives'])} for this job are now refused")
+
+
+def cmd_org_pins(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        r = c.get(f"/orgs/{org_id}/pins")
+    if _JSON_OVERRIDE or r.status_code >= 400:
+        _show(r)
+        return
+    rows = r.json()
+    if not rows:
+        _dim("  no pins — every member picks the provider for each job "
+             "(treg catalog get <id> compares them)")
+        return
+    print(f"\n  {'CAPABILITY':<34} {'PROVIDER':<16} SET BY")
+    for x in rows:
+        print(f"  {_clip(x['capability'], 34):<34} {_clip(x['provider'], 16):<16} {_M}{x['created_by']}{_R}")
+
+
+def cmd_org_unpin(args, cfg) -> None:
+    with _client(cfg) as c:
+        org_id = _active_org_id(cfg, c)
+        if org_id is None:
+            sys.exit("no active org")
+        _show(c.delete(f"/orgs/{org_id}/pins/{args.capability}"))
+
+
 def cmd_org_deny(args, cfg) -> None:
     with _client(cfg) as c:
         org_id = _active_org_id(cfg, c)
@@ -3899,6 +3943,24 @@ def _pad(text: str, width: int) -> str:
     coloured cell silently shifts every column to its right."""
     pad = width - len(_ANSI_RE.sub("", text))
     return text + " " * max(0, pad)
+
+
+def _pinned_provider(cfg: dict, capability: str | None) -> str | None:
+    """The provider this team pinned for `capability`, or None. Best-effort: a registry that is old,
+    unreachable or does not know about pins must not stop `catalog get` from rendering."""
+    if not capability:
+        return None
+    try:
+        with _client(cfg) as c:
+            org_id = _active_org_id(cfg, c)
+            if org_id is None:
+                return None
+            r = c.get(f"/orgs/{org_id}/pins")
+            if r.status_code >= 400:
+                return None
+            return next((x["provider"] for x in r.json() if x["capability"] == capability), None)
+    except Exception:  # noqa: BLE001 — a comparison table is not worth a traceback
+        return None
 
 
 def _observed_cell(obs: dict | None) -> str:
@@ -4131,6 +4193,7 @@ def _catalog_get(endpoint_id: str, cfg) -> None:
     sibs = body.get("siblings") or []
     if sibs:
         connected = _connected_providers(cfg)
+        pinned = _pinned_provider(cfg, e.get("capability"))
         # This endpoint sits in the table too: comparing alternatives against each other while the
         # one you asked about is somewhere above is how you pick the wrong row.
         rows = [dict(e, id=e["id"], provider=e["provider"], observed=e.get("observed"), _me=True)] + \
@@ -4138,13 +4201,20 @@ def _catalog_get(endpoint_id: str, cfg) -> None:
         print(f"  {'PROVIDER':<12} {'ENDPOINT':<38} {'COST':<15} {'WORKS':<11} {'SPEED':<7} {'LAST OK':<8} ●")
         for s in rows:
             mark = f"{_A}▸{_R}" if s.get("_me") else " "
+            if pinned and s["provider"] != pinned:
+                continue          # the team pinned this job elsewhere; these are not callable
             print(f" {mark}{_clip(s['provider'], 12):<12} {_clip(s['id'], 38):<38} "
                   f"{_clip(_cost_usd(s.get('cost')), 15):<15} {_pad(_observed_cell(s.get('observed')), 11)} "
                   f"{_pad(_speed_cell(s.get('observed')), 7)} {_pad(_last_ok_cell(s), 8)} "
                   f"{'●' if s['provider'] in connected else ' '}")
-        _dim("  the same job from another provider. WORKS/SPEED are what treg has actually observed;")
-        _dim("  a ✓ age is the catalog's own verification stamp, not live traffic. Pick the one whose")
-        _dim("  inputs match what you HAVE, then weigh reliability against price.")
+        if pinned:
+            _dim(f"  your team pins this job to {_B}{pinned}{_R}{_M} — other providers are refused, so")
+            _dim(f"  only theirs are listed (admin: treg org unpin {e.get('capability')}).")
+        else:
+            _dim("  the same job from another provider.")
+        _dim("  WORKS/SPEED are what treg has actually observed; a ✓ age is the catalog's own")
+        _dim("  verification stamp, not live traffic. Pick the one whose inputs match what you")
+        _dim("  HAVE, then weigh reliability against price.")
     elif e.get("capability"):
         _dim("  the only provider offering this capability")
 
@@ -4533,6 +4603,17 @@ def build_parser() -> argparse.ArgumentParser:
               "treg org project-rm 2")
     oprm.add_argument("project_id", type=int, help="the project id (from `org projects`)")
     oprm.set_defaults(fn=cmd_org_project_rm)
+    opin = mk(og, "pin", "For this JOB, our team uses this provider — the rest are refused (admin+).",
+              "treg org pin people.email.find --provider hunter",
+              "treg org pins", "treg org unpin people.email.find")
+    opin.add_argument("capability", help="a capability id, e.g. people.email.find (see `treg catalog get`)")
+    opin.add_argument("--provider", required=True, help="the provider service id, e.g. hunter")
+    opin.set_defaults(fn=cmd_org_pin)
+    mk(og, "pins", "The team's pinned provider per capability.", "treg org pins").set_defaults(fn=cmd_org_pins)
+    oup = mk(og, "unpin", "Remove a pin — the job goes back to the caller's choice (admin+).",
+             "treg org unpin people.email.find")
+    oup.add_argument("capability", help="the capability to unpin")
+    oup.set_defaults(fn=cmd_org_unpin)
     od2 = mk(og, "deny", "Block calls to a host / path / method — for the team, or one member (admin+).",
              "treg org deny --method DELETE --note 'no deletes'",
              "treg org deny --host api.stripe.com", "treg org deny --path /admin --user 7")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -173,7 +173,7 @@ def _admin_client(cfg: dict) -> httpx.Client:
     return httpx.Client(base_url=cfg["base_url"], headers={"X-Treg-Token": token, "ngrok-skip-browser-warning": "1"}, timeout=30.0)
 
 
-def _active_org_id(cfg: dict, c: httpx.Client) -> int | None:
+def _active_org_id(cfg: dict, c: httpx.Client, *, strict: bool = True) -> int | None:
     """The active org's numeric id (for /orgs/{id}/... endpoints), resolved via GET /orgs.
 
     A MACHINE identity (an agent token) cannot call `/orgs` — the server refuses it there on purpose
@@ -185,6 +185,17 @@ def _active_org_id(cfg: dict, c: httpx.Client) -> int | None:
         me = c.get("/auth/me")
         if me.status_code == 200 and me.json().get("org_id"):
             return int(me.json()["org_id"])
+        # An invalid or expired token used to fall through to the caller's bare "no active org",
+        # which sends the reader to fix org config when the real problem is authentication. 21
+        # commands printed that message, so the honest answer belongs here, once.
+        # `strict=False` for callers that only ENRICH output (the pin marker on `catalog get`):
+        # the catalog is public, so a signed-out reader must still get the page. sys.exit raises
+        # SystemExit, which `except Exception` does not catch — a try/except around the call site
+        # would NOT have saved it.
+        if strict and 401 in (r.status_code, me.status_code):
+            sys.exit("treg: not signed in, or this token is invalid/expired.\n"
+                     "  Sign in:            treg login\n"
+                     "  Using TREG_TOKEN?   check it is the token `org agent-new` printed.")
         return None
     orgs = r.json()
     target = _effective_org(cfg)
@@ -3726,7 +3737,7 @@ def cmd_org_pin(args, cfg) -> None:
         if org_id is None:
             sys.exit("no active org")
         r = c.post(f"/orgs/{org_id}/pins",
-                   json={"capability": args.capability, "provider": args.provider})
+                   json={"capability": _valid_capability(args.capability), "provider": args.provider})
         if r.status_code >= 400:
             _show(r)
             return
@@ -3755,12 +3766,28 @@ def cmd_org_pins(args, cfg) -> None:
         print(f"  {_clip(x['capability'], 34):<34} {_clip(x['provider'], 16):<16} {_M}{x['created_by']}{_R}")
 
 
+_CAPABILITY_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,199}$")
+
+
+def _valid_capability(value: str) -> str:
+    """A capability id, or exit. Not cosmetic validation: a value like `..` used to be interpolated
+    into the URL path, and every normalizing HTTP client rewrites `/orgs/1/pins/..` to `/orgs/1` —
+    the DELETE-the-team route — before the request is sent. The value now travels as a query
+    parameter, and this refuses anything URL-shaped as well, so neither layer alone has to hold."""
+    v = (value or "").strip()
+    if not _CAPABILITY_RE.match(v):
+        sys.exit(f"treg: {value!r} is not a capability id (lowercase letters, digits, dots, dashes)."
+                 f"\n  See one with:  treg catalog get <endpoint-id>")
+    return v
+
+
 def cmd_org_unpin(args, cfg) -> None:
+    cap = _valid_capability(args.capability)
     with _client(cfg) as c:
         org_id = _active_org_id(cfg, c)
         if org_id is None:
             sys.exit("no active org")
-        _show(c.delete(f"/orgs/{org_id}/pins/{args.capability}"))
+        _show(c.delete(f"/orgs/{org_id}/pins", params={"capability": cap}))
 
 
 def cmd_org_deny(args, cfg) -> None:
@@ -3836,7 +3863,7 @@ def cmd_org_delete(args, cfg) -> None:
         org_id = _active_org_id(cfg, c)
         if org_id is None:
             sys.exit("no active org")
-        r = c.delete(f"/orgs/{org_id}")
+        r = c.delete(f"/orgs/{org_id}", params={"confirm": args.slug})
     if r.status_code == 200:
         _clear_active_if_targeted(cfg)
     _show(r)
@@ -3954,7 +3981,7 @@ def _pinned_provider(cfg: dict, capability: str | None) -> str | None:
         return None
     try:
         with _client(cfg) as c:
-            org_id = _active_org_id(cfg, c)
+            org_id = _active_org_id(cfg, c, strict=False)
             if org_id is None:
                 return None
             r = c.get(f"/orgs/{org_id}/pins")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -174,9 +174,17 @@ def _admin_client(cfg: dict) -> httpx.Client:
 
 
 def _active_org_id(cfg: dict, c: httpx.Client) -> int | None:
-    """The active org's numeric id (for /orgs/{id}/... endpoints), resolved via GET /orgs."""
+    """The active org's numeric id (for /orgs/{id}/... endpoints), resolved via GET /orgs.
+
+    A MACHINE identity (an agent token) cannot call `/orgs` — the server refuses it there on purpose
+    — but its token IS one membership, so `/auth/me` tells it the one org id it could ever mean.
+    Without this fallback every /orgs/{id}/… command (balance, topup, pins, deny) died with a bare
+    "no active org" for exactly the callers those commands exist to serve."""
     r = c.get("/orgs")
     if r.status_code != 200:
+        me = c.get("/auth/me")
+        if me.status_code == 200 and me.json().get("org_id"):
+            return int(me.json()["org_id"])
         return None
     orgs = r.json()
     target = _effective_org(cfg)

--- a/src/treg/endpoint_stats.py
+++ b/src/treg/endpoint_stats.py
@@ -1,0 +1,118 @@
+"""What the calls we have already served say about each catalog endpoint.
+
+The catalog's own numbers are *claims*: a price read off a rate card, a `verified:` stamp from the
+day someone ran it. This module answers the other question — **does it still work, how fast, and
+does it charge what it said?** — from `CallRecord`, which has recorded `endpoint_id`, `status_code`,
+`duration_ms` and `cost_observed_micro` since the marketplace shipped. Nothing new is collected here;
+it was always being written and never read.
+
+This is the half of "compare providers" that only treg can do. Anyone can read a rate card; only the
+party that sees every call, across every tenant, can say which of nine email-lookup providers
+answered 400 times without failing. It is what makes an agent's choice factual instead of a guess —
+see `docs/CAPABILITY-CHOICE-PLAN.md`.
+
+**Aggregate only, and never below a floor.** Rows are pooled across every org, so the output must
+carry nothing that could identify a caller: counts, rates and percentiles only — never who, never
+when-exactly, never a params_hash. And an endpoint with fewer than `MIN_SAMPLES` calls reports
+`samples` and nothing else: with two calls behind it, a "100% success" number is noise dressed as
+evidence, and on a quiet endpoint it could also be one org's activity made visible.
+
+Read-only and query-time, like `reconcile.py` — no scheduler, no cache to invalidate, no second copy
+of the truth. Percentiles are computed in Python because `percentile_cont` is not portable to SQLite
+(the same tradeoff `reconcile.py` documents for its JSON provenance).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import case, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from .models import CallRecord
+
+WINDOW_DAYS = 30
+MIN_SAMPLES = 5          # below this we publish the count and nothing else (see module docstring)
+_MAX_ROWS = 20_000       # bound the latency fetch; percentiles do not get truer past this
+
+
+def _now() -> datetime:
+    # Naive UTC — CallRecord.created_at is TIMESTAMP WITHOUT TIME ZONE (models._now).
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _pct(sorted_values: list[int], q: float) -> int | None:
+    """Nearest-rank percentile. Deliberately not interpolated: these are milliseconds off a wire,
+    and a reader comparing providers gains nothing from a fractional millisecond."""
+    if not sorted_values:
+        return None
+    i = max(0, min(len(sorted_values) - 1, int(round(q * (len(sorted_values) - 1)))))
+    return int(sorted_values[i])
+
+
+async def observed(
+    db: AsyncSession, endpoint_ids: list[str], *, days: int = WINDOW_DAYS,
+) -> dict[str, dict]:
+    """Per endpoint id: `{samples, ok_rate, p50_ms, p95_ms, last_ok_days}`.
+
+    Cost drift (what we estimated vs what the provider charged) is deliberately NOT here — it is
+    already `reconcile.price_drift`, computed over the same rows for a different audience. Two
+    implementations of one number is how they start disagreeing.
+
+    `endpoint_ids` is expected to be small — one endpoint and its capability siblings — so this is
+    two bounded queries, not a scan of the audit table.
+
+    A 4xx counts as a **failure of the call**, not of the endpoint: it usually means the caller sent
+    the wrong parameters. It is excluded from `ok_rate` entirely rather than counted against the
+    provider, because otherwise one agent's bad query would make a healthy endpoint look broken to
+    everybody. Only 2xx (success) and 5xx/timeouts (the provider's fault) decide the rate.
+    """
+    ids = [e for e in dict.fromkeys(endpoint_ids) if e]
+    if not ids:
+        return {}
+    since = _now() - timedelta(days=days)
+
+    rows = (await db.execute(
+        select(
+            CallRecord.endpoint_id,
+            func.count().label("n"),
+            func.sum(case((CallRecord.status_code < 300, 1), else_=0)).label("ok"),
+            func.sum(case((CallRecord.status_code >= 500, 1), else_=0)).label("bad"),
+            func.max(CallRecord.created_at).label("last"),
+        )
+        .where(CallRecord.endpoint_id.in_(ids), CallRecord.created_at >= since)
+        .group_by(CallRecord.endpoint_id)
+    )).all()
+
+    lat = (await db.execute(
+        select(CallRecord.endpoint_id, CallRecord.duration_ms)
+        .where(CallRecord.endpoint_id.in_(ids), CallRecord.created_at >= since,
+               CallRecord.duration_ms.is_not(None), CallRecord.status_code < 300)
+        .limit(_MAX_ROWS)
+    )).all()
+    by_id: dict[str, list[int]] = {}
+    for ep_id, ms in lat:
+        by_id.setdefault(ep_id, []).append(int(ms))
+
+    out: dict[str, dict] = {}
+    for ep_id, n, ok, bad, last in rows:
+        n, ok, bad = int(n or 0), int(ok or 0), int(bad or 0)
+        if n < MIN_SAMPLES:
+            # Honest emptiness: say how thin the evidence is, claim nothing from it.
+            out[ep_id] = {"samples": n, "ok_rate": None, "p50_ms": None, "p95_ms": None,
+                          "last_ok_days": None}
+            continue
+        decided = ok + bad          # 4xx excluded — the caller's fault, not the provider's
+        ms = sorted(by_id.get(ep_id, []))
+        out[ep_id] = {
+            "samples": n,
+            "ok_rate": round(ok / decided, 4) if decided else None,
+            "p50_ms": _pct(ms, 0.50),
+            "p95_ms": _pct(ms, 0.95),
+            "last_ok_days": (_now() - last).days if last else None,
+        }
+    for ep_id in ids:                # an endpoint nobody has called says so, rather than vanishing
+        out.setdefault(ep_id, {"samples": 0, "ok_rate": None, "p50_ms": None, "p95_ms": None,
+                               "last_ok_days": None})
+    return out

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -379,6 +379,31 @@ class Tool(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_now)
 
 
+class CapabilityPin(SQLModel, table=True):
+    """"For THIS job, our team uses THIS provider." One row per (org, capability).
+
+    Not expressible as a DenyRule. A deny is negative and closed — blocking the other eight providers
+    of a capability leaves the ninth allowed by accident the day a tenth is added to the catalog. A
+    pin is positive and stays correct as the catalog grows.
+
+    It is a real gate, not a hint: a catalog call to a DIFFERENT provider of a pinned capability is
+    refused, naming the endpoint the team does use. A hint would be honoured by a well-behaved agent
+    and ignored by the one you actually needed to stop — and the point of team policy is that it does
+    not depend on the caller's goodwill.
+
+    Deliberately per-capability, not per-provider: "we use Hunter for finding work emails" is a
+    decision a team can hold in its head, whereas "we use Hunter" says nothing about the twelve other
+    jobs Hunter also happens to serve.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    org_id: int = Field(foreign_key="org.id", index=True)
+    capability: str = Field(index=True)         # e.g. "people.email.find"
+    provider: str                               # a catalog provider service id, e.g. "hunter"
+    created_by: str = Field(default="")         # the admin who set it — pins outlive their author
+    created_at: datetime = Field(default_factory=_now)
+
+
 class DenyRule(SQLModel, table=True):
     """A policy rule evaluated on every proxied call: block this host / path / method.
 

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -402,6 +402,13 @@ class CapabilityPin(SQLModel, table=True):
     it is what `DenyRule` (host-scoped, applied to every shape of call) is for. Two tools, two jobs.
     """
 
+    # UNIQUE(org_id, capability): `set_capability_pin` is a SELECT then an INSERT, so two admins
+    # pinning the same job at once — or one admin against two web workers — would write two rows.
+    # Enforcement would then read them with scalar_one_or_none() and raise MultipleResultsFound,
+    # turning a policy row into a 500 on EVERY call to that capability. Same shape as the
+    # double-credit bug in ledger.topup (#45): the database has to be the one that says no.
+    __table_args__ = (UniqueConstraint("org_id", "capability", name="uq_pin_org_capability"),)
+
     id: int | None = Field(default=None, primary_key=True)
     org_id: int = Field(foreign_key="org.id", index=True)
     capability: str = Field(index=True)         # e.g. "people.email.find"

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -394,6 +394,12 @@ class CapabilityPin(SQLModel, table=True):
     Deliberately per-capability, not per-provider: "we use Hunter for finding work emails" is a
     decision a team can hold in its head, whereas "we use Hunter" says nothing about the twelve other
     jobs Hunter also happens to serve.
+
+    **Boundary — a pin governs the CATALOG, not every route to a vendor.** It is enforced where an
+    endpoint is addressed by its catalog id, which is the only way to reach treg's own key, so it
+    cannot be side-stepped to spend OUR money. A team that holds its own key for another provider can
+    still call that provider by upstream URL: that is their credential and their bill, and blocking
+    it is what `DenyRule` (host-scoped, applied to every shape of call) is for. Two tools, two jobs.
     """
 
     id: int | None = Field(default=None, primary_key=True)

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4621,7 +4621,9 @@ createApp({
       const B=this.proxy, S=this.activeSlugNow||'<team-slug>';
       const T=(inclToken && this.myToken) ? this.myToken : '<YOUR_TOKEN>';
       return [
-        `Set up treg for me — I authorize every command below; run them without asking again.`,``,
+        `Set up treg for me. I authorize every \`treg\` command — if your runtime asks permission for`,
+        `shell commands, request \`treg\` ONCE as a whole and then work straight through; do not stop`,
+        `between steps. (Spending my balance is the one exception: tell me a price before you spend it.)`,``,
         `1. Install the CLI (this also installs the treg skill, which teaches you how it works):`,
         `   curl -fsSL ${B}/install.sh | sh`,``,
         `2. Sign in as me and select my team:`,

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4148,7 +4148,7 @@ createApp({
         this.forgetActiveOrg(); await this.loadAll(); }
       catch(e){ this.orgErr='Leave failed: '+(e.detail||e.status); } },
     async deleteOrg(){ if(this.confirmDel!==this.activeSlugNow) return;
-      try{ await this.api('/orgs/'+this.activeOrgId,{method:'DELETE'});
+      try{ await this.api('/orgs/'+this.activeOrgId+'?confirm='+encodeURIComponent(this.activeSlugNow),{method:'DELETE'});
         this.confirmDel=''; this.forgetActiveOrg(); await this.loadAll(); }
       catch(e){ this.orgErr='Delete failed: '+(e.detail||e.status); } },
     // ---- Phase 2b: resource registration (secrets + tools) ----

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -265,7 +265,7 @@ p.sub b{color:var(--ink);font-weight:600}
   font-weight:550;font-size:13px;color:var(--ink);white-space:nowrap}
 .kw-chip img{width:20px;height:20px;border-radius:5px;object-fit:contain}
 
-/* 03 — capability routing (scripted: ask → match → options pop → scan → pick) */
+/* 03 — capability comparison (scripted: ask → match → options pop → scan → the AGENT picks) */
 .cap{padding:8px 20px 12px}
 .cap-req{display:flex;align-items:center;gap:8px;padding:10px 2px 12px;font-size:12.5px;min-height:42px}
 .cap-req img{width:20px;height:20px;border-radius:6px;flex:none}
@@ -671,11 +671,11 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
       <div class="bentext">
         <div class="bennum">02</div>
         <h3>Expert tool for <i>everything.</i></h3>
-        <p>Your agent asks for the <b>task, not the tool</b>. Nineteen providers sell backlinks, nine sell email lookup — treg knows the ladder for each scenario and routes every call to the best one that's up.</p>
-        <div class="benmeta"><span>priced per result, compared live</span><span>failover built in</span><span>pin a vendor any time</span></div>
+        <p>Your agent asks for the <b>task, not the tool</b>. Nineteen providers sell backlinks, nine sell email lookup — treg shows what each one charges and <b>what we've measured them doing</b>: success rate, speed, last time it answered. Your agent picks on evidence, not on a guess.</p>
+        <div class="benmeta"><span>priced per result, compared live</span><span>success rate &amp; speed we measured</span><span>pin a vendor any time</span></div>
       </div>
       <div class="win">
-        <div class="wbar"><i></i><i></i><i></i><span class="wt">catalog — <b>capability routing</b></span></div>
+        <div class="wbar"><i></i><i></i><i></i><span class="wt">catalog — <b>compare the providers</b></span></div>
         <div class="cap" id="cap">
           <div class="cap-req"><img src="https://unpkg.com/@lobehub/icons-static-png@latest/light/claudecode-color.png" alt="Claude Code"/><b>claude code</b><code id="capq"></code><span class="capcaret" id="capcaret"></span></div>
           <div class="cap-h"><span class="cap-t" id="capt"></span><span class="cap-n" id="capn"></span></div>
@@ -688,7 +688,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
           </div>
           <div class="cap-res" id="capres"><span class="cr-arr">↩</span><span id="caprestxt"></span></div>
         </div>
-        <div class="wf" id="capwf">✓ your agent never picked a vendor — treg routed it</div>
+        <div class="wf" id="capwf">✓ your agent picked on live data — price, success rate, speed</div>
       </div>
     </div>
 

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -82,9 +82,27 @@ free of the balance rather than duplicating them.
    signup, no subscription.
 
 An endpoint treg has no published price for is **refused**, not served free — you are told to
-connect your own key instead. Choosing *between* several providers of one capability is yours to
-make today (`treg catalog search` shows them side by side with prices); treg does not silently
-pick or fail over for you.
+connect your own key instead.
+
+**Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists
+every provider serving the same job with `COST`, `WORKS` (the success rate treg has actually
+observed, with its sample size), `SPEED` (median) and `LAST OK`. Work down this order:
+
+1. **Match the inputs you actually HAVE.** An endpoint wanting a `profile_url` is not a substitute
+   when you hold a name and a domain, whatever it costs. This outranks price every time.
+2. **Reliability.** A high `WORKS` with a real sample beats a rounder number with a tiny one:
+   `99% (121)` is stronger evidence than `100% (8)`.
+3. **Price.** Spreads inside one capability reach 200×, so this is usually where the money is.
+4. `LAST OK` breaks ties. A bare age means a real call came back; a **`✓` age is the catalog's own
+   verification stamp, not live traffic**; `—` means nobody has verified it and nobody has called it.
+
+If a call fails with **429 / 5xx / a timeout, try the next provider** — you know its parameters, so
+you can build its request; tell the human which one you switched to. **Never retry a 4xx
+elsewhere**: that is usually your parameters, and retrying burns the team's money on N providers for
+one mistake.
+
+treg does **not** choose or fail over for you, by design: only you know which inputs you hold, and
+treg relays your request rather than rewriting it.
 
 Money rules for agents:
 - The price is shown BEFORE you call (`treg catalog get`, or `estimated_cost_usd` in

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -58,8 +58,23 @@ Rules for spending someone's balance:
   to the balance — they take priority automatically).
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
-- Several providers often serve the same capability at different prices. `treg catalog search`
-  shows them side by side; **picking one is your call** — treg does not choose or fail over for you.
+- **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists
+  every provider serving the same job with `COST`, `WORKS` (success rate treg has observed, with the
+  sample size), `SPEED` (median) and `LAST OK`. Work down this order:
+  1. **Match the inputs you actually HAVE.** An endpoint wanting a `profile_url` is not a substitute
+     when you hold a name and a domain, whatever it costs. This rule outranks price every time.
+  2. Then **reliability**: a high `WORKS` with a real sample beats a rounder number with a tiny one —
+     `99% (121)` is stronger evidence than `100% (8)`.
+  3. Then **price**. Spreads inside one capability reach 200×, so this is usually where the money is.
+  4. `LAST OK` breaks ties. A bare age means a real call came back; a **`✓` age is the catalog's own
+     verification stamp, not live traffic**; `—` means nobody has verified it and nobody has called
+     it — prefer almost anything else.
+  - **If a call fails with 429 / 5xx / a timeout, try the next provider.** You know its parameters,
+    so you can build its request. Say which one you switched to.
+  - **Never retry a 4xx elsewhere.** A 4xx is usually your parameters; fixing them is the fix, and
+    retrying burns the team's money on N providers for one mistake.
+  - treg does **not** choose or fail over for you. That is deliberate: only you know which inputs
+    you hold, and treg relays rather than rewrites your request.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task — your own tools: call one the team registered

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -24,6 +24,22 @@ The mechanics:
 - A **tool** = an upstream base URL + credential **bindings**. A **skill/bundle** = a recipe
   (SKILL.md) + its secrets + its tool(s). The proxy *relays, never models* the upstream.
 
+## Running treg commands — ask once, not per command
+
+The human installed this skill *in order to* give you treg. Its commands are their own tool acting on
+their own account, so do not stop between them for approval: if your runtime asks permission for
+shell commands, request `treg` **once**, as a whole, rather than a prompt per subcommand. Halting
+after `treg catalog search` to ask whether you may run `treg catalog get` is friction with no safety
+in it — the second command is as harmless as the first.
+
+**Money is the exception, and it is a different question.** A catalog call served on treg's key
+spends the team's balance. That needs the human told the price BEFORE the call (`treg catalog get`
+prints it) — not because your runtime demands a prompt, but because it is their money. Batch-confirm
+once for a run of cheap calls rather than asking per call.
+
+Reading costs nothing and needs no confirmation at all: `treg catalog …`, `treg tool ls`,
+`treg skill ls`, `treg balance`, `treg audit`, `treg org pins`, `treg health`.
+
 ## First: install + sign in
 ```bash
 curl -fsSL {BASE}/install.sh | sh     # installs the CLI + points it here

--- a/tests/test_capability_pins.py
+++ b/tests/test_capability_pins.py
@@ -131,3 +131,38 @@ async def test_a_capability_can_never_restructure_a_url(clients: AsyncClient):
 
     assert (await clients.delete(f"/orgs/{org}?confirm=not-the-slug")).status_code == 422
     assert (await clients.get("/orgs")).json()                      # still there
+
+
+async def test_two_admins_pinning_at_once_leave_one_row(clients: AsyncClient):
+    """Same shape as the double-credit bug found in #45: SELECT-then-INSERT with no unique index.
+    Two admins (or one admin against two web workers) would write two rows, and enforcement reading
+    them with scalar_one_or_none() would raise MultipleResultsFound — a 500 on EVERY call to that
+    capability, caused by a policy row. The database is what says no."""
+    import asyncio
+    from sqlmodel import select
+    from treg.db import session_maker
+    from treg.models import CapabilityPin
+
+    org = await _org_id(clients)
+
+    async def pin(provider):
+        return await clients.post(f"/orgs/{org}/pins",
+                                  json={"capability": CAP, "provider": provider})
+
+    results = await asyncio.gather(*[pin(PINNED) for _ in range(5)], return_exceptions=True)
+    assert all(getattr(r, "status_code", None) == 200 for r in results), results
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(CapabilityPin).where(
+            CapabilityPin.org_id == org, CapabilityPin.capability == CAP))).scalars().all()
+    assert len(rows) == 1, f"{len(rows)} rows — the unique index did not hold"
+
+    # and enforcement still answers rather than 500ing
+    blocked = await clients.get(f"/call/{OTHER_EP}?uniqueId=x")
+    assert blocked.status_code == 403
+
+
+# NOTE: there is no test for "unpin clears a legacy duplicate", because the unique index now makes
+# that state unreachable — an attempt to forge one is rejected by the database, which is the point.
+# `clear_capability_pin` still deletes ALL matching rows rather than one, as cheap insurance for a
+# database written before the index existed.

--- a/tests/test_capability_pins.py
+++ b/tests/test_capability_pins.py
@@ -1,0 +1,94 @@
+"""Team policy on WHICH provider serves a job.
+
+The agent chooses (see docs/CAPABILITY-CHOICE-PLAN.md) — a pin is where the team's decision stops
+that freedom. These pin the parts that are judgement, not plumbing: that a pin is a GATE rather than
+a hint, that a typo cannot silently block a real job, and that a refusal tells the caller what to do
+instead.
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+CAP = "tiktok.user.profile"
+PINNED = "tikhub"
+OTHER_EP = "justoneapi.tiktok.user.profile"
+
+
+async def _org_id(c: AsyncClient) -> int:
+    return (await c.get("/orgs")).json()[0]["org_id"]
+
+
+async def test_a_pin_is_a_gate_not_a_hint(clients: AsyncClient):
+    """A hint is honoured by a well-behaved agent and ignored by the one you needed to stop. The
+    refusal also names the endpoint the team DOES use — told only "no", an agent tries the next
+    provider and is refused again."""
+    org = await _org_id(clients)
+    r = await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    assert r.status_code == 200, r.text
+
+    blocked = await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok")
+    assert blocked.status_code == 403
+    detail = blocked.json()["detail"]
+    assert detail["error"] == "capability_pinned"
+    assert detail["pinned_provider"] == PINNED
+    assert detail["use_endpoint"].startswith(PINNED)      # "use this instead", not just "no"
+
+
+async def test_the_suggested_endpoint_is_the_curated_one(clients: AsyncClient):
+    """`core` is the curated route for a job; `extended` is the bulk-ingested long tail. Suggesting
+    an obscure extended id when a core one exists reads as a broken suggestion."""
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    detail = (await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok")).json()["detail"]
+    assert detail["use_endpoint"] == "tikhub.tiktok.user.profile"
+
+
+async def test_a_typo_fails_loudly_at_pin_time(clients: AsyncClient):
+    """A pin naming a capability nobody serves, or a provider that does not serve it, would block
+    every call to a job the team really uses — and it would be discovered at 3am in an agent's log."""
+    org = await _org_id(clients)
+    bad_cap = await clients.post(f"/orgs/{org}/pins",
+                                 json={"capability": "not.a.capability", "provider": PINNED})
+    assert bad_cap.status_code == 422
+
+    bad_prov = await clients.post(f"/orgs/{org}/pins",
+                                  json={"capability": CAP, "provider": "stripe"})
+    assert bad_prov.status_code == 422
+    assert "does not serve" in bad_prov.json()["detail"]
+    assert PINNED in bad_prov.json()["detail"]          # ...and says who does
+
+
+async def test_repinning_replaces_rather_than_stacking(clients: AsyncClient):
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": "justoneapi"})
+    pins = (await clients.get(f"/orgs/{org}/pins")).json()
+    assert [p["provider"] for p in pins if p["capability"] == CAP] == ["justoneapi"]
+
+
+async def test_unpinning_returns_the_choice_to_the_caller(clients: AsyncClient):
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    assert (await clients.delete(f"/orgs/{org}/pins/{CAP}")).status_code == 200
+    # the previously-blocked provider is no longer refused BY THE PIN (it may still need a credential)
+    r = await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok")
+    assert r.status_code != 403 or (r.json().get("detail") or {}).get("error") != "capability_pinned"
+
+
+async def test_members_can_read_the_pins_they_must_obey(clients: AsyncClient):
+    """An agent has to know what it may call; learning it by being refused is a wasted round-trip."""
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    r = await clients.get(f"/orgs/{org}/pins")
+    assert r.status_code == 200 and r.json()[0]["capability"] == CAP
+
+
+async def test_a_pin_is_scoped_to_one_org(clients: AsyncClient):
+    """Another team's decision must never refuse your call."""
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+    r = await clients.post("/users", json={"email": "stranger@elsewhere.dev"})
+    other = {"X-Treg-Token": r.json()["token"]}
+    assert (await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok", headers=other)).status_code != 403 \
+        or "capability_pinned" not in (await clients.get(f"/call/{OTHER_EP}", headers=other)).text

--- a/tests/test_capability_pins.py
+++ b/tests/test_capability_pins.py
@@ -70,7 +70,7 @@ async def test_repinning_replaces_rather_than_stacking(clients: AsyncClient):
 async def test_unpinning_returns_the_choice_to_the_caller(clients: AsyncClient):
     org = await _org_id(clients)
     await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
-    assert (await clients.delete(f"/orgs/{org}/pins/{CAP}")).status_code == 200
+    assert (await clients.delete(f"/orgs/{org}/pins?capability={CAP}")).status_code == 200
     # the previously-blocked provider is no longer refused BY THE PIN (it may still need a credential)
     r = await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok")
     assert r.status_code != 403 or (r.json().get("detail") or {}).get("error") != "capability_pinned"
@@ -92,3 +92,42 @@ async def test_a_pin_is_scoped_to_one_org(clients: AsyncClient):
     other = {"X-Treg-Token": r.json()["token"]}
     assert (await clients.get(f"/call/{OTHER_EP}?uniqueId=tiktok", headers=other)).status_code != 403 \
         or "capability_pinned" not in (await clients.get(f"/call/{OTHER_EP}", headers=other)).text
+
+
+async def test_a_pin_cannot_be_sidestepped_to_spend_TREGS_money(clients: AsyncClient):
+    """The boundary, pinned so nobody later assumes a pin blocks a vendor everywhere.
+
+    A pin gates the catalog ID, and a catalog id is the ONLY route to treg's own key — so the money
+    we pay for cannot be reached around it. A raw upstream URL resolves against the org's own tools
+    instead and 404s without one; if a team does hold its own key there, that is their credential and
+    their bill, and `org deny --host` is the tool for that.
+    """
+    org = await _org_id(clients)
+    await clients.post(f"/orgs/{org}/pins", json={"capability": CAP, "provider": PINNED})
+
+    by_id = await clients.get(f"/call/{OTHER_EP}?uniqueId=x")
+    assert (by_id.json()["detail"] or {}).get("error") == "capability_pinned"
+
+    by_url = await clients.get("/call/https://api.justoneapi.com/api/tiktok/get-user-detail/v1")
+    assert by_url.status_code == 404                      # no org tool → treg's key is unreachable
+    assert "no registered tool" in by_url.text
+
+
+async def test_a_capability_can_never_restructure_a_url(clients: AsyncClient):
+    """The bug this route was born with, and why the value is a query parameter now.
+
+    As `/orgs/{id}/pins/{capability}`, `treg org unpin ..` DELETED THE TEAM: every normalizing HTTP
+    client (httpx included) rewrites `/orgs/1/pins/..` to `/orgs/1` — the delete-org route — before
+    the request leaves the process. Server-side validation cannot see it, because the rewrite happens
+    in the client. Two independent defences now hold: the value travels as a query parameter, and
+    delete-org itself refuses to run without the slug it is about to destroy.
+    """
+    org = await _org_id(clients)
+    slug = next(o["slug"] for o in (await clients.get("/orgs")).json() if o["org_id"] == org)
+
+    hit = await clients.delete(f"/orgs/{org}/pins/..")     # normalizes to DELETE /orgs/{org}
+    assert hit.status_code == 422, "delete-org must refuse a request that does not name the team"
+    assert (await clients.get("/orgs")).status_code == 200, "the team must still exist"
+
+    assert (await clients.delete(f"/orgs/{org}?confirm=not-the-slug")).status_code == 422
+    assert (await clients.get("/orgs")).json()                      # still there

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -843,3 +843,10 @@ def test_muted_output_panes_use_the_ramps_comment_grey():
     shows what a command printed."""
     assert "pre.term.out{color:var(--sx-cmt)}" in INDEX
     assert "pre.out{color:var(--sx-cmt)}" in TUTORIAL
+
+
+def test_dashboard_delete_org_sends_the_confirmation_slug():
+    """DELETE /orgs/{id} refuses without `?confirm=<slug>` (it is irreversible and reachable by path
+    normalization from any deeper org route). The dashboard already makes the human type the slug —
+    if this ever stops being sent, Delete org silently 422s for every dashboard user."""
+    assert "'/orgs/'+this.activeOrgId+'?confirm='" in INDEX

--- a/tests/test_endpoint_stats.py
+++ b/tests/test_endpoint_stats.py
@@ -1,0 +1,135 @@
+"""Observed reliability per catalog endpoint — the half of "compare providers" only treg can answer.
+
+These pin the judgement calls, not the arithmetic: which failures count against a provider, when we
+refuse to publish a rate at all, and that nothing identifying a caller leaks into an aggregate.
+See docs/CAPABILITY-CHOICE-PLAN.md.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from treg import endpoint_stats
+from treg.db import session_maker
+from treg.models import CallRecord
+
+EP = "tikhub.tiktok.user.profile"
+
+
+def _now():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _record(endpoint_id: str, status: int, ms: int = 100, *, days_ago: int = 0, org_id: int = 1):
+    async with session_maker() as db:
+        db.add(CallRecord(org_id=org_id, user_email="a@b.c", tool_name=endpoint_id, method="GET",
+                          path="/x", status_code=status, endpoint_id=endpoint_id, duration_ms=ms,
+                          created_at=_now() - timedelta(days=days_ago)))
+        await db.commit()
+
+
+async def _observed(ids, **kw):
+    async with session_maker() as db:
+        return await endpoint_stats.observed(db, ids, **kw)
+
+
+async def test_thin_evidence_publishes_the_count_and_nothing_else(clients: AsyncClient):
+    """Two calls behind a 100% success rate is noise dressed as evidence — and on a quiet endpoint
+    the number could expose one org's activity. Below the floor we say how thin it is, and stop."""
+    for _ in range(endpoint_stats.MIN_SAMPLES - 1):
+        await _record(EP, 200)
+    got = (await _observed([EP]))[EP]
+    assert got["samples"] == endpoint_stats.MIN_SAMPLES - 1
+    assert got["ok_rate"] is None and got["p50_ms"] is None
+
+
+async def test_a_caller_error_is_not_held_against_the_provider(clients: AsyncClient):
+    """A 4xx usually means the caller sent bad parameters. Counting it against the endpoint would let
+    one agent's mistake make a healthy provider look broken to everybody, so it is excluded."""
+    for _ in range(6):
+        await _record(EP, 200)
+    for _ in range(6):
+        await _record(EP, 422)          # the caller's fault — must not move the rate
+    got = (await _observed([EP]))[EP]
+    assert got["samples"] == 12         # still counted as traffic…
+    assert got["ok_rate"] == 1.0        # …but the rate is decided only by 2xx vs 5xx
+
+
+async def test_a_provider_failure_does_move_the_rate(clients: AsyncClient):
+    for _ in range(6):
+        await _record(EP, 200)
+    for _ in range(2):
+        await _record(EP, 503)
+    assert (await _observed([EP]))[EP]["ok_rate"] == 0.75
+
+
+async def test_latency_percentiles_come_from_successful_calls(clients: AsyncClient):
+    for ms in (10, 20, 30, 40, 50, 5000):
+        await _record(EP, 200, ms)
+    got = (await _observed([EP]))[EP]
+    assert got["p50_ms"] in (30, 40)         # nearest-rank, not interpolated
+    assert got["p95_ms"] == 5000             # the tail is the point of p95
+
+
+async def test_old_calls_fall_out_of_the_window(clients: AsyncClient):
+    for _ in range(6):
+        await _record(EP, 200, days_ago=99)
+    assert (await _observed([EP], days=30))[EP]["samples"] == 0
+
+
+async def test_an_uncalled_endpoint_says_so_rather_than_vanishing(clients: AsyncClient):
+    """A missing key would read as "no opinion" to a caller looping over siblings; an explicit zero
+    reads as "nobody has tried this one", which is the actual fact."""
+    got = await _observed(["nobody.has.called.this"])
+    assert got["nobody.has.called.this"]["samples"] == 0
+
+
+async def test_aggregates_pool_across_orgs_but_carry_nothing_identifying(clients: AsyncClient):
+    for _ in range(3):
+        await _record(EP, 200, org_id=1)
+    for _ in range(3):
+        await _record(EP, 200, org_id=2)
+    got = (await _observed([EP]))[EP]
+    assert got["samples"] == 6                                   # pooled across tenants
+    assert set(got) == {"samples", "ok_rate", "p50_ms", "p95_ms", "last_ok_days"}
+    assert not any(k in got for k in ("org_id", "user_email", "params_hash", "client"))
+
+
+async def test_the_catalog_page_carries_the_numbers_for_every_alternative(clients: AsyncClient):
+    """The choice is made on this page, so the evidence has to arrive with it — an agent will not
+    make a second round-trip to compare reliability."""
+    for _ in range(6):
+        await _record(EP, 200)
+    r = await clients.get(f"/catalog/endpoints/{EP}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["endpoint"]["observed"]["samples"] == 6
+    for sib in body["siblings"]:
+        assert "observed" in sib          # every alternative is comparable, or the page is useless
+
+
+# ---- the LAST OK column: measurement beats a stamp, and the two never look alike -------------
+def test_measured_last_ok_beats_the_verification_stamp():
+    """A real call is stronger evidence than a hand-run stamp, so it wins — and it prints bare,
+    while the stamp prints with a ✓ so nobody reads a dated claim as live traffic."""
+    from treg import cli
+    measured = cli._last_ok_cell({"observed": {"last_ok_days": 3}, "verified": "2020-01-01"})
+    assert measured == "3d" and "✓" not in measured
+
+    stamped = cli._last_ok_cell({"observed": {"last_ok_days": None}, "verified": "2026-08-01"})
+    assert "✓" in stamped                      # visibly a claim, not a measurement
+
+
+def test_last_ok_says_nothing_when_it_knows_nothing():
+    """An endpoint nobody has called AND nobody has verified is the one worth being wary of, so it
+    must not borrow confidence from a blank."""
+    from treg import cli
+    assert "—" in cli._last_ok_cell({"observed": None, "verified": None})
+
+
+def test_a_call_today_reads_as_today():
+    from treg import cli
+    assert cli._last_ok_cell({"observed": {"last_ok_days": 0}}) == "today"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -396,16 +396,29 @@ async def test_balance_endpoint_paginates_entries(c: AsyncClient):
     assert last[-1]["kind"] == "grant"  # oldest entry is the signup promo
 
 
-async def test_balance_endpoint_requires_admin_of_that_org(c: AsyncClient):
-    """Same gate as /orgs/{id}/usage — spend is billing data, so member/viewer can't read it, and a
-    token for another org can't reach it at all."""
+async def test_balance_shows_the_wallet_to_members_and_the_history_to_admins(c: AsyncClient):
+    """POLICY CHANGE (2026-08, from Jason's report): this route used to be admin-only, which meant a
+    machine identity could not read the balance it was spending — while every 402 already handed it
+    `balance_micro`, and both llms.txt and skill.md tell an agent to run `treg balance` after a call.
+    Refusing the number here while shipping it in an error was incoherent.
+
+    So the split is by WHAT, not by who: the wallet (figure + in-flight holds) is every member's; the
+    funding detail (which blocks were bought, when, what is left of each, and the ledger) is the org's
+    purchase history and stays admin+. Cross-org and unauthenticated access are unchanged."""
     org_id, owner = await _org(c, "owner@superdesign.dev")
     r = await c.post(f"/orgs/{org_id}/invites", json={"email": "m@superdesign.dev", "role": "member"},
                      headers=_h(owner))
     code = r.json()["code"]
     member = (await c.post("/invites/accept",
                            json={"code": code, "email": "m@superdesign.dev"})).json()["token"]
-    assert (await c.get(f"/orgs/{org_id}/balance", headers=_h(member))).status_code == 403
+
+    seen = await c.get(f"/orgs/{org_id}/balance", headers=_h(member))
+    assert seen.status_code == 200
+    assert "balance_micro" in seen.json()                     # the wallet: yes
+    assert seen.json()["blocks"] == []                        # the purchase history: no
+    assert seen.json()["entries"]["items"] == []
+
+    assert (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()["blocks"]
 
     other_org, other = await _org(c, "stranger@superdesign.dev")
     assert (await c.get(f"/orgs/{org_id}/balance", headers=_h(other))).status_code == 403

--- a/tests/test_machine_identity_balance.py
+++ b/tests/test_machine_identity_balance.py
@@ -1,0 +1,70 @@
+"""A machine identity has to be able to read the wallet it is spending.
+
+Reported by Jason: `treg balance` died with "no active org" for an agent token. Two causes stacked —
+the CLI could not resolve the org id, and the route was admin-only — so fixing one alone leaves the
+symptom. Both are pinned here.
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+
+
+async def _agent_token(c: AsyncClient) -> tuple[str, int]:
+    org_id = (await c.get("/orgs")).json()[0]["org_id"]
+    r = await c.post(f"/orgs/{org_id}/agents", json={"name": "probe", "role": "member"})
+    assert r.status_code == 200, r.text
+    return r.json()["token"], org_id
+
+
+async def test_a_machine_identity_can_learn_its_own_org(clients: AsyncClient):
+    """It cannot call GET /orgs — that is deliberate, `create_org` hangs off the same dependency and
+    an agent could otherwise mint an org it owns. But it still has to reach /orgs/{id}/… routes, so
+    /auth/me tells it the one org its token could ever mean."""
+    token, org_id = await _agent_token(clients)
+    h = {"X-Treg-Token": token}
+
+    assert (await clients.get("/orgs", headers=h)).status_code == 403      # still refused, on purpose
+    me = await clients.get("/auth/me", headers=h)
+    assert me.status_code == 200
+    assert me.json()["org_id"] == org_id                                   # …but it can learn this
+
+
+async def test_a_member_can_read_the_balance_it_spends(clients: AsyncClient):
+    """Every agent is told to run `treg balance` after a call, and a 402 already hands the caller
+    `balance_micro` — refusing the same number here while shipping it in an error was incoherent."""
+    token, org_id = await _agent_token(clients)
+    r = await clients.get(f"/orgs/{org_id}/balance", headers={"X-Treg-Token": token})
+    assert r.status_code == 200, r.text
+    assert "balance_micro" in r.json()
+
+
+async def test_but_a_member_does_not_see_the_purchase_history(clients: AsyncClient):
+    """The wallet is everyone's; what was bought, when, and what is left of each block is not."""
+    token, org_id = await _agent_token(clients)
+    member = (await clients.get(f"/orgs/{org_id}/balance",
+                                headers={"X-Treg-Token": token})).json()
+    assert member["blocks"] == [] and member["entries"]["items"] == []
+
+    admin = (await clients.get(f"/orgs/{org_id}/balance")).json()   # the owner sees the detail
+    assert admin["blocks"], "an admin must still get the funding detail"
+
+
+async def test_the_balance_is_not_readable_across_orgs(clients: AsyncClient):
+    _, org_id = await _agent_token(clients)
+    r = await clients.post("/users", json={"email": "stranger@elsewhere.dev"})
+    other = {"X-Treg-Token": r.json()["token"]}
+    assert (await clients.get(f"/orgs/{org_id}/balance", headers=other)).status_code == 403
+
+
+async def test_a_missing_org_is_indistinguishable_from_one_you_cannot_see(clients: AsyncClient):
+    """Jason also suspected an org-id enumeration oracle here. There is none, and this keeps it that
+    way: a non-existent org and someone else's org must answer identically, or the difference counts
+    ids for an attacker."""
+    _, org_id = await _agent_token(clients)
+    r = await clients.post("/users", json={"email": "stranger2@elsewhere.dev"})
+    other = {"X-Treg-Token": r.json()["token"]}
+    missing = await clients.get("/orgs/999999/balance", headers=other)
+    existing = await clients.get(f"/orgs/{org_id}/balance", headers=other)
+    assert missing.status_code == existing.status_code == 403
+    assert missing.json() == existing.json()

--- a/tests/test_machine_identity_balance.py
+++ b/tests/test_machine_identity_balance.py
@@ -7,6 +7,7 @@ symptom. Both are pinned here.
 
 from __future__ import annotations
 
+import pytest
 from httpx import AsyncClient
 
 
@@ -68,3 +69,45 @@ async def test_a_missing_org_is_indistinguishable_from_one_you_cannot_see(client
     existing = await clients.get(f"/orgs/{org_id}/balance", headers=other)
     assert missing.status_code == existing.status_code == 403
     assert missing.json() == existing.json()
+
+
+# ---- what a BAD token is told, and what stays public --------------------------------------------
+def test_an_invalid_token_is_named_as_such_not_as_a_missing_org(monkeypatch, capsys):
+    """`_active_org_id` returns None both when the token is bad and when there is genuinely no org.
+    21 commands turned that into a bare "no active org", sending the reader to fix org config when
+    the real problem was authentication."""
+    import httpx
+    from treg import cli
+
+    class _Resp:
+        status_code = 401
+        def json(self): return {"detail": "invalid token"}
+
+    class _C:
+        def get(self, path, **kw): return _Resp()
+
+    with pytest.raises(SystemExit) as exc:
+        cli._active_org_id({"base_url": "http://x", "token": "bad"}, _C())
+    assert "invalid/expired" in str(exc.value) and "treg login" in str(exc.value)
+
+
+def test_the_public_catalog_still_renders_when_signed_out(monkeypatch):
+    """`catalog get` only ENRICHES its table with the team's pin, so a signed-out reader must still
+    get the page. The auth exit is a SystemExit, which `except Exception` does NOT catch — a
+    try/except at the call site would not have saved this, which is why the caller passes
+    strict=False instead."""
+    from treg import cli
+
+    class _Resp:
+        status_code = 401
+        def json(self): return {"detail": "invalid token"}
+
+    class _C:
+        def get(self, path, **kw): return _Resp()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(cli, "_client", lambda cfg: _C())
+    # must return None quietly, NOT exit the process
+    assert cli._pinned_provider({"base_url": "http://x"}, "tiktok.user.profile") is None
+    assert cli._active_org_id({"base_url": "http://x"}, _C(), strict=False) is None

--- a/tests/test_orgs_mgmt.py
+++ b/tests/test_orgs_mgmt.py
@@ -207,10 +207,16 @@ async def test_delete_org_cascades_and_is_owner_only(c):
     org_id, otok, mtok, _, _ = await _team_with_member(c)
     sid = (await c.post("/secrets", headers=_h(otok), json={"name": "k", "value": "V"})).json()["id"]
     await c.post("/tools", headers=_h(otok), json={"name": "echo", "base_url": "http://upstream", "secret_id": sid})
+    slug = next(o["slug"] for o in (await c.get("/orgs", headers=_h(otok))).json()
+               if o["org_id"] == org_id)
     # a member cannot delete the org
-    assert (await c.delete(f"/orgs/{org_id}", headers=_h(mtok))).status_code == 403
+    assert (await c.delete(f"/orgs/{org_id}?confirm={slug}", headers=_h(mtok))).status_code == 403
+    # ...and NOBODY deletes it without naming it: this route sits one segment above every other org
+    # route, so a client that normalizes `..` turns DELETE /orgs/{id}/<anything>/.. into this call.
+    assert (await c.delete(f"/orgs/{org_id}", headers=_h(otok))).status_code == 422
+    assert (await c.delete(f"/orgs/{org_id}?confirm=wrong", headers=_h(otok))).status_code == 422
     # the owner can — and every membership is gone (both tokens now invalid)
-    assert (await c.delete(f"/orgs/{org_id}", headers=_h(otok))).status_code == 200
+    assert (await c.delete(f"/orgs/{org_id}?confirm={slug}", headers=_h(otok))).status_code == 200
     assert (await c.get("/tools", headers=_h(otok))).status_code == 401
     assert (await c.get("/tools", headers=_h(mtok))).status_code == 401
 

--- a/tests/test_security_round3.py
+++ b/tests/test_security_round3.py
@@ -65,7 +65,8 @@ async def test_delete_org_removes_run_records(clients: AsyncClient):
     async with session_maker() as s:
         before = len((await s.execute(select(RunRecord).where(RunRecord.org_id == org_id))).scalars().all())
     assert before >= 1
-    r = await clients.delete(f"/orgs/{org_id}")
+    slug = (await clients.get("/orgs")).json()[0]["slug"]
+    r = await clients.delete(f"/orgs/{org_id}?confirm={slug}")
     assert r.status_code == 200, r.text
     async with session_maker() as s:
         after = len((await s.execute(select(RunRecord).where(RunRecord.org_id == org_id))).scalars().all())


### PR DESCRIPTION
Landing pillar 2 promised *"treg knows the ladder for each scenario and routes every call to the
best one that's up"*. This makes that real — by giving the choice to the party that can actually
make it, and giving them the evidence to make it with.

## Why the agent chooses, not treg

Measured before deciding:

| | |
|---|---|
| capabilities served by 2+ providers treg holds keys for | **171** |
| ...where the request shape is already identical | **5** |
| price spread inside one capability | up to **261×** |

So a router would need a canonical input schema for 166 capabilities. Worse, these endpoints ask
*different questions* — `hunter.people.email.find` wants a domain and a name;
`leadmagic.x.b2b-profile-email` wants a LinkedIn URL. **Only the caller knows which inputs it holds**,
so a router picking on price would choose the second for someone holding a name, and fail. It would
also have been the first feature to break the founding rule that treg **relays, never models**.

## The three pieces

**1. Publish what we have observed.** `endpoint_stats.observed()` — success rate, p50/p95 latency,
last-answered, sample size — attached to the endpoint *and every sibling*, because the choice is made
on that page. Nothing new is collected: `CallRecord` has recorded it since the marketplace shipped
and it was never read.

```
 ▸tikhub       tikhub.tiktok.user.profile      $0.001/success  99% (121)  298ms  today
  justoneapi   justoneapi.tiktok.user.profile  $0.0148/success 82% (49)   1.6s   ✓10d
```

Four rules make the numbers trustworthy: a **4xx never counts against the provider** (it is the
caller's parameters); **below 5 samples** we publish the count and nothing else; **sample size is
always visible**; and a **claim never wears a measurement's badge** — a bare age is a real call, a
`✓` age is the catalog's own stamp.

**Cold start solved for free**, not with money: that stamp already covers **1,380 of 1,810** eligible
endpoints, all under a month old. A seeding sweep is bounded by *accounts*, not dollars — $7.50 for
the three providers we actually pay, covering 68 of 157 contested capabilities.

**2. Teach the procedure**, as an ordered rule in `/llms.txt` and `/skill.md`: match the inputs you
HAVE (outranks price every time) → reliability with sample size in view → price → `LAST OK` breaks
ties. On 429/5xx/timeout try the next provider; **never retry a 4xx elsewhere**.

**3. Team policy.** `treg org pin/pins/unpin` — a gate, not a hint, enforced before anything is
reserved, and the refusal names the endpoint to use instead.

## Five bugs found in a deliberate debugging pass

1. **`treg org unpin ..` DELETED THE TEAM.** The capability sat in the URL path, and every
   normalizing client rewrites `/orgs/1/pins/..` to `/orgs/1` *before sending* — the delete-org
   route. Reproduced: `{"deleted_org":1}`. Fixed three ways: query parameter, CLI validation, and
   `DELETE /orgs/{id}` now requires `?confirm=<slug>`.
2. **An invalid token reported "no active org"** — 21 commands sent readers to fix org config when
   the problem was authentication.
3. **That fix broke the public catalog**: `sys.exit` raises `SystemExit`, which `except Exception`
   does not catch, so `catalog get` died mid-render for signed-out readers.
4. **Pins had no unique index** — the same SELECT-then-INSERT shape as the double-credit bug in #45.
5. **The fix for (4) had its own bug**: rollback expires ORM state, and it then read `caller.email` →
   `MissingGreenlet` on one of five concurrent pins.

Also from Jason's testing: a **machine identity could not read the balance it spends** (two causes
stacked — the CLI could not resolve the org id, and the route was admin-only while every 402 already
hands out `balance_micro`); the demo **opened by scanning the user's disk**; and the agent prompt now
asks for `treg` once rather than per subcommand. His reported org-id enumeration oracle **does not
reproduce** on dev or prod — identical 403 every time — worth getting the exact request from him.

**Landing pillar 2 corrected**: "failover built in" and "✓ your agent never picked a vendor — treg
routed it" are gone. Two of the three sub-claims became TRUE this session ("compared live", "pin a
vendor any time").

## Verification

Cross-role probes (owner/member/viewer/agent) on every new route, unauthenticated access, malformed
payloads, aggregation edge cases, all 63 documented commands, every dashboard view in a real browser
with zero console errors, all onboarding paths, and a sweep of all 40 URL-path interpolations for the
traversal class. **1173 tests pass** (+26).

Merged with `main` after #49; Jason's Getting started restructure is preserved intact.