### PR TITLE
feat(catalog): akta serves on the platform key at its documented rate card

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -155,7 +155,9 @@ are admin-scale windows over a bounded number of metered calls, the same tradeof
             → ledger.reserve (the UPDATE gate; 402 if short)
             → relay upstream
             → settle at the observed cost when the provider reports one
-              (dataforseo `cost`, scrapecreators `credits_charged`), else at the estimate;
+              (dataforseo `cost`, scrapecreators `credits_charged`, akta `credits_consumed` —
+              the last is what makes akta's per-section enrich billable: the estimate is an
+              upper bound, the settle is the real charge), else at the estimate;
               release instead when the call was not billable
 
 Closing the hold runs on its **own session** (the request's may be mid-rollback from the very error

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -6329,12 +6329,15 @@ _PLATFORM_BODY_MAX = 8 * 1024 * 1024  # buffer ceiling for a metered response (A
 def _observed_cost_micro(provider: str, body: bytes) -> int | None:
     """The provider's OWN reported charge for this call, in micro-USD, or None when it doesn't say.
 
-    Two providers volunteer the number, in two different denominations:
+    Three providers volunteer the number, in two different denominations:
       - dataforseo: a top-level `cost` in USD — including 0 when it decided not to charge (a free
         route, or a request it rejected before metering). That zero is real information and settles the
         call at zero, which is why the test is `>= 0` and not truthiness.
-      - scrapecreators: `credits_charged`, converted through the provider's credit rate (fx.yaml) —
-        the same conversion `cost_view` uses, so a settle can't disagree with the catalog's price.
+      - scrapecreators (`credits_charged`) and akta (`credits_consumed`): provider credits, converted
+        through the provider's credit rate (fx.yaml) — the same conversion `cost_view` uses, so a
+        settle can't disagree with the catalog's price. Akta is the one that NEEDS this: its enrich
+        route is priced per SECTION requested and its news route adds a per-article rider, so the
+        catalog's single estimate can only be an upper bound — the actual charge lives here.
 
     Everyone else settles at the estimate. This is the same signal the catalog's `observed_cost`
     harvests, which is what lets phase 5's drift detector compare the two numbers directly."""
@@ -6351,9 +6354,9 @@ def _observed_cost_micro(provider: str, body: bytes) -> int | None:
         if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
             return int(cost * 1_000_000 + 0.5)
         return None
-    if provider == "scrapecreators":
-        credits = doc.get("credits_charged")
-        rate = catalog_store.load().credit_rates.get("scrapecreators")
+    if provider in ("scrapecreators", "akta"):
+        credits = doc.get("credits_charged" if provider == "scrapecreators" else "credits_consumed")
+        rate = catalog_store.load().credit_rates.get(provider)
         if isinstance(credits, (int, float)) and not isinstance(credits, bool) and credits >= 0 and rate:
             return int(credits * rate * 1_000_000 + 0.5)
         return None

--- a/src/treg/catalog/akta.extended.yaml
+++ b/src/treg/catalog/akta.extended.yaml
@@ -218,5 +218,6 @@ endpoints:
     value: 0
     currency: USD
     unit: call
+    confidence: documented
     note: documented free — does not consume credits
   docs_url: https://docs.akta.pro/api-reference/supporting-apis/request-status

--- a/src/treg/catalog/akta.yaml
+++ b/src/treg/catalog/akta.yaml
@@ -58,16 +58,15 @@ endpoints:
       queryParams: {company: "canva.com", sections: "location"}
     cost:
       type: per_success
-      value: null
+      value: 17.5
       currency: credit
       per: 1
       unit: call
       source: docs
-      checked: '2026-07-28'
-      confidence: unknown
-      note: 'OBSERVED 2026-07-31: the test_request (sections=location) reported credits_consumed 0.50,
-        exactly the rate card''s per-section figure — the model is confirmed, but no single `value`
-        can express it, which is why this stays unknown. Priced PER SECTION requested: 2 credits each for firmographic, business_model, company_assessment, product_offering and technology; 1.5 for management_profile and strategic_signal; 1 for customer_profile and industry; 0.5 for trust_signal, company_hierarchy, digital_presence, financial_estimate and location; 5 for the Enterprise-only mna_and_investment. Credits are $0.05 pay-as-you-go, $0.04 on subscription.'
+      source_url: https://docs.akta.pro/getting-started/pricing
+      checked: '2026-08-07'
+      confidence: documented
+      note: 'Priced PER SECTION requested, all rates documented on the rate card: 2 credits each for firmographic, business_model, company_assessment, product_offering and technology; 1.5 for management_profile and strategic_signal; 1 for customer_profile and industry; 0.5 for trust_signal, company_hierarchy, digital_presence, financial_estimate and location; 3 for the Enterprise-only funding_detail and 5 for mna_and_investment. value is the UPPER BOUND — every standard (non-Enterprise) section at once = 17.5 credits; it sizes the hold and the displayed price, while the settle charges the actual `credits_consumed` the response reports (see api._observed_cost_micro), so a sections=location call costs the documented 0.5 credits, not 17.5. OBSERVED 2026-07-31: the test_request (sections=location) reported credits_consumed 0.50, exactly the rate card''s figure. Credits are $0.05 pay-as-you-go, $0.04 on subscription.'
     verified: 2026-07-31
     example_response: examples/akta.companies.enrich.json
     docs_url: https://docs.akta.pro/api-reference/company-data
@@ -87,7 +86,7 @@ endpoints:
       note: "the trailing slash on the path is required — without it Akta 307-redirects and the key is dropped. This is the registry's health probe as well as the name→UUID resolver for every other endpoint"
     test_request:
       queryParams: {query: "canva.com"}
-    cost: {type: free, value: 0, currency: USD, unit: call, note: 'documented free, and OBSERVED free 2026-07-28 and again 2026-07-31 — the response reports credits_consumed 0.00'}
+    cost: {type: free, value: 0, currency: USD, unit: call, confidence: verified, note: 'documented free, and OBSERVED free 2026-07-28 and again 2026-07-31 — the response reports credits_consumed 0.00'}
     verified: 2026-07-31
     example_response: examples/akta.companies.search.json
     docs_url: https://docs.akta.pro/api-reference/supporting-apis/company-search
@@ -123,15 +122,15 @@ endpoints:
       queryParams: {company: "canva.com", limit: 1}
     cost:
       type: per_call
-      value: 0.1
+      value: 0.2
       currency: credit
       per: 1
       unit: call
-      source: observed
+      source: docs
       source_url: https://docs.akta.pro/getting-started/pricing
-      checked: '2026-07-31'
-      confidence: inferred
-      note: '0.1 credit base fee per call PLUS 0.01 credit per article returned, so `limit` is the dial: the default 10 articles costs 0.2 credits, the max 1,000 costs 10.1. value here is the base per-call fee ONLY, which is why this stays `inferred` despite being observed — OBSERVED live 2026-07-31: a limit=1 call reported credits_consumed 0.11, i.e. the 0.1 base plus 0.01 for the single article, confirming the formula rather than the recorded number.'
+      checked: '2026-08-07'
+      confidence: documented
+      note: 'the rate card documents the formula exactly: 0.1 credit base fee per call PLUS 0.01 credit per article returned, so `limit` is the dial — limit=1 is 0.11 credits, the max 1,000 is 10.1. value here is the DEFAULT page (10 articles = 0.2 credits); it sizes the hold and the displayed price, while the settle charges the actual `credits_consumed` the response reports (see api._observed_cost_micro). OBSERVED live 2026-07-31: a limit=1 call reported credits_consumed 0.11, confirming the formula.'
     verified: 2026-07-31
     example_response: examples/akta.companies.news.json
     docs_url: https://docs.akta.pro/api-reference/news-signals
@@ -191,7 +190,7 @@ endpoints:
       note: "returns ranked industry codes with similarity scores — use it to build the `industry` filter that akta.companies.news accepts"
     test_request:
       queryParams: {query: "graphic design software"}
-    cost: {type: free, value: 0, currency: USD, unit: call, note: 'the endpoint page documents it as free (0 credits) and Akta''s rate card carries no line item for it either way; OBSERVED credits_consumed 0.00 on live calls 2026-07-28 and 2026-07-31, so free is measured here, not just documented'}
+    cost: {type: free, value: 0, currency: USD, unit: call, confidence: verified, note: 'the endpoint page documents it as free (0 credits) and Akta''s rate card carries no line item for it either way; OBSERVED credits_consumed 0.00 on live calls 2026-07-28 and 2026-07-31, so free is measured here, not just documented'}
     verified: 2026-07-31
     example_response: examples/akta.companies.industry.resolve.json
     docs_url: https://docs.akta.pro/api-reference/supporting-apis/industry-search

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -404,6 +404,11 @@ def test_observed_cost_only_trusts_a_real_number():
     assert A._observed_cost_micro("tikhub", b'{"cost": 0.5}') is None, "tikhub doesn't report a charge"
     assert A._observed_cost_micro("scrapecreators", b'{"credits_charged": 2}') == 2 * EP_CALL_MICRO
     assert A._observed_cost_micro("scrapecreators", b'{"success": true}') is None
+    # akta reports `credits_consumed` — the field that makes its per-section enrich billable at
+    # actuals rather than the catalog's upper-bound estimate. $0.05/credit (fx.yaml).
+    assert A._observed_cost_micro("akta", b'{"credits_consumed": 0.5}') == 25_000
+    assert A._observed_cost_micro("akta", b'{"credits_consumed": 0}') == 0, "a reported zero is honoured"
+    assert A._observed_cost_micro("akta", b'{"credits_charged": 2}') is None, "wrong field name means we never learned it"
 
 
 async def test_daily_cap_fails_closed(clients: AsyncClient, platform_on, monkeypatch):


### PR DESCRIPTION
Akta's $0.05/credit was already in fx.yaml (the pay-as-you-go rate Jason confirmed from the dashboard), but only 4/12 endpoints could serve on the platform key. The blockers were per-endpoint, each closed with docs.akta.pro's rate card as the source:

- **enrich** — priced per section requested, so no single `value` existed. `_observed_cost_micro` now reads akta's `credits_consumed` (same actual-cost settle as dataforseo/scrapecreators), so the catalog carries the documented 17.5-credit upper bound while calls bill at their real per-section cost (a `sections=location` call settles at the documented 0.5 credits).
- **news** — the 0.1/call + 0.01/article formula is documented; recorded at the default page (0.2 credits = $0.01) with settle-on-actuals covering the article rider.
- **search / industry.resolve / request-status** — documented and observed free, refused only because the cost blocks never carried a `confidence`. Now verified/documented.

Result: 10/12 akta endpoints platform-eligible (company-addition stays excluded as account-kind, request-status rides with it). Tests: new `credits_consumed` cases in the observed-cost unit test; full suite 1173 green. money.md settle line updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PKxhT8D1ecGUJaKwPonkd