### PR TITLE
docs(context): sync the fragments to what actually shipped in 0.7.0

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -674,6 +674,12 @@ Four rules worth keeping:
 - **Below `MIN_SAMPLES` we publish the count and nothing else.** "100% from two calls" is noise
   dressed as evidence, and on a quiet endpoint a rate could expose one org's activity.
 - **Sample size is always visible**, so `100% (8)` cannot beat `99% (121)` by looking rounder.
+- **"Free" is a price, not a missing one.** `platform_eligible` used to demand
+  `confidence in (verified, documented)` for every route, but `confidence` says how much we trust a
+  NUMBER we are about to charge — and a free route has no number. Requiring it anyway refused 61
+  endpoints across 8 providers (28 of Hunter's 35) as though "costs nothing" meant "we don't know",
+  which is the one distinction this file otherwise keeps apart. A `type: free` route is now eligible
+  without provenance; a PAID route without provenance is still refused.
 - **A claim never wears a measurement's badge.** The `LAST OK` column prints a bare age when a real
   call produced it and a **`✓` age** when it came from the catalog's `verified:` stamp — the same
   discipline `confidence:` already applies to price. The stamp is the cold-start answer: it covers

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -117,8 +117,16 @@ cooldown stamped in the DB *before* the charge so a second web worker sees it, a
 limit, and an idempotency key derived from the threshold crossing — so a burst of concurrent calls
 that all notice the low balance produces exactly ONE charge.
 
-Authorization: `_billing_org` requires **admin or owner**. A card and a spend policy are the org's
-money, not a member's preference.
+Authorization splits by WHAT, not by who. `_billing_org` (the `/billing/*` routes — cards, top-ups,
+auto-top-up policy) requires **admin or owner**: a card and a spend policy are the org's money, not a
+member's preference.
+
+`GET /orgs/{id}/balance` is different, and deliberately so. Any **member** sees the figure and the
+in-flight holds; the **funding detail** (credit blocks, the ledger) stays admin+. It used to be
+admin-only, which meant a machine identity could not read the balance it was spending — while every
+402 already hands the caller `balance_micro`, and both `llms.txt` and `skill.md` tell an agent to run
+`treg balance` after a call. Refusing the number there while shipping it in an error was incoherent.
+(Reported by Jason, 2026-08-07.)
 
 ## The spend ceiling (`api.py`)
 

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -62,7 +62,8 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `require_identity`) accepts one with no code (403 if the invite's email ≠ yours). `list_members` /
   `remove_member`
   (`GET`/`DELETE /orgs/{id}/members[/{user}]`, admin+); `set_member_role` (`PATCH …/members/{user}`,
-  owner-only), `leave_org` (`POST /orgs/{id}/leave`), `delete_org` (`DELETE /orgs/{id}`, owner-only — via
+  owner-only), `leave_org` (`POST /orgs/{id}/leave`), `delete_org` (`DELETE /orgs/{id}?confirm=<slug>`, owner-only
+  AND the slug is REQUIRED — see hardening — via
   `_cascade_delete_org`, which now also sweeps each org's `RunRecord` rows);
   `list_invites` / `revoke_invite` (`GET`/`DELETE /orgs/{id}/invites[/{id}]`, admin+). Full behavior:
   [multi-tenancy](../architecture/multi-tenancy.md).
@@ -420,6 +421,18 @@ surfaced by `GET /tools` / `/bundles/{id}`).
   `base_url`/passthrough) into a `422`/`400`.
 - **CSRF/redirect:** `auth_logout` rejects a cross-`Origin` request (forced-logout CSRF); `oauth_start`
   pins `redirect_uri` to treg's own `/oauth/callback` (consent-phishing guard).
