### PR TITLE
fix(mcp): every tool needs a credential, catalog included

### DIFF
--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -16,8 +16,10 @@ daily cap, the platform daily cap, the balance reserve and the settle — a seco
 re-implemented any of that is exactly how one copy quietly stops being enforced. The cost is one
 in-process round trip with no socket, which measured at well under a millisecond.
 
-Only the **public catalog** is read directly (`catalog_store`), because it is already parsed in
-memory, needs no database and no identity, and answering from it takes ~1 ms.
+The **catalog** is read directly from `catalog_store` rather than through the API, because it is
+already parsed in memory and answering from it takes ~1 ms. That is a performance choice, not a
+permission one: every tool requires a credential, and the transport refuses an uncredentialed call
+before it reaches any of them.
 
 **Headers are not identity.** The SDK's own docstring says it and it is worth repeating: the bearer
 token arriving on an MCP request is client-supplied input. It is validated against the database on
@@ -316,7 +318,7 @@ async def _resolve_org(client: httpx.AsyncClient) -> tuple[int | None, str | Non
 
 
 # --------------------------------------------------------------------------------------------
-# The catalog — public, in memory, no identity needed
+# The catalog — read straight from memory. Still credentialed: the transport challenges first.
 # --------------------------------------------------------------------------------------------
 
 @mcp.tool(
@@ -543,10 +545,16 @@ def _allowed_origins() -> list[str]:
     return sorted(dict.fromkeys(origins))
 
 
-# The tools that touch money or a team's data. `catalog_search` and `catalog_get` are deliberately
-# absent: the catalog is public, and someone evaluating treg should see what is in it and what it
-# costs before creating an account — the same data /catalog/search already serves on the website.
-_NEEDS_AUTH = {"call", "balance", "my_tools"}
+# EVERY tool needs a credential. An earlier version left `catalog_search` and `catalog_get` open so a
+# client could browse before signing up, which made the contract "some tools need auth, some do not"
+# — a rule each client has to learn by trying. Unclecode's call, and the simpler one: connect, then
+# use treg.
+#
+# Note what this does and does not buy. `/catalog/search` is still public on the WEBSITE — the
+# landing page and `treg catalog search` both rely on it — so this is about giving MCP clients one
+# predictable rule, not about hiding the catalog. Anyone wanting the data unauthenticated can still
+# take the website route, and closing that is a separate decision with different consequences.
+_NEEDS_AUTH = {"catalog_search", "catalog_get", "call", "balance", "my_tools"}
 
 
 class RequireAuthForProtectedTools:

--- a/src/treg/web/connect-demo.html
+++ b/src/treg/web/connect-demo.html
@@ -65,10 +65,10 @@ pre{background:#141414;border:1px solid #262626;border-radius:8px;padding:12px;o
 
   <div class="step">
     <h3>3. Call tools <span id="s3" class="state off">no token</span></h3>
-    <p>The same five tools any MCP client gets. <b>catalog_search</b> and <b>catalog_get</b> are
-    public; the rest need the token you just granted. <b>call</b> is the only one that spends the
-    team's balance, so it does what treg asks an agent to do — reads the price first and asks before
-    spending.</p>
+    <p>The same five tools any MCP client gets. All of them need the token you just granted — an
+    unauthenticated call is answered with a 401 telling the client where to authorize. <b>call</b> is
+    the only one that spends the team's balance, so it does what treg asks an agent to do — reads the
+    price first and asks before spending.</p>
     <div class="tools">
       <button class="tool" data-tool="catalog_search" disabled>catalog_search</button>
       <button class="tool" data-tool="catalog_get" disabled>catalog_get</button>

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -98,11 +98,12 @@ async def test_the_server_lists_exactly_the_five_tools(clients):
     assert names == {"catalog_search", "catalog_get", "call", "balance", "my_tools"}
 
 
-async def test_catalog_search_answers_without_any_token(clients):
-    """The catalog is public — discovery must work before anyone has signed up, or the first
-    impression of the plugin is an auth error."""
+async def test_catalog_search_returns_priced_results(clients):
+    """Search is the entry point: an agent asks for a task and gets endpoints with prices. Needs a
+    credential now, like every tool — see test_EVERY_tool_needs_a_credential_including_the_catalog."""
+    token = (await clients.post("/users", json={"email": "searcher@superdesign.dev"})).json()["token"]
     async with mcp_session(clients) as c:
-        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 3})
+        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 3}, token=token)
     assert out["results"], out
     first = out["results"][0]
     assert first["endpoint_id"] and first["provider"]
