### PR TITLE
fix(skill): drift.sh reported a vacuous "no drift" as a pass

### DIFF
--- a/.agents/skills/tools-registry-context/scripts/drift.sh
+++ b/.agents/skills/tools-registry-context/scripts/drift.sh
@@ -18,11 +18,39 @@ globs=$(python3 -c "import json;print(' '.join(json.load(open('$CONFIG')).get('s
 extre=$(python3 -c "import json;e=json.load(open('$CONFIG')).get('source_exts',[]);print('\\.('+'|'.join(e)+')\$' if e else '')" 2>/dev/null || true)
 
 cd "$ROOT"
+
+# An EMPTY RANGE and a CLEAN RANGE are different answers, and conflating them is how drift ships.
+# The default range is origin/main..HEAD, so running this while standing ON main (typically right
+# after a merge, which is exactly when someone thinks to check) diffs a branch against itself: zero
+# commits, zero changed files, "no drift" — a pass that proves nothing. Four stale fragments reached
+# production behind that reassurance. So: say when there is nothing to compare, and exit non-zero.
+if git rev-parse --verify --quiet "${RANGE%%..*}" >/dev/null 2>&1; then
+  commits=$(git rev-list --count "$RANGE" 2>/dev/null || echo 0)
+  if [ "$commits" -eq 0 ]; then
+    echo "⚠ NOTHING TO COMPARE — this is not a pass."
+    echo ""
+    echo "  '$RANGE' contains no commits: HEAD is at or behind the base, so there is no work to"
+    echo "  check. On the default range that means you are standing on the base branch itself."
+    echo ""
+    echo "  Branch: $(git branch --show-current 2>/dev/null || echo 'detached')  HEAD: $(git log --oneline -1 --format=%h)"
+    echo ""
+    echo "  To check work that is already merged, name a range that contains it:"
+    # Only a VERSION-shaped tag means "the last release" — this repo also carries evidence tags
+    # (pr-evidence, …) and `git describe` would happily offer one of those as a release boundary.
+    last_tag=$(git tag --list --sort=-v:refname 'v[0-9]*' '[0-9]*' 2>/dev/null | head -1)
+    [ -n "$last_tag" ] && printf '    drift.sh %-22s # since the last release\n' "$last_tag..HEAD"
+    printf '    drift.sh %-22s # the last 20 commits\n' "HEAD~20..HEAD"
+    echo ""
+    echo "  Run it BEFORE merging, from the branch, and the default range is the right one."
+    exit 2
+  fi
+fi
+
 changed=$(git diff --name-only "$RANGE" -- $globs 2>/dev/null || true)
 [ -n "$extre" ] && changed=$(printf '%s\n' "$changed" | grep -E "$extre" || true)
 
 if [ -z "$changed" ]; then
-  echo "No documented-source changes in $RANGE."
+  echo "No documented-source changes in $RANGE ($(git rev-list --count "$RANGE" 2>/dev/null || echo '?') commit(s) examined)."
   exit 0
 fi
 


### PR DESCRIPTION
The default range is `origin/main..HEAD`, so running the drift check while standing **on main** —
exactly when someone thinks to run it, right after merging — diffs a branch against itself. Zero
commits, zero changed files, `No documented-source changes`. **A pass that proves nothing was
checked.**

Not hypothetical: it reported clean today with **four stale fragments** in the tree —

- `money.md` still claiming the balance route was admin-only
- `catalog.md` missing the free-price rule
- `api.md` missing a **required** `?confirm=` parameter on a destructive route
- `cli.md` missing the machine-identity fallback

All four reached production behind that reassurance (fixed in #56).

## The fix

An empty range and a clean range are different answers. Now:

- **empty range** → says so loudly, prints branch + HEAD so the cause is obvious, suggests ranges
  that *do* contain the work, exits **2**
- **clean range** → also reports how many commits it examined, so "nothing changed" carries the
  evidence that something was looked at

Only **version-shaped** tags are offered as "the last release" — this repo carries evidence tags
(`pr-evidence`, `meta-consent-notice-evidence`) and `git describe` was suggesting one as a release
boundary.

Verified across all four states: vacuous (exit 2), real range with source changes (maps to
fragments), real range with none (exit 0 + commit count), and today's work with an explicit range.
Nothing calls this from CI, so the new exit code breaks no automation.

Note: only the `.agents/` copy is tracked — `.claude/` is gitignored. Both were patched identically.