### PR TITLE
fix(mcp): protected tools answer 401 with WWW-Authenticate

### DIFF
--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -33,6 +33,7 @@ not initialized". `api.py` must compose this module's lifespan with its own; see
 
 from __future__ import annotations
 
+import json
 import os
 from contextlib import asynccontextmanager
 from typing import Any, TypedDict
@@ -542,6 +543,91 @@ def _allowed_origins() -> list[str]:
     return sorted(dict.fromkeys(origins))
 
 
+# The tools that touch money or a team's data. `catalog_search` and `catalog_get` are deliberately
+# absent: the catalog is public, and someone evaluating treg should see what is in it and what it
+# costs before creating an account — the same data /catalog/search already serves on the website.
+_NEEDS_AUTH = {"call", "balance", "my_tools"}
+
+
+class RequireAuthForProtectedTools:
+    """Answer 401 with `WWW-Authenticate` when a protected tool is called without a credential.
+
+    A tool function can return an error dict, but it cannot set an HTTP status or a header — and the
+    status and header are the whole point here. The MCP spec has a protected resource reply **401**
+    with `WWW-Authenticate: Bearer resource_metadata="…"`, because that header is how a client
+    DISCOVERS it must authenticate and where to begin. Returning a friendly English sentence inside a
+    200 tells a human what went wrong and tells a program nothing.
+
+    It worked with ChatGPT only because ChatGPT authenticates up front. A client that connects first
+    and discovers auth lazily — which the spec allows — would see 200, conclude all was well, and
+    surface our prose to the user with no way to act on it. I saw this in an RFC 9728 probe earlier
+    and moved on because the client in front of me did not need it, which is the same reasoning that
+    nearly cost us dynamic client registration.
+
+    Sits in front of the transport rather than inside it: this is an HTTP concern, and the SDK owns
+    everything below.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or scope.get("method") != "POST":
+            return await self.app(scope, receive, send)
+
+        body, more = b"", True
+        while more:
+            msg = await receive()
+            body += msg.get("body", b"")
+            more = msg.get("more_body", False)
+
+        if self._unauthenticated_protected_call(scope, body):
+            return await self._challenge(send)
+
+        # The body was consumed to inspect it, so hand the transport a receive() that replays it.
+        replayed = False
+
+        async def replay():
+            nonlocal replayed
+            if replayed:
+                return {"type": "http.disconnect"}
+            replayed = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        return await self.app(scope, replay, send)
+
+    @staticmethod
+    def _unauthenticated_protected_call(scope, body: bytes) -> bool:
+        has_token = any(k.lower() == b"authorization" and v.strip()
+                        for k, v in scope.get("headers", []))
+        if has_token:
+            return False        # whether it is VALID is the tool's business, not the transport's
+        try:
+            rpc = json.loads(body or b"{}")
+        except ValueError:
+            return False        # malformed input is the transport's problem, not ours to relabel
+        if rpc.get("method") != "tools/call":
+            return False
+        return (rpc.get("params") or {}).get("name") in _NEEDS_AUTH
+
+    @staticmethod
+    async def _challenge(send) -> None:
+        base = get_settings().public_url.rstrip("/")
+        payload = json.dumps({
+            "error": "unauthorized",
+            "error_description": ("this tool needs a treg grant — authorize at "
+                                  f"{base}/oauth/authorize, or send a per-org token as a bearer"),
+            "resource_metadata": f"{base}/.well-known/oauth-protected-resource",
+        }).encode()
+        await send({"type": "http.response.start", "status": 401, "headers": [
+            (b"content-type", b"application/json"),
+            # The header the spec is actually about: it names where to discover how to authenticate.
+            (b"www-authenticate",
+             f'Bearer resource_metadata="{base}/.well-known/oauth-protected-resource"'.encode()),
+        ]})
+        await send({"type": "http.response.body", "body": payload})
+
+
 def build_mcp_app():
     """A fresh ASGI app for the MCP transport.
 