@@ -110,8 +111,9 @@ async def test_catalog_search_answers_without_any_token(clients):
 
 
 async def test_search_says_so_when_nothing_matches(clients):
+    token = (await clients.post("/users", json={"email": "nomatch@superdesign.dev"})).json()["token"]
     async with mcp_session(clients) as c:
-        out = await _call_tool(c, "catalog_search", {"query": "zzzz-no-such-capability"})
+        out = await _call_tool(c, "catalog_search", {"query": "zzzz-no-such-capability"}, token=token)
     assert out["count"] == 0
     assert "hint" in out
 
@@ -258,8 +260,9 @@ async def test_the_deployments_own_host_is_allowed():
 async def test_the_price_is_visible_before_spending(clients):
     """An agent that cannot see a price before calling cannot warn the human, and the skill's rule is
     to state the cost first. Search must carry the number."""
+    token = (await clients.post("/users", json={"email": "pricer@superdesign.dev"})).json()["token"]
     async with mcp_session(clients) as c:
-        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 5})
+        out = await _call_tool(c, "catalog_search", {"query": "backlinks", "limit": 5}, token=token)
     assert any(r.get("usd_per_call") is not None for r in out["results"])
 
 
@@ -383,7 +386,7 @@ async def test_the_schema_tolerates_NULLS_not_just_missing_keys(clients):
 
 # ---- refusing in the right SHAPE, not just refusing ------------------------------------------
 
-@pytest.mark.parametrize("tool", ["call", "balance", "my_tools"])
+@pytest.mark.parametrize("tool", ["call", "balance", "my_tools", "catalog_search", "catalog_get"])
 async def test_a_protected_tool_answers_401_with_WWW_Authenticate(clients, tool):
     """The spec has a protected resource reply 401 with `WWW-Authenticate: Bearer
     resource_metadata="…"`, because that header is how a client DISCOVERS it must authenticate and
@@ -406,15 +409,19 @@ async def test_a_protected_tool_answers_401_with_WWW_Authenticate(clients, tool)
 
 @pytest.mark.parametrize("tool,args", [("catalog_search", {"query": "backlinks"}),
                                        ("catalog_get", {"endpoint_id": "hunter.people.email.find"})])
-async def test_the_PUBLIC_tools_still_answer_without_a_token(clients, tool, args):
-    """Deliberate, and worth protecting: someone evaluating treg should see what is in the catalog
-    and what it costs before creating an account. Nothing tenant-specific or spendable is exposed —
-    the same data /catalog/search already serves on the website."""
+async def test_EVERY_tool_needs_a_credential_including_the_catalog(clients, tool, args):
+    """One rule instead of two. An earlier version left the catalog tools open so a client could
+    browse before signing up, which made the contract "some tools need auth, some do not" — something
+    each client has to learn by trying.
+
+    This is about a predictable contract, not about hiding the catalog: /catalog/search is still
+    public on the WEBSITE, which the landing page and `treg catalog search` both rely on."""
     async with mcp_session(clients) as c:
         r = await c.post("http://localhost/mcp/", json={
             "jsonrpc": "2.0", "id": 1, "method": "tools/call",
             "params": {"name": tool, "arguments": args}}, headers=MCP_HEADERS)
-    assert r.status_code == 200, r.text
+    assert r.status_code == 401, r.text
+    assert "resource_metadata" in r.headers.get("www-authenticate", "")
 
 
 async def test_discovery_still_works_unauthenticated(clients):


### PR DESCRIPTION
One rule instead of two. The previous split — catalog tools open, the rest protected — meant *"some
tools need auth, some do not"*, which every client learns by trying. Now: **connect, then use treg.**

## What this does and does not buy

`/catalog/search` is **still public on the website** — the landing page and `treg catalog search`
both rely on it. So this gives MCP clients one predictable rule; it does not hide the catalog. Anyone
wanting that data unauthenticated can still take the website route, and closing that is a separate
decision with different consequences. This change is for MCP only, as specified.

## `initialize` and `tools/list` stay open — deliberately

That is how the flow **starts**: connect → list what exists → call a tool → get the 401 with
`WWW-Authenticate` → authorize. If discovery itself challenged, ChatGPT could not scan the server to
find the tools at all, and the connector page would show nothing.

## Also

Corrected two comments and the connect-demo copy that still described the old behaviour. The catalog
is still read straight from memory rather than through the API — that stays, but it is a **speed**
choice, not a permission one, and the docstring now says so instead of implying identity is
unnecessary.

Three tests that assumed anonymous catalog access were given tokens (their subject is unchanged); the
one asserting public access was inverted.

**1288 pass**, verified live: 401 for all five tools, 200 for `initialize` and `tools/list`.