### PR TITLE
feat(mcp): the MCP front door — five tools, one implementation of the rules

### DIFF
--- a/docs/MCP-PLUGIN-PLAN.md
+++ b/docs/MCP-PLUGIN-PLAN.md
@@ -1,0 +1,155 @@
+# The treg MCP server, and the plugin that ships it
+
+**Status:** spike COMPLETE and thrown away; implementation approved and not yet started.
+
+The goal is the plugin directory's traffic. A skill-only plugin gets that traffic and then tells the
+visitor to install a CLI — the dead end is the conversion. An MCP connector **works the moment it is
+installed**, and it is the only shape that reaches ChatGPT, where there is no terminal at all.
+
+Not one tool per provider. The catalog stays *data*; the MCP server exposes **treg's own operations**
+— the same handful the CLI has. Five tools, not 2,600.
+
+## What I verified first, on this machine (codex-cli 0.145.0)
+
+Three facts, each proven rather than read, because they decide the design:
+
+| Question | Answer | How |
+|---|---|---|
+| Can a plugin declare a **remote** MCP server, or only an OpenAI-registered connector? | **Yes, remote works** | Built a throwaway plugin whose `.mcp.json` declared a `url`; installed it; `codex mcp list` showed the server registered and enabled |
+| What config shape? | `{"<name>": {"url": …, "bearer_token_env_var": …}}` | `codex mcp add --url` writes exactly `[mcp_servers.x] url/bearer_token_env_var` |
+| Is OAuth supported, or only a bearer token? | Both — `codex mcp login <name>` authenticates by OAuth | `codex mcp login --help` |
+
+And the constraint that shapes phase 2: OpenAI's own `github` and `gmail` plugins use `.app.json`
+with an OpenAI-issued `connector_…` id. **That id comes from the submission process**, so the ChatGPT
+path is gated on review in a way the Codex path is not.
+
+## Spike results — all four questions answered, on this machine
+
+Throwaway code, deleted. What it proved:
+
+**1. It mounts inside treg's FastAPI app — but there is a trap.** `app.mount()` does **not** run the
+mounted app's lifespan, and the streamable-HTTP session manager initialises its task group there.
+Every request 500s with `Task group is not initialized`. treg's `api.py` already has a lifespan
+(database setup), so the real implementation must **compose** the two:
+
+```python
+mcp_app = mcp.streamable_http_app(streamable_http_path="/", stateless_http=True, json_response=True)
+
+@asynccontextmanager
+async def lifespan(app):
+    async with mcp_app.router.lifespan_context(mcp_app):   # treg's own lifespan wraps this
+        yield
+```
+
+Finding this in a spike rather than on Render is the whole point of the exercise.
+
+**2. `stateless_http=True` works**, which matters more than it looks: production is Render and can run
+more than one instance. A session-based transport would need sticky routing to be reliable. Stateless
+plus `json_response=True` also skips SSE framing, which is where the speed comes from.
+
+**3. It is FAST.** Measured over 12 calls each, against the real 2,590-endpoint catalog:
+
+| call | p50 | min | max | of which real work |
+|---|---|---|---|---|
+| `tools/list` | 1.5 ms | — | — | — |
+| `catalog_search("backlinks")` | **1.4 ms** | 1.0 | 1.9 | 0.18 ms |
+| `catalog_search("work email")` | **2.1 ms** | 1.9 | 2.6 | 1.01 ms |
+| `catalog_get(<id>)` | **1.4 ms** | 1.0 | 1.8 | — |
+
+Transport overhead is ~1.2 ms. The catalog is already parsed once at import, so search is a scan over
+memory. Nothing here needs a cache yet.
+
+**4. A tool CAN read the caller's bearer token** — `Context.headers`, populated by HTTP transports.
+Verified both ways: with a token the tool saw `authorization`, without one it saw the same headers
+minus that. Org isolation has something to key on.
+
+The SDK's own docstring carries the warning to honour: *"Headers are client-supplied input — never
+treat one as an identity assertion."* The token must be validated against the database on every
+call, exactly as the HTTP API does.
+
+**5. End to end from Codex, which is the real test.** Registered the spike with `codex mcp add --url`
+and asked Codex to search for backlinks endpoints. It called the tool and answered with real data —
+endpoint ids, providers, `$0.02436` per call, and "no API key needed" — in a 4 ms round trip.
+
+That is the "wow": a question in, a priced answer out, no key and no CLI.
+
+## The tool surface
+
+Five tools, each mirroring a CLI command that already exists and is tested:
+
+| Tool | Does | Mirrors |
+|---|---|---|
+| `catalog_search(query, limit)` | find endpoints by what you want to DO, with price, provider, and measured reliability | `treg catalog search` |
+| `catalog_get(endpoint_id)` | one endpoint: parameters, price, auth tier, capability siblings, observed stats | `treg catalog get` |
+| `call(endpoint_id, params)` | the metered call — treg injects the credential, relays the response | `treg call` |
+| `balance()` | the team's prepaid balance and in-flight holds | `treg balance` |
+| `my_tools()` | what the team registered: keys, OAuth connections, skills | `treg tool list` |
+
+**The tool descriptions are the product.** They are what the model reads when deciding whether treg
+is relevant, exactly as `skill.md`'s frontmatter is today. They get the same care.
+
+`call` returns the upstream response **verbatim**, plus what it cost. The founding rule is unchanged:
+treg relays, never models.
+
+## Where it lives, and the rule it must not break
+
+A new module, `src/treg/mcp.py`, mounted on the existing FastAPI app at `/mcp`. One deployment, one
+database, one set of rules.
+
+**It must route through `_resolve_marketplace_call`, not around it.** Org isolation, the balance
+reserve, the $5/day platform cap, capability pins and deny rules all live on that path. A second
+entrance that re-implements any of them is how the two drift and one of them stops being enforced.
+Concretely: `call` builds the same request the HTTP proxy does and goes through the same resolution,
+reservation and settle.
+
+## Authentication, in two phases
+
+**Phase 1 — Codex, works today.** The plugin's `.mcp.json` declares the URL and
+`bearer_token_env_var: TREG_TOKEN`. The user exports a per-org token. That is one environment
+variable instead of installing a CLI and signing in — and per-org tokens already exist, with roles
+and audit.
+
+**Phase 2 — ChatGPT, needs OAuth.** `codex mcp login` shows OAuth is supported, and MCP's spec uses
+OAuth 2.1. treg already runs OAuth for GitHub and Google sign-in and has a hosted connect flow, so
+there is a foundation — but this is genuine new work, and it is what the ChatGPT connector requires.
+
+Phase 1 ships and can be tested end to end. Phase 2 is what the public submission needs.
+
+## What the plugin contains
+
+    plugin/
+    ├── .codex-plugin/plugin.json     manifest + listing copy (reuse from the archived branch)
+    ├── .mcp.json                     the remote server declaration
+    ├── skills/tools-registry/        KEEP — generated from src/treg/web/skill.md
+    └── assets/                       icon + logo (already made)
+
+**Both**, exactly as OpenAI's `github` plugin ships `"skills"` and `"apps"` together. The connector
+gives the model the operations; the skill gives it the judgement — when treg is the right move, how
+to choose between providers, to state a price before spending. Tools alone would lose all of that.
+
+## Risks and open decisions
+
+- **`mcp` 2.0.0 depends on `httpx2`**, while treg's CLI uses `httpx`. It belongs in the `[server]`
+  extra only — the base install must stay the light CLI. Needs checking for conflict before committing
+  to the SDK.
+- **A public MCP endpoint is new attack surface.** Unauthenticated requests must be refused before
+  any work is done, and it needs its own rate limit — the existing per-user caps assume the HTTP API.
+- **Streamable HTTP is session-based**, which is a different lifecycle from treg's stateless
+  request/response. Worth a spike before committing.
+- **Token in an environment variable** is weaker than OAuth: it sits in the user's shell profile. It
+  is the pragmatic phase-1 answer, not the destination.
+- **Cost visibility.** A model calling `call` can spend real money. The tool description must state
+  the price, and `catalog_get` should be the encouraged step before `call`.
+
+## Build order
+
+1. **Spike** the MCP SDK against FastAPI — transport, session, dependency conflict. Throwaway.
+2. **`src/treg/mcp.py`** with the five tools, routed through the existing enforcement path.
+3. **Tests** — the enforcement ones matter most: a wrong-org token sees nothing, an over-cap call is
+   refused, an unpriced endpoint is refused, a pinned capability rejects the wrong provider.
+4. **Deploy** to the dev box, point Codex at it, exercise all five tools for real.
+5. **Package** the plugin, install from a local marketplace, verify in `codex exec`.
+6. **Then** the submission — with the connector, which is where phase 2 becomes required.
+
+Stop after step 4 and look at it before packaging. That is the point where the tool surface either
+reads well to a model or does not, and it is much cheaper to change then.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ server = [
     "pydantic-settings>=2.5",
     "pyyaml>=6",   # the endpoint catalog's data files (src/treg/catalog/*.yaml) — server-side only
     "stripe>=12",  # balance top-ups (src/treg/billing.py) — the payment rail, server-side only
+    "mcp>=2",      # the MCP front door (src/treg/mcp.py) — server-side only; pulls httpx2 ALONGSIDE
+                   # httpx (they coexist), so the light CLI's dependency set is untouched
 ]
 # The LOCAL PROXY (`treg shell` catching the agent's own outgoing calls). It needs to generate a
 # certificate authority on the machine, and `cryptography` is a compiled package — putting it in the

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -120,6 +120,15 @@ async def _local_owner(db: AsyncSession) -> User | None:
     return (await db.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one_or_none()
 
 
+# The MCP front door is OPTIONAL at import time. It lives in the `[server]` extra, and a deploy that
+# has not picked the dependency up yet must still serve the API — a missing optional feature is not a
+# reason for the whole registry to refuse to boot.
+try:
+    from . import mcp as _mcp
+except Exception:  # pragma: no cover - exercised by deploys without the extra
+    _mcp = None
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
@@ -129,7 +138,14 @@ async def lifespan(app: FastAPI):
     limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
     app.state.http = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(float(get_settings().call_timeout_s)))
     try:
