### PR TITLE
fix(api): deleting a team 500s — the cascade missed four org-scoped tables

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -51,7 +51,8 @@ from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
-from .models import ROLE_RANK, Bundle, CallRecord, CapabilityPin, DenyRule, Invite, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User
+from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold, Invite,
+                     LedgerEntry, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User)
 from .proxy import relay
 
 
@@ -1728,11 +1729,29 @@ async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
     return len(actives) <= 1
 
 
+# Every model carrying an `org_id`. Deleting the org without clearing these leaves rows pointing at
+# a row that no longer exists, and the delete fails with a 500 at the foreign key.
+#
+# This list has to be kept in step with the schema, and twice it was not: the money tables arrived
+# with the prepaid balance and `CapabilityPin` with capability pins, and neither was added here. The
+# effect was invisible until someone tried it — since every NEW team is granted $1.00, every team has
+# a CreditBlock, so NO team could be deleted at all. `test_org_delete_clears_every_org_scoped_table`
+# now walks the models module and fails if a new one is ever missed, rather than trusting this list.
+#
+# Order matters: LedgerEntry references a CreditBlock, so it goes first.
+_ORG_SCOPED_MODELS = (
+    Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project,
+    CapabilityPin, LedgerEntry, Hold, CreditBlock,
+    Membership,   # last: it is what makes the caller a member of the org being deleted
+)
+
+
 async def _cascade_delete_org(org: Org, db: AsyncSession) -> None:
     """Delete every org-scoped row then the org. Shared by owner delete_org + admin force-delete."""
-    for model in (Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project, Membership):
+    for model in _ORG_SCOPED_MODELS:
         for r in (await db.execute(select(model).where(model.org_id == org.id))).scalars().all():
             await db.delete(r)
+        await db.flush()   # honour the ordering above rather than leaving it to the unit of work
     await db.delete(org)
 
 

--- a/tests/test_orgs.py
+++ b/tests/test_orgs.py
@@ -1,0 +1,56 @@
+
+
+# ---- deleting a team must clear everything that points at it -------------------------------
+
+async def test_org_delete_clears_EVERY_org_scoped_table(clients):
+    """The list in `_cascade_delete_org` has to stay in step with the schema, and twice it did not:
+    the money tables arrived with the prepaid balance and `CapabilityPin` with capability pins, and
+    neither was added. The effect was invisible until someone tried it — and because every NEW team
+    is granted $1.00, every team has a CreditBlock, so NO team could be deleted at all. Production
+    returned a bare 500.
+
+    So this walks the models module rather than restating the list: any future model carrying an
+    `org_id` fails here until it is handled."""
+    import inspect
+
+    from sqlmodel import SQLModel
+
+    from treg import models as m
+    from treg.api import _ORG_SCOPED_MODELS
+
+    covered = {model.__name__ for model in _ORG_SCOPED_MODELS}
+    missing = []
+    for name, obj in vars(m).items():
+        if not (inspect.isclass(obj) and issubclass(obj, SQLModel) and obj is not SQLModel):
+            continue
+        table = getattr(obj, "__table__", None)
+        if table is not None and "org_id" in table.columns and name not in covered:
+            missing.append(name)
+    assert not missing, (
+        f"these models carry org_id but _cascade_delete_org never deletes them: {missing}. "
+        f"A team holding any of these rows cannot be deleted — the foreign key fails with a 500.")
+
+
+async def test_a_team_with_a_BALANCE_can_still_be_deleted(clients):
+    """The exact production failure, end to end. A team is granted $1.00 on creation, so it owns a
+    CreditBlock and a LedgerEntry from its first moment — which is precisely why every delete broke.
+
+    WORTH KNOWING: this test passes even with the bug present. The suite runs on SQLite, which does
+    not enforce foreign keys by default; production is Postgres, which does. That difference is why
+    the bug shipped and why the tests were quiet about it. The guard that actually holds is
+    `test_org_delete_clears_EVERY_org_scoped_table` above, which checks the SCHEMA rather than the
+    behaviour. This test is kept because it documents the real-world shape of the failure, but do not
+    mistake it for the protection."""
+    r = await clients.post("/orgs", json={"name": "throwaway-team"})
+    assert r.status_code == 200, r.text
+    org_id, slug, token = r.json()["org_id"], r.json()["org"], r.json()["token"]
+    # the new team's OWN token: a per-org token has its org baked in, so X-Treg-Org cannot switch it
+    hdr = {"X-Treg-Token": token}
+
+    bal = await clients.get(f"/orgs/{org_id}/balance", headers=hdr)
+    assert bal.status_code == 200 and bal.json()["balance_micro"] > 0, (
+        "expected the new-team grant — without a balance this test would not reproduce the bug")
+
+    gone = await clients.request("DELETE", f"/orgs/{org_id}", params={"confirm": slug}, headers=hdr)
+    assert gone.status_code == 200, gone.text
+    assert (await clients.get(f"/orgs/{org_id}/balance", headers=hdr)).status_code != 200


### PR DESCRIPTION
Production, on a real team: `DELETE /orgs/{id}` returns a bare **500**.

`_cascade_delete_org` deletes ten org-scoped tables. The schema has **fourteen**. The four it never
knew about:

| Missing | Arrived with |
|---|---|
| `CreditBlock`, `LedgerEntry`, `Hold` | the prepaid balance |
| `CapabilityPin` | capability pins — my own omission |

**The consequence is worse than it sounds.** Every new team is granted $1.00 on creation, so every
team owns a `CreditBlock` from its first moment — meaning **no team could be deleted at all, by
anyone**, since the balance shipped. Nobody noticed because nobody tried.

## Why the suite was quiet

It runs on **SQLite, which does not enforce foreign keys by default**; production is **Postgres,
which does**. An end-to-end delete test passes with the bug present — I checked.

So the guard here checks the **schema**, not the behaviour: it walks `treg.models` for anything
carrying an `org_id` and fails if the cascade does not handle it. That catches the *next* table
someone adds, not just these four. Verified by reverting the fix and watching it fail.

The end-to-end test is kept because it documents the real shape of the failure, with a docstring
saying plainly that it is not the protection.

Also added a `flush()` between models so the documented ordering (`LedgerEntry` before the
`CreditBlock` it references) is honoured rather than left to the unit of work.

**1211 tests pass.**