### PR TITLE
fix(oauth): signing in mid-authorization returns you to the consent screen

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1285,6 +1285,11 @@ async def dashboard(
 ):
     """Serve the single-file dashboard (same-origin, so it calls this API directly).
 
+    Also the place a parked OAuth authorization resumes. Every browser sign-in door — GitHub, Google,
+    the email code — ends here, so honouring the cookie at this ONE point covers all of them, rather
+    than threading a return value through five handlers that each finish differently (two redirect,
+    one answers JSON).
+
     In frictionless local mode the dashboard opens ALREADY SIGNED IN: with no valid session we
     attach one for the machine's single user, so `curl … | sh` reaches a working dashboard without
     an account. Only reachable when `single_user_ok` holds (local sqlite + loopback URL), so this
@@ -1293,8 +1298,15 @@ async def dashboard(
     index = _WEB_DIR / "index.html"
     if not index.exists():
         return HTMLResponse("<h3>tools-registry API. Dashboard not bundled.</h3>")
+    signed_in = await _user_from_session(treg_session, db)
+    # A parked authorization resumes here, but ONLY once the user is actually signed in — otherwise
+    # this would bounce them back to /oauth/authorize, which would bounce them here again.
+    if signed_in and (parked := _take_oauth_return(request)) is not None:
+        resume = RedirectResponse(parked, status_code=302)
+        resume.delete_cookie(OAUTH_RETURN_COOKIE)
+        return resume
     resp = FileResponse(index, headers={"Cache-Control": "no-cache"})
-    if not await _user_from_session(treg_session, db):
+    if not signed_in:
         owner = await _local_owner(db)
         if owner is not None:
             resp.set_cookie(sess.COOKIE, sess.make(owner.id, token_version=owner.token_version),
@@ -1672,6 +1684,36 @@ def _consent_page(*, client_name: str, client_uri: str, user_email: str, teams: 
         f"</div></div></body></html>")
 
 
+OAUTH_RETURN_COOKIE = "treg_oauth_return"
+
+
+def _remember_oauth_return(resp, request: Request) -> None:
+    """Park where to come back to after the user signs in.
+
+    A RELATIVE path, deliberately — never a full URL. A stored absolute URL would have to be
+    validated against our own origin before being redirected to, and getting that check subtly wrong
+    is how open redirects happen. A path cannot leave the site.
+
+    Short-lived: this is a detour of seconds, and a stale one would silently hijack the next sign-in.
+    """
+    target = request.url.path + (f"?{request.url.query}" if request.url.query else "")
+    resp.set_cookie(OAUTH_RETURN_COOKIE, target, httponly=True, samesite="lax",
+                    secure=_is_https(request), max_age=600)
+
+
+def _take_oauth_return(request: Request) -> str | None:
+    """The parked destination, if it is one we actually park — else None.
+
+    Only `/oauth/authorize` is honoured. Accepting any path would turn this cookie into a general
+    "redirect me anywhere after login" primitive, which is a phishing aid rather than a feature.
+    """
+    # Starlette quotes a cookie value containing separators, and not every client strips the quotes
+    # back off. Tolerating them here costs nothing; assuming they are absent cost a failing test and
+    # would have cost a silently-dropped authorization in production.
+    target = (request.cookies.get(OAUTH_RETURN_COOKIE) or "").strip('"')
+    return target if target.startswith("/oauth/authorize?") else None
+
+
 def _wrong_resource(resource: str) -> str | None:
     """Is this `resource` one we actually protect? Returns an error message, or None if fine.
 
@@ -1768,10 +1810,13 @@ async def oauth_authorize(
 
     user = await _user_from_session(treg_session, db)
     if user is None:
-        # Sign in first, then come back to this exact request.
-        from urllib.parse import quote
-
-        return RedirectResponse(f"/?next={quote(str(request.url), safe='')}", status_code=302)
+        # Sign in first, then come back to THIS request. Parked in a cookie rather than a `?next=`
+        # query the sign-in page would have to understand — the first version invented that
+        # convention and nothing implemented it, so the user signed in and landed on the dashboard
+        # with the authorization silently dropped.
+        resp = RedirectResponse("/", status_code=302)
+        _remember_oauth_return(resp, request)
+        return resp
 
     memberships = (await db.execute(
         select(Membership).where(Membership.user_id == user.id))).scalars().all()

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, TypedDict
 from urllib.parse import urlsplit
 
 import httpx
@@ -82,6 +82,91 @@ mcp = MCPServer(
         "measured; choosing is yours. There is no automatic routing and no failover."
     ),
 )