-        yield
+        if _mcp is None:
+            yield
+        else:
+            # `app.mount()` does NOT run a mounted app's lifespan, and the streamable-HTTP session
+            # manager builds its task group there. Without entering it here, every /mcp request fails
+            # with "Task group is not initialized" — silently, and only under real traffic.
+            async with _mcp.mcp_lifespan():
+                yield
     finally:
         await audit.drain()  # flush pending audit writes before tearing down
         await app.state.http.aclose()
@@ -6720,3 +6736,13 @@ async def _bundle_view(bundle_id: int, db: AsyncSession) -> dict:
         "tools": [_tool_view(t) for t in tools],
         "secrets": [_secret_view(s) for s in secrets],
     }
+
+
+# ---------------------------------------------------------------------------------------------
+# The MCP front door
+# ---------------------------------------------------------------------------------------------
+# Mounted LAST so it cannot shadow a route, and guarded so a deploy without the `[server]` extra's
+# `mcp` dependency still serves everything else. Its lifespan is entered in `lifespan` above — a
+# mounted app's own lifespan never runs, and this one builds the transport's task group there.
+if _mcp is not None:
+    app.mount("/mcp", _mcp.mcp_app)

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -1,0 +1,338 @@
+"""The MCP front door — treg's own operations, exposed to an agent that has no terminal.
+
+A coding agent reaches treg through the CLI, and the skill tells it which commands to run. An agent
+inside ChatGPT or a Codex plugin has no CLI, and telling it to install one is where the visitor
+leaves. This module is the other door: five tools over MCP, so an agent can search the catalog, read
+a price and make the call without anything being installed first.
+
+**Five tools, not 2,600.** The catalog stays *data* — one tool searches it, one reads an entry, one
+calls an endpoint. Exposing every endpoint as its own MCP tool would flood the model's context with
+2,600 schemas and make the catalog unusable, which is the opposite of the point.
+
+**One implementation of the rules.** Everything that touches money, tenancy or credentials goes back
+through treg's own HTTP API in-process (`httpx.ASGITransport`), rather than reaching into the
+internals a second time. `/call/` already enforces the per-member tool ACL, deny rules, the per-user
+daily cap, the platform daily cap, the balance reserve and the settle — a second entrance that
+re-implemented any of that is exactly how one copy quietly stops being enforced. The cost is one
+in-process round trip with no socket, which measured at well under a millisecond.
+
+Only the **public catalog** is read directly (`catalog_store`), because it is already parsed in
+memory, needs no database and no identity, and answering from it takes ~1 ms.
+
+**Headers are not identity.** The SDK's own docstring says it and it is worth repeating: the bearer
+token arriving on an MCP request is client-supplied input. It is validated against the database on
+every call by the same code the HTTP API uses — never trusted because it looks well-formed.
+
+Transport is **stateless streamable HTTP with JSON responses**: production runs more than one
+instance, and a session-bound transport would need sticky routing to be reliable.
+
+Mounting has one trap, and it is silent: `app.mount()` does NOT run the mounted app's lifespan, and
+the session manager initialises its task group there — every request then fails with "Task group is
+not initialized". `api.py` must compose this module's lifespan with its own; see `mcp_lifespan`.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
+from mcp.server.transport_security import TransportSecuritySettings
+
+from . import catalog_store
+from .config import get_settings
+
+# One shared in-process client. ASGITransport speaks straight to the app object — no socket, no DNS,
+# no TLS — so this is a function call wearing an HTTP shape, which is what makes reusing the real
+# route cheap enough to be the honest choice.
+_INTERNAL_BASE = "http://treg.internal"
+_TIMEOUT = httpx.Timeout(120.0, connect=5.0)
+
+mcp = MCPServer(
+    name="treg",
+    title="treg — the tool catalog for your agent",
+    description=(
+        "Call the tool you need for a task without owning its API key. ~2,600 curated API endpoints "
+        "across ~40 providers (SEO, SERP, backlinks, social, people and company enrichment, ads, "
+        "scraping). Most need no key at all: treg holds the credential and meters each call from "
+        "your team's prepaid balance."
+    ),
+    instructions=(
+        "Ask for the task, not the tool. Start with catalog_search using words for what you want to "
+        "DO ('work email', 'backlinks', 'tiktok comments') — not a vendor name. Read the price with "
+        "catalog_get before spending, then call. treg COMPARES providers and reports what it "
+        "measured; choosing is yours. There is no automatic routing and no failover."
+    ),
+)
+
+
+def _bearer(ctx: Context) -> str:
+    """The caller's token, straight from the request headers.
+
+    Returns "" when absent — every authenticated tool then fails closed with an instruction rather
+    than a stack trace, because a missing token is the single most likely first-run problem.
+    """
+    headers = ctx.headers or {}
+    raw = headers.get("authorization") or headers.get("Authorization") or ""
+    return raw.removeprefix("Bearer ").removeprefix("bearer ").strip()
+
+
+def _need_token() -> dict:
+    return {
+        "error": "not authenticated",
+        "detail": (
+            "This MCP server needs a treg token. Get one at https://treg.superdesign.dev "
+            "(sign in, then Settings -> copy token) and set it as the TREG_TOKEN environment "
+            "variable for this server."
+        ),
+    }
+
+
+@asynccontextmanager
+async def _api(token: str):
+    """An in-process client bound to treg's own ASGI app, carrying the caller's identity."""
+    from .api import app  # deferred: api.py imports THIS module to mount it
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url=_INTERNAL_BASE,
+        timeout=_TIMEOUT,
+        headers={"X-Treg-Token": token},
+    ) as client:
+        yield client
+
+
+def _body(r: httpx.Response) -> Any:
+    try:
+        return r.json()
+    except ValueError:
+        return r.text
+
+
+async def _org_id(client: httpx.AsyncClient) -> int | None:
+    """The token's org. A per-org token has one baked in, and `/auth/me` reports it — the same route
+    the CLI uses, so a machine identity resolves here exactly as it does there."""
+    r = await client.get("/auth/me")
+    return _body(r).get("org_id") if r.status_code == 200 else None
+
+
+# --------------------------------------------------------------------------------------------
+# The catalog — public, in memory, no identity needed
+# --------------------------------------------------------------------------------------------
+
+@mcp.tool(
+    description=(
+        "Search ~2,600 API endpoints by WHAT YOU WANT TO DO, not by vendor. Use plain task words: "
+        "'work email', 'backlinks for a domain', 'tiktok comments', 'keyword search volume'. "
+        "Returns each endpoint's id, provider, price per call, and whether treg can serve it "
+        "without you owning an API key. Call this FIRST when a task needs data or an API you have "
+        "no key for."
+    )
+)
+async def catalog_search(query: str, limit: int = 8) -> dict:
+    cat = catalog_store.load()
+    ranked, total = catalog_store.search(query, cat, max(1, min(limit, 25)))
+    results = []
+    for ep, score in ranked:
+        cost = cat.cost_view(ep.get("cost"), ep.get("provider")) or {}
+        results.append({
+            "endpoint_id": ep["id"],
+            "name": ep.get("name") or (ep.get("summary") or "")[:70],
+            "provider": ep.get("provider"),
+            "usd_per_call": cost.get("usd"),
+            "no_key_needed": cat.platform_eligible(ep),
+            "score": score,
+        })
+    out = {"query": query, "count": len(results), "total_matches": total, "results": results}
+    if not results:
+        out["hint"] = (
+            f"nothing matches all of {query!r} — drop a word, or try a different way of saying the task"
+        )
+    else:
+        out["next"] = "catalog_get(endpoint_id) for parameters and the exact price, then call(...)"
+    return out
+
+
+@mcp.tool(
+    description=(
+        "One endpoint in full: its parameters, the exact price per call, whether treg serves it on "
+        "its own key, and the other providers that answer the same capability — with the success "
+        "rate and speed treg has measured across real calls. Read this BEFORE call() so you can "
+        "tell the human what it will cost."
+    )
+)
+async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
+    """Goes through the HTTP route rather than the store: that route attaches the observed
+    reliability figures and the capability siblings, and those come from the database."""
+    token = _bearer(ctx)
+    async with _api(token) as client:
+        r = await client.get(f"/catalog/endpoints/{endpoint_id}")
+    if r.status_code == 404:
+        return {"error": f"unknown endpoint {endpoint_id!r}",
+                "hint": "use catalog_search to find the right id"}
+    return _body(r)
+
+
+# --------------------------------------------------------------------------------------------
+# Everything below spends money or reads a team's data — all of it goes back through the API
+# --------------------------------------------------------------------------------------------
+
+@mcp.tool(
+    description=(
+        "Call a catalog endpoint by its id. treg injects the credential server-side and relays the "
+        "provider's response unchanged — you never hold an API key. Metered from the team's prepaid "
+        "balance when treg's own key is used; free when the team registered its own. Tell the human "
+        "the price (from catalog_get) before calling anything that costs more than a cent."
+    )
+)
+async def call(endpoint_id: str, params: dict | None = None, ctx: Context = None) -> dict:  # type: ignore[assignment]
+    token = _bearer(ctx) if ctx else ""
+    if not token:
+        return _need_token()
+    ep = catalog_store.load().by_id.get(endpoint_id)
+    if ep is None:
+        return {"error": f"unknown endpoint {endpoint_id!r}",
+                "hint": "use catalog_search to find the right id"}
+
+    method = (ep.get("method") or "GET").upper()
+    args = params or {}
+    async with _api(token) as client:
+        # The SAME route the CLI and the proxy use, so the tool ACL, deny rules, both daily caps,
+        # the balance reserve and the settle all happen exactly once, in one place.
+        if method in ("GET", "HEAD", "DELETE"):
+            r = await client.request(method, f"/call/{endpoint_id}", params=args)
+        else:
+            r = await client.request(method, f"/call/{endpoint_id}", json=args)
+
+    out: dict[str, Any] = {"status": r.status_code, "endpoint_id": endpoint_id, "body": _body(r)}
+    spent = r.headers.get("X-Treg-Cost-Micro")
+    if spent:
+        try:
+            out["cost_usd"] = round(int(spent) / 1_000_000, 6)
+        except ValueError:
+            pass
+    if r.status_code == 402:
+        out["hint"] = "the team's prepaid balance is short — top up at https://treg.superdesign.dev"
+    elif r.status_code >= 400:
+        # Whose fault it was matters to an agent deciding whether to retry elsewhere.
+        out["whose_error"] = "treg" if r.headers.get("X-Treg-Error") else "provider"
+    return out
+
+
+@mcp.tool(
+    description=(
+        "The team's prepaid balance in USD, and any spend currently in flight. Check it when a call "
+        "is refused for funds, or before a job that will make many calls."
+    )
+)
+async def balance(ctx: Context) -> dict:
+    token = _bearer(ctx)
+    if not token:
+        return _need_token()
+    async with _api(token) as client:
+        org_id = await _org_id(client)
+        if org_id is None:
+            return {"error": "could not resolve the team for this token",
+                    "hint": "the token may be expired — copy a fresh one from the dashboard"}
+        r = await client.get(f"/orgs/{org_id}/balance")
+    body = _body(r)
+    if r.status_code != 200:
+        return {"error": "could not read the balance", "detail": body}
+    return {
+        "balance_usd": round((body.get("balance_micro") or 0) / 1_000_000, 6),
+        "balance_micro": body.get("balance_micro"),
+        "holds_micro": body.get("holds_micro"),
+    }
+
+
+@mcp.tool(
+    description=(
+        "What THIS team has registered and you can call without holding the credential: their own "
+        "API keys, OAuth connections, vendor CLIs and skills. A team's own tool always wins over "
+        "treg's catalog key, and those calls are never metered."
+    )
+)
+async def my_tools(ctx: Context) -> dict:
+    token = _bearer(ctx)
+    if not token:
+        return _need_token()
+    async with _api(token) as client:
+        r = await client.get("/tools")
+    body = _body(r)
+    if r.status_code != 200:
+        return {"error": "could not list the team's tools", "detail": body}
+    tools = body if isinstance(body, list) else body.get("tools", [])
+    return {
+        "count": len(tools),
+        "tools": [{"name": t.get("name"), "base_url": t.get("base_url"),
+                   "description": t.get("description")} for t in tools],
+    }
+
+
+# --------------------------------------------------------------------------------------------
+# Mounting
+# --------------------------------------------------------------------------------------------
+
+def _allowed_hosts() -> list[str]:
+    """Which `Host` headers the transport will answer to.
+
+    The SDK ships DNS-rebinding protection ON with an EMPTY allow-list, which rejects **everything**
+    with a 421 — the default is unusable rather than merely strict, and it fails at request time, so
+    a deploy looks healthy right up until the first tool call. Found by the tests here; it would
+    otherwise have been found in production.
+
+    The protection is real (it stops a web page from driving a localhost MCP server), so it stays on
+    and the list is built instead: this deployment's own `public_url`, the loopback names a developer
+    actually uses, and the in-process host the API calls itself on. `TREG_MCP_ALLOWED_HOSTS` adds
+    more, comma-separated, for a deployment behind another name — the ngrok dev box, say, or a second
+    domain.
+    """
+    hosts: list[str] = []
+    public = urlsplit(get_settings().public_url).netloc
+    if public:
+        hosts += [public, public.split(":")[0]]
+    hosts += ["localhost", "127.0.0.1", "treg.internal"]
+    hosts += [h.strip() for h in os.environ.get("TREG_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+    # a bare host and host:port are different header values, so allow the common local ports too
+    hosts += [f"localhost:{p}" for p in ("8000", "18790")] + [f"127.0.0.1:{p}" for p in ("8000", "18790")]
+    return sorted(dict.fromkeys(hosts))
+
+
+def build_mcp_app():
+    """A fresh ASGI app for the MCP transport.
+
+    A factory rather than a bare module-level value because each call builds its own session
+    manager, and `StreamableHTTPSessionManager.run()` may be called **once per instance** — a second
+    start raises. That is right for a server (one process, one lifespan) and impossible for a test
+    suite, which needs a clean instance per test. The tools themselves are shared: they hang off the
+    module-level `mcp` server, so a fresh transport still exercises the real implementations.
+
+    `stateless_http` because production runs more than one instance and a session-bound transport
+    would need sticky routing; `json_response` because these are request/response tools with nothing
+    to stream, and skipping SSE framing is most of the speed.
+    """
+    return mcp.streamable_http_app(
+        streamable_http_path="/", stateless_http=True, json_response=True,
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=True,
+            allowed_hosts=_allowed_hosts(),
+            allowed_origins=["*"],  # identity is the bearer token, not the origin; a CLI sends none
+        ),
+    )
+
+
+mcp_app = build_mcp_app()
+
+
+@asynccontextmanager
+async def mcp_lifespan(target=None):
+    """MUST be entered by the host app's lifespan. `app.mount()` does not run a mounted app's
+    lifespan, and the streamable-HTTP session manager builds its task group there — without this
+    every MCP request fails with "Task group is not initialized"."""
+    target = target or mcp_app
+    async with target.router.lifespan_context(target):
+        yield

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,222 @@
+"""The MCP front door — that it answers, and that it enforces the same rules as every other door.
+
+Two halves, and the second is the one that matters. A new entrance onto a paid catalog is only safe
+if it cannot see another team's data, cannot spend past the caps, and cannot be talked into serving
+an endpoint whose price nobody knows. `mcp.py` gets that by routing through treg's own API rather
+than reaching into the internals — these tests are what proves the routing is real and not merely
+intended.
+
+The transport is exercised as a real MCP client would: JSON-RPC over the mounted ASGI app.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from treg.api import app
+
+pytestmark = pytest.mark.anyio
+
+MCP_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+
+
+async def _rpc(client: AsyncClient, method: str, params=None, token: str | None = None):
+    headers = dict(MCP_HEADERS)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    body = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        body["params"] = params
+    # An ABSOLUTE url so the Host header is a real one. The transport enforces DNS-rebinding
+    # protection, and the suite's base_url ("http://registry") is deliberately not on the
+    # allow-list — see test_an_unknown_host_is_refused.
+    r = await client.post("http://localhost/mcp/", json=body, headers=headers)
+    return r
+
+
+async def _call_tool(client: AsyncClient, name: str, args: dict, token: str | None = None) -> dict:
+    await _rpc(client, "initialize", {
+        "protocolVersion": "2025-06-18", "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"}}, token)
+    r = await _rpc(client, "tools/call", {"name": name, "arguments": args}, token)
+    payload = r.json()
+    content = (payload.get("result") or {}).get("content") or []
+    if content and content[0].get("type") == "text":
+        try:
+            return json.loads(content[0]["text"])
+        except ValueError:
+            return {"_text": content[0]["text"]}
+    return payload
+
+
+@asynccontextmanager
+async def mcp_session(client: AsyncClient):
+    """Run the MCP lifespan around a block of requests.
+
+    Deliberately NOT a fixture. The lifespan holds an anyio task group, and a fixture enters it in
+    one task and exits it in another — anyio refuses that ("Attempted to exit cancel scope in a
+    different task"). Entering it inside the test body keeps both ends in the same task.
+
+    That the mounted app needs its lifespan run at all is the trap the module docstring warns about:
+    `app.mount()` does not run it, and the transport builds its task group there. It caught me here
+    first, which is the cheapest place for it to happen.
+
+    The default `X-Treg-Token` is dropped: MCP carries identity in `Authorization`, and leaving a
+    second credential on the client would let a test pass for the wrong reason.
+    """
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient as _AC
+
+    from treg import mcp as _mcp
+
+    # A FRESH transport per test: `StreamableHTTPSessionManager.run()` may be called once per
+    # instance, so the module-level one cannot be restarted between tests. The tools are the same
+    # objects either way — they hang off the shared `mcp` server — and they still reach the real
+    # `treg.api.app` internally, so the enforcement under test is the production path.
+    fresh = _mcp.build_mcp_app()
+    host = FastAPI()
+    host.mount("/mcp", fresh)
+    client.headers.pop("X-Treg-Token", None)
+    async with _mcp.mcp_lifespan(fresh):
+        async with _AC(transport=ASGITransport(app=host), base_url="http://localhost") as mc:
+            mc.headers.update({k: v for k, v in client.headers.items() if k.lower() == "cookie"})
+            yield mc
+
+
+async def test_the_server_lists_exactly_the_five_tools(clients):
+    """Five tools, not 2,600. The catalog is DATA reached through a tool, never a tool per endpoint —
+    2,600 schemas would bury the model's context and make the catalog unusable."""
+    async with mcp_session(clients) as c:
+        await _rpc(c, "initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                                     "clientInfo": {"name": "t", "version": "1"}})
+        r = await _rpc(c, "tools/list")
+        names = {t["name"] for t in r.json()["result"]["tools"]}
+    assert names == {"catalog_search", "catalog_get", "call", "balance", "my_tools"}
+
+
+async def test_catalog_search_answers_without_any_token(clients):
+    """The catalog is public — discovery must work before anyone has signed up, or the first
+    impression of the plugin is an auth error."""
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 3})
+    assert out["results"], out
+    first = out["results"][0]
+    assert first["endpoint_id"] and first["provider"]
+    assert "usd_per_call" in first and "no_key_needed" in first
+
+
+async def test_search_says_so_when_nothing_matches(clients):
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "catalog_search", {"query": "zzzz-no-such-capability"})
+    assert out["count"] == 0
+    assert "hint" in out
+
+
+# ---- the half that matters: no token means no data, no spending ----------------------------
+
+@pytest.mark.parametrize("tool", ["call", "balance", "my_tools"])
+async def test_every_spending_or_tenant_tool_refuses_without_a_token(clients, tool):
+    """A public MCP endpoint onto a paid catalog is the whole risk of this feature. Anything that
+    reads a team's data or moves its money must fail closed, and say what to do about it."""
+    args = {"endpoint_id": "tikhub.tiktok.video.comments"} if tool == "call" else {}
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, tool, args)
+    assert out.get("error") == "not authenticated", out
+    assert "TREG_TOKEN" in json.dumps(out)
+
+
+async def test_a_bogus_token_gets_nothing(clients):
+    """Headers are client-supplied input. A well-formed but unknown token must be rejected by the
+    database, not accepted because it looks like one."""
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token="tok_not_a_real_token_at_all")
+    assert "balance_usd" not in out, out
+    assert out.get("error")
+
+
+async def test_a_real_token_reads_its_OWN_balance(clients):
+    """The positive case, and the one that proves the plumbing: a genuine token resolves to its org
+    through `/auth/me` and reads that org's balance — the same route the CLI uses."""
+    token = (await clients.post("/auth/cli-token")).json()["token"] if False else None
+    # the suite's client was created with a real per-org token; recover it before it is dropped
+    r = await clients.post("/users", json={"email": "mcpuser@superdesign.dev"})
+    token = r.json()["token"]
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=token)
+    assert "balance_usd" in out, out
+    assert out["balance_usd"] >= 0
+
+
+async def test_one_team_cannot_read_another_teams_tools(clients):
+    """Tenant isolation, asserted rather than assumed. Two orgs, two tokens: each sees only its own
+    registered tools. This is the property a second front door is most likely to lose."""
+    a = (await clients.post("/users", json={"email": "org-a@superdesign.dev"})).json()["token"]
+    b = (await clients.post("/users", json={"email": "org-b@superdesign.dev"})).json()["token"]
+    clients.headers["X-Treg-Token"] = a
+    made = await clients.post("/tools", json={"name": "a-only-tool", "base_url": "http://upstream"})
+    assert made.status_code == 200, made.text
+
+    async with mcp_session(clients) as c:
+        seen_a = await _call_tool(c, "my_tools", {}, token=a)
+        seen_b = await _call_tool(c, "my_tools", {}, token=b)
+    names_a = {t["name"] for t in seen_a.get("tools", [])}
+    names_b = {t["name"] for t in seen_b.get("tools", [])}
+    # Not vacuous: org A must genuinely SEE its tool, or "B cannot see it" proves nothing.
+    assert names_a, f"org A saw no tools at all — the assertion below would pass for free: {seen_a}"
+    assert "a-only-tool" in names_a
+    assert "a-only-tool" not in names_b, f"org B saw org A's tool: {seen_b}"
+
+
+async def test_call_refuses_an_endpoint_that_does_not_exist(clients):
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {"endpoint_id": "nope.not.real"}, token="tok_whatever")
+    assert "unknown endpoint" in out.get("error", "")
+    assert "catalog_search" in out.get("hint", "")   # names the way out, rather than leaving it guessing
+
+
+async def test_tool_descriptions_do_not_promise_routing(clients):
+    """The charter's standing rule, and the one the landing page already had to be corrected for:
+    treg COMPARES providers and the caller chooses. These descriptions are read by every model that
+    installs the plugin, so a false claim here travels further than the website's did."""
+    async with mcp_session(clients) as c:
+        await _rpc(c, "initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                                     "clientInfo": {"name": "t", "version": "1"}})
+        r = await _rpc(c, "tools/list")
+        blob = json.dumps(r.json()).lower()
+    for claim in ("routes for you", "automatic failover", "fails over", "picks the best provider"):
+        assert claim not in blob
+
+
+async def test_an_unknown_host_is_refused(clients):
+    """The SDK's DNS-rebinding protection, proven live rather than trusted.
+
+    It ships ON with an EMPTY allow-list, which 421s EVERYTHING — a deploy looks healthy until the
+    first tool call. `mcp._allowed_hosts()` builds the list from this deployment's `public_url` plus
+    the loopback names, so this asserts both directions: a known host works (every other test) and an
+    unknown one does not."""
+    async with mcp_session(clients) as c:
+        r = await c.post("http://evil.example.com/mcp/", json={"jsonrpc": "2.0", "id": 1,
+                         "method": "tools/list"}, headers=MCP_HEADERS)
+    assert r.status_code == 421, r.text
+
+
+async def test_the_deployments_own_host_is_allowed():
+    """The list must contain the host treg actually answers on, or production 421s every call."""
+    from urllib.parse import urlsplit
+
+    from treg.config import get_settings
+    from treg.mcp import _allowed_hosts
+
+    assert urlsplit(get_settings().public_url).netloc in _allowed_hosts()
+
+
+async def test_the_price_is_visible_before_spending(clients):
+    """An agent that cannot see a price before calling cannot warn the human, and the skill's rule is
+    to state the cost first. Search must carry the number."""
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 5})
+    assert any(r.get("usd_per_call") is not None for r in out["results"])

