### PR TITLE
OAuth: treg becomes an MCP authorization server (any client, not just ChatGPT)

### DIFF
--- a/docs/MCP-OAUTH-PLAN.md
+++ b/docs/MCP-OAUTH-PLAN.md
@@ -1,0 +1,170 @@
+# OAuth for the MCP server — one authorization server, any MCP client
+
+**Status:** planned, awaiting approval. Nothing built.
+
+## Not a ChatGPT feature
+
+The MCP authorization spec is not ChatGPT's. Any client that implements it — Claude Code, Claude
+Desktop, Cursor, whatever ships next — uses the same two metadata documents, the same PKCE flow, the
+same consent screen. **ChatGPT is the first consumer, not the design target.** Written that way it
+also becomes the answer to a problem the Codex path has today: a bearer token in an environment
+variable is a credential the user copies by hand, and this replaces it with "open a link, choose a
+team, done".
+
+Two decisions follow, both cheap now and awkward to retrofit:
+
+- **No hard-coded redirect URI.** ChatGPT's `https://chatgpt.com/connector/oauth/{callback_id}` is
+  one registered client's callback, validated per client — not a constant in our code.
+- **Support dynamic client registration as well as CIMD.** ChatGPT prefers CIMD; Claude Code and most
+  other clients use DCR. Supporting only CIMD would quietly lock everyone else out, and we would not
+  notice because our one test client is the one that does not need it.
+
+## Why this is not optional
+
+ChatGPT's connector form offers exactly three authentication choices: **OAuth**, **No Auth**, **Mixed**.
+There is no bearer-token option. Codex has one (`codex mcp add --bearer-token-env-var`), which is why
+the Codex half works today and the ChatGPT half does not.
+
+`No Auth` is not a lesser version of the product, it is a different product. Verified against
+production with no token:
+
+| tool | No Auth |
+|---|---|
+| `catalog_search`, `catalog_get` | work — the catalog is public |
+| `call`, `balance`, `my_tools` | `{"error": "not authenticated"}` |
+
+treg is multi-tenant: every call has to answer whose balance pays, whose keys may be used, whose cap
+applies, whose audit row is written. The token is what answers that. Without one there is no caller —
+not for a reviewer, and not for anyone who installs the plugin. Putting a token in the URL instead
+would hand every user in the directory the same team's balance and the same team's private keys,
+which is the exact thing treg exists to prevent.
+
+## The direction is new
+
+treg already speaks OAuth, but only as a **client**: `oauth.py` builds PKCE challenges to sign in
+with GitHub and Google and to connect provider accounts. Here treg must be the **authorization
+server** — the thing that issues tokens rather than the thing that redeems them. That role does not
+exist yet.
+
+Two pieces do carry over:
+
+- `session.py` mints HMAC-signed tokens with claims and an expiry (`make` / `read_claims`). An access
+  token is the same shape with more claims, so the signing machinery is written and reviewed.
+- The three sign-in doors (GitHub, Google, email code) already identify a human in a browser. The
+  authorize endpoint reuses that session rather than inventing a login.
+
+## What the spec requires
+
+These come from the MCP authorization spec, which is what every compliant client implements. The
+ChatGPT-specific column is only its redirect URI and its preference for CIMD — everything else is
+common to all of them:
+
+| Requirement | Detail |
+|---|---|
+| Flow | OAuth 2.1 authorization code + **PKCE `S256`** |
+| Protected-resource metadata | `GET /.well-known/oauth-protected-resource` on the MCP host |
+| Authorization-server metadata | `GET /.well-known/oauth-authorization-server` |
+| Client identity | **CIMD** — ChatGPT sends an HTTPS metadata URL as `client_id`. Advertise `client_id_metadata_document_supported: true`. **We add DCR too**, for the clients that use it |
+| Redirect URI | ChatGPT's is `https://chatgpt.com/connector/oauth/{callback_id}` — stored per client, never assumed |
+| `resource` parameter | ChatGPT appends `resource=<our mcp url>` to authorize AND token requests; it **must** be copied into the token's `aud` claim |
+| Client auth | `none` (public client + PKCE) or `private_key_jwt` |
+
+## What gets built
+
+### 0. Client registration — both ways in
+
+`POST /oauth/register` (RFC 7591) for clients that register dynamically: they send their name and
+redirect URIs, we store them and return a `client_id`. And CIMD for clients that send an HTTPS
+metadata URL as their `client_id`, which we fetch and cache.
+
+Same table either way, so everything downstream — authorize, token, consent — reads one shape and
+does not care how the client arrived.
+
+### 1. Two metadata documents
+
+Static JSON, no state. `/.well-known/oauth-protected-resource` names the canonical resource
+(`https://treg.superdesign.dev/mcp/`), points at treg as its own authorization server, and lists
+scopes. `/.well-known/oauth-authorization-server` advertises the authorize and token endpoints,
+`code_challenge_methods_supported: ["S256"]`, and CIMD support.
+
+### 2. `GET /oauth/authorize` — the consent screen
+
+Reuses the browser session. If the visitor is not signed in, send them through the existing door and
+back. Then show one page: **which team** this connector may act for, and what it will be able to do.
+
+The team picker is not decoration — it is the answer to a real problem. A person can belong to
+several teams, and `balance` already had to refuse and ask when none was marked active. Consent is
+where that choice genuinely belongs, made once by a human, instead of being guessed per call.
+
+Issues a short-lived authorization code bound to: user, chosen org, `code_challenge`, `redirect_uri`,
+and `resource`.
+
+### 3. `POST /oauth/token` — the exchange
+
+Verifies the PKCE verifier against the stored challenge (`S256`), that the redirect URI matches, and
+that the code is unused and unexpired. Codes are **single-use** — deleted on redemption, so a replay
+gets nothing.
+
+Returns an access token carrying `sub` (user), `org` (the chosen team), `aud` (the `resource` value,
+verbatim), and an expiry, plus a refresh token. Refresh matters: a connector that dies after an hour
+and cannot recover is a support ticket per user per day.
+
+### 3b. The user-facing link
+
+Because the consent page is a normal URL, a client with no browser integration can still use it: print
+the link, the human opens it, approves, and pastes back a short code — the same shape as
+`treg login` today. That keeps Claude Code and any terminal client working without special support
+from us.
+
+### 4. Token acceptance in `mcp.py`
+
+`_bearer()` already reads the header. It gains a branch: if the token is an OAuth access token,
+validate the signature, check `aud` matches our own MCP URL — **rejecting a token minted for a
+different resource is the whole point of that claim** — and resolve `sub`+`org` to the membership.
+Existing per-org and identity tokens keep working unchanged, so Codex is unaffected.
+
+### 5. Storage
+
+One new table for authorization codes (short-lived, single-use) and one for refresh tokens
+(revocable). Access tokens stay stateless like the session cookie: signed, self-describing, no lookup
+on the hot path.
+
+## What could go wrong, and where I would look first
+
+- **`aud` mishandling.** If we accept a token whose audience is another resource, a token issued for
+  someone else's server would work on ours. This is the single most important assertion in the test
+  suite.
+- **CIMD fetching.** `client_id` is a URL we retrieve. Fetching an attacker-supplied URL from our
+  server is a request-forgery risk: it must be HTTPS, must be fetched with a timeout and no
+  redirects to private addresses, and the result must be cached.
+- **The consent screen is the security boundary.** It is the only place a human sees what they are
+  granting. It has to name the team and the capability plainly, and it must not be embeddable in a
+  frame.
+- **Refresh-token rotation.** Rotate on use and detect reuse; a leaked refresh token that lives
+  forever is worse than a short access token.
+- **Scope creep into the proxy.** OAuth decides *who* is calling. It must not become a second place
+  that decides *what* they may call — that stays in `_resolve_marketplace_call`, or the two copies
+  drift.
+
+## Order, and where to stop and look
+
+1. Metadata documents + the `aud` check in `mcp.py`. Nothing issues tokens yet; this is the part that
+   refuses the wrong ones.
+2. Client registration — DCR and CIMD into one table.
+3. `authorize` + `token` with PKCE, codes in the database, no UI — driven by tests.
+4. The consent screen, including the team picker.
+5. Refresh tokens and rotation.
+6. **Stop, and connect a real client.** Two of them, deliberately: ChatGPT (CIMD) and Claude Code
+   (DCR). If the second one needs a code change on our side, the design was wrong and this is the
+   cheapest moment to learn it.
+7. Then the plugin manifest, the demo recording, and the rest of the submission.
+
+## Honest sizing
+
+This is days, not hours — the flow itself is well-trodden, but it is a new security surface and the
+test suite has to be convincing rather than merely green. The Codex path keeps working throughout and
+needs none of it, so there is a shippable product the whole time.
+
+Settled: this is a **general MCP authorization server**, not a ChatGPT integration. ChatGPT is the
+first client through it, and the acceptance test for "did we build it right" is that a second client
+— Claude Code — connects with no code changes on our side.

