### PR TITLE
fix(mcp): `call` can reach the team's own tools, not only the catalog

### DIFF
--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -216,22 +216,31 @@ async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
 
 @mcp.tool(
     description=(
-        "Call a catalog endpoint by its id. treg injects the credential server-side and relays the "
-        "provider's response unchanged — you never hold an API key. Metered from the team's prepaid "
-        "balance when treg's own key is used; free when the team registered its own. Tell the human "
-        "the price (from catalog_get) before calling anything that costs more than a cent."
+        "Call something through treg. Either a CATALOG endpoint by its id (from catalog_search), or "
+        "one of THIS TEAM'S own tools as '<tool-name>/<path>' (from my_tools) — e.g. "
+        "'render/v1/services'. treg injects the credential server-side and relays the provider's "
+        "response unchanged, so you never hold an API key. Catalog calls on treg's key are metered "
+        "from the team's prepaid balance; a team's own tool is never metered. Tell the human the "
+        "price (from catalog_get) before calling anything that costs more than a cent."
     )
 )
-async def call(endpoint_id: str, params: dict | None = None, ctx: Context = None) -> dict:  # type: ignore[assignment]
+async def call(endpoint_id: str, params: dict | None = None,
+               method: str | None = None, ctx: Context = None) -> dict:  # type: ignore[assignment]
     token = _bearer(ctx) if ctx else ""
     if not token:
         return _need_token()
-    ep = catalog_store.load().by_id.get(endpoint_id)
-    if ep is None:
-        return {"error": f"unknown endpoint {endpoint_id!r}",
-                "hint": "use catalog_search to find the right id"}
 
-    method = (ep.get("method") or "GET").upper()
+    # BOTH halves answer here, exactly as `treg call` does: `/call/{rest}` resolves a team's own tool
+    # first and falls back to a catalog id, so an org tool always wins over the catalog. Pre-checking
+    # the catalog and refusing anything absent would have made `my_tools` a list of things the agent
+    # could see and never call — which is how this gap was found.
+    ep = catalog_store.load().by_id.get(endpoint_id)
+    if ep is None and "/" not in endpoint_id:
+        return {"error": f"unknown endpoint {endpoint_id!r}",
+                "hint": "use catalog_search for a catalog id, or my_tools then "
+                        "'<tool-name>/<path>' for one of this team's own tools"}
+
+    method = (method or (ep.get("method") if ep else None) or "GET").upper()
     args = params or {}
     async with _api(token) as client:
         # The SAME route the CLI and the proxy use, so the tool ACL, deny rules, both daily caps,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -189,6 +189,23 @@ async def test_one_team_cannot_read_another_teams_tools(clients):
     assert "a-only-tool" not in names_b, f"org B saw org A's tool: {seen_b}"
 
 
+async def test_call_reaches_the_TEAMS_OWN_tools_too(clients):
+    """`my_tools` lists what the team registered; `call` must be able to call it.
+
+    The first version pre-checked the catalog and refused anything absent, which made `my_tools` a
+    list of things an agent could see and never use — found by trying it on production. `/call/`
+    already resolves a team's own tool first and falls back to a catalog id, so the fix was to stop
+    second-guessing it."""
+    made = await clients.post("/tools", json={"name": "echo", "base_url": "http://upstream"})
+    assert made.status_code == 200, made.text
+    token = clients.headers.get("X-Treg-Token")
+
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {"endpoint_id": "echo/anything"}, token=token)
+    assert out.get("status") == 200, out
+    assert "unknown endpoint" not in json.dumps(out)
+
+
 async def test_call_refuses_an_endpoint_that_does_not_exist(clients):
     async with mcp_session(clients) as c:
         out = await _call_tool(c, "call", {"endpoint_id": "nope.not.real"}, token="tok_whatever")


### PR DESCRIPTION
Found by **using it on production**, not by reading it: `my_tools` listed the seven tools this team
has registered, and `call` refused every one of them with *"unknown endpoint"*. The tool that lists
what an agent can use was paired with a tool that could not use them.

The cause was `call` pre-checking `catalog_store.by_id` and refusing anything absent. `/call/{rest}`
already resolves a team's own tool **first** and falls back to a catalog id — that ordering *is* the
product's "your own key always wins over treg's" rule — so the fix is to stop second-guessing it.

`call` now takes either shape:

- a catalog id from `catalog_search` — e.g. `hunter.people.email.find`
- `<tool-name>/<path>` from `my_tools` — e.g. `render/v1/services`

The catalog lookup survives only to choose the HTTP method and to give a good error for a bare name
that matches nothing. An optional `method` argument covers a team tool needing POST.

A test now registers a tool and calls it through MCP, so the two halves stay connected.

**1209 tests pass.**