+
+
+# ---------------------------------------------------------------------------------------------
+# What each tool returns. These exist so a model knows the SHAPE of an answer before it gets one —
+# ChatGPT's connector review asks for them, and a model that has to guess at field names guesses.
+#
+# EVERY FIELD IS OPTIONAL (`total=False`), and that is the load-bearing detail. A strict schema is
+# validated on the way out, so the first `{"error": "not authenticated"}` would raise instead of
+# returning — turning a refusal written to tell an agent exactly how to recover into an opaque tool
+# failure. Optional fields document the success shape while letting the error shape through, which is
+# the trade worth making: a schema is a hint to the model, not a gate on our own error handling.
+
+# NULLABLE as well as optional. `total=False` says a key may be ABSENT; it does not say the value may
+# be null, and real rows carry nulls — a registered tool with no description, an endpoint with no
+# published price. The first version typed these as plain `str` and a team tool with
+# `description: None` failed validation, so `my_tools` returned a schema error instead of the team's
+# tools. Caught by the isolation test's "org A must genuinely SEE its tool" assertion, which exists
+# precisely so a passing-for-free result is impossible.
+class SearchResult(TypedDict, total=False):
+    endpoint_id: str | None
+    name: str | None
+    provider: str | None
+    usd_per_call: float | None
+    no_key_needed: bool | None
+    score: int | None
+
+
+class SearchOut(TypedDict, total=False):
+    query: str | None
+    count: int | None
+    total_matches: int | None
+    results: list[SearchResult]
+    hint: str
+    next: str
+    error: str
+    detail: str
+
+
+class CatalogGetOut(TypedDict, total=False):
+    endpoint: dict[str, Any]        # the full catalog entry: params, cost, observed reliability
+    provider: dict[str, Any]
+    siblings: list[dict[str, Any]]  # other providers of the same capability, for comparison
+    call_template: str
+    example_response: dict[str, Any]
+    hints: list[str]
+    error: str
+    detail: str
+
+
+class CallOut(TypedDict, total=False):
+    status: int | None              # the UPSTREAM status, relayed
+    endpoint_id: str | None
+    body: Any                       # the provider's response, verbatim
+    cost_usd: float
+    whose_error: str                # "treg" or "provider" — who to blame, and whether to retry
+    hint: str
+    error: str
+    detail: str
+
+
+class BalanceOut(TypedDict, total=False):
+    team: str | None
+    balance_usd: float | None
+    balance_micro: int | None
+    holds_micro: int | None
+    error: str
+    detail: str
+    teams: list[str]                # when a person is in several and none is active
+    hint: str
+
+
+class TeamTool(TypedDict, total=False):
+    name: str | None
+    base_url: str | None
+    description: str | None
+
+
+class MyToolsOut(TypedDict, total=False):
+    team: str | None
+    count: int | None
+    tools: list[TeamTool]
+    error: str
+    detail: str
+    teams: list[str]
+    hint: str
 
 
 def _bearer(ctx: Context) -> str:
@@ -241,9 +326,10 @@ async def _resolve_org(client: httpx.AsyncClient) -> tuple[int | None, str | Non
         "without you owning an API key. Call this FIRST when a task needs data or an API you have "
         "no key for."
     ),
-    annotations=_READS
+    annotations=_READS,
+    structured_output=True
 )
-async def catalog_search(query: str, limit: int = 8) -> dict:
+async def catalog_search(query: str, limit: int = 8) -> SearchOut:
     cat = catalog_store.load()
     ranked, total = catalog_store.search(query, cat, max(1, min(limit, 25)))
     results = []
@@ -274,9 +360,10 @@ async def catalog_search(query: str, limit: int = 8) -> dict:
         "rate and speed treg has measured across real calls. Read this BEFORE call() so you can "
         "tell the human what it will cost."
     ),
-    annotations=_READS
+    annotations=_READS,
+    structured_output=True
 )
-async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
+async def catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
     """Goes through the HTTP route rather than the store: that route attaches the observed
     reliability figures and the capability siblings, and those come from the database."""
     token = _bearer(ctx)