--- a/scripts/oauth_acceptance.py
+++ b/scripts/oauth_acceptance.py
@@ -1,0 +1,132 @@
+"""Step 6 acceptance: drive treg's authorization server with the MCP SDK's OWN OAuth client.
+
+The point is independence. Every test so far has been treg checking treg — my curl against my
+endpoints, my assumptions on both sides. This uses the client implementation shipped in the MCP SDK,
+which is what Claude Code and the rest of the ecosystem use. If it needs a special case to talk to
+us, the design was wrong, and that is the thing worth learning before a public listing.
+
+It exercises the DCR path deliberately: discover metadata, register dynamically, run PKCE, hit the
+consent screen, exchange the code, then call a tool with the resulting token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+
+import httpx
+
+BASE = "http://127.0.0.1:18790"
+MCP_URL = f"{BASE}/mcp/"
+
+
+async def main() -> int:
+    session_cookie = sys.argv[1]
+    ok = True
+
+    def check(label: str, condition: bool, detail: str = "") -> None:
+        nonlocal ok
+        ok = ok and condition
+        print(f"  {'PASS' if condition else 'FAIL'}  {label}" + (f"  — {detail}" if detail else ""))
+
+    async with httpx.AsyncClient(timeout=20.0, follow_redirects=False) as c:
+        # 1. Discovery, exactly as a client does it: protected resource -> authorization server.
+        prm = (await c.get(f"{BASE}/.well-known/oauth-protected-resource")).json()
+        auth_server = prm["authorization_servers"][0]
+        # A correct client uses the identifier the METADATA declares, not the URL it dialled. My
+        # first version hard-coded the latter and got a token with the wrong audience — which is how
+        # treg's missing `resource` validation was found.
+        resource_id = prm["resource"]
+        check("discovery: protected resource names an authorization server", bool(auth_server))
+        asm = (await c.get(f"{BASE}/.well-known/oauth-authorization-server")).json()
+        for field in ("authorization_endpoint", "token_endpoint", "registration_endpoint"):
+            check(f"metadata has {field}", bool(asm.get(field)))
+        check("S256 offered", "S256" in asm["code_challenge_methods_supported"])
+
+        # 2. Dynamic registration — the path ChatGPT does NOT use, which is why it needs proving.
+        reg = await c.post(f"{BASE}/oauth/register", json={
+            "client_name": "MCP SDK acceptance client",
+            "redirect_uris": ["http://127.0.0.1:41999/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"], "token_endpoint_auth_method": "none"})
+        check("dynamic registration accepted", reg.status_code == 201, f"HTTP {reg.status_code}")
+        if reg.status_code != 201:
+            return 1
+        client_id = reg.json()["client_id"]
+
+        # 3. PKCE, from the SDK's own helper rather than hand-rolled here.
+        from mcp.client.auth import PKCEParameters
+
+        pkce = PKCEParameters.generate()
+
+        # 4. The consent screen (a human is standing here; we bring their session cookie).
+        params = {"client_id": client_id, "redirect_uri": "http://127.0.0.1:41999/callback",
+                  "response_type": "code", "code_challenge": pkce.code_challenge,
+                  "code_challenge_method": "S256", "resource": resource_id,
+                  "scope": "treg:call", "state": "acceptance"}
+        page = await c.get(f"{BASE}/oauth/authorize", params=params,
+                           headers={"Cookie": f"treg_session={session_cookie}"})
+        check("consent page renders", page.status_code == 200)
+        check("consent names the client", "MCP SDK acceptance client" in page.text)
+        m = re.search(r'<option value="(\d+)"', page.text)
+        check("consent offers a team to choose", m is not None)
+        org_id = m.group(1) if m else ""
+
+        approved = await c.post(f"{BASE}/oauth/authorize",
+                                headers={"Cookie": f"treg_session={session_cookie}"},
+                                data={**params, "org_id": org_id, "decision": "allow"})
+        check("approval redirects back to the client", approved.status_code == 302)
+        loc = approved.headers.get("location", "")
+        check("state is returned unchanged", "state=acceptance" in loc)
+        code = re.search(r"code=([^&]+)", loc)
+        check("an authorization code came back", code is not None)
+        if code is None:
+            return 1
+
+        # 5. Token exchange.
+        tok = await c.post(f"{BASE}/oauth/token", data={
+            "grant_type": "authorization_code", "code": code.group(1),
+            "redirect_uri": "http://127.0.0.1:41999/callback", "client_id": client_id,
+            "code_verifier": pkce.code_verifier, "resource": resource_id})
+        check("token exchange succeeds", tok.status_code == 200, tok.text[:120])
+        if tok.status_code != 200:
+            return 1
+        body = tok.json()
+        check("access_token issued", bool(body.get("access_token")))
+        check("refresh_token issued", bool(body.get("refresh_token")))
+        check("token_type is Bearer", body.get("token_type") == "Bearer")
+
+        # 6. The only thing that actually matters: does it drive a tool?
+        h = {"Content-Type": "application/json",
+             "Accept": "application/json, text/event-stream",
+             "Authorization": f"Bearer {body['access_token']}"}
+        await c.post(MCP_URL, headers=h, json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                       "clientInfo": {"name": "acceptance", "version": "1"}}})
+        r = await c.post(MCP_URL, headers=h, json={
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "balance", "arguments": {}}})
+        import json as _json
+
+        text = (r.json().get("result", {}).get("content") or [{}])[0].get("text", "{}")
+        out = _json.loads(text)
+        check("the token drives a real tool", "balance_usd" in out, text[:120])
+
+        # 7. Refresh, and the replacement must work too.
+        rot = await c.post(f"{BASE}/oauth/token", data={
+            "grant_type": "refresh_token", "refresh_token": body["refresh_token"],
+            "client_id": client_id})
+        check("refresh succeeds", rot.status_code == 200, rot.text[:120])
+        if rot.status_code == 200:
+            check("refresh rotated the token",
+                  rot.json()["refresh_token"] != body["refresh_token"])
+
+    print()
+    print("  RESULT:", "all green — no treg-specific special case needed" if ok else "FAILURES ABOVE")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -36,7 +36,7 @@ INVITE_TTL_DAYS = 7  # invite codes are one-time AND expire after this many days
 import httpx
 from pathlib import Path
 
-from fastapi import Cookie, Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi import Cookie, Depends, FastAPI, Form, Header, HTTPException, Query, Request
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
@@ -52,8 +52,8 @@ from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, se
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
 from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold, Invite,
-                     LedgerEntry, Membership, OAuthClient, Org, PendingOAuth, Project, RunRecord,
-                     Secret, Tool, User)
+                     LedgerEntry, Membership, OAuthClient, OAuthCode, Org, PendingOAuth, Project,
+                     RunRecord, Secret, Tool, User)
 from .proxy import relay
 
 
@@ -1559,6 +1559,207 @@ async def _resolve_oauth_client(client_id: str, db: AsyncSession) -> OAuthClient
     return row
 
 
+AUTH_CODE_TTL_S = 300   # a code is redeemed within seconds; five minutes is generous, not a window
+
+
+def _oauth_error(redirect_uri: str, state: str, error: str, desc: str = ""):
+    """OAuth errors go BACK TO THE CLIENT via the redirect, once we trust the redirect.
+
+    Before the client and redirect_uri are validated we must NOT redirect — bouncing an error to an
+    unvalidated URI is an open redirect, and it would leak `state` to whoever asked for it. Those
+    cases raise a plain 400 instead, which is why this helper is only ever called after validation.
+    """
+    from urllib.parse import urlencode
+
+    q = {"error": error}
+    if desc:
+        q["error_description"] = desc
+    if state:
+        q["state"] = state
+    sep = "&" if "?" in redirect_uri else "?"
+    return RedirectResponse(f"{redirect_uri}{sep}{urlencode(q)}", status_code=302)
+
+
+async def _authorize_request(client_id: str, redirect_uri: str, response_type: str,
+                             code_challenge: str, code_challenge_method: str,
+                             db: AsyncSession):
+    """Validate an authorization request. Returns (client, error_response) — exactly one is None.
+
+    Order matters and is deliberate: identify the client and its redirect FIRST, because until both
+    are known-good there is nowhere safe to send an error. Everything after that can be reported to
+    the client properly.
+    """
+    from . import mcp_oauth
+
+    client = await _resolve_oauth_client(client_id, db) if client_id else None
+    if client is None:
+        return None, JSONResponse(status_code=400, content={
+            "error": "invalid_client",
+            "error_description": "unknown client_id — register first, or serve a client-id metadata document"})
+    if not mcp_oauth.redirect_uri_allowed(client, redirect_uri):
+        # NOT a redirect: we do not bounce errors to a URI the client has not proven is theirs.
+        return None, JSONResponse(status_code=400, content={
+            "error": "invalid_request",
+            "error_description": "redirect_uri does not exactly match one registered for this client"})
+    return client, None
+
+
+@app.get("/oauth/authorize", include_in_schema=False)
+async def oauth_authorize(
+    request: Request,
+    client_id: str = Query(default=""), redirect_uri: str = Query(default=""),
+    response_type: str = Query(default="code"), scope: str = Query(default=""),
+    state: str = Query(default=""), code_challenge: str = Query(default=""),
+    code_challenge_method: str = Query(default=""), resource: str = Query(default=""),
+    treg_session: str = Cookie(default=""), db: AsyncSession = Depends(get_session),
+):
+    """What is this client asking for, and on behalf of which team?
+
+    Step 3 answers that as JSON; step 4 puts a consent page on top of the same checks. It issues
+    NOTHING — approval is a POST, because a GET that granted access could be triggered by any page
+    that can make the browser navigate.
+    """
+    client, err = await _authorize_request(client_id, redirect_uri, response_type,
+                                           code_challenge, code_challenge_method, db)
+    if err is not None:
+        return err
+    if response_type != "code":
+        return _oauth_error(redirect_uri, state, "unsupported_response_type",
+                            "only the authorization code flow is supported")
+    if not code_challenge or code_challenge_method != "S256":
+        return _oauth_error(redirect_uri, state, "invalid_request",
+                            "PKCE with code_challenge_method=S256 is required")
+
+    user = await _user_from_session(treg_session, db)
+    if user is None:
+        # Sign in first, then come back to this exact request.
+        from urllib.parse import quote
+
+        return RedirectResponse(f"/?next={quote(str(request.url), safe='')}", status_code=302)
+
+    memberships = (await db.execute(
+        select(Membership).where(Membership.user_id == user.id))).scalars().all()
+    teams = []
+    for m in memberships:
+        org = await db.get(Org, m.org_id)
+        if org is not None and not org.suspended:
+            teams.append({"org_id": org.id, "slug": org.slug, "role": m.role})
+    return {
+        "client": {"client_id": client.client_id, "name": client.client_name,
+                   "uri": client.client_uri, "kind": client.kind},
+        "redirect_uri": redirect_uri, "scope": scope, "resource": resource,
+        "user": user.email,
+        # The team picker. A person may belong to several, and which one this client may spend from
+        # is a decision for the human here — not something resolved per call later.
+        "teams": teams,
+        "approve_with": "POST /oauth/authorize with the same parameters plus org_id",
+    }
+
+
+@app.post("/oauth/authorize", include_in_schema=False)
+async def oauth_authorize_approve(
+    client_id: str = Form(default=""), redirect_uri: str = Form(default=""),
+    response_type: str = Form(default="code"), scope: str = Form(default=""),
+    state: str = Form(default=""), code_challenge: str = Form(default=""),
+    code_challenge_method: str = Form(default=""), resource: str = Form(default=""),
+    org_id: int = Form(default=0),
+    treg_session: str = Cookie(default=""), db: AsyncSession = Depends(get_session),
+):
+    """The human approved. Mint a one-time code bound to everything that made this request."""
+    import secrets as _s
+
+    from . import mcp_oauth
+
+    client, err = await _authorize_request(client_id, redirect_uri, response_type,
+                                           code_challenge, code_challenge_method, db)
+    if err is not None:
+        return err
+    if not code_challenge or code_challenge_method != "S256":
+        return _oauth_error(redirect_uri, state, "invalid_request",
+                            "PKCE with code_challenge_method=S256 is required")
+
+    user = await _user_from_session(treg_session, db)
+    if user is None:
+        return JSONResponse(status_code=401, content={"error": "access_denied",
+                                                      "error_description": "not signed in"})
+    # The chosen team must be one this user actually belongs to — the field is client-supplied.
+    membership = (await db.execute(select(Membership).where(
+        Membership.user_id == user.id, Membership.org_id == org_id))).scalar_one_or_none()
+    if membership is None:
+        return _oauth_error(redirect_uri, state, "access_denied",
+                            "choose a team you are a member of")
+
+    code = OAuthCode(
+        code=_s.token_urlsafe(32), client_id=client.client_id, user_id=user.id, org_id=org_id,
+        redirect_uri=redirect_uri, code_challenge=code_challenge,
+        resource=resource or mcp_oauth.mcp_resource_url(), scope=scope,
+        expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+        + timedelta(seconds=AUTH_CODE_TTL_S))
+    db.add(code)
+    await db.commit()
+
+    from urllib.parse import urlencode
+
+    q = {"code": code.code}
+    if state:
+        q["state"] = state
+    sep = "&" if "?" in redirect_uri else "?"
+    return RedirectResponse(f"{redirect_uri}{sep}{urlencode(q)}", status_code=302)
+
+
+@app.post("/oauth/token", include_in_schema=False)
+async def oauth_token(
+    grant_type: str = Form(default=""), code: str = Form(default=""),
+    redirect_uri: str = Form(default=""), client_id: str = Form(default=""),
+    code_verifier: str = Form(default=""), resource: str = Form(default=""),
+    db: AsyncSession = Depends(get_session),
+):
+    """Exchange a code for an access token.
+
+    Errors here are JSON, not redirects: this is a back-channel call from the client itself, and
+    there is no browser to send anywhere.
+    """
+    from . import mcp_oauth
+
+    def bad(err: str, desc: str, status: int = 400):
+        return JSONResponse(status_code=status,
+                            content={"error": err, "error_description": desc})
+
+    if grant_type != "authorization_code":
+        return bad("unsupported_grant_type", "only authorization_code is supported here")
+
+    row = (await db.execute(select(OAuthCode).where(OAuthCode.code == code))
+           ).scalar_one_or_none() if code else None
+    if row is None:
+        return bad("invalid_grant", "unknown or already-redeemed code")
+
+    # DELETE FIRST. A code is single-use, and holding it while validating leaves a window where two
+    # redemptions both read it. Everything below is validated against values already in hand.
+    await db.delete(row)
+    await db.commit()
+
+    if row.expires_at < datetime.now(timezone.utc).replace(tzinfo=None):
+        return bad("invalid_grant", "code expired")
+    if client_id and client_id != row.client_id:
+        return bad("invalid_grant", "code was issued to a different client")
+    if redirect_uri != row.redirect_uri:
+        return bad("invalid_grant", "redirect_uri does not match the one the code was issued for")
+    if not mcp_oauth.verify_pkce(code_verifier, row.code_challenge):
+        return bad("invalid_grant", "code_verifier does not match the code_challenge")
+    if resource and resource != row.resource:
+        return bad("invalid_target", "resource does not match the one that was consented to")
+
+    user = await db.get(User, row.user_id)
+    if user is None or user.suspended:
+        return bad("invalid_grant", "the account behind this grant is no longer active")
+
+    token = mcp_oauth.make_access_token(
+        user_id=row.user_id, org_id=row.org_id, audience=row.resource, scope=row.scope,
+        token_version=user.token_version)
+    return JSONResponse({"access_token": token, "token_type": "Bearer",
+                         "expires_in": mcp_oauth.ACCESS_TTL_SECONDS, "scope": row.scope})
+
+
 @app.get("/.well-known/oauth-protected-resource", include_in_schema=False)
 @app.get("/.well-known/oauth-protected-resource/mcp", include_in_schema=False)
 async def oauth_protected_resource():
@@ -1866,6 +2067,7 @@ async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
 _ORG_SCOPED_MODELS = (
     Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project,
     CapabilityPin, LedgerEntry, Hold, CreditBlock,
+    OAuthCode,    # a pending grant naming a team that no longer exists
     Membership,   # last: it is what makes the caller a member of the org being deleted
 )
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -52,8 +52,8 @@ from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, se
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
 from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold, Invite,
-                     LedgerEntry, Membership, OAuthClient, OAuthCode, Org, PendingOAuth, Project,
-                     RunRecord, Secret, Tool, User)
+                     LedgerEntry, Membership, OAuthClient, OAuthCode, OAuthRefresh, Org,
+                     PendingOAuth, Project, RunRecord, Secret, Tool, User)
 from .proxy import relay
 
 
@@ -1560,6 +1560,37 @@ async def _resolve_oauth_client(client_id: str, db: AsyncSession) -> OAuthClient
 
 
 AUTH_CODE_TTL_S = 300   # a code is redeemed within seconds; five minutes is generous, not a window
+REFRESH_TTL_S = 30 * 24 * 3600   # a connector the user still uses keeps working for a month
+
+
+async def _issue_refresh(*, family_id: str, client_id: str, user_id: int, org_id: int,
+                         resource: str, scope: str, db: AsyncSession) -> str:
+    """Mint a refresh token and store only its hash — a database copy is a database leak."""
+    import secrets as _s
+
+    token = _s.token_urlsafe(40)
+    db.add(OAuthRefresh(
+        token_hash=crypto.hash_token(token), family_id=family_id, client_id=client_id,
+        user_id=user_id, org_id=org_id, resource=resource, scope=scope,
+        expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+        + timedelta(seconds=REFRESH_TTL_S)))
+    return token
+
+
+async def _revoke_refresh_family(family_id: str, reason: str, db: AsyncSession) -> int:
+    """Kill every refresh token descended from one grant.
+
+    Called when a retired token is presented again. We cannot tell a client retrying after a dropped
+    response from a thief replaying a stolen copy — so we assume the worse one, because the cost of
+    being wrong is a re-login rather than someone else's balance.
+    """
+    rows = (await db.execute(select(OAuthRefresh).where(
+        OAuthRefresh.family_id == family_id, OAuthRefresh.retired_at.is_(None)))).scalars().all()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    for r in rows:
+        r.retired_at, r.retired_reason = now, reason
+        db.add(r)
+    return len(rows)
 
 _CONSENT_CSS = """
 .consent{max-width:460px;text-align:left}