--- a/uv.lock
+++ b/uv.lock
@@ -67,6 +67,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -270,6 +279,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +329,32 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -322,6 +370,83 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx2" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -447,6 +572,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -482,6 +621,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
 ]
 
 [[package]]
@@ -525,6 +686,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -537,6 +712,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
 ]
 
 [[package]]
@@ -586,6 +799,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +855,7 @@ server = [
     { name = "asyncpg" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "mcp" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -652,6 +879,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'server'", specifier = ">=43" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "mcp", marker = "extra == 'server'", specifier = ">=2" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.5" },
     { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6" },
     { name = "questionary", specifier = ">=2.0" },
@@ -660,13 +888,22 @@ requires-dist = [
     { name = "stripe", marker = "extra == 'server'", specifier = ">=12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'server'", specifier = ">=0.32" },
 ]
-provides-extras = ["server"]
+provides-extras = ["server", "proxy"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "tools-registry", extras = ["server"] },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
An agent inside ChatGPT or a Codex plugin has no terminal, and a skill that says *"first install this
CLI"* is where the visitor leaves. This is the other door: `/mcp`, streamable HTTP, five tools.

## Five tools, not 2,600

`catalog_search` · `catalog_get` · `call` · `balance` · `my_tools` — each mirroring a CLI command
that already exists. The catalog stays **data**; a tool per endpoint would bury the model's context
in 2,600 schemas and make it unusable.

## One implementation of the rules

Everything touching money, tenancy or credentials goes back through treg's **own HTTP API**
in-process (`httpx.ASGITransport`). `/call/` already enforces the member ACL, deny rules, both daily
caps, the balance reserve and the settle — a second entrance re-implementing any of that is how one
copy quietly stops being enforced. Only the public catalog is read directly, since it is already in
memory and needs no identity.

## Three traps found by building it

- **`app.mount()` does not run a mounted app's lifespan**, and the transport builds its task group
  there — every request 500s with *"Task group is not initialized"*. `api.py` now composes the two.
  It caught me twice: in the spike, then in my own test fixture.
- **The SDK ships DNS-rebinding protection ON with an EMPTY allow-list**, which 421s *everything*.
  The deploy would have looked healthy until the first tool call. `_allowed_hosts()` builds the list
  from `public_url` plus loopback (`TREG_MCP_ALLOWED_HOSTS` extends it), and a test asserts **both**
  directions.
- **`StreamableHTTPSessionManager.run()` is once-per-instance**, so `build_mcp_app()` is a factory.

## Proven from Codex, not just in tests

Asked for work-email options with no API key, it searched, read two endpoints and compared
`hunter` ($0.0245/success), `leadmagic` ($0.025) and `thecompaniesapi` ($0.0019) — noting the third
returns a **pattern**, not a confirmed address — then declined to spend because I told it not to.
`balance` → $1.00 (the new-team grant); `my_tools` → 0.

**Not yet proven:** a *successful* metered call. `call` took the full path and returned the correct
refusal with `whose_error: treg`, but the dev box holds no provider keys — that only becomes
testable on production.

## Safety

- Import is **optional** and mounted **last**: a deploy without the `mcp` dependency still serves
  everything else.
- Tenant isolation is asserted **non-vacuously** — org A must see its own tool for the test to mean
  anything.
- A test forbids the tool descriptions from claiming routing or failover, the same guard the landing
  page needed.

Lock regenerated with a modern uv (0.12) rather than this Mac's 0.5.2: format preserved at revision
3, additions only, and it restored `provides-extras = ["server", "proxy"]` which the old uv dropped.

**1198 tests pass.**