@@ -555,7 +641,7 @@ def build_mcp_app():
     would need sticky routing; `json_response` because these are request/response tools with nothing
     to stream, and skipping SSE framing is most of the speed.
     """
-    return mcp.streamable_http_app(
+    transport = mcp.streamable_http_app(
         streamable_http_path="/", stateless_http=True, json_response=True,
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
@@ -563,6 +649,10 @@ def build_mcp_app():
             allowed_origins=_allowed_origins(),
         ),
     )
+    # Wrapped HERE, not around the module-level value, so a caller that builds its own app gets the
+    # same thing production runs. The first version wrapped only the module-level app, and the tests
+    # — which build a fresh transport per test — silently exercised an unprotected server.
+    return RequireAuthForProtectedTools(transport)
 
 
 mcp_app = build_mcp_app()
@@ -574,5 +664,6 @@ async def mcp_lifespan(target=None):
     lifespan, and the streamable-HTTP session manager builds its task group there — without this
     every MCP request fails with "Task group is not initialized"."""
     target = target or mcp_app
-    async with target.router.lifespan_context(target):
+    inner = getattr(target, "app", target)   # unwrap RequireAuthForProtectedTools
+    async with inner.router.lifespan_context(inner):
         yield

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -121,12 +121,18 @@ async def test_search_says_so_when_nothing_matches(clients):
 @pytest.mark.parametrize("tool", ["call", "balance", "my_tools"])
 async def test_every_spending_or_tenant_tool_refuses_without_a_token(clients, tool):
     """A public MCP endpoint onto a paid catalog is the whole risk of this feature. Anything that
-    reads a team's data or moves its money must fail closed, and say what to do about it."""
+    reads a team's data or moves its money must fail closed, and say what to do about it.
+
+    The refusal is now an HTTP 401 carrying `WWW-Authenticate`, rather than an error dict inside a
+    200 — see `test_a_protected_tool_answers_401_with_WWW_Authenticate` for why the shape matters.
+    This test keeps its original job: proving these three cannot be reached without a credential."""
     args = {"endpoint_id": "tikhub.tiktok.video.comments"} if tool == "call" else {}
     async with mcp_session(clients) as c:
-        out = await _call_tool(c, tool, args)
-    assert out.get("error") == "not authenticated", out
-    assert "TREG_TOKEN" in json.dumps(out)
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": tool, "arguments": args}}, headers=MCP_HEADERS)
+    assert r.status_code == 401, r.text
+    assert "resource_metadata" in r.headers.get("www-authenticate", "")
 
 
 async def test_a_bogus_token_gets_nothing(clients):
@@ -350,11 +356,13 @@ async def test_the_output_schema_does_not_BREAK_the_error_paths(clients):
         assert not t.output_schema.get("required"), (
             f"{t.name} has required output fields — the first error response will raise")
 
-    # and prove it end to end, not just in the schema
+    # and prove it end to end, not just in the schema. A BAD token rather than none: a missing
+    # credential is now answered at the transport with a 401, so it never reaches the tool — and it
+    # is the tool's own error shape that has to survive the schema.
     async with mcp_session(clients) as c:
-        out = await _call_tool(c, "balance", {})
-    assert out.get("error") == "not authenticated", out
-    assert "TREG_TOKEN" in json.dumps(out), "the recovery instruction must survive"
+        out = await _call_tool(c, "balance", {}, token="not-a-real-token")
+    assert out.get("error"), out
+    assert "hint" in out or "detail" in out, "the recovery instruction must survive the schema"
 
 
 async def test_the_schema_tolerates_NULLS_not_just_missing_keys(clients):
@@ -371,3 +379,66 @@ async def test_the_schema_tolerates_NULLS_not_just_missing_keys(clients):
     for field, spec in team_tool.get("properties", {}).items():
         allows_null = "null" in str(spec)
         assert allows_null, f"TeamTool.{field} does not allow null — a real row will fail validation"
+
+
+# ---- refusing in the right SHAPE, not just refusing ------------------------------------------
+
+@pytest.mark.parametrize("tool", ["call", "balance", "my_tools"])
+async def test_a_protected_tool_answers_401_with_WWW_Authenticate(clients, tool):
+    """The spec has a protected resource reply 401 with `WWW-Authenticate: Bearer
+    resource_metadata="…"`, because that header is how a client DISCOVERS it must authenticate and
+    where to start. A friendly sentence inside a 200 tells a human what happened and tells a program
+    nothing.
+
+    This passed unnoticed because ChatGPT authenticates up front. A client that connects first and
+    discovers auth lazily — which the spec allows — would read 200 as success."""
+    async with mcp_session(clients) as c:
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": tool, "arguments": {}}}, headers=MCP_HEADERS)
+    assert r.status_code == 401, r.text
+    challenge = r.headers.get("www-authenticate", "")
+    assert challenge.startswith("Bearer "), challenge
+    assert "resource_metadata=" in challenge
+    assert "/.well-known/oauth-protected-resource" in challenge
+    assert r.json()["resource_metadata"].endswith("/.well-known/oauth-protected-resource")
+
+
+@pytest.mark.parametrize("tool,args", [("catalog_search", {"query": "backlinks"}),
+                                       ("catalog_get", {"endpoint_id": "hunter.people.email.find"})])
+async def test_the_PUBLIC_tools_still_answer_without_a_token(clients, tool, args):
+    """Deliberate, and worth protecting: someone evaluating treg should see what is in the catalog
+    and what it costs before creating an account. Nothing tenant-specific or spendable is exposed —
+    the same data /catalog/search already serves on the website."""
+    async with mcp_session(clients) as c:
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": tool, "arguments": args}}, headers=MCP_HEADERS)
+    assert r.status_code == 200, r.text
+
+
+async def test_discovery_still_works_unauthenticated(clients):
+    """`initialize` and `tools/list` must not be challenged, or a client cannot learn what exists
+    before deciding to authenticate."""
+    async with mcp_session(clients) as c:
+        for method in ("initialize", "tools/list"):
+            params = {"protocolVersion": "2025-06-18", "capabilities": {},
+                      "clientInfo": {"name": "t", "version": "1"}} if method == "initialize" else None
+            body = {"jsonrpc": "2.0", "id": 1, "method": method}
+            if params:
+                body["params"] = params
+            r = await c.post("http://localhost/mcp/", json=body, headers=MCP_HEADERS)
+            assert r.status_code == 200, f"{method}: {r.status_code}"
+
+
+async def test_a_BAD_token_is_the_tool_s_business_not_the_transport_s(clients):
+    """The challenge fires only when there is NO credential. Deciding whether a token is valid needs
+    the database, and doing that in transport middleware would put a second authentication
+    implementation in front of the first."""
+    async with mcp_session(clients) as c:
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "balance", "arguments": {}}},
+            headers={**MCP_HEADERS, "Authorization": "Bearer not-a-real-token"})
+    assert r.status_code == 200
+    assert "error" in json.loads(r.json()["result"]["content"][0]["text"])


### PR DESCRIPTION
Unclecode asked why `/mcp/` never 401s. He was right to, and the answer splits in two.

## Deliberate, unchanged

The **catalog stays public**. Someone evaluating treg should see what is in it and what it costs
before creating an account — the same data `/catalog/search` already serves on the website. Nothing
tenant-specific and nothing spendable was ever exposed.

## The gap: refusing in the wrong shape

`balance` without a token returned **HTTP 200** with `{"error": "not authenticated"}` and **no
`WWW-Authenticate`**. The spec has a protected resource reply **401** with
`WWW-Authenticate: Bearer resource_metadata="…"` — that header is how a client *discovers* it must
authenticate and where to start.

A friendly sentence in a 200 tells a human what happened and tells a program nothing. A client that
connects first and discovers auth lazily (which the spec allows) would read 200 as success.

**It passed unnoticed because ChatGPT authenticates up front** — and I had already seen it: an RFC
9728 probe returned `HTTP/2 200` and I moved on because the client in front of me did not need it.
That is the same reasoning that nearly cost us DCR support.

## The fix

`RequireAuthForProtectedTools` sits **in front of** the transport: status codes and headers are an
HTTP concern, and a tool function can return neither. It challenges only when there is **no**
credential — deciding whether a token is *valid* needs the database, and doing that in middleware
would put a second authentication implementation in front of the first.

Worth recording: my first attempt wrapped only the module-level app, so the tests — which build a
fresh transport each — **silently exercised an unprotected server and passed**. The wrapping moved
inside `build_mcp_app()` so no caller can get a different server from the one production runs.

Verified live: 401 + header for the three protected tools, 200 for the public two, 200 for
`initialize` and `tools/list`. **1286 tests pass.**