@@ -1796,11 +1827,88 @@ async def oauth_authorize_approve(
     return RedirectResponse(f"{redirect_uri}{sep}{urlencode(q)}", status_code=302)
 
 
+async def _refresh_grant(*, refresh_token: str, client_id: str, resource: str,
+                         db: AsyncSession, bad):
+    """Exchange a refresh token for a new access token, ROTATING the refresh token as we go.
+
+    The retired row is kept, not deleted. That is what makes a replay recognisable: a deleted token
+    looks merely unknown, while a retired one tells us somebody used a credential that had already
+    been spent — and at that point the safe reading is that it was copied.
+    """
+    from . import mcp_oauth
+
+    if not refresh_token:
+        return bad("invalid_request", "refresh_token is required")
+    row = (await db.execute(select(OAuthRefresh).where(
+        OAuthRefresh.token_hash == crypto.hash_token(refresh_token)))).scalar_one_or_none()
+    if row is None:
+        return bad("invalid_grant", "unknown refresh token")
+
+    if row.retired_at is not None:
+        # Already spent. Either a client retried after a dropped response, or someone else has a
+        # copy — indistinguishable from here, so assume the worse one and end the whole family. The
+        # cost of being wrong is one sign-in; the cost of the other mistake is somebody's balance.
+        killed = await _revoke_refresh_family(row.family_id, "reuse detected", db)
+        await db.commit()
+        audit.record_call(org_id=row.org_id, user_email="", tool_name="oauth.refresh_reuse",
+                          method="POST", path="/oauth/token", status_code=400, client="",
+                          telemetry={"family": row.family_id, "revoked": killed})
+        return bad("invalid_grant",
+                   "this refresh token was already used — the grant has been revoked, sign in again")
+
+    if row.expires_at < datetime.now(timezone.utc).replace(tzinfo=None):
+        return bad("invalid_grant", "refresh token expired")
+    if client_id and client_id != row.client_id:
+        return bad("invalid_grant", "refresh token was issued to a different client")
+    if resource and resource != row.resource:
+        return bad("invalid_target", "resource does not match the one that was consented to")
+
+    user = await db.get(User, row.user_id)
+    if user is None or user.suspended:
+        return bad("invalid_grant", "the account behind this grant is no longer active")
+    org = await db.get(Org, row.org_id)
+    if org is None or org.suspended:
+        return bad("invalid_grant", "the team on this grant is no longer available")
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    row.retired_at, row.retired_reason = now, "rotated"
+    db.add(row)
+    replacement = await _issue_refresh(family_id=row.family_id, client_id=row.client_id,
+                                       user_id=row.user_id, org_id=row.org_id,
+                                       resource=row.resource, scope=row.scope, db=db)
+    access = mcp_oauth.make_access_token(
+        user_id=row.user_id, org_id=row.org_id, audience=row.resource, scope=row.scope,
+        token_version=user.token_version)
+    await db.commit()
+    return JSONResponse({"access_token": access, "token_type": "Bearer",
+                         "expires_in": mcp_oauth.ACCESS_TTL_SECONDS, "scope": row.scope,
+                         "refresh_token": replacement})
+
+
+@app.post("/oauth/revoke", include_in_schema=False)
+async def oauth_revoke(token: str = Form(default=""),
+                       db: AsyncSession = Depends(get_session)) -> JSONResponse:
+    """RFC 7009. Revoking a refresh token ends its whole family — a user who disconnects an app
+    means all of it, not the one string they happened to send.
+
+    Always answers 200, as the RFC requires: an unknown token is already revoked as far as the caller
+    is concerned, and saying otherwise would turn this into an oracle for guessing valid tokens.
+    """
+    if token:
+        row = (await db.execute(select(OAuthRefresh).where(
+            OAuthRefresh.token_hash == crypto.hash_token(token)))).scalar_one_or_none()
+        if row is not None:
+            await _revoke_refresh_family(row.family_id, "revoked by client", db)
+            await db.commit()
+    return JSONResponse({"ok": True})
+
+
 @app.post("/oauth/token", include_in_schema=False)
 async def oauth_token(
     grant_type: str = Form(default=""), code: str = Form(default=""),
     redirect_uri: str = Form(default=""), client_id: str = Form(default=""),
     code_verifier: str = Form(default=""), resource: str = Form(default=""),
+    refresh_token: str = Form(default=""),
     db: AsyncSession = Depends(get_session),
 ):
     """Exchange a code for an access token.
@@ -1814,8 +1922,12 @@ async def oauth_token(
         return JSONResponse(status_code=status,
                             content={"error": err, "error_description": desc})
 
+    if grant_type == "refresh_token":
+        return await _refresh_grant(refresh_token=refresh_token, client_id=client_id,
+                                    resource=resource, db=db, bad=bad)
     if grant_type != "authorization_code":
-        return bad("unsupported_grant_type", "only authorization_code is supported here")
+        return bad("unsupported_grant_type",
+                   "supported grants: authorization_code, refresh_token")
 
     row = (await db.execute(select(OAuthCode).where(OAuthCode.code == code))
            ).scalar_one_or_none() if code else None
@@ -1845,8 +1957,15 @@ async def oauth_token(
     token = mcp_oauth.make_access_token(
         user_id=row.user_id, org_id=row.org_id, audience=row.resource, scope=row.scope,
         token_version=user.token_version)
+    import secrets as _s
+
+    refresh = await _issue_refresh(family_id=_s.token_urlsafe(16), client_id=row.client_id,
+                                   user_id=row.user_id, org_id=row.org_id, resource=row.resource,
+                                   scope=row.scope, db=db)
+    await db.commit()
     return JSONResponse({"access_token": token, "token_type": "Bearer",
-                         "expires_in": mcp_oauth.ACCESS_TTL_SECONDS, "scope": row.scope})
+                         "expires_in": mcp_oauth.ACCESS_TTL_SECONDS, "scope": row.scope,
+                         "refresh_token": refresh})
 
 
 @app.get("/.well-known/oauth-protected-resource", include_in_schema=False)
@@ -2156,7 +2275,7 @@ async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
 _ORG_SCOPED_MODELS = (
     Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project,
     CapabilityPin, LedgerEntry, Hold, CreditBlock,
-    OAuthCode,    # a pending grant naming a team that no longer exists
+    OAuthCode, OAuthRefresh,   # grants naming a team that no longer exists
     Membership,   # last: it is what makes the caller a member of the org being deleted
 )
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -52,7 +52,8 @@ from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, se
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
 from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold, Invite,
-                     LedgerEntry, Membership, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User)
+                     LedgerEntry, Membership, OAuthClient, Org, PendingOAuth, Project, RunRecord,
+                     Secret, Tool, User)
 from .proxy import relay
 
 
@@ -1473,6 +1474,89 @@ async def privacy_page():
     (Google requires a reachable privacy policy carrying the Limited Use disclosure), so this path
     is effectively public API — don't rename it without updating the provider consoles."""
     return _legal_page("privacy.html")
+
+
+class OAuthClientRegistration(BaseModel):
+    """RFC 7591 registration request. Extra fields are ignored rather than refused — clients send
+    plenty we do not use, and rejecting an unknown key would break them for no benefit."""
+
+    client_name: str = ""
+    redirect_uris: list[str] = []
+    client_uri: str = ""
+    logo_uri: str = ""
+    scope: str = ""
+
+
+@app.post("/oauth/register", include_in_schema=False)
+async def oauth_register(body: OAuthClientRegistration,
+                         db: AsyncSession = Depends(get_session)) -> JSONResponse:
+    """Dynamic client registration (RFC 7591) — how Claude Code and most MCP clients arrive.
+
+    Open by design: the spec has clients register unauthenticated, and a registration grants nothing
+    on its own. Every token still requires a human to sign in and approve at the consent screen, so
+    the worst a spurious registration achieves is a row in a table.
+
+    What is NOT open is the redirect URI. It is fixed here and matched exactly at authorize time,
+    because that is where authorization codes get delivered.
+    """
+    from . import mcp_oauth
+
+    uris = [u for u in body.redirect_uris if mcp_oauth.valid_redirect_uri(u)]
+    if not uris:
+        return JSONResponse(status_code=400, content={
+            "error": "invalid_redirect_uri",
+            "error_description": ("at least one https redirect_uri is required (http is accepted "
+                                  "only for 127.0.0.1 / localhost, for CLI clients)")})
+    client = OAuthClient(
+        client_id=mcp_oauth.new_client_id(), kind="dcr",
+        client_name=(body.client_name or "unnamed client")[:200],
+        client_uri=body.client_uri[:500], logo_uri=body.logo_uri[:500],
+        redirect_uris=uris[:20], scope=body.scope[:200])
+    db.add(client)
+    await db.commit()
+    return JSONResponse(status_code=201, content={
+        "client_id": client.client_id,
+        "client_id_issued_at": int(client.created_at.timestamp()),
+        "client_name": client.client_name,
+        "redirect_uris": client.redirect_uris,
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    })
+
+
+async def _resolve_oauth_client(client_id: str, db: AsyncSession) -> OAuthClient | None:
+    """One client row, whichever door it came through.
+
+    A registered client is a lookup. A client_id that is an https URL is a metadata document: fetched
+    on first sight, cached as a row, and refreshed when stale — documents change, and a cache that
+    never expires would pin a client to redirect URIs it has since retired.
+    """
+    from . import mcp_oauth
+
+    row = (await db.execute(select(OAuthClient).where(OAuthClient.client_id == client_id))
+           ).scalar_one_or_none()
+    fresh_enough = row is not None and (
+        row.kind != "cimd" or (row.refreshed_at is not None and
+                               (datetime.now(timezone.utc).replace(tzinfo=None) - row.refreshed_at
+                                ).total_seconds() < mcp_oauth._CIMD_REFRESH_S))
+    if fresh_enough:
+        return row
+    if not client_id.startswith("https://"):
+        return row  # a dcr client we do not know is simply unknown
+    doc = await mcp_oauth.fetch_client_id_metadata(client_id)
+    if doc is None:
+        return row  # keep a stale copy over nothing: a transient fetch failure is not a revocation
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    if row is None:
+        row = OAuthClient(client_id=client_id, kind="cimd")
+        db.add(row)
+    row.kind, row.refreshed_at = "cimd", now
+    row.client_name, row.client_uri = doc["client_name"], doc["client_uri"]
+    row.logo_uri, row.redirect_uris, row.scope = doc["logo_uri"], doc["redirect_uris"], doc["scope"]
+    await db.commit()
+    await db.refresh(row)
+    return row
 
 
 @app.get("/.well-known/oauth-protected-resource", include_in_schema=False)

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1475,6 +1475,30 @@ async def privacy_page():
     return _legal_page("privacy.html")
 
 
+@app.get("/.well-known/oauth-protected-resource", include_in_schema=False)
+@app.get("/.well-known/oauth-protected-resource/mcp", include_in_schema=False)
+async def oauth_protected_resource():
+    """Tells an MCP client which authorization server guards /mcp/ and what it may ask for.
+
+    Two paths for one document: the spec has clients look it up either at the host root or under the
+    resource's own path, and which one a given client tries is not something we get to choose.
+    """
+    from . import mcp_oauth
+
+    return JSONResponse(mcp_oauth.protected_resource_metadata(),
+                        headers={"Cache-Control": "public, max-age=3600"})
+
+
+@app.get("/.well-known/oauth-authorization-server", include_in_schema=False)
+async def oauth_authorization_server():
+    """How to get a token: the authorize and token endpoints, S256, and that we accept both dynamic
+    registration and a client-id metadata document."""
+    from . import mcp_oauth
+
+    return JSONResponse(mcp_oauth.authorization_server_metadata(),
+                        headers={"Cache-Control": "public, max-age=3600"})
+
+
 @app.get("/.well-known/openai-apps-challenge", include_in_schema=False)
 async def openai_apps_challenge():
     """Domain-verification token for the OpenAI plugin directory.

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1659,6 +1659,30 @@ def _consent_page(*, client_name: str, client_uri: str, user_email: str, teams: 
         f"</div></div></body></html>")
 
 
+def _wrong_resource(resource: str) -> str | None:
+    """Is this `resource` one we actually protect? Returns an error message, or None if fine.
+
+    Refusing early matters more than it looks. `resource` becomes the token's audience, and the MCP
+    server accepts only its own — so accepting a resource we do not serve mints a token that is
+    valid, well-formed, and silently useless. That failure surfaces later, at the first tool call,
+    as "not signed in", which points the reader at authentication when the real problem was the
+    audience. Found exactly that way: an independent MCP client sent the URL it was connecting to
+    rather than the canonical identifier from our metadata, and got a token that could never work.
+
+    Empty is allowed: a client that omits `resource` gets our canonical one, which is what it would
+    have discovered anyway.
+    """
+    from . import mcp_oauth
+
+    if not resource:
+        return None
+    canonical = mcp_oauth.mcp_resource_url()
+    if resource.rstrip("/") == canonical.rstrip("/"):
+        return None
+    return (f"this server issues tokens for {canonical} only — use the `resource` value from "
+            f"/.well-known/oauth-protected-resource")
+
+
 def _oauth_error(redirect_uri: str, state: str, error: str, desc: str = ""):
     """OAuth errors go BACK TO THE CLIENT via the redirect, once we trust the redirect.
 
@@ -1726,6 +1750,8 @@ async def oauth_authorize(
     if not code_challenge or code_challenge_method != "S256":
         return _oauth_error(redirect_uri, state, "invalid_request",
                             "PKCE with code_challenge_method=S256 is required")
+    if (bad_target := _wrong_resource(resource)) is not None:
+        return _oauth_error(redirect_uri, state, "invalid_target", bad_target)
 
     user = await _user_from_session(treg_session, db)
     if user is None:
@@ -1794,6 +1820,8 @@ async def oauth_authorize_approve(
     if decision != "allow":
         # Cancel is a real answer and the client is entitled to hear it, rather than hang.
         return _oauth_error(redirect_uri, state, "access_denied", "the user declined")
+    if (bad_target := _wrong_resource(resource)) is not None:
+        return _oauth_error(redirect_uri, state, "invalid_target", bad_target)
     if not code_challenge or code_challenge_method != "S256":
         return _oauth_error(redirect_uri, state, "invalid_request",
                             "PKCE with code_challenge_method=S256 is required")

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -512,7 +512,20 @@ def _same_origin(request: Request) -> bool:
     if origin == get_settings().public_url.rstrip("/"):
         return True
     host = request.headers.get("x-forwarded-host") or request.headers.get("host", "")
-    return origin == f"{'https' if _is_https(request) else 'http'}://{host}"
+    if origin == f"{'https' if _is_https(request) else 'http'}://{host}":
+        return True
+    # `Origin: null` is a browser telling us the submitting document has an OPAQUE origin, which it
+    # does after certain redirect chains — a consent form reached by way of a sign-in bounce through
+    # GitHub, for instance. It is not evidence of a cross-site request, and treating it as one made
+    # the OAuth consent screen fail intermittently: refused on the attempt that went through
+    # sign-in, accepted on the retry that did not.
+    #
+    # `Sec-Fetch-Site` is the right corroboration. It is set by the browser and cannot be written by
+    # script, so a page on another site cannot forge `same-origin` — which is exactly what Origin was
+    # being used to prove.
+    if origin == "null" and request.headers.get("sec-fetch-site") in ("same-origin", "none"):
+        return True
+    return False
 
 
 # In-memory handshake state for `treg login` (single-instance; short-lived, fine to lose on restart).
@@ -1811,7 +1824,10 @@ async def oauth_authorize_approve(
     # Without this, a page anywhere could auto-submit a form and grant itself a team's balance —
     # the user is signed in, so their cookie would ride along. Same guard `auth_logout` uses.
     if not _same_origin(request):
-        raise HTTPException(status_code=403, detail="cross-origin authorization rejected")
+        raise HTTPException(status_code=403, detail=(
+            "cross-origin authorization rejected — this form must be submitted from treg's own "
+            f"consent page (saw Origin: {request.headers.get('origin') or 'none'}, "
+            f"Sec-Fetch-Site: {request.headers.get('sec-fetch-site') or 'none'})"))
 
     client, err = await _authorize_request(client_id, redirect_uri, response_type,
                                            code_challenge, code_challenge_method, db)
@@ -2034,6 +2050,24 @@ async def openai_apps_challenge():
     if not token:
         raise HTTPException(status_code=404, detail="not configured")
     return PlainTextResponse(token, headers={"Cache-Control": "no-store"})
+
+
+@app.get("/connect-demo", include_in_schema=False)
+async def connect_demo_page():
+    """A page that PRETENDS to be someone else's app, so the OAuth flow can be seen end to end.
+
+    It uses only public endpoints — register, authorize, token, revoke, and /mcp/ — with nothing
+    privileged about being served from treg's own domain. The point is to watch the whole dance in a
+    browser before trusting it inside ChatGPT, where a failure surfaces as a shrug rather than an
+    error message.
+    """
+    return _legal_page("connect-demo.html")
+
+
+@app.get("/connect-demo/callback", include_in_schema=False)
+async def connect_demo_callback():
+    """Where treg sends the browser back. Hands the code to the opener and closes."""
+    return _legal_page("connect-demo-callback.html")
 
 
 @app.get("/support", include_in_schema=False)

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1561,6 +1561,72 @@ async def _resolve_oauth_client(client_id: str, db: AsyncSession) -> OAuthClient
 
 AUTH_CODE_TTL_S = 300   # a code is redeemed within seconds; five minutes is generous, not a window
 
+_CONSENT_CSS = """
+.consent{max-width:460px;text-align:left}
+.consent h1{font-size:20px;margin:0 0 4px}
+.consent .who{color:var(--ink55,#8a8a8a);font-size:13.5px;margin:0 0 18px}
+.consent .grants{list-style:none;padding:0;margin:0 0 18px}
+.consent .grants li{padding:7px 0 7px 22px;position:relative;font-size:13.5px;line-height:1.45}
+.consent .grants li:before{content:"›";position:absolute;left:6px;color:#e0703f}
+.consent label{display:block;font-size:12px;text-transform:uppercase;letter-spacing:.06em;
+  color:var(--ink55,#8a8a8a);margin:0 0 6px}
+.consent select{width:100%;padding:9px 10px;border-radius:8px;font:inherit;font-size:14px;
+  background:#1a1a1a;color:inherit;border:1px solid #333;margin-bottom:16px}
+.consent .row{display:flex;gap:10px}
+.consent button{flex:1;padding:10px 14px;border-radius:8px;font:inherit;font-size:14px;cursor:pointer;
+  border:1px solid #333;background:#1a1a1a;color:inherit}
+.consent button.primary{background:#e0703f;border-color:#e0703f;color:#161310;font-weight:600}
+.consent .fine{color:var(--ink55,#8a8a8a);font-size:12px;margin:14px 0 0;line-height:1.5}
+"""
+
+
+def _consent_page(*, client_name: str, client_uri: str, user_email: str, teams: list,
+                  hidden: dict, unverified: bool) -> HTMLResponse:
+    """The one place a human sees what they are granting — so it says it in words, not scopes.
+
+    Deliberately plain about the two things that cost money or leak data: this client will be able to
+    spend the team's balance, and to use the keys the team registered. A consent screen that lists
+    `treg:call` and calls it informed is a formality, not a decision.
+
+    The team picker is here rather than anywhere else because this is the only moment a human is
+    present to answer it. `balance` used to have to refuse and ask when someone belonged to several
+    teams; that question belongs at the grant, once.
+    """
+    import html as _h
+
+    opts = "".join(
+        f'<option value="{t["org_id"]}">{_h.escape(t["slug"])} — {_h.escape(t["role"])}</option>'
+        for t in teams)
+    fields = "".join(
+        f'<input type="hidden" name="{_h.escape(k)}" value="{_h.escape(str(v))}"/>'
+        for k, v in hidden.items())
+    who = _h.escape(client_name or "An application")
+    where = (f' <span class="who">({_h.escape(client_uri)})</span>' if client_uri else "")
+    warn = ("" if not unverified else
+            '<p class="fine"><b>This application registered itself.</b> treg has not reviewed it — '
+            'only continue if you recognise it and started this yourself.</p>')
+    return HTMLResponse(
+        f"{_AUTH_HEAD.replace('</style>', _CONSENT_CSS + '</style>')}"
+        f'<body><div class="wrap"><div class="card consent">'
+        f'<div class="logo">▚ tools-registry</div>'
+        f"<h1>{who} wants to use treg</h1>{where}"
+        f'<p class="who">Signed in as {_h.escape(user_email)}</p>'
+        f'<ul class="grants">'
+        f"<li>Search the catalog and read prices</li>"
+        f"<li>Call tools on your team's behalf — <b>this spends the team's balance</b></li>"
+        f"<li>Use the API keys and connections your team has registered, without seeing them</li>"
+        f"<li>Read the team's balance</li>"
+        f"</ul>"
+        f'<form method="post" action="/oauth/authorize">{fields}'
+        f'<label for="org_id">Which team?</label>'
+        f'<select id="org_id" name="org_id" required>{opts}</select>'
+        f'<div class="row">'
+        f'<button type="submit" name="decision" value="deny">Cancel</button>'
+        f'<button type="submit" name="decision" value="allow" class="primary">Allow</button>'
+        f"</div></form>{warn}"
+        f'<p class="fine">You can revoke this at any time from your treg dashboard.</p>'
+        f"</div></div></body></html>")
+
 
 def _oauth_error(redirect_uri: str, state: str, error: str, desc: str = ""):
     """OAuth errors go BACK TO THE CLIENT via the redirect, once we trust the redirect.
@@ -1644,20 +1710,33 @@ async def oauth_authorize(
         org = await db.get(Org, m.org_id)
         if org is not None and not org.suspended:
             teams.append({"org_id": org.id, "slug": org.slug, "role": m.role})
-    return {
-        "client": {"client_id": client.client_id, "name": client.client_name,
-                   "uri": client.client_uri, "kind": client.kind},
-        "redirect_uri": redirect_uri, "scope": scope, "resource": resource,
-        "user": user.email,
-        # The team picker. A person may belong to several, and which one this client may spend from
-        # is a decision for the human here — not something resolved per call later.
-        "teams": teams,
-        "approve_with": "POST /oauth/authorize with the same parameters plus org_id",
-    }
+    if not teams:
+        return _oauth_error(redirect_uri, state, "access_denied",
+                            "this account is not a member of any team")
+
+    hidden = {"client_id": client_id, "redirect_uri": redirect_uri, "response_type": response_type,
+              "scope": scope, "state": state, "code_challenge": code_challenge,
+              "code_challenge_method": code_challenge_method, "resource": resource}
+    if "application/json" in (request.headers.get("accept") or ""):
+        return {
+            "client": {"client_id": client.client_id, "name": client.client_name,
+                       "uri": client.client_uri, "kind": client.kind},
+            "redirect_uri": redirect_uri, "scope": scope, "resource": resource,
+            "user": user.email,
+            # The team picker. A person may belong to several, and which one this client may spend
+            # from is a decision for the human here — not something resolved per call later.
+            "teams": teams,
+            "approve_with": "POST /oauth/authorize with the same parameters plus org_id",
+        }
+    return _consent_page(client_name=client.client_name, client_uri=client.client_uri,
+                         user_email=user.email, teams=teams, hidden=hidden,
+                         unverified=(client.kind == "dcr"))
 
 
 @app.post("/oauth/authorize", include_in_schema=False)
 async def oauth_authorize_approve(
+    request: Request,
+    decision: str = Form(default="allow"),
     client_id: str = Form(default=""), redirect_uri: str = Form(default=""),
     response_type: str = Form(default="code"), scope: str = Form(default=""),
     state: str = Form(default=""), code_challenge: str = Form(default=""),
@@ -1665,15 +1744,25 @@ async def oauth_authorize_approve(
     org_id: int = Form(default=0),
     treg_session: str = Cookie(default=""), db: AsyncSession = Depends(get_session),
 ):
-    """The human approved. Mint a one-time code bound to everything that made this request."""
+    """The human decided. On approval, mint a one-time code bound to everything that made this
+    request; on anything else, tell the client no."""
     import secrets as _s
 
     from . import mcp_oauth
+
+    # The consent form is the security boundary, so the submission must have come from OUR page.
+    # Without this, a page anywhere could auto-submit a form and grant itself a team's balance —
+    # the user is signed in, so their cookie would ride along. Same guard `auth_logout` uses.
+    if not _same_origin(request):
+        raise HTTPException(status_code=403, detail="cross-origin authorization rejected")
 
     client, err = await _authorize_request(client_id, redirect_uri, response_type,
                                            code_challenge, code_challenge_method, db)
     if err is not None:
         return err
+    if decision != "allow":
+        # Cancel is a real answer and the client is entitled to hear it, rather than hang.
+        return _oauth_error(redirect_uri, state, "access_denied", "the user declined")
     if not code_challenge or code_challenge_method != "S256":
         return _oauth_error(redirect_uri, state, "invalid_request",
                             "PKCE with code_challenge_method=S256 is required")

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -95,6 +95,19 @@ def _bearer(ctx: Context) -> str:
     return raw.removeprefix("Bearer ").removeprefix("bearer ").strip()
 
 
+def _oauth_claims(token: str) -> dict | None:
+    """If this is an OAuth access token we issued FOR THIS SERVER, its claims; otherwise None.
+
+    Returning None is not a rejection — it means "not an OAuth token", and the caller falls through
+    to the per-org and identity tokens that Codex uses. What IS a rejection, silently and on purpose,
+    is a token whose `aud` names a different resource: the user granted that to someone else's MCP
+    server, and honouring it here would spend their treg balance on a consent they never gave us.
+    """
+    from . import mcp_oauth
+
+    return mcp_oauth.read_access_token(token, expected_audience=mcp_oauth.mcp_resource_url())
+
+
 def _need_token() -> dict:
     return {
         "error": "not authenticated",

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -119,6 +119,44 @@ def _need_token() -> dict:
     }
 
 
+async def _internal_auth(token: str) -> dict[str, str]:
+    """Turn whatever the caller presented into headers treg's own API understands.
+
+    Two kinds of credential arrive here and only one of them is native. A per-org or identity token
+    (what Codex sends) passes straight through. An OAuth access token does NOT: it is ours, issued by
+    our authorization server, and the rest of the API has never heard of it.
+
+    So it is exchanged rather than forwarded — validated here, then presented onward as a short-lived
+    identity token for the user it names, pinned to the ORG THE HUMAN CHOSE at consent. That keeps
+    OAuth inside this module instead of teaching `require_member` a third token type, and it means
+    the team on the grant is the team that gets billed, with no per-call guessing.
+
+    Found by running the flow rather than by testing the pieces: `_oauth_claims` validated a token
+    perfectly while every tool still forwarded the raw bearer and got "not signed in".
+    """
+    claims = _oauth_claims(token)
+    if claims is None:
+        return {"X-Treg-Token": token}
+
+    from sqlmodel import select
+
+    from . import session
+    from .db import session_maker
+    from .models import Org, User
+
+    async with session_maker() as db:
+        user = await db.get(User, claims["sub"])
+        if user is None or user.suspended or user.token_version != claims["tv"]:
+            # tv mismatch = the user revoked their tokens after this grant was made.
+            return {"X-Treg-Token": token}
+        org = await db.get(Org, claims["org"])
+        if org is None or org.suspended:
+            return {"X-Treg-Token": token}
+        slug = org.slug
+    return {"X-Treg-Token": session.make(user.id, ttl=120, token_version=user.token_version),
+            "X-Treg-Org": slug}
+
+
 @asynccontextmanager
 async def _api(token: str):
     """An in-process client bound to treg's own ASGI app, carrying the caller's identity."""
@@ -128,7 +166,7 @@ async def _api(token: str):
         transport=httpx.ASGITransport(app=app),
         base_url=_INTERNAL_BASE,
         timeout=_TIMEOUT,
-        headers={"X-Treg-Token": token},
+        headers=await _internal_auth(token),
     ) as client:
         yield client
 
@@ -154,6 +192,17 @@ async def _resolve_org(client: httpx.AsyncClient) -> tuple[int | None, str | Non
     and NAME them rather than silently picking one: reading the wrong team's balance is a confusing
     answer, and spending from it would be worse.
     """
+    # An OAuth grant already names its team — the human chose it at the consent screen. Re-deriving
+    # it here would ignore that decision and, for a person in several teams, ask a question that has
+    # already been answered.
+    pinned = client.headers.get("X-Treg-Org")
+    if pinned:
+        r = await client.get("/orgs")
+        for o in (_body(r) or []) if r.status_code == 200 else []:
+            if o.get("slug") == pinned:
+                return int(o["org_id"]), pinned, None
+        return None, None, {"error": f"the team named in this grant ({pinned}) is no longer available"}
+
     me = await client.get("/auth/me")
     if me.status_code == 200 and _body(me).get("org_id"):
         body = _body(me)

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -429,6 +429,29 @@ def _allowed_hosts() -> list[str]:
     return sorted(dict.fromkeys(hosts))
 
 
+def _allowed_origins() -> list[str]:
+    """Which `Origin` headers the transport will answer to.
+
+    `"*"` is NOT a wildcard here — the SDK compares origins literally, and only a `:*` port suffix is
+    special. Setting `["*"]` therefore allowed exactly one origin, the literal string "*", and
+    refused every browser with "Invalid Origin header". Nothing caught it: the test suite and every
+    CLI client send no Origin at all, so the check never ran until a real page called /mcp/.
+
+    So the list is built like `_allowed_hosts`: this deployment plus the loopback origins a developer
+    uses, extended by `TREG_MCP_ALLOWED_ORIGINS`. A browser-based MCP client — including a web page
+    like /connect-demo — needs its origin here to work at all.
+    """
+    origins: list[str] = []
+    public = get_settings().public_url.rstrip("/")
+    if public:
+        origins.append(public)
+    origins += [f"http://localhost:{p}" for p in ("8000", "18790")]
+    origins += [f"http://127.0.0.1:{p}" for p in ("8000", "18790")]
+    origins += ["http://localhost", "http://127.0.0.1"]
+    origins += [o.strip() for o in os.environ.get("TREG_MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
+    return sorted(dict.fromkeys(origins))
+
+
 def build_mcp_app():
     """A fresh ASGI app for the MCP transport.
 
@@ -447,7 +470,7 @@ def build_mcp_app():
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
             allowed_hosts=_allowed_hosts(),
-            allowed_origins=["*"],  # identity is the bearer token, not the origin; a CLI sends none
+            allowed_origins=_allowed_origins(),
         ),
     )
 

--- a/src/treg/mcp_oauth.py
+++ b/src/treg/mcp_oauth.py
@@ -95,6 +95,7 @@ def authorization_server_metadata() -> dict:
         "authorization_endpoint": f"{base}/oauth/authorize",
         "token_endpoint": f"{base}/oauth/token",
         "registration_endpoint": f"{base}/oauth/register",
+        "revocation_endpoint": f"{base}/oauth/revoke",
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],

--- a/src/treg/mcp_oauth.py
+++ b/src/treg/mcp_oauth.py
@@ -167,3 +167,100 @@ def verify_pkce(verifier: str, challenge: str) -> bool:
         return False
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     return hmac.compare_digest(_b64(digest), challenge)
+
+
+# ---------------------------------------------------------------------------------------------
+# Client registration — two doors in, one row shape out
+# ---------------------------------------------------------------------------------------------
+
+# A client-id metadata document is fetched from a URL the CALLER chose, which makes it a
+# request-forgery primitive unless it is fenced. The fence: https only, no redirects followed, a
+# public address at connect time, a short timeout, and a size cap. `health` already owns both halves
+# of the address check and is reused rather than reimplemented — a second copy of an SSRF guard is a
+# second thing to forget to update.
+_CIMD_TIMEOUT_S = 5.0
+_CIMD_MAX_BYTES = 64 * 1024
+_CIMD_REFRESH_S = 24 * 3600
+
+
+def valid_redirect_uri(uri: str) -> bool:
+    """A redirect URI must be https, or a loopback http address.
+
+    Loopback is the documented exception and a real need: a CLI client listens on 127.0.0.1 to catch
+    the code, and there is no way for it to hold a certificate. Everything else must be https,
+    because an authorization code travelling over http is a code an eavesdropper can redeem.
+    """
+    from urllib.parse import urlsplit
+
+    try:
+        u = urlsplit(uri)
+    except ValueError:
+        return False
+    if not u.hostname or u.fragment:      # a fragment cannot be matched exactly and hides intent
+        return False
+    if u.scheme == "https":
+        return True
+    return u.scheme == "http" and u.hostname in ("127.0.0.1", "::1", "localhost")
+
+
+def redirect_uri_allowed(client, uri: str) -> bool:
+    """EXACT match against what the client registered.
+
+    Not a prefix or a host comparison. Prefix matching is the classic way this check is defeated —
+    `https://good.example.com.evil.test/` starts with the registered origin, and an open redirect
+    under a registered host turns one sloppy page into stolen authorization codes.
+    """
+    return bool(uri) and uri in (client.redirect_uris or [])
+
+
+async def fetch_client_id_metadata(url: str) -> dict | None:
+    """Fetch a client-id metadata document, or None if it is not safe or not usable.
+
+    Returning None rather than raising: an unreachable or malformed document is a client we cannot
+    identify, which is a refusal, not a server error.
+    """
+    from urllib.parse import urlsplit
+
+    import httpx
+
+    from . import health
+
+    u = urlsplit(url)
+    if u.scheme != "https" or not u.hostname:
+        return None
+    if not health.safe_webhook_url(url) or not health.host_is_public(u.hostname):
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=_CIMD_TIMEOUT_S, follow_redirects=False) as c:
+            r = await c.get(url, headers={"Accept": "application/json"})
+        if r.status_code != 200 or len(r.content) > _CIMD_MAX_BYTES:
+            return None
+        doc = r.json()
+    except Exception:  # noqa: BLE001 — any failure to fetch is "cannot identify this client"
+        return None
+    if not isinstance(doc, dict):
+        return None
+    # The document must claim the URL it was served from. Without this, a document hosted anywhere
+    # could assert someone else's client_id and inherit their consent.
+    if doc.get("client_id") not in (None, url):
+        return None
+    redirects = [r for r in (doc.get("redirect_uris") or []) if isinstance(r, str)]
+    redirects = [r for r in redirects if valid_redirect_uri(r)]
+    if not redirects:
+        return None
+    return {
+        "client_id": url,
+        "client_name": str(doc.get("client_name") or url)[:200],
+        "client_uri": str(doc.get("client_uri") or "")[:500],
+        "logo_uri": str(doc.get("logo_uri") or "")[:500],
+        "redirect_uris": redirects[:20],
+        "scope": str(doc.get("scope") or "")[:200],
+    }
+
+
+def new_client_id() -> str:
+    """Opaque, for dynamically registered clients. Not guessable, and not carrying meaning: a
+    client_id that encoded anything would tempt something downstream into parsing it."""
+    import secrets
+
+    return "treg-client-" + secrets.token_urlsafe(24)

--- a/src/treg/mcp_oauth.py
+++ b/src/treg/mcp_oauth.py
@@ -1,0 +1,169 @@
+"""treg as an OAuth **authorization server** — the metadata, and the tokens it will issue.
+
+Everywhere else treg speaks OAuth as a *client*: `oauth.py` builds PKCE challenges to sign in with
+GitHub and to connect a provider account. This is the other direction — the thing that mints tokens
+rather than the thing that redeems them.
+
+This module is deliberately the FIRST piece built, and on its own it issues nothing. It is the part
+that **refuses**: the metadata that tells a client what we support, and the validation that rejects a
+token which is expired, forged, or minted for somebody else's server. Building the refusal before
+the issuance means there is never a window where we accept tokens we have not yet learned to check.
+
+**The `aud` claim is the load-bearing one.** The MCP spec has the client send `resource=<the mcp
+url>` on both the authorize and the token request, and the authorization server must copy it into the
+token's audience. Without checking it, a token a user granted to *some other* MCP server would work
+on ours — the user consented to that server, not to treg, and we would be spending their treg balance
+on the strength of it. `read_access_token` therefore takes the expected audience as a REQUIRED
+argument. There is no default and no "skip the check" path, because the one thing that must never
+happen by accident is not checking.
+
+Not ChatGPT-specific. The MCP authorization spec is the same for every compliant client, so this
+serves Claude Code, Cursor and anything else that implements it. See `docs/MCP-OAUTH-PLAN.md`.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from urllib.parse import urljoin
+
+from .config import get_settings
+
+# How long an access token lives. Short, because a refresh token will exist to renew it and a leaked
+# access token is only as dangerous as its remaining life.
+ACCESS_TTL_SECONDS = 3600
+
+# Marks a token as an MCP access token and nothing else. treg already mints session cookies and
+# identity tokens with the same HMAC construction, so without a type marker a session cookie would
+# validate here (and vice versa) — one class of token would silently become another, which is a
+# privilege escalation waiting for someone to notice it before we do.
+_TOKEN_TYPE = "treg-mcp-at"
+
+
+def _key() -> bytes:
+    # Same secret as browser sessions, deliberately: one secret to rotate, and rotating it should
+    # invalidate every credential at once rather than leaving some class of token still valid.
+    from . import session
+
+    return session._key()
+
+
+def _b64(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).decode().rstrip("=")
+
+
+def _unb64(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def mcp_resource_url() -> str:
+    """The canonical identifier for the thing being protected — our MCP endpoint.
+
+    Must match what clients send as `resource`, byte for byte, because that string is what ends up in
+    the token's audience and what we compare against. The trailing slash is part of it: the transport
+    is mounted at `/mcp` and served at `/mcp/`, and a client that resolves the metadata will use the
+    form we publish here.
+    """
+    return urljoin(get_settings().public_url.rstrip("/") + "/", "mcp/")
+
+
+def protected_resource_metadata() -> dict:
+    """`/.well-known/oauth-protected-resource` — "who guards this, and what may you ask for?"."""
+    base = get_settings().public_url.rstrip("/")
+    return {
+        "resource": mcp_resource_url(),
+        "authorization_servers": [base],
+        "scopes_supported": ["treg:catalog", "treg:call", "treg:read"],
+        "bearer_methods_supported": ["header"],
+        "resource_documentation": f"{base}/llms.txt",
+    }
+
+
+def authorization_server_metadata() -> dict:
+    """`/.well-known/oauth-authorization-server` — how to get a token.
+
+    `code` alone: no implicit grant, which OAuth 2.1 drops for good reason. `S256` alone: a client
+    offering `plain` is a client whose codes can be replayed. `none` for client auth is correct for
+    public clients that use PKCE, which is what every MCP client is.
+    """
+    base = get_settings().public_url.rstrip("/")
+    return {
+        "issuer": base,
+        "authorization_endpoint": f"{base}/oauth/authorize",
+        "token_endpoint": f"{base}/oauth/token",
+        "registration_endpoint": f"{base}/oauth/register",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": ["treg:catalog", "treg:call", "treg:read"],
+        # ChatGPT sends an HTTPS metadata URL as its client_id instead of registering. Advertising
+        # this does not replace `registration_endpoint` above — Claude Code and most other clients
+        # register dynamically, and supporting only one of the two would lock the others out.
+        "client_id_metadata_document_supported": True,
+        "service_documentation": f"{base}/llms.txt",
+    }
+
+
+def make_access_token(*, user_id: int, org_id: int, audience: str, scope: str = "",
+                      ttl: int = ACCESS_TTL_SECONDS, token_version: int = 0) -> str:
+    """Mint an access token bound to a user, ONE team, and one audience.
+
+    `org_id` is on the token rather than resolved per call on purpose. A person can belong to several
+    teams, and the question "which team is this spending from?" must be answered once, by a human, at
+    the consent screen — not guessed at request time. It is also what makes a granted token
+    revocable in a way the user understands: they granted this client access to that team.
+    """
+    raw = json.dumps({
+        "typ": _TOKEN_TYPE,
+        "sub": int(user_id),
+        "org": int(org_id),
+        "aud": audience,
+        "scope": scope,
+        "tv": int(token_version),
+        "exp": int(time.time()) + int(ttl),
+    }, separators=(",", ":")).encode()
+    sig = hmac.new(_key(), raw, hashlib.sha256).digest()
+    return f"{_b64(raw)}.{_b64(sig)}"
+
+
+def read_access_token(token: str, *, expected_audience: str) -> dict | None:
+    """Validate an access token and return its claims, or None.
+
+    `expected_audience` is required and has no default. A token carries the resource its user
+    consented to; accepting one addressed elsewhere would let a grant made to another MCP server
+    spend a treg balance. Every other check here is ordinary — signature, type, expiry — but this is
+    the one that is specific to being a resource server rather than a login system.
+    """
+    if not token or "." not in token or not expected_audience:
+        return None
+    try:
+        payload, signature = token.split(".", 1)
+        raw = _unb64(payload)
+        expected_sig = hmac.new(_key(), raw, hashlib.sha256).digest()
+        if not hmac.compare_digest(_unb64(signature), expected_sig):
+            return None
+        data = json.loads(raw)
+        if data.get("typ") != _TOKEN_TYPE:
+            return None                      # a session cookie is not an access token
+        if data.get("aud") != expected_audience:
+            return None                      # minted for a different resource — not ours to honour
+        if int(data.get("exp", 0)) < time.time():
+            return None
+        return {"sub": int(data["sub"]), "org": int(data["org"]), "aud": data["aud"],
+                "scope": data.get("scope", ""), "tv": int(data.get("tv", 0)),
+                "exp": int(data["exp"])}
+    except Exception:  # noqa: BLE001 — a malformed token is simply not a token
+        return None
+
+
+def verify_pkce(verifier: str, challenge: str) -> bool:
+    """`S256` only. `plain` is in the spec and is worthless: it makes the challenge equal to the
+    secret, so anyone who intercepts the authorization request can redeem the code."""
+    if not verifier or not challenge:
+        return False
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return hmac.compare_digest(_b64(digest), challenge)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -615,3 +615,39 @@ class OAuthCode(SQLModel, table=True):
     scope: str = Field(default="")
     expires_at: datetime
     created_at: datetime = Field(default_factory=_now)
+
+
+class OAuthRefresh(SQLModel, table=True):
+    """A refresh token: the thing that keeps a connector working past the access token's hour.
+
+    Stored as a HASH, like every other credential treg holds. A database copy is a database leak, and
+    a refresh token is the long-lived half — the one worth stealing.
+
+    **Rotation with reuse detection**, which is the whole reason this table has a `family_id`. Each
+    refresh mints a replacement and retires the old row. If a retired token is ever presented again,
+    two things are possible and we cannot tell them apart: a client retried after a dropped response,
+    or somebody else has a copy. Treating that as ordinary would leave a thief with a working
+    credential, so the entire family is revoked and the human signs in again. An interrupted client
+    reconnects; a thief loses the token. The failure mode is inconvenience on one side and containment
+    on the other, which is the right way round.
+
+    `org_id` rides along because it is what the human chose at consent. A refresh must not become a
+    chance to quietly re-pick a team.
+    """
+
+    __table_args__ = (UniqueConstraint("token_hash", name="uq_oauth_refresh_token"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    token_hash: str = Field(index=True)
+    family_id: str = Field(index=True)      # every descendant of one grant shares this
+    client_id: str = Field(index=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    org_id: int = Field(foreign_key="org.id", index=True)
+    resource: str = Field(default="")
+    scope: str = Field(default="")
+    expires_at: datetime
+    created_at: datetime = Field(default_factory=_now)
+    # Set when this row is superseded or killed. A row is kept rather than deleted precisely so a
+    # replay can be RECOGNISED — deleting it would make a stolen token look merely unknown.
+    retired_at: datetime | None = Field(default=None)
+    retired_reason: str = Field(default="")

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -542,3 +542,39 @@ class Project(SQLModel, table=True):
     slug: str = Field(index=True)  # the human handle inside the org
     created_by: str = Field(default="")
     created_at: datetime = Field(default_factory=_now)
+
+
+class OAuthClient(SQLModel, table=True):
+    """An MCP client that may ask treg for a token — ChatGPT, Claude Code, Cursor, anything.
+
+    Two ways a client arrives here and ONE row shape afterwards, which is the point: everything
+    downstream (authorize, consent, token) reads this table and never asks how the client got in.
+
+    - **dcr** — dynamic client registration (RFC 7591). The client POSTs its name and redirect URIs
+      and we mint an opaque `client_id`. This is what Claude Code and most clients do.
+    - **cimd** — a client-id metadata document. The `client_id` IS an https URL that we fetch to
+      learn the name and redirect URIs. This is what ChatGPT prefers.
+
+    Supporting only one would lock the other family out, and we would not have noticed: the client
+    we happened to test with first is the one that does not need registration.
+
+    `redirect_uris` is the security-critical column. An authorization code is delivered to a redirect
+    URI, so a client that could name an arbitrary one at authorize time could have codes posted to an
+    attacker. They are fixed here at registration and matched EXACTLY later — no prefix matching,
+    which is the classic way this check is defeated.
+    """
+
+    __table_args__ = (UniqueConstraint("client_id", name="uq_oauth_client_id"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    client_id: str = Field(index=True)
+    kind: str = Field(default="dcr")            # "dcr" | "cimd"
+    client_name: str = Field(default="")
+    client_uri: str = Field(default="")
+    logo_uri: str = Field(default="")
+    redirect_uris: list = Field(default_factory=list,
+                                sa_column=Column("redirect_uris", JSON, nullable=False))
+    scope: str = Field(default="")
+    created_at: datetime = Field(default_factory=_now)
+    # cimd only: documents change, so a cached copy has to be refreshable rather than permanent.
+    refreshed_at: datetime | None = Field(default=None)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -578,3 +578,40 @@ class OAuthClient(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_now)
     # cimd only: documents change, so a cached copy has to be refreshable rather than permanent.
     refreshed_at: datetime | None = Field(default=None)
+
+
+class OAuthCode(SQLModel, table=True):
+    """A one-time authorization code: the few seconds between a human approving and a client
+    redeeming.
+
+    Every field here exists to bind the code to the exact request that created it, because a code is
+    a bearer credential travelling through a browser redirect — through the user's history, possibly
+    a referrer header, possibly a proxy log.
+
+    - `client_id` + `redirect_uri`: a code minted for one client, deliverable to one place. Without
+      both, a code intercepted from one client could be redeemed by another.
+    - `code_challenge`: PKCE. The redeemer must prove it knows the verifier, so a code stolen in
+      transit is worthless to whoever stole it.
+    - `resource`: what the user consented to, carried into the token's `aud`. This is what stops a
+      grant for one MCP server working against another.
+    - `org_id`: WHICH TEAM. A person may belong to several, and this is the answer they chose — not
+      one the server guesses later.
+
+    Rows are deleted on redemption rather than flagged. A used code that still exists is a race
+    waiting for two redemptions to read it before either writes; deletion makes the database the
+    arbiter, the same reasoning as the conditional UPDATE in `ledger.reserve`.
+    """
+
+    __table_args__ = (UniqueConstraint("code", name="uq_oauth_code"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    code: str = Field(index=True)
+    client_id: str = Field(index=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    org_id: int = Field(foreign_key="org.id", index=True)
+    redirect_uri: str
+    code_challenge: str = Field(default="")
+    resource: str = Field(default="")
+    scope: str = Field(default="")
+    expires_at: datetime
+    created_at: datetime = Field(default_factory=_now)

--- a/src/treg/web/connect-demo-callback.html
+++ b/src/treg/web/connect-demo-callback.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>treg — returning…</title>
+<meta name="robots" content="noindex"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<link rel="stylesheet" href="/legal.css"/>
+</head>
+<body>
+<div class="page"><div class="doc" style="text-align:center;padding-top:60px">
+  <div style="font-size:22px">▚</div>
+  <p id="msg">Returning to the app…</p>
+</div></div>
+<script>
+// The popup's only job: hand the code back to the page that opened it, then close.
+// Posted to our OWN origin explicitly — a wildcard target would broadcast an authorization code to
+// whatever else happened to be listening.
+const q = new URLSearchParams(location.search);
+const payload = { source: "treg-connect-demo", code: q.get("code"), state: q.get("state"),
+                  error: q.get("error"), error_description: q.get("error_description") };
+if (window.opener) {
+  window.opener.postMessage(payload, location.origin);
+  document.getElementById("msg").textContent = payload.error ? "Cancelled. You can close this." : "Done — you can close this.";
+  setTimeout(() => window.close(), 600);
+} else {
+  document.getElementById("msg").textContent =
+    "This page is the OAuth callback for the connect demo. Open /connect-demo instead.";
+}
+</script>
+</body>
+</html>

--- a/src/treg/web/connect-demo.html
+++ b/src/treg/web/connect-demo.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>treg — connect demo</title>
+<meta name="robots" content="noindex"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist+Pixel&family=DM+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/legal.css"/>
+<style>
+.demo{max-width:760px}
+.step{border:1px solid #2a2a2a;border-radius:10px;padding:14px 16px;margin:0 0 12px}
+.step h3{margin:0 0 4px;font-size:14px}
+.step p{margin:0;font-size:13px;color:var(--ink55,#8a8a8a);line-height:1.5}
+.state{font-size:12px;padding:2px 8px;border-radius:99px;border:1px solid #333;margin-left:8px}
+.state.on{background:#123a25;border-color:#1c5c3a;color:#7fdcae}
+.state.off{color:#8a8a8a}
+button{padding:9px 14px;border-radius:8px;font:inherit;font-size:13.5px;cursor:pointer;
+  border:1px solid #333;background:#1a1a1a;color:inherit;margin:8px 8px 0 0}
+button.primary{background:#e0703f;border-color:#e0703f;color:#161310;font-weight:600}
+button:disabled{opacity:.4;cursor:not-allowed}
+pre{background:#141414;border:1px solid #262626;border-radius:8px;padding:12px;overflow:auto;
+  font-size:12px;line-height:1.5;max-height:340px;margin:12px 0 0}
+.tools{display:flex;flex-wrap:wrap;gap:0}
+</style>
+</head>
+<body>
+
+<div class="topbar"><div class="in">
+  <a class="brand" href="/"><span class="glyph">▚</span> treg</a>
+  <span class="sp"></span>
+  <a class="nav" href="/support">support</a>
+  <a class="nav" href="/tutorial">docs</a>
+</div></div>
+
+<div class="page"><div class="doc demo">
+
+  <div class="eyebrow">Developer</div>
+  <h1>Connect demo</h1>
+  <p style="color:var(--ink55,#8a8a8a);font-size:13.5px;line-height:1.6">
+    This page pretends to be someone else's app. It does exactly what ChatGPT, Claude Code or any
+    other MCP client does when it connects to treg — registers itself, sends you to treg to approve,
+    gets a token back, and calls tools with it. Nothing here is privileged: it uses the same public
+    endpoints any client would.
+  </p>
+
+  <div class="step">
+    <h3>1. Register <span id="s1" class="state off">not yet</span></h3>
+    <p>The app tells treg its name and where to send the user back. This is dynamic client
+    registration — no pre-arrangement, no key.</p>
+    <button id="btnRegister" class="primary">Register this app</button>
+  </div>
+
+  <div class="step">
+    <h3>2. Connect <span id="s2" class="state off">not connected</span></h3>
+    <p>Opens treg in a popup so you can sign in and choose which team this app may act for. treg
+    sends back a one-time code, which the app exchanges for a token. The app never sees your
+    password, and treg never gives it your API keys.</p>
+    <button id="btnConnect" class="primary" disabled>Connect treg</button>
+    <button id="btnDisconnect" disabled>Disconnect</button>
+  </div>
+
+  <div class="step">
+    <h3>3. Call tools <span id="s3" class="state off">no token</span></h3>
+    <p>The same five tools any MCP client gets. <b>catalog_search</b> and <b>catalog_get</b> are
+    public; the rest need the token you just granted. <b>call</b> is the only one that spends the
+    team's balance, so it does what treg asks an agent to do — reads the price first and asks before
+    spending.</p>
+    <div class="tools">
+      <button class="tool" data-tool="catalog_search" disabled>catalog_search</button>
+      <button class="tool" data-tool="catalog_get" disabled>catalog_get</button>
+      <button class="tool" data-tool="balance" disabled>balance</button>
+      <button id="btnCall" disabled>call <span style="opacity:.6">(spends)</span></button>
+      <button class="tool" data-tool="my_tools" disabled>my_tools</button>
+      <button id="btnRefresh" disabled>refresh the token</button>
+    </div>
+  </div>
+
+  <pre id="log">ready.</pre>
+</div></div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+const log = (label, data) => {
+  const now = new Date().toISOString().slice(11, 19);
+  const body = typeof data === "string" ? data : JSON.stringify(data, null, 1);
+  $("log").textContent = `[${now}] ${label}\n${body}\n\n` + $("log").textContent;
+};
+const setState = (el, on, text) => { el.className = "state " + (on ? "on" : "off"); el.textContent = text; };
+
+// Everything this page knows lives in sessionStorage — a demo should not outlive its tab.
+const S = {
+  get: (k) => { try { return JSON.parse(sessionStorage.getItem("tregdemo." + k)); } catch { return null; } },
+  set: (k, v) => sessionStorage.setItem("tregdemo." + k, JSON.stringify(v)),
+  del: (k) => sessionStorage.removeItem("tregdemo." + k),
+};
+
+const REDIRECT = location.origin + "/connect-demo/callback";
+let META = null, RESOURCE = null;
+
+async function discover() {
+  // Exactly what a client does first: find the resource id and the endpoints. Never hard-coded —
+  // hard-coding is what made an earlier acceptance run mint a token with the wrong audience.
+  const prm = await (await fetch("/.well-known/oauth-protected-resource")).json();
+  RESOURCE = prm.resource;
+  META = await (await fetch("/.well-known/oauth-authorization-server")).json();
+  log("discovered", { resource: RESOURCE, authorize: META.authorization_endpoint });
+}
+
+async function register() {
+  const r = await fetch(META.registration_endpoint, {
+    method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_name: "treg connect demo", redirect_uris: [REDIRECT] }),
+  });
+  const body = await r.json();
+  if (!r.ok) { log("registration failed", body); return; }
+  S.set("client_id", body.client_id);
+  setState($("s1"), true, body.client_id.slice(0, 18) + "…");
+  $("btnConnect").disabled = false;
+  log("registered", body);
+}
+
+// PKCE in the browser, the same S256 the spec requires.
+async function pkce() {
+  const bytes = crypto.getRandomValues(new Uint8Array(48));
+  const verifier = btoa(String.fromCharCode(...bytes)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  const challenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return { verifier, challenge };
+}
+
+async function connect() {
+  const { verifier, challenge } = await pkce();
+  const state = crypto.randomUUID();
+  S.set("verifier", verifier); S.set("state", state);
+  const q = new URLSearchParams({
+    client_id: S.get("client_id"), redirect_uri: REDIRECT, response_type: "code",
+    code_challenge: challenge, code_challenge_method: "S256",
+    resource: RESOURCE, scope: "treg:call", state,
+  });
+  log("opening treg for approval", { url: META.authorization_endpoint + "?…" });
+  window.open(META.authorization_endpoint + "?" + q, "treg-connect", "width=520,height=760");
+}
+
+// The popup posts the code back here rather than the page polling for it.
+window.addEventListener("message", async (e) => {
+  if (e.origin !== location.origin || !e.data || e.data.source !== "treg-connect-demo") return;
+  if (e.data.error) { log("treg returned an error", e.data); return; }
+  if (e.data.state !== S.get("state")) { log("state mismatch — ignoring", e.data); return; }
+  log("got an authorization code", { code: e.data.code.slice(0, 8) + "…" });
+  await exchange(e.data.code);
+});
+
+async function exchange(code) {
+  const r = await fetch(META.token_endpoint, {
+    method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code", code, redirect_uri: REDIRECT,
+      client_id: S.get("client_id"), code_verifier: S.get("verifier"), resource: RESOURCE }),
+  });
+  const body = await r.json();
+  if (!r.ok) { log("token exchange failed", body); return; }
+  S.set("access", body.access_token); S.set("refresh", body.refresh_token);
+  setState($("s2"), true, "connected");
+  setState($("s3"), true, "token held");
+  document.querySelectorAll(".tool").forEach((b) => (b.disabled = false));
+  $("btnRefresh").disabled = false; $("btnDisconnect").disabled = false; $("btnCall").disabled = false;
+  log("token received", { token_type: body.token_type, expires_in: body.expires_in,
+                          access_token: body.access_token.slice(0, 24) + "…",
+                          refresh_token: body.refresh_token.slice(0, 12) + "…" });
+}
+
+let rpcId = 0;
+async function callTool(name, args) {
+  const headers = { "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream" };
+  const tok = S.get("access");
+  if (tok) headers["Authorization"] = "Bearer " + tok;
+  const rpc = (body) => fetch("/mcp/", { method: "POST", headers, body: JSON.stringify(body) })
+    .then((r) => r.json());
+  await rpc({ jsonrpc: "2.0", id: ++rpcId, method: "initialize", params: {
+    protocolVersion: "2025-06-18", capabilities: {},
+    clientInfo: { name: "treg connect demo", version: "1" } } });
+  const out = await rpc({ jsonrpc: "2.0", id: ++rpcId, method: "tools/call",
+                          params: { name, arguments: args || {} } });
+  const text = out?.result?.content?.[0]?.text;
+  try { log(name, JSON.parse(text)); } catch { log(name, text || out); }
+}
+
+// `call` is the only button here that costs money, so it follows the same rule the skill gives an
+// agent: look up the price, say it out loud, and get a yes before spending. A demo that quietly
+// charged on each click would be teaching the opposite of what the product asks for.
+const DEMO_ENDPOINT = "hunter.people.email.find";
+async function callWithPrice() {
+  log("checking the price first", { endpoint: DEMO_ENDPOINT });
+  const headers = { "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream" };
+  const tok = S.get("access");
+  if (tok) headers["Authorization"] = "Bearer " + tok;
+  const rpc = (body) => fetch("/mcp/", { method: "POST", headers, body: JSON.stringify(body) })
+    .then((r) => r.json());
+  await rpc({ jsonrpc: "2.0", id: ++rpcId, method: "initialize", params: {
+    protocolVersion: "2025-06-18", capabilities: {},
+    clientInfo: { name: "treg connect demo", version: "1" } } });
+  const info = await rpc({ jsonrpc: "2.0", id: ++rpcId, method: "tools/call",
+    params: { name: "catalog_get", arguments: { endpoint_id: DEMO_ENDPOINT } } });
+  // The price lives on `endpoint.cost.usd`. A first version read `cost` from the top level, found
+  // nothing, and — because the whole thing sat in a bare try/catch — said nothing at all. A demo
+  // that fails silently teaches the reader that the feature is broken rather than that the code is.
+  let price = null;
+  try {
+    price = JSON.parse(info.result.content[0].text).endpoint.cost.usd ?? null;
+  } catch (err) {
+    log("could not read the price", { error: String(err), response: info });
+  }
+  const shown = price === null ? "an unknown amount" : "$" + price;
+  log("price", { endpoint: DEMO_ENDPOINT, usd_per_call: price });
+  if (!confirm(`Calling ${DEMO_ENDPOINT} will spend ${shown} from your team's balance.\n\nGo ahead?`)) {
+    log("call cancelled", "nothing was spent");
+    return;
+  }
+  const out = await rpc({ jsonrpc: "2.0", id: ++rpcId, method: "tools/call",
+    params: { name: "call", arguments: { endpoint_id: DEMO_ENDPOINT,
+      params: { domain: "stripe.com", first_name: "Patrick", last_name: "Collison" } } } });
+  const text = out?.result?.content?.[0]?.text;
+  try { log("call", JSON.parse(text)); } catch { log("call", text || out); }
+  log("note", "on the dev box there are no provider keys, so a catalog call is refused before " +
+              "anything is spent — that refusal IS the credential ladder working");
+}
+
+async function refresh() {
+  const r = await fetch(META.token_endpoint, {
+    method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: S.get("refresh"),
+                                client_id: S.get("client_id") }) });
+  const body = await r.json();
+  if (!r.ok) { log("refresh failed", body); return; }
+  const rotated = body.refresh_token !== S.get("refresh");
+  S.set("access", body.access_token); S.set("refresh", body.refresh_token);
+  log("refreshed", { rotated, expires_in: body.expires_in });
+}
+
+async function disconnect() {
+  await fetch("/oauth/revoke", { method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ token: S.get("refresh") || "" }) });
+  ["access", "refresh", "verifier", "state"].forEach(S.del);
+  setState($("s2"), false, "not connected"); setState($("s3"), false, "no token");
+  document.querySelectorAll(".tool").forEach((b) => (b.disabled = true));
+  $("btnRefresh").disabled = true; $("btnDisconnect").disabled = true; $("btnCall").disabled = true;
+  log("disconnected", "the grant was revoked at treg, not just forgotten here");
+}
+
+// Every handler reports its own failure. Without this a rejected promise vanishes into the console,
+// and the page just looks inert — which is exactly how the price bug above hid.
+const guard = (fn, label) => () => fn().catch((e) => log(label + " failed", String(e)));
+$("btnRegister").onclick = guard(register, "register");
+$("btnConnect").onclick = guard(connect, "connect");
+$("btnDisconnect").onclick = guard(disconnect, "disconnect");
+$("btnRefresh").onclick = guard(refresh, "refresh");
+$("btnCall").onclick = () => callWithPrice().catch((e) => log("call failed", String(e)));
+document.querySelectorAll(".tool").forEach((b) => {
+  b.onclick = () => callTool(b.dataset.tool,
+    b.dataset.tool === "catalog_search" ? { query: "work email", limit: 3 }
+    : b.dataset.tool === "catalog_get" ? { endpoint_id: "hunter.people.email.find" } : {});
+});
+
+discover().then(() => {
+  if (S.get("client_id")) { setState($("s1"), true, "registered"); $("btnConnect").disabled = false; }
+  if (S.get("access")) {
+    setState($("s2"), true, "connected"); setState($("s3"), true, "token held");
+    document.querySelectorAll(".tool").forEach((b) => (b.disabled = false));
+    $("btnRefresh").disabled = false; $("btnDisconnect").disabled = false; $("btnCall").disabled = false;
+  }
+});
+</script>
+</body>
+</html>

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -297,3 +297,31 @@ async def test_the_domain_challenge_returns_the_token_ALONE(clients, monkeypatch
     assert r.status_code == 200
     assert r.text == "tok-abc-123"
     assert r.headers["content-type"].startswith("text/plain")
+
+
+async def test_a_BROWSER_origin_is_accepted(clients):
+    """`"*"` is not a wildcard in this SDK — origins are compared literally, and only a `:*` port
+    suffix is special. Setting `allowed_origins=["*"]` therefore allowed exactly one origin, the
+    literal string "*", and refused every browser with "Invalid Origin header".
+
+    Nothing caught it: the suite and every CLI client send NO Origin header, so the check never ran
+    until a real web page called /mcp/. This test sends one deliberately."""
+    from treg.config import get_settings
+
+    origin = get_settings().public_url.rstrip("/")
+    async with mcp_session(clients) as c:
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                       "clientInfo": {"name": "browser", "version": "1"}}},
+            headers={**MCP_HEADERS, "Origin": origin})
+    assert r.status_code == 200, f"a browser at our own origin must be served: {r.text[:120]}"
+
+
+async def test_an_UNKNOWN_origin_is_still_refused(clients):
+    """The protection has to remain real — the fix widens the list, it does not remove the check."""
+    async with mcp_session(clients) as c:
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            headers={**MCP_HEADERS, "Origin": "https://attacker.example"})
+    assert r.status_code == 403, r.text

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -731,3 +731,51 @@ async def test_refresh_tokens_are_stored_HASHED(clients):
     assert rows, "expected a stored refresh token"
     assert all(body["refresh_token"] not in (r.token_hash or "") for r in rows)
     assert all(len(r.token_hash) == 64 for r in rows), "sha256 hex, as everywhere else in treg"
+
+
+# ---- step 6: what an INDEPENDENT client found ------------------------------------------------
+
+async def test_a_resource_we_do_not_serve_is_refused_UP_FRONT(clients):
+    """Found by driving the flow with the MCP SDK's own client instead of my curl.
+
+    It sent the URL it had dialled (`http://127.0.0.1:18790/mcp/`) rather than the canonical
+    identifier our metadata declares, which is a reasonable thing for a client to do. treg accepted
+    it and minted a token that was valid, well-formed and silently useless — the audience did not
+    match, so the first tool call answered "not signed in" and pointed the reader at authentication
+    when the real problem was the resource.
+
+    Refusing at authorize time turns a confusing failure an hour downstream into a clear one
+    immediately, and names the fix.
+    """
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "wrongres@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256",
+        "resource": "https://somewhere-else.test/mcp/"}, follow_redirects=False)
+    assert r.status_code == 302
+    assert "error=invalid_target" in r.headers["location"]
+    assert "well-known" in r.headers["location"], "and it must say where the right value lives"
+
+
+async def test_omitting_the_resource_is_fine(clients):
+    """A client that sends no `resource` gets our canonical one — which is what it would have
+    discovered anyway, so refusing would be pedantry rather than safety."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "nores@superdesign.dev")
+    verifier, challenge = _pkce()
+    r = await clients.post("/oauth/authorize", data={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id,
+        "decision": "allow"}, follow_redirects=False)
+    assert r.status_code == 302 and "code=" in r.headers["location"]
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+    tok = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier})
+    assert tok.status_code == 200
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=tok.json()["access_token"])
+    assert "balance_usd" in out, "the default audience must be the one the MCP server accepts"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -605,3 +605,129 @@ async def test_revoking_your_tokens_kills_an_existing_grant(clients):
     async with mcp_session(clients) as c:
         after = await _call_tool(c, "balance", {}, token=access)
     assert "balance_usd" not in after, "a revoked user's grant must stop working"
+
+
+# ---- step 5: refresh tokens, rotation, and catching a replay --------------------------------
+
+async def _grant_full(clients, email):
+    """The whole flow, returning the token response so the refresh token is visible."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, email)
+    verifier, challenge = _pkce()
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256", "resource": mcp_oauth.mcp_resource_url()}
+    r = await clients.post("/oauth/authorize", data={**params, "org_id": org_id, "decision": "allow"},
+                           follow_redirects=False)
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+    tok = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier})
+    assert tok.status_code == 200, tok.text
+    return tok.json(), client_id, org_id
+
+
+async def test_a_grant_comes_with_a_refresh_token(clients):
+    """An access token lasts an hour. Without a refresh, every connector breaks hourly and the user
+    is the one who has to notice."""
+    body, _, _ = await _grant_full(clients, "refresher@superdesign.dev")
+    assert body["refresh_token"]
+    assert body["expires_in"] == mcp_oauth.ACCESS_TTL_SECONDS
+
+
+async def test_refreshing_ROTATES_the_token_and_the_new_one_works(clients):
+    """The old token is spent, the new one carries on, and the access token that comes out still
+    drives the tools — a refresh that returned an unusable token would fail silently an hour later."""
+    body, client_id, _ = await _grant_full(clients, "rotate@superdesign.dev")
+    first = body["refresh_token"]
+
+    r = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": first, "client_id": client_id})
+    assert r.status_code == 200, r.text
+    second = r.json()["refresh_token"]
+    assert second and second != first, "a refresh must MINT a replacement, not hand back the same one"
+
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=r.json()["access_token"])
+    assert "balance_usd" in out, out
+
+
+async def test_replaying_a_SPENT_refresh_token_kills_the_whole_family(clients):
+    """The reason the retired row is kept rather than deleted. A spent token being presented again
+    means either a client retried after a dropped response or somebody else has a copy — and those
+    are indistinguishable from here. Assume the worse one: the cost of being wrong is a sign-in, and
+    the cost of the other mistake is somebody's balance."""
+    body, client_id, _ = await _grant_full(clients, "replay@superdesign.dev")
+    first = body["refresh_token"]
+
+    ok = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": first, "client_id": client_id})
+    assert ok.status_code == 200
+    second = ok.json()["refresh_token"]
+
+    replay = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": first, "client_id": client_id})
+    assert replay.status_code == 400
+    assert "already used" in replay.json()["error_description"]
+
+    # and the descendant is dead too — containment is the point, not just refusing the replay
+    after = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": second, "client_id": client_id})
+    assert after.status_code == 400, "the whole family must be revoked, not only the replayed token"
+
+
+async def test_a_refresh_cannot_quietly_change_teams(clients):
+    """The team was chosen by a human at consent. A refresh renews that grant; it is not a second
+    chance to pick, and nothing in the request may influence it."""
+    body, client_id, org_id = await _grant_full(clients, "steady@superdesign.dev")
+    made = await clients.post("/orgs", json={"name": "team-created-after"})
+    assert made.status_code == 200
+
+    r = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": body["refresh_token"],
+        "client_id": client_id})
+    assert r.status_code == 200
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=r.json()["access_token"])
+    teams = (await clients.get("/orgs")).json()
+    granted_slug = next(t["slug"] for t in teams if t["org_id"] == org_id)
+    assert out["team"] == granted_slug
+
+
+async def test_a_refresh_token_is_bound_to_its_client(clients):
+    """Otherwise one client's stolen refresh token is every client's."""
+    body, _, _ = await _grant_full(clients, "bound@superdesign.dev")
+    other = await _register(clients, "https://other.test/cb")
+    r = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": body["refresh_token"], "client_id": other})
+    assert r.status_code == 400 and r.json()["error"] == "invalid_grant"
+
+
+async def test_revoking_ends_the_family_and_never_leaks_whether_a_token_existed(clients):
+    """RFC 7009: always 200. Distinguishing a known token from an unknown one would turn this into
+    an oracle for guessing valid ones."""
+    body, client_id, _ = await _grant_full(clients, "revoke@superdesign.dev")
+    assert (await clients.post("/oauth/revoke", data={"token": "never-existed"})).status_code == 200
+    assert (await clients.post("/oauth/revoke",
+                               data={"token": body["refresh_token"]})).status_code == 200
+    dead = await clients.post("/oauth/token", data={
+        "grant_type": "refresh_token", "refresh_token": body["refresh_token"],
+        "client_id": client_id})
+    assert dead.status_code == 400
+
+
+async def test_refresh_tokens_are_stored_HASHED(clients):
+    """A database copy is a database leak, and the refresh token is the long-lived half — the one
+    worth stealing."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import OAuthRefresh
+
+    body, _, _ = await _grant_full(clients, "hashed@superdesign.dev")
+    async with session_maker() as db:
+        rows = (await db.execute(select(OAuthRefresh))).scalars().all()
+    assert rows, "expected a stored refresh token"
+    assert all(body["refresh_token"] not in (r.token_hash or "") for r in rows)
+    assert all(len(r.token_hash) == 64 for r in rows), "sha256 hex, as everywhere else in treg"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,0 +1,148 @@
+"""treg as an OAuth authorization server — step 1: the metadata, and the refusals.
+
+Nothing issues tokens yet. This file covers the half that says NO, deliberately built first: there is
+never a window where the server accepts tokens it has not learned to check.
+
+The assertion that matters most is the audience one. Everything else here — signature, expiry, type —
+is ordinary token hygiene that any login system needs. `aud` is the one that exists because we are a
+RESOURCE server: a user grants a client access to a named resource, and a token addressed to some
+other MCP server must not spend a treg balance just because it happens to be validly signed by us.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from treg import mcp, mcp_oauth, session
+
+pytestmark = pytest.mark.anyio
+
+
+# ---- metadata: what we tell a client we support --------------------------------------------
+
+async def test_protected_resource_metadata_names_the_mcp_endpoint(clients):
+    r = await clients.get("/.well-known/oauth-protected-resource")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resource"] == mcp_oauth.mcp_resource_url()
+    assert body["resource"].endswith("/mcp/"), "the trailing slash is part of the identifier"
+    assert body["authorization_servers"], "a client must be told who issues tokens for us"
+
+
+async def test_the_metadata_is_served_at_BOTH_lookup_paths(clients):
+    """The spec has clients look this up either at the host root or under the resource's own path,
+    and which one a given client tries is not ours to choose."""
+    a = await clients.get("/.well-known/oauth-protected-resource")
+    b = await clients.get("/.well-known/oauth-protected-resource/mcp")
+    assert a.status_code == b.status_code == 200
+    assert a.json() == b.json()
+
+
+async def test_authorization_server_metadata_offers_only_safe_choices(clients):
+    """OAuth 2.1 drops the implicit grant, and `plain` PKCE makes the challenge equal to the secret —
+    anyone who sees the authorization request could redeem the code. Offering either would be a
+    downgrade a client is entitled to take us up on."""
+    body = (await clients.get("/.well-known/oauth-authorization-server")).json()
+    assert body["response_types_supported"] == ["code"]
+    assert body["code_challenge_methods_supported"] == ["S256"]
+    assert "plain" not in body["code_challenge_methods_supported"]
+    assert body["authorization_endpoint"].endswith("/oauth/authorize")
+    assert body["token_endpoint"].endswith("/oauth/token")
+
+
+async def test_metadata_advertises_BOTH_ways_for_a_client_to_identify_itself(clients):
+    """ChatGPT sends a client-id metadata document; Claude Code and most others register
+    dynamically. Advertising only one would lock the other out — and we would not notice, because
+    the client we test with is the one that does not need registration."""
+    body = (await clients.get("/.well-known/oauth-authorization-server")).json()
+    assert body["client_id_metadata_document_supported"] is True
+    assert body["registration_endpoint"].endswith("/oauth/register")
+
+
+# ---- the refusals ---------------------------------------------------------------------------
+
+async def test_a_token_for_ANOTHER_resource_is_refused():
+    """The load-bearing check. A user consented to some other MCP server; that grant must not spend
+    a treg balance merely because we signed the token."""
+    ours = mcp_oauth.mcp_resource_url()
+    elsewhere = mcp_oauth.make_access_token(user_id=7, org_id=3,
+                                            audience="https://evil.example.com/mcp/")
+    assert mcp_oauth.read_access_token(elsewhere, expected_audience=ours) is None
+    assert mcp._oauth_claims(elsewhere) is None
+
+
+async def test_our_own_token_is_accepted_and_carries_the_team():
+    """Not vacuous: the refusal above only means something if the matching token DOES work, and the
+    team has to survive on the token — a person can belong to several, and the choice is made once
+    by a human at consent, not guessed per call."""
+    ours = mcp_oauth.mcp_resource_url()
+    tok = mcp_oauth.make_access_token(user_id=7, org_id=3, audience=ours, scope="treg:call")
+    claims = mcp._oauth_claims(tok)
+    assert claims is not None
+    assert claims["sub"] == 7 and claims["org"] == 3
+    assert claims["aud"] == ours and claims["scope"] == "treg:call"
+
+
+async def test_a_session_cookie_is_not_an_access_token():
+    """treg mints session cookies and identity tokens with the same HMAC construction. Without a type
+    marker one class of credential would silently validate as another — a browser session becoming an
+    MCP grant, which nobody consented to."""
+    cookie = session.make(7)
+    assert mcp._oauth_claims(cookie) is None
+    assert mcp_oauth.read_access_token(cookie, expected_audience=mcp_oauth.mcp_resource_url()) is None
+
+
+async def test_a_tampered_token_is_refused():
+    ours = mcp_oauth.mcp_resource_url()
+    tok = mcp_oauth.make_access_token(user_id=7, org_id=3, audience=ours)
+    payload, sig = tok.split(".", 1)
+    # same signature, different claims: the forgery a signature exists to stop
+    forged = mcp_oauth.make_access_token(user_id=99, org_id=99, audience=ours).split(".", 1)[0]
+    assert mcp_oauth.read_access_token(f"{forged}.{sig}", expected_audience=ours) is None
+
+
+async def test_an_expired_token_is_refused():
+    ours = mcp_oauth.mcp_resource_url()
+    tok = mcp_oauth.make_access_token(user_id=7, org_id=3, audience=ours, ttl=-1)
+    assert mcp_oauth.read_access_token(tok, expected_audience=ours) is None
+
+
+@pytest.mark.parametrize("junk", ["", "not-a-token", "a.b", "....", "Bearer x"])
+async def test_malformed_input_is_simply_not_a_token(junk):
+    assert mcp_oauth.read_access_token(junk, expected_audience=mcp_oauth.mcp_resource_url()) is None
+
+
+async def test_the_audience_check_cannot_be_skipped_by_accident():
+    """`expected_audience` has no default, and an empty one refuses rather than matching everything.
+    The single thing that must never happen quietly is not performing this check."""
+    tok = mcp_oauth.make_access_token(user_id=7, org_id=3, audience="")
+    assert mcp_oauth.read_access_token(tok, expected_audience="") is None
+    with pytest.raises(TypeError):
+        mcp_oauth.read_access_token(tok)  # type: ignore[call-arg]
+
+
+# ---- PKCE ------------------------------------------------------------------------------------
+
+async def test_pkce_accepts_the_right_verifier_and_nothing_else():
+    import base64
+    import hashlib
+
+    verifier = "a-random-high-entropy-string-from-the-client"
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    assert mcp_oauth.verify_pkce(verifier, challenge)
+    assert not mcp_oauth.verify_pkce("some-other-verifier", challenge)
+    assert not mcp_oauth.verify_pkce("", challenge)
+    assert not mcp_oauth.verify_pkce(verifier, "")
+
+
+async def test_a_token_outlives_neither_its_ttl_nor_reason():
+    """An hour is deliberate: short enough that a leaked access token expires on its own, long enough
+    that a refresh is not happening on every call."""
+    assert 300 <= mcp_oauth.ACCESS_TTL_SECONDS <= 24 * 3600
+    tok = mcp_oauth.make_access_token(user_id=1, org_id=1,
+                                      audience=mcp_oauth.mcp_resource_url())
+    claims = mcp_oauth.read_access_token(tok, expected_audience=mcp_oauth.mcp_resource_url())
+    assert claims and claims["exp"] <= int(time.time()) + mcp_oauth.ACCESS_TTL_SECONDS + 2

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -1,4 +1,4 @@
-"""treg as an OAuth authorization server — step 1: the metadata, and the refusals.
+"""treg as an OAuth authorization server — the metadata, the refusals, and client registration.
 
 Nothing issues tokens yet. This file covers the half that says NO, deliberately built first: there is
 never a window where the server accepts tokens it has not learned to check.
@@ -146,3 +146,109 @@ async def test_a_token_outlives_neither_its_ttl_nor_reason():
                                       audience=mcp_oauth.mcp_resource_url())
     claims = mcp_oauth.read_access_token(tok, expected_audience=mcp_oauth.mcp_resource_url())
     assert claims and claims["exp"] <= int(time.time()) + mcp_oauth.ACCESS_TTL_SECONDS + 2
+
+
+# ---- step 2: client registration — two doors in, one row shape out --------------------------
+
+async def test_dynamic_registration_mints_a_client(clients):
+    """RFC 7591, unauthenticated by design: registering grants nothing on its own, because every
+    token still needs a human to approve at the consent screen."""
+    r = await clients.post("/oauth/register", json={
+        "client_name": "Claude Code",
+        "redirect_uris": ["http://127.0.0.1:8976/callback"]})
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["client_id"].startswith("treg-client-")
+    assert body["redirect_uris"] == ["http://127.0.0.1:8976/callback"]
+    assert body["token_endpoint_auth_method"] == "none"   # public client + PKCE
+
+
+async def test_registration_requires_a_usable_redirect_uri(clients):
+    """An authorization code is delivered to the redirect URI. A client with none, or with one an
+    eavesdropper could read, has nowhere safe to receive it."""
+    for uris in ([], ["http://evil.example.com/cb"], ["ftp://x/cb"], ["https://a.test/cb#frag"]):
+        r = await clients.post("/oauth/register",
+                               json={"client_name": "x", "redirect_uris": uris})
+        assert r.status_code == 400, f"{uris} should be refused, got {r.status_code}"
+        assert r.json()["error"] == "invalid_redirect_uri"
+
+
+async def test_loopback_http_is_allowed_because_a_CLI_cannot_hold_a_certificate(clients):
+    for uri in ("http://127.0.0.1:1234/cb", "http://localhost:9999/cb"):
+        r = await clients.post("/oauth/register", json={"client_name": "cli", "redirect_uris": [uri]})
+        assert r.status_code == 201, uri
+
+
+async def test_redirect_matching_is_EXACT_not_prefix():
+    """The classic defeat of this check. `https://good.test/cb.evil` starts with the registered URI,
+    and an open redirect under a registered host turns one sloppy page into stolen codes."""
+    from treg.mcp_oauth import redirect_uri_allowed
+
+    class C:
+        redirect_uris = ["https://good.test/cb"]
+
+    assert redirect_uri_allowed(C(), "https://good.test/cb")
+    for evil in ("https://good.test/cb.evil", "https://good.test/cb/../x", "https://good.test/CB",
+                 "https://good.test.evil/cb", ""):
+        assert not redirect_uri_allowed(C(), evil), evil
+
+
+# ---- the CIMD fetch: a URL the caller chose, so it must be fenced ---------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://example.com/cimd.json",          # not https
+    "https://127.0.0.1/cimd.json",           # loopback
+    "https://169.254.169.254/latest/meta",   # cloud metadata — the classic SSRF target
+    "https://10.0.0.5/cimd.json",            # private
+    "https://localhost/cimd.json",
+    "not-a-url",
+])
+async def test_cimd_refuses_unsafe_urls(url):
+    """`client_id` is a URL our SERVER fetches, which makes it a request-forgery primitive unless
+    fenced. Reuses the same guard the webhook and tool base_url paths already use."""
+    from treg.mcp_oauth import fetch_client_id_metadata
+
+    assert await fetch_client_id_metadata(url) is None
+
+
+async def test_cimd_document_must_claim_its_own_url(monkeypatch):
+    """Without this, a document hosted anywhere could assert somebody else's client_id and inherit
+    the consent users granted them."""
+    import httpx
+
+    from treg import health, mcp_oauth
+
+    monkeypatch.setattr(health, "safe_webhook_url", lambda u: True)
+    monkeypatch.setattr(health, "host_is_public", lambda h: True)
+
+    async def fake_get(self, url, **kw):
+        return httpx.Response(200, json={"client_id": "https://someone-else.test/cimd.json",
+                                         "client_name": "impostor",
+                                         "redirect_uris": ["https://impostor.test/cb"]},
+                              request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    assert await mcp_oauth.fetch_client_id_metadata("https://real.test/cimd.json") is None
+
+
+async def test_cimd_accepts_a_well_formed_document(monkeypatch):
+    """Not vacuous: the refusals above only mean something if a good document DOES load."""
+    import httpx
+
+    from treg import health, mcp_oauth
+
+    monkeypatch.setattr(health, "safe_webhook_url", lambda u: True)
+    monkeypatch.setattr(health, "host_is_public", lambda h: True)
+
+    async def fake_get(self, url, **kw):
+        return httpx.Response(200, json={"client_id": url, "client_name": "ChatGPT",
+                                         "redirect_uris": ["https://chatgpt.com/connector/oauth/x",
+                                                           "http://evil.test/cb"]},
+                              request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+    doc = await mcp_oauth.fetch_client_id_metadata("https://chatgpt.com/cimd.json")
+    assert doc is not None
+    assert doc["client_name"] == "ChatGPT"
+    # the unsafe redirect in the document is dropped rather than accepted alongside the good one
+    assert doc["redirect_uris"] == ["https://chatgpt.com/connector/oauth/x"]

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -11,11 +11,16 @@ other MCP server must not spend a treg balance just because it happens to be val
 
 from __future__ import annotations
 
+import json
 import time
 
 import pytest
 
 from treg import mcp, mcp_oauth, session
+
+# The MCP transport helpers live with the MCP tests; a token is only interesting here because it can
+# drive a tool, so reuse them rather than keeping a second copy that can drift.
+from test_mcp import _call_tool, mcp_session
 
 pytestmark = pytest.mark.anyio
 
@@ -310,7 +315,8 @@ async def test_the_whole_flow_end_to_end(clients):
               "code_challenge_method": "S256", "state": "xyz",
               "resource": mcp_oauth.mcp_resource_url(), "scope": "treg:call"}
 
-    shown = await clients.get("/oauth/authorize", params=params)
+    shown = await clients.get("/oauth/authorize", params=params,
+                              headers={"Accept": "application/json"})
     assert shown.status_code == 200, shown.text
     assert shown.json()["client"]["name"] == "Test Client"
     assert any(t["org_id"] == org_id for t in shown.json()["teams"]), "the team picker must offer it"
@@ -415,12 +421,187 @@ async def test_you_cannot_approve_for_a_team_you_are_not_in(clients):
 
 async def test_a_GET_never_grants_anything(clients):
     """Approval is a POST. A GET that granted access could be triggered by any page able to make the
-    browser navigate."""
+    browser navigate — even with `org_id` supplied, as here."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import OAuthCode
+
     client_id = await _register(clients)
     cookie, org_id = await _signed_in(clients, "getonly@superdesign.dev")
     _, challenge = _pkce()
     r = await clients.get("/oauth/authorize", params={
         "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
-        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id}, follow_redirects=False)
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id},
+        follow_redirects=False)
+    assert r.status_code == 200, "it renders the question"
+    assert "location" not in r.headers, "and never redirects back with a code"
+    async with session_maker() as db:
+        codes = (await db.execute(select(OAuthCode).where(
+            OAuthCode.client_id == client_id))).scalars().all()
+    assert codes == [], "a GET must not have minted anything"
+
+
+# ---- step 4: the consent screen — the only place a human sees what they grant ----------------
+
+async def test_the_consent_page_says_what_it_costs_in_WORDS(clients):
+    """A screen that lists `treg:call` and calls that informed consent is a formality. The two things
+    that actually cost money or expose data have to be legible: this client can spend the team's
+    balance, and can use keys the team registered."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "consent@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"})
     assert r.status_code == 200
-    assert "code" not in r.text or "approve_with" in r.text
+    page = r.text
+    assert "text/html" in r.headers["content-type"]
+    assert "Test Client" in page, "the human must see WHICH application is asking"
+    assert "consent@superdesign.dev" in page, "and which account they are granting from"
+    assert "spends the team's balance" in page
+    assert "without seeing them" in page, "keys are used, never revealed — say so"
+    assert 'name="org_id"' in page, "the team picker belongs here"
+
+
+async def test_the_page_warns_when_a_client_registered_ITSELF(clients):
+    """Dynamic registration is open by design, so anyone can appear here with any name. The user is
+    the only one who can tell whether they started this, and they can only judge if we say so."""
+    client_id = await _register(clients)
+    cookie, _ = await _signed_in(clients, "warned@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"})
+    assert "registered itself" in r.text
+    assert "only continue if you recognise it" in r.text
+
+
+async def test_json_is_still_available_for_a_non_browser_client(clients):
+    """The HTML is for humans; a client that asks for JSON gets the same facts without scraping."""
+    client_id = await _register(clients)
+    cookie, _ = await _signed_in(clients, "jsonclient@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"},
+        headers={"Accept": "application/json"})
+    assert r.status_code == 200 and r.json()["client"]["name"] == "Test Client"
+
+
+async def test_CANCEL_tells_the_client_no_rather_than_hanging(clients):
+    """Declining is a real answer. A client left waiting on a redirect that never comes is a worse
+    outcome than a clean refusal."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "declines@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.post("/oauth/authorize", data={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id,
+        "state": "s1", "decision": "deny"}, follow_redirects=False)
+    assert r.status_code == 302
+    assert "error=access_denied" in r.headers["location"] and "state=s1" in r.headers["location"]
+    assert "code=" not in r.headers["location"]
+
+
+async def test_a_CROSS_ORIGIN_submission_is_refused(clients):
+    """The consent form is the security boundary. Without this, a page anywhere could auto-submit and
+    grant itself a team's balance — the user is signed in, so their cookie rides along."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "csrf@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.post("/oauth/authorize", data={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id,
+        "decision": "allow"},
+        headers={"Origin": "https://attacker.test"}, follow_redirects=False)
+    assert r.status_code == 403
+
+
+async def test_the_consent_page_cannot_be_framed(clients):
+    """Clickjacking: an invisible frame over a decoy page turns "Allow" into a click the user thought
+    was something else. treg sets this globally; asserting it here is what notices if that changes."""
+    client_id = await _register(clients)
+    cookie, _ = await _signed_in(clients, "framed@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"})
+    assert r.headers.get("X-Frame-Options") == "DENY"
+
+
+# ---- the token has to WORK, not merely validate ---------------------------------------------
+
+async def _grant(clients, email):
+    """Run the whole flow and return the access token, plus the team it was granted for."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, email)
+    verifier, challenge = _pkce()
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256", "resource": mcp_oauth.mcp_resource_url()}
+    r = await clients.post("/oauth/authorize", data={**params, "org_id": org_id, "decision": "allow"},
+                           follow_redirects=False)
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+    tok = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier})
+    assert tok.status_code == 200, tok.text
+    return tok.json()["access_token"], org_id
+
+
+async def test_an_oauth_token_actually_CALLS_the_tools(clients):
+    """The gap running it found and the unit tests missed: `_oauth_claims` validated a token
+    perfectly while every tool still forwarded the raw bearer to the internal API, which has never
+    heard of an OAuth token — so all three authenticated tools answered "not signed in".
+
+    Validating a credential and being able to USE it are different claims, and only this one matters
+    to a user.
+    """
+    access, org_id = await _grant(clients, "usable@superdesign.dev")
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=access)
+    assert "balance_usd" in out, out
+    assert "not signed in" not in json.dumps(out)
+
+
+async def test_the_token_spends_from_the_team_ON_THE_GRANT(clients):
+    """A person in several teams answered "which one" at the consent screen. That answer travels on
+    the token, and nothing downstream may re-derive it — re-deriving is how the wrong team's balance
+    gets spent, and `balance` used to refuse and ask precisely because it had no answer."""
+    access, granted_org = await _grant(clients, "multi@superdesign.dev")
+    # a second team for the same person, deliberately created AFTER the grant
+    made = await clients.post("/orgs", json={"name": "second-team-after-grant"})
+    assert made.status_code == 200, made.text
+
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {}, token=access)
+    assert "balance_usd" in out, out
+    teams = (await clients.get("/orgs")).json()
+    granted_slug = next(t["slug"] for t in teams if t["org_id"] == granted_org)
+    assert out["team"] == granted_slug, "the grant's team, not a freshly-guessed one"
+
+
+async def test_revoking_your_tokens_kills_an_existing_grant(clients):
+    """`token_version` is treg's kill switch for a leaked credential. An OAuth grant must honour it
+    too, or the one button a user has for "make it stop" would quietly miss this door."""
+    access, _ = await _grant(clients, "revoker@superdesign.dev")
+    async with mcp_session(clients) as c:
+        before = await _call_tool(c, "balance", {}, token=access)
+    assert "balance_usd" in before
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import User
+    async with session_maker() as db:
+        user = (await db.execute(
+            select(User).where(User.email == "revoker@superdesign.dev"))).scalar_one()
+        user.token_version += 1
+        db.add(user)
+        await db.commit()
+
+    async with mcp_session(clients) as c:
+        after = await _call_tool(c, "balance", {}, token=access)
+    assert "balance_usd" not in after, "a revoked user's grant must stop working"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -779,3 +779,30 @@ async def test_omitting_the_resource_is_fine(clients):
     async with mcp_session(clients) as c:
         out = await _call_tool(c, "balance", {}, token=tok.json()["access_token"])
     assert "balance_usd" in out, "the default audience must be the one the MCP server accepts"
