### PR TITLE
fix(mcp): call accepts an array body — DataForSEO's 217 endpoints were uncallable

### DIFF
--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -384,7 +384,9 @@ async def catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
 
 @mcp.tool(
     description=(
-        "Call something through treg. Either a CATALOG endpoint by its id (from catalog_search), or "
+        "Call something through treg. `params` is the request body for a POST (an object, or an "
+        "ARRAY of task objects for providers like DataForSEO that expect one) and the query string "
+        "for a GET. Either a CATALOG endpoint by its id (from catalog_search), or "
         "one of THIS TEAM'S own tools as '<tool-name>/<path>' (from my_tools) — e.g. "
         "'render/v1/services'. treg injects the credential server-side and relays the provider's "
         "response unchanged, so you never hold an API key. Catalog calls on treg's key are metered "
@@ -394,7 +396,7 @@ async def catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
     annotations=_CALLS,
     structured_output=True
 )
-async def call(endpoint_id: str, params: dict | None = None,
+async def call(endpoint_id: str, params: dict | list | None = None,
                method: str | None = None, ctx: Context = None) -> CallOut:  # type: ignore[assignment]
     token = _bearer(ctx) if ctx else ""
     if not token:
@@ -411,11 +413,18 @@ async def call(endpoint_id: str, params: dict | None = None,
                         "'<tool-name>/<path>' for one of this team's own tools"}
 
     method = (method or (ep.get("method") if ep else None) or "GET").upper()
-    args = params or {}
+    # A LIST is a legitimate body, not a mistake. DataForSEO — the largest provider in the catalog at
+    # 217 endpoints — takes an ARRAY of task objects on every one of its `live` POST routes, so a
+    # dict-only signature made all of them uncallable. Found by trying one rather than by reading the
+    # type. Query strings still need key/value pairs, so a list is only meaningful as a body.
+    args = params if params is not None else {}
     async with _api(token) as client:
         # The SAME route the CLI and the proxy use, so the tool ACL, deny rules, both daily caps,
         # the balance reserve and the settle all happen exactly once, in one place.
         if method in ("GET", "HEAD", "DELETE"):
+            if isinstance(args, list):
+                return {"error": "this endpoint takes query parameters, so `params` must be an "
+                                 "object, not a list", "endpoint_id": endpoint_id}
             r = await client.request(method, f"/call/{endpoint_id}", params=args)
         else:
             r = await client.request(method, f"/call/{endpoint_id}", json=args)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -449,3 +449,37 @@ async def test_a_BAD_token_is_the_tool_s_business_not_the_transport_s(clients):
             headers={**MCP_HEADERS, "Authorization": "Bearer not-a-real-token"})
     assert r.status_code == 200
     assert "error" in json.loads(r.json()["result"]["content"][0]["text"])
+
+
+async def test_call_accepts_an_ARRAY_body(clients):
+    """DataForSEO — the largest provider in the catalog at 217 endpoints — takes an ARRAY of task
+    objects on every one of its `live` POST routes. A dict-only `params` made all of them uncallable
+    with a pydantic type error, which reads as "you passed it wrong" rather than "this tool cannot
+    express that".
+
+    Found by trying a real call for the demo, not by reading the signature."""
+    token = (await clients.post("/users", json={"email": "arraybody@superdesign.dev"})).json()["token"]
+    # register the tool AS THAT TOKEN's org — a tool created in another org is correctly invisible
+    prev = clients.headers.get("X-Treg-Token")
+    clients.headers["X-Treg-Token"] = token
+    made = await clients.post("/tools", json={"name": "echo", "base_url": "http://upstream"})
+    if prev:
+        clients.headers["X-Treg-Token"] = prev
+    assert made.status_code == 200, made.text
+
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {
+            "endpoint_id": "echo/anything", "method": "POST",
+            "params": [{"keyword": "payment api", "depth": 10}]}, token=token)
+    assert out.get("status") == 200, out
+    assert "validation error" not in json.dumps(out)
+
+
+async def test_a_list_is_refused_for_a_GET_with_a_clear_reason(clients):
+    """A query string is key/value pairs, so a list has no meaning there. Saying so beats a pydantic
+    trace that blames the caller for the tool's own limitation."""
+    token = (await clients.post("/users", json={"email": "listget@superdesign.dev"})).json()["token"]
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {
+            "endpoint_id": "hunter.people.email.find", "params": [{"x": 1}]}, token=token)
+    assert "must be an object, not a list" in json.dumps(out), out


### PR DESCRIPTION
Found while hunting for a demo endpoint, by trying a real call rather than reading the signature.

DataForSEO takes an **array of task objects** on every one of its `live` POST routes — that is its
API shape. `call` typed `params` as `dict | None`, so every one of those endpoints answered with a
pydantic type error, which reads as *"you passed it wrong"* when the truth was *"this tool cannot
express that"*.

DataForSEO is the **largest provider in the catalog at 217 endpoints**, so a whole family was
silently unreachable through MCP while working fine through the CLI.

`params` is now `dict | list | None`. A list on a GET is still refused — a query string is key/value
pairs — but with a sentence explaining why rather than a validation trace that blames the caller for
the tool's limitation. The description states both shapes, since the model reads it before deciding
what to send.

**1290 pass.**