### PR TITLE
fix(oauth): the consent screen shows which team can actually pay

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1650,9 +1650,21 @@ def _consent_page(*, client_name: str, client_uri: str, user_email: str, teams: 
     """
     import html as _h
 
+    def _label(t: dict) -> str:
+        bal = t.get("balance_usd")
+        if bal is None:
+            money = ""
+        elif bal <= 0:
+            # Named, not hidden: an empty team is still a legitimate choice when the work uses the
+            # team's OWN keys, which are never metered. Saying "no balance" is the useful warning;
+            # removing the option would be wrong.
+            money = "  ·  no balance — catalog calls will be refused"
+        else:
+            money = f"  ·  ${bal:.2f}"
+        return f'{t["slug"]} — {t["role"]}{money}'
+
     opts = "".join(
-        f'<option value="{t["org_id"]}">{_h.escape(t["slug"])} — {_h.escape(t["role"])}</option>'
-        for t in teams)
+        f'<option value="{t["org_id"]}">{_h.escape(_label(t))}</option>' for t in teams)
     fields = "".join(
         f'<input type="hidden" name="{_h.escape(k)}" value="{_h.escape(str(v))}"/>'
         for k, v in hidden.items())
@@ -1824,7 +1836,13 @@ async def oauth_authorize(
     for m in memberships:
         org = await db.get(Org, m.org_id)
         if org is not None and not org.suspended:
-            teams.append({"org_id": org.id, "slug": org.slug, "role": m.role})
+            # The BALANCE belongs on this list. Choosing a team here decides which balance the
+            # client spends for the life of the grant, and a list of slugs makes the one question
+            # that matters — "which of these can actually pay?" — invisible at the moment of
+            # choosing. Unclecode picked a $0.00 team on the first real ChatGPT connect and the call
+            # was refused; nothing on the page could have told him.
+            teams.append({"org_id": org.id, "slug": org.slug, "role": m.role,
+                          "balance_usd": round((org.balance_micro or 0) / 1_000_000, 4)})
     if not teams:
         return _oauth_error(redirect_uri, state, "access_denied",
                             "this account is not a member of any team")

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -858,3 +858,53 @@ async def test_a_signed_out_visitor_is_not_bounced_in_a_loop(clients):
     clients.cookies.set("treg_oauth_return", "/oauth/authorize?client_id=x")
     r = await clients.get("/app", follow_redirects=False)
     assert r.status_code == 200
+
+
+async def test_the_team_picker_shows_which_team_can_PAY(clients):
+    """Choosing a team here decides which balance the client spends for the life of the grant, so
+    "which of these can actually pay?" has to be visible at the moment of choosing.
+
+    Unclecode picked a $0.00 team on the first real ChatGPT connect; the call was refused and nothing
+    on the page could have told him. A team with no balance is still a legitimate choice — a team's
+    OWN keys are never metered — so it is LABELLED rather than hidden."""
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "picker@superdesign.dev")
+    _, challenge = _pkce()
+    r = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"})
+    assert r.status_code == 200
+    page = r.text
+    # a new team carries the $1.00 grant, so the amount must be on the option
+    assert "$1.00" in page, f"the balance is not shown in the picker: {page[page.find('org_id'):][:300]}"
+
+    # and the JSON view carries it too, for a client that renders its own picker
+    j = await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"},
+        headers={"Accept": "application/json"})
+    assert any("balance_usd" in t for t in j.json()["teams"])
+
+
+async def test_a_team_with_no_balance_is_labelled_not_hidden(clients):
+    """Removing the option would be wrong: work that uses the team's OWN registered keys is never
+    metered, so an empty team is a perfectly good choice for it."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import Org
+
+    client_id = await _register(clients)
+    cookie, org_id = await _signed_in(clients, "broke@superdesign.dev")
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == org_id))).scalar_one()
+        org.balance_micro = 0
+        db.add(org)
+        await db.commit()
+
+    _, challenge = _pkce()
+    page = (await clients.get("/oauth/authorize", params={
+        "client_id": client_id, "redirect_uri": "https://client.test/cb", "response_type": "code",
+        "code_challenge": challenge, "code_challenge_method": "S256"})).text
+    assert "no balance" in page
+    assert f'value="{org_id}"' in page, "the team must still be selectable"


### PR DESCRIPTION
Choosing a team on the consent screen decides which balance the client spends for the **life of the
grant** — and the picker listed slugs and roles only, so *"which of these can actually pay?"* was
invisible at the moment of choosing.

Unclecode picked a $0.00 team on the first real ChatGPT connect. The call was refused (correctly),
and nothing on the page could have warned him. Worse: the model paraphrased treg's specific refusal —
*"the team's prepaid balance is short — top up at…"* — as *"blocked by safety checks"*, then answered
from a web search instead. The actionable message never reached the human.

## The change

Each option now reads `slug — role · $1.00`, and an empty team reads
`no balance — catalog calls will be refused`. The JSON view carries `balance_usd` too, for clients
that render their own picker.

## The judgement call

A team with no balance is **labelled, not hidden**. Removing the option would be wrong — work that
uses the team's *own* registered keys is never metered, so an empty team is a perfectly good choice
for that. The warning is the useful part; taking away the choice is not. A test asserts it stays
selectable.

Verified in a browser, not just in markup. **2 new tests, 1279 pass.**