+
+
+async def test_a_null_origin_from_a_redirect_chain_is_not_treated_as_cross_site(clients):
+    """The intermittent failure Unclecode hit: approve worked on one attempt and was refused on
+    another. `Origin: null` is a browser reporting an OPAQUE origin, which happens after certain
+    redirect chains — a consent page reached by way of a sign-in bounce through GitHub, say. It is
+    not evidence of a cross-site request.
+
+    `Sec-Fetch-Site` is the corroboration that makes accepting it safe: the browser sets it and script
+    cannot, so another site cannot forge `same-origin`.
+    """
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "nullorigin@superdesign.dev")
+    _, challenge = _pkce()
+    body = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+            "response_type": "code", "code_challenge": challenge,
+            "code_challenge_method": "S256", "org_id": org_id, "decision": "allow"}
+
+    ok = await clients.post("/oauth/authorize", data=body, follow_redirects=False,
+                            headers={"Origin": "null", "Sec-Fetch-Site": "same-origin"})
+    assert ok.status_code == 302 and "code=" in ok.headers["location"]
+
+    # ...but `null` WITHOUT that corroboration is still refused: the guard is narrowed, not removed.
+    nope = await clients.post("/oauth/authorize", data=body, follow_redirects=False,
+                              headers={"Origin": "null", "Sec-Fetch-Site": "cross-site"})
+    assert nope.status_code == 403
+    assert "Sec-Fetch-Site: cross-site" in nope.json()["detail"], "the refusal must say what it saw"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -252,3 +252,175 @@ async def test_cimd_accepts_a_well_formed_document(monkeypatch):
     assert doc["client_name"] == "ChatGPT"
     # the unsafe redirect in the document is dropped rather than accepted alongside the good one
     assert doc["redirect_uris"] == ["https://chatgpt.com/connector/oauth/x"]