+- **Destructive routes name their target:** `DELETE /orgs/{id}` requires `?confirm=<slug>` and 422s
+  without it. It is irreversible and sits one path segment above every other org route, so any client
+  that normalizes `..` turns `DELETE /orgs/{id}/<anything>/..` into it — `treg org unpin ..` really
+  did delete a team in testing, because httpx rewrites the path before the request is sent. Server-
+  side validation cannot see that, so the defence is the confirmation, plus keeping user-supplied
+  values out of path segments (the pin capability moved to a query parameter for the same reason).
+  The CLI and the dashboard already made a human type the slug; now the API insists too.
+- **A machine identity can learn its own org:** `GET /auth/me` returns `org_id`/`org`/`role` when the
+  caller authenticated with a token. `require_identity` refuses machine identities on `/orgs` by
+  design (`create_org` hangs off it, so an agent could otherwise mint an org it owns) — but its token
+  IS one membership, and without this every `/orgs/{id}/…` command died with "no active org" for
+  exactly the callers those commands serve.
 - **Config default:** returning the OTP in the response (`dev_code`) is now gated by a dedicated
   `expose_dev_code` — true only on a local sqlite box, never on a real (Postgres) deploy — so a
   misconfigured `email_dev_mode` can't leak the code and enable an unauth takeover in prod.

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -32,6 +32,13 @@ once, base64-encoded with `X-Treg-Body-Encoding: base64`, which the server decod
 [api](api.md)). This is what lets `treg upload` push SQL-bearing recipes and `treg call` proxy
 SQL/HTML bodies through Cloudflare/Render. Transparent — no effect on any request that isn't blocked.
 
+`_active_org_id(cfg, c, strict=True)` resolves the active org's numeric id via `GET /orgs`, falling
+back to `/auth/me` when that 403s — which is what a MACHINE identity gets, since the server refuses it
+there on purpose. An invalid token now exits naming the real problem instead of the bare "no active
+org" that 21 commands used to print. `strict=False` is for callers that only ENRICH output (the pin
+marker on `catalog get`): the catalog is public, and `sys.exit` raises `SystemExit`, which
+`except Exception` does NOT catch — so a try/except at the call site would not have saved that page.
+
 ## Config + client (identity-first)
 `~/.treg/config.json` (`CONFIG_PATH`) is v2: `{base_url, token, email, active_org, identity, admin_token}`
 — **one bearer token + an active org slug** (`_load_config` migrates a legacy multi-org or flat config on

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -210,6 +210,8 @@ in the `X-Treg-Token` header on every call. Never share the upstream key - share
     treg org members | set-role <user_id> <role>  roster / change a role (owner)
     treg org invites | revoke <invite_id>         pending invites (admin+)
     treg org leave | delete <slug>                self-remove / delete (owner, confirm-by-name)
+    treg org pin <capability> --provider <p>      for THIS job the team uses THIS provider; calls to
+      treg org pins | unpin <capability>          any other provider of it are refused (admin+)
 
     treg secret add <name> (--value V | --file F | --dir D) [--kind env|oauth|secret_file]
     treg secret ls | rm <id> | update <id> …


### PR DESCRIPTION
`drift.sh` reported clean, but that was **vacuous** — it compares a branch against `main`, and I was
standing *on* `main`, so it had nothing to diff. Checking the fragments against the code instead found
four real gaps, all from changes made after the last sync.

| Fragment | What was wrong |
|---|---|
| `architecture/money.md` | still implied `GET /orgs/{id}/balance` was admin-only. It is not: any **member** now sees the figure and in-flight holds, while funding detail (blocks, ledger) stays admin+ |
| `architecture/catalog.md` | never described the free-price rule — `platform_eligible` demanded provenance for every route, so 61 free endpoints were refused as though "costs nothing" meant "we don't know" |
| `interface/api.md` | no mention of `DELETE /orgs/{id}?confirm=<slug>` — **required** now, and a contract change. Also documents `/auth/me` returning `org_id` so a machine identity can reach `/orgs/{id}/…` at all |
| `interface/cli.md` | nothing on `_active_org_id`'s `/auth/me` fallback, the honest auth error that replaced 21 bare "no active org" messages, or why `strict=False` exists |

## And one file with real reach

`/llms.txt` was missing **`treg org pin/pins/unpin`** entirely. That is the agent-facing front door,
and a command that changes what an agent is *allowed to call* belongs in it. This is the only change
here that affects anything running — the other four are internal design notes.

1184 tests pass.