@@ -301,10 +388,11 @@ async def catalog_get(endpoint_id: str, ctx: Context) -> dict:
         "from the team's prepaid balance; a team's own tool is never metered. Tell the human the "
         "price (from catalog_get) before calling anything that costs more than a cent."
     ),
-    annotations=_CALLS
+    annotations=_CALLS,
+    structured_output=True
 )
 async def call(endpoint_id: str, params: dict | None = None,
-               method: str | None = None, ctx: Context = None) -> dict:  # type: ignore[assignment]
+               method: str | None = None, ctx: Context = None) -> CallOut:  # type: ignore[assignment]
     token = _bearer(ctx) if ctx else ""
     if not token:
         return _need_token()
@@ -349,9 +437,10 @@ async def call(endpoint_id: str, params: dict | None = None,
         "The team's prepaid balance in USD, and any spend currently in flight. Check it when a call "
         "is refused for funds, or before a job that will make many calls."
     ),
-    annotations=_READS
+    annotations=_READS,
+    structured_output=True
 )
-async def balance(ctx: Context) -> dict:
+async def balance(ctx: Context) -> BalanceOut:
     token = _bearer(ctx)
     if not token:
         return _need_token()
@@ -377,9 +466,10 @@ async def balance(ctx: Context) -> dict:
         "API keys, OAuth connections, vendor CLIs and skills. A team's own tool always wins over "
         "treg's catalog key, and those calls are never metered."
     ),
-    annotations=_READS
+    annotations=_READS,
+    structured_output=True
 )
-async def my_tools(ctx: Context) -> dict:
+async def my_tools(ctx: Context) -> MyToolsOut:
     token = _bearer(ctx)
     if not token:
         return _need_token()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -325,3 +325,49 @@ async def test_an_UNKNOWN_origin_is_still_refused(clients):
             "jsonrpc": "2.0", "id": 1, "method": "tools/list"},
             headers={**MCP_HEADERS, "Origin": "https://attacker.example"})
     assert r.status_code == 403, r.text
+
+
+async def test_every_tool_declares_what_it_RETURNS(clients):
+    """ChatGPT's connector review flags a tool with no output schema, and a model that has to guess
+    at field names guesses. Each tool now declares its shape."""
+    from treg.mcp import mcp as server
+
+    for t in await server.list_tools():
+        assert t.output_schema, f"{t.name} has no output schema"
+        assert t.output_schema.get("properties"), f"{t.name}'s schema is empty"
+
+
+async def test_the_output_schema_does_not_BREAK_the_error_paths(clients):
+    """The load-bearing detail. A strict schema is validated on the way out, so `{"error": "not
+    authenticated"}` would RAISE instead of returning — turning a refusal written to tell an agent
+    how to recover into an opaque tool failure.
+
+    Every field is optional so both shapes pass. A schema is a hint to the model, not a gate on our
+    own error handling."""
+    from treg.mcp import mcp as server
+
+    for t in await server.list_tools():
+        assert not t.output_schema.get("required"), (
+            f"{t.name} has required output fields — the first error response will raise")
+
+    # and prove it end to end, not just in the schema
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "balance", {})
+    assert out.get("error") == "not authenticated", out
+    assert "TREG_TOKEN" in json.dumps(out), "the recovery instruction must survive"
+
+
+async def test_the_schema_tolerates_NULLS_not_just_missing_keys(clients):
+    """`total=False` says a key may be ABSENT; it does not say the value may be null. Real rows carry
+    nulls — a registered tool with no description, an endpoint with no published price — and typing
+    those as plain `str` made `my_tools` return a schema error instead of the team's tools.
+
+    Asserted on the schema so the next field added is held to the same rule."""
+    from treg.mcp import mcp as server
+
+    tools = {t.name: t.output_schema for t in await server.list_tools()}
+    defs = tools["my_tools"].get("$defs", {})
+    team_tool = defs.get("TeamTool", {})
+    for field, spec in team_tool.get("properties", {}).items():
+        allows_null = "null" in str(spec)
+        assert allows_null, f"TeamTool.{field} does not allow null — a real row will fail validation"

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -806,3 +806,55 @@ async def test_a_null_origin_from_a_redirect_chain_is_not_treated_as_cross_site(
                               headers={"Origin": "null", "Sec-Fetch-Site": "cross-site"})
     assert nope.status_code == 403
     assert "Sec-Fetch-Site: cross-site" in nope.json()["detail"], "the refusal must say what it saw"
