### PR TITLE
feat(mcp): tool annotations + domain-verification endpoint

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1475,6 +1475,22 @@ async def privacy_page():
     return _legal_page("privacy.html")
 
 
+@app.get("/.well-known/openai-apps-challenge", include_in_schema=False)
+async def openai_apps_challenge():
+    """Domain-verification token for the OpenAI plugin directory.
+
+    The portal issues a token and fetches it here to confirm we control the host serving the MCP
+    endpoint. It must return THAT token as plain text and nothing else — the documentation is
+    explicit that JSON, a list, or several tokens all fail. 404 when unset, which is correct for
+    every deployment that is not ours: an empty file would read as a verification that never
+    completes.
+    """
+    token = (get_settings().openai_apps_challenge or "").strip()
+    if not token:
+        raise HTTPException(status_code=404, detail="not configured")
+    return PlainTextResponse(token, headers={"Cache-Control": "no-store"})
+
+
 @app.get("/support", include_in_schema=False)
 @app.get("/contact", include_in_schema=False)
 @app.get("/help", include_in_schema=False)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -159,6 +159,11 @@ class Settings(BaseSettings):
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.
     public_url: str = "https://treg.superdesign.dev"
+    # Proof to OpenAI's plugin directory that we control this domain. The portal generates a token
+    # and fetches it from /.well-known/openai-apps-challenge; that endpoint must return THAT token
+    # and nothing else — not JSON, not a list. Empty (the default) leaves the route 404, which is the
+    # right answer for every deployment that is not ours.
+    openai_apps_challenge: str = ""
 
     # Human login via GitHub OAuth (dashboard sessions). Create a GitHub OAuth App with callback
     # <public_url>/auth/github/callback and set these; empty disables the GitHub button.

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -42,9 +42,23 @@ import httpx
 from mcp.server import MCPServer
 from mcp.server.mcpserver import Context
 from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
 
 from . import catalog_store
 from .config import get_settings
+
+# Every tool must declare what it can DO, and the review process checks these against real behaviour.
+# Read-only means it changes nothing anywhere; open-world means it can change state visible on the
+# public internet; destructive means an effect that cannot be undone.
+_READS = ToolAnnotations(read_only_hint=True, destructive_hint=False, open_world_hint=False,
+                         idempotent_hint=True)
+# `call` is the honest exception, and it is honest in the strongest direction: it relays whatever the
+# caller asks to whichever upstream the endpoint names. That can be a POST that publishes, an email
+# that sends, or a DELETE — treg does not model the upstream, so it cannot promise the call is safe,
+# and claiming otherwise here would be a false assurance in exactly the place a model consults before
+# acting. It also spends real money from the team's balance.
+_CALLS = ToolAnnotations(read_only_hint=False, destructive_hint=True, open_world_hint=True,
+                         idempotent_hint=False)
 
 # One shared in-process client. ASGITransport speaks straight to the app object — no socket, no DNS,
 # no TLS — so this is a function call wearing an HTTP shape, which is what makes reusing the real
@@ -164,7 +178,8 @@ async def _resolve_org(client: httpx.AsyncClient) -> tuple[int | None, str | Non
         "Returns each endpoint's id, provider, price per call, and whether treg can serve it "
         "without you owning an API key. Call this FIRST when a task needs data or an API you have "
         "no key for."
-    )
+    ),
+    annotations=_READS
 )
 async def catalog_search(query: str, limit: int = 8) -> dict:
     cat = catalog_store.load()
@@ -196,7 +211,8 @@ async def catalog_search(query: str, limit: int = 8) -> dict:
         "its own key, and the other providers that answer the same capability — with the success "
         "rate and speed treg has measured across real calls. Read this BEFORE call() so you can "
         "tell the human what it will cost."
