### PR TITLE
release: 0.7.1

### DIFF
--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Call ~2,600 curated API endpoints across ~40 providers without owning the keys — treg holds the credential and meters each call from your team's prepaid balance.",
   "author": {
     "name": "superdesign",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -58,7 +58,7 @@ Then:
 ```bash
 codex plugin list                   # treg@superdesign-local — not installed
 codex plugin add treg@superdesign-local     # the @marketplace suffix is REQUIRED
-codex plugin list                   # installed, enabled, 0.7.0
+codex plugin list                   # installed, enabled, 0.7.1
 ```
 
 Installed copies land in `~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION/`. Confirm the skill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.7.0"
+version = "0.7.1"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump 0.7.0 → 0.7.1.

Ships the **skill rename (tools-registry → treg)** to the installed CLI: `treg skill bootstrap` now writes into `<agent>/skills/treg/` and cleans up the old `tools-registry/` folder. Prod already serves the renamed `skill.md` (`name: treg`); this closes the gap so `pip`/`brew`/`install.sh` users get the `treg` skill folder too. Also bundles the onboarding + catalog Try-it work already merged (#64, #65).

Build verified: `treg 0.7.1`, light install (no fastapi leak), twine PASSED, no secrets in wheel, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)