+
+
+# ---- signing in mid-authorization must RETURN you to the authorization ----------------------
+
+async def test_a_signed_out_user_is_returned_to_the_consent_screen(clients):
+    """The bug ChatGPT found on its first real connect. A signed-out user clicking "Sign in with
+    treg" landed on the dashboard and the authorization was silently dropped.
+
+    The cause was a `?next=` query I invented and nothing implemented, so the sign-in doors simply
+    ignored it. The destination is now parked in a cookie and resumed at the dashboard, which is the
+    one point every browser door ends at.
+    """
+    client_id = await _register(clients)
+    _, challenge = _pkce()
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256"}
+
+    clients.cookies.clear()
+    sent_away = await clients.get("/oauth/authorize", params=params, follow_redirects=False)
+    assert sent_away.status_code == 302
+    parked = (sent_away.cookies.get("treg_oauth_return") or "").strip('"')
+    assert parked.startswith("/oauth/authorize?"), f"nothing was parked: {parked!r}"
+    assert params["client_id"] in parked, "the parked destination must be THIS request"
+
+    # now sign in and land on the dashboard, as every browser door does
+    cookie, _ = await _signed_in(clients, "returner@superdesign.dev")
+    clients.cookies.set("treg_oauth_return", parked)
+    back = await clients.get("/app", follow_redirects=False)
+    assert back.status_code == 302, "the dashboard must resume the parked authorization"
+    assert back.headers["location"].startswith("/oauth/authorize?")
+
+
+async def test_the_parked_destination_cannot_be_used_as_an_open_redirect(clients):
+    """The cookie is only honoured for /oauth/authorize. Accepting any path would make it a general
+    "send me anywhere after login" primitive — a phishing aid rather than a feature."""
+    cookie, _ = await _signed_in(clients, "openredir@superdesign.dev")
+    for evil in ("https://attacker.test/", "//attacker.test/", "/app/../oauth/authorize?x=1",
+                 "/anything-else"):
+        clients.cookies.set("treg_oauth_return", evil)
+        r = await clients.get("/app", follow_redirects=False)
+        assert r.status_code == 200, f"{evil!r} must NOT be honoured, got {r.status_code}"
+    clients.cookies.delete("treg_oauth_return")
+
+
+async def test_a_signed_out_visitor_is_not_bounced_in_a_loop(clients):
+    """Resuming only once signed in. Otherwise the dashboard would send them to /oauth/authorize,
+    which would send them back here, forever."""
+    clients.cookies.clear()
+    clients.cookies.set("treg_oauth_return", "/oauth/authorize?client_id=x")
+    r = await clients.get("/app", follow_redirects=False)
+    assert r.status_code == 200


### PR DESCRIPTION
ChatGPT's **first real connect** found this. Clicking *"Sign in with treg"* while signed out landed
on the dashboard and the authorization was silently dropped — no error, no consent screen, nothing to
debug from.

The cause was a `?next=` convention **I invented and nothing implements**. Grepping for it found
exactly one occurrence: my own redirect. The sign-in doors have never read it.

## The fix

The destination is parked in a short-lived cookie and resumed at the **dashboard** — the one point
every browser door ends at. GitHub, Google and the email code all arrive there, and they finish
differently enough (two redirect, one answers JSON) that threading a return value through each would
have been three chances to get it wrong.

Two deliberate choices:

- **A relative path, never a full URL.** An absolute one would need validating against our own origin
  first, and subtly mis-writing that check is how open redirects happen. A path cannot leave the site.
- **Only `/oauth/authorize` is honoured.** Otherwise the cookie becomes a general "send me anywhere
  after login" primitive — a phishing aid, not a feature. A test walks four attempts at exactly that.

Resuming happens **only once signed in**, or the dashboard would bounce to `/oauth/authorize` which
would bounce back here forever. Also tested.

One smaller catch: Starlette **quotes** a cookie value containing separators and not every client
strips them. Tolerating quotes on read costs nothing; assuming they are absent would have dropped the
authorization in production while passing locally.

**3 new tests, 1274 pass.**