-    )
+    ),
+    annotations=_READS
 )
 async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
     """Goes through the HTTP route rather than the store: that route attaches the observed
@@ -222,7 +238,8 @@ async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
         "response unchanged, so you never hold an API key. Catalog calls on treg's key are metered "
         "from the team's prepaid balance; a team's own tool is never metered. Tell the human the "
         "price (from catalog_get) before calling anything that costs more than a cent."
-    )
+    ),
+    annotations=_CALLS
 )
 async def call(endpoint_id: str, params: dict | None = None,
                method: str | None = None, ctx: Context = None) -> dict:  # type: ignore[assignment]
@@ -269,7 +286,8 @@ async def call(endpoint_id: str, params: dict | None = None,
     description=(
         "The team's prepaid balance in USD, and any spend currently in flight. Check it when a call "
         "is refused for funds, or before a job that will make many calls."
-    )
+    ),
+    annotations=_READS
 )
 async def balance(ctx: Context) -> dict:
     token = _bearer(ctx)
@@ -296,7 +314,8 @@ async def balance(ctx: Context) -> dict:
         "What THIS team has registered and you can call without holding the credential: their own "
         "API keys, OAuth connections, vendor CLIs and skills. A team's own tool always wins over "
         "treg's catalog key, and those calls are never metered."
-    )
+    ),
+    annotations=_READS
 )
 async def my_tools(ctx: Context) -> dict:
     token = _bearer(ctx)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -255,3 +255,45 @@ async def test_the_price_is_visible_before_spending(clients):
     async with mcp_session(clients) as c:
         out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 5})
     assert any(r.get("usd_per_call") is not None for r in out["results"])
+
+
+# ---- what the plugin directory's review checks ---------------------------------------------
+
+async def test_every_tool_declares_what_it_can_do(clients):
+    """The submission portal validates `readOnlyHint`/`openWorldHint`/`destructiveHint` against the
+    tool's real behaviour, and a model consults them before acting. The four reading tools change
+    nothing; `call` is the honest exception — it relays whatever the caller asks to whichever
+    upstream the endpoint names, which can be a POST that publishes, an email that sends or a DELETE.
+    treg does not model the upstream, so it cannot promise the call is safe, and saying otherwise
+    here would be a false assurance in the exact place it matters."""
+    from treg.mcp import mcp as server
+
+    ann = {t.name: t.annotations for t in await server.list_tools()}
+    assert set(ann) == {"catalog_search", "catalog_get", "call", "balance", "my_tools"}
+    for name in ("catalog_search", "catalog_get", "balance", "my_tools"):
+        a = ann[name]
+        assert a and a.read_only_hint is True, name
+        assert a.destructive_hint is False and a.open_world_hint is False, name
+    a = ann["call"]
+    assert a.read_only_hint is False
+    assert a.destructive_hint is True and a.open_world_hint is True
+
+
+async def test_the_domain_challenge_is_404_until_configured(clients):
+    """Empty means unset, and unset must 404. An empty 200 would read to the portal as a
+    verification that never completes, which is harder to debug than a plain absence."""
+    r = await clients.get("/.well-known/openai-apps-challenge")
+    assert r.status_code == 404
+
+
+async def test_the_domain_challenge_returns_the_token_ALONE(clients, monkeypatch):
+    """The portal is explicit: that URL must return the token and nothing else — not JSON, not a
+    list, not several tokens. Returning a JSON body here is a documented rejection."""
+    from treg import config
+
+    settings = config.get_settings()
+    monkeypatch.setattr(settings, "openai_apps_challenge", "tok-abc-123", raising=False)
+    r = await clients.get("/.well-known/openai-apps-challenge")
+    assert r.status_code == 200
+    assert r.text == "tok-abc-123"
+    assert r.headers["content-type"].startswith("text/plain")


### PR DESCRIPTION
Reading the submission portal's own requirements turned up two hard blockers that would have failed
at **Scan Tools**, not at submit.

## 1. Tool annotations

Every tool must declare `readOnlyHint` / `openWorldHint` / `destructiveHint`, and review validates
them against real behaviour.

| tool | readOnly | destructive | openWorld |
|---|---|---|---|
| `catalog_search`, `catalog_get`, `balance`, `my_tools` | ✅ | ❌ | ❌ |
| `call` | ❌ | ✅ | ✅ |

`call` is marked in the **strongest** direction deliberately. It relays whatever the caller asks to
whichever upstream the endpoint names — that can be a POST that publishes, an email that sends, or a
DELETE. treg does not model the upstream (the founding rule), so it **cannot** promise the call is
safe, and a comfortable annotation would be a false assurance in the exact place a model consults
before acting. It also spends real money.

## 2. Domain verification

`/.well-known/openai-apps-challenge` on the MCP host. The portal issues a token; the endpoint must
return **that token as plain text and nothing else** — the docs are explicit that JSON, a list, or
multiple tokens all fail.

Driven by a new `openai_apps_challenge` setting, and **404 while empty** — right for every deployment
that is not ours, and an empty 200 would read as a verification that never completes, which is harder
to debug than a plain absence.

**1214 tests pass.**