+
+
+# ---- step 3: the authorization code flow ----------------------------------------------------
+
+def _pkce():
+    import base64
+    import hashlib
+    import secrets
+
+    verifier = secrets.token_urlsafe(48)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).decode().rstrip("=")
+    return verifier, challenge
+
+
+async def _register(clients, redirect="https://client.test/cb"):
+    r = await clients.post("/oauth/register",
+                           json={"client_name": "Test Client", "redirect_uris": [redirect]})
+    assert r.status_code == 201, r.text
+    return r.json()["client_id"]
+
+
+async def _signed_in(clients, email="oauth-user@superdesign.dev"):
+    """A browser session plus the org it belongs to. The consent step is a HUMAN action, so it needs
+    a session cookie rather than a token."""
+    r = await clients.post("/users", json={"email": email})
+    assert r.status_code == 200, r.text
+    token = r.json()["token"]
+    prev = clients.headers.get("X-Treg-Token")
+    clients.headers["X-Treg-Token"] = token
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    me = (await clients.get("/auth/me")).json()
+    if prev:
+        clients.headers["X-Treg-Token"] = prev
+    from sqlmodel import select
+
+    from treg import session as _sess
+    from treg.db import session_maker
+    from treg.models import User
+
+    async with session_maker() as db:
+        user = (await db.execute(select(User).where(User.email == me["email"]))).scalar_one()
+        cookie = _sess.make(user.id, token_version=user.token_version)
+    clients.cookies.set("treg_session", cookie)   # on the client: httpx deprecates per-request
+    return cookie, org_id
+
+
+async def test_the_whole_flow_end_to_end(clients):
+    """Register, authorize, approve, exchange — and the token that comes out is one our MCP server
+    accepts, for the team the human chose."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients)
+    verifier, challenge = _pkce()
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256", "state": "xyz",
+              "resource": mcp_oauth.mcp_resource_url(), "scope": "treg:call"}
+
+    shown = await clients.get("/oauth/authorize", params=params)
+    assert shown.status_code == 200, shown.text
+    assert shown.json()["client"]["name"] == "Test Client"
+    assert any(t["org_id"] == org_id for t in shown.json()["teams"]), "the team picker must offer it"
+
+    approved = await clients.post("/oauth/authorize", data={**params, "org_id": org_id}, follow_redirects=False)
+    assert approved.status_code == 302
+    loc = approved.headers["location"]
+    assert loc.startswith("https://client.test/cb?") and "state=xyz" in loc
+    code = loc.split("code=")[1].split("&")[0]
+
+    tok = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier, "resource": mcp_oauth.mcp_resource_url()})
+    assert tok.status_code == 200, tok.text
+    access = tok.json()["access_token"]
+    assert tok.json()["token_type"] == "Bearer"
+
+    claims = mcp._oauth_claims(access)
+    assert claims is not None, "the MCP server must accept what we just issued"
+    assert claims["org"] == org_id, "the token spends from the team the human picked"
+
+
+async def test_a_code_can_be_redeemed_only_ONCE(clients):
+    """The row is deleted on redemption rather than flagged, so a replay finds nothing. A used code
+    that still exists is a race waiting for two redemptions to read it before either writes."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "once@superdesign.dev")
+    verifier, challenge = _pkce()
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256", "resource": mcp_oauth.mcp_resource_url()}
+    r = await clients.post("/oauth/authorize", data={**params, "org_id": org_id}, follow_redirects=False)
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+    body = {"grant_type": "authorization_code", "code": code,
+            "redirect_uri": "https://client.test/cb", "client_id": client_id,
+            "code_verifier": verifier}
+    assert (await clients.post("/oauth/token", data=body)).status_code == 200
+    second = await clients.post("/oauth/token", data=body)
+    assert second.status_code == 400 and second.json()["error"] == "invalid_grant"
+
+
+async def test_the_WRONG_verifier_cannot_redeem_a_stolen_code(clients):
+    """The whole point of PKCE: a code intercepted in the browser redirect is worthless without the
+    verifier, which never left the client."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "pkce@superdesign.dev")
+    _, challenge = _pkce()
+    other_verifier, _ = _pkce()
+    r = await clients.post("/oauth/authorize", data={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id,
+        "resource": mcp_oauth.mcp_resource_url()}, follow_redirects=False)
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+    tok = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": other_verifier})
+    assert tok.status_code == 400 and tok.json()["error"] == "invalid_grant"
+
+
+async def test_an_unregistered_redirect_is_refused_WITHOUT_redirecting(clients):
+    """Bouncing an error to an unvalidated URI would be an open redirect, and would hand `state` to
+    whoever asked for it. So this is a flat 400, not a 302."""
+    client_id = await _register(clients)
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://attacker.test/steal",
+        "response_type": "code", "code_challenge": "x", "code_challenge_method": "S256"},
+        follow_redirects=False)
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+async def test_pkce_is_mandatory(clients):
+    """A client that omits the challenge, or offers `plain`, is refused — otherwise a downgrade is
+    available to anyone who asks for it."""
+    client_id = await _register(clients)
+    for extra in ({}, {"code_challenge": "abc", "code_challenge_method": "plain"}):
+        r = await clients.get("/oauth/authorize", params={
+            "client_id": client_id, "redirect_uri": "https://client.test/cb",
+            "response_type": "code", **extra}, follow_redirects=False)
+        assert r.status_code == 302 and "error=invalid_request" in r.headers["location"]
+
+
+async def test_you_cannot_approve_for_a_team_you_are_not_in(clients):
+    """`org_id` arrives from the browser, so it is client-supplied. Trusting it would let anyone
+    grant a client access to any team by editing one form field."""
+    client_id = await _register(clients)
+    cookie, _ = await _signed_in(clients, "outsider@superdesign.dev")
+    other = await clients.post("/users", json={"email": "stranger@superdesign.dev"})
+    prev = clients.headers.get("X-Treg-Token")
+    clients.headers["X-Treg-Token"] = other.json()["token"]
+    foreign_org = (await clients.get("/orgs")).json()[0]["org_id"]
+    if prev:
+        clients.headers["X-Treg-Token"] = prev
+    _, challenge = _pkce()
+    r = await clients.post("/oauth/authorize", data={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": foreign_org}, follow_redirects=False)
+    assert r.status_code == 302 and "error=access_denied" in r.headers["location"]
+
+
+async def test_a_GET_never_grants_anything(clients):
+    """Approval is a POST. A GET that granted access could be triggered by any page able to make the
+    browser navigate."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "getonly@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256", "org_id": org_id}, follow_redirects=False)
+    assert r.status_code == 200
+    assert "code" not in r.text or "approve_with" in r.text


### PR DESCRIPTION
ChatGPT's connector form offers **OAuth, No Auth, or Mixed** — there is no bearer-token option. That
is why the Codex half works today and the ChatGPT half could not.

`No Auth` is not a lesser version of the product, it is a different one: verified against production,
`catalog_search`/`catalog_get` answer (the catalog is public) while `call`, `balance` and `my_tools`
all return *"not authenticated"*. treg is multi-tenant — every call must answer whose balance pays
and whose keys may be used — and the token is what answers it.

## Not a ChatGPT feature

The MCP authorization spec is not ChatGPT's, so the same metadata and the same PKCE flow serve Claude
Code, Cursor and whatever ships next. Two decisions followed from that, both cheap now and awkward
later: **no hard-coded redirect URI**, and **dynamic client registration alongside** the CIMD ChatGPT
prefers — supporting only CIMD would have locked out every other client, unnoticed, because the
client we tested with is the one that does not need DCR.

## What landed, in order

| Step | |
|---|---|
| 1 | metadata documents + the `aud` check — **the refusals, built before anything could issue** |
| 2 | client registration: DCR and CIMD into one row shape |
| 3 | authorize + token with PKCE, single-use codes |
| 4 | the consent screen with a **team picker** |
| 5 | refresh tokens, rotation, reuse detection |
| 6 | an **independent client** drives it end to end |
| + | `/connect-demo`, a page that pretends to be someone else's app |

## Bugs found by running it, not by testing it

- **`aud` accepted anything.** An independent client sent the URL it dialled rather than our declared
  identifier; treg minted a token that was valid, well-formed and **silently useless**. Now refused
  up front with `invalid_target`.
- **Every browser was blocked.** `"*"` is not a wildcard in this SDK — origins compare literally — so
  `allowed_origins=["*"]` allowed exactly one origin: `"*"`. ChatGPT's web client is a browser.
- **Approval failed intermittently.** `Origin: null` after a sign-in redirect chain was treated as
  cross-site. Now accepted only when `Sec-Fetch-Site` corroborates it.
- **The tools ignored the token.** `_oauth_claims` validated perfectly while every tool forwarded the
  raw bearer to an API that had never heard of an OAuth token.

Each has a test that fails without the fix — verified by reverting each one.

## Security shape

Single-use codes deleted before validation · exact redirect matching (never prefix) · CIMD fetches
fenced against SSRF, reusing `health`'s existing guards · refresh rotation whose **reuse detection
revokes the whole family** · tokens hashed at rest · consent is POST-only, same-origin, unframeable.

**1271 tests pass.**