### PR TITLE
feat(api): /call/ reports what it cost

### DIFF
--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -7316,6 +7316,12 @@ async def call_tool(
         charged, observed = await _platform_settle(mk, response.status_code, body)
         _audit(response.status_code, observed_micro=observed, charged_micro=charged,
                duration_ms=duration_ms, response_bytes=len(body))
+        # Tell the caller what the call actually cost. Both llms.txt and skill.md instruct an agent to
+        # report the price it spent, and until now the only way to find out was to read the balance
+        # before and after — which races with any other call and cannot attribute a figure to a
+        # request. The header is set only on a METERED call: a team's own key is never charged, and a
+        # `0` there would read as "free" rather than "not applicable".
+        response.headers["X-Treg-Cost-Micro"] = str(charged)
         return response
     # Fire-and-forget audit — does not block the streaming response (rule #2).
     _audit(response.status_code, duration_ms=duration_ms)

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -430,8 +430,12 @@ async def call(endpoint_id: str, params: dict | list | None = None,
             r = await client.request(method, f"/call/{endpoint_id}", json=args)
 
     out: dict[str, Any] = {"status": r.status_code, "endpoint_id": endpoint_id, "body": _body(r)}
+    # Set by /call/ on a METERED call only — a team's own key is never charged, and its absence
+    # therefore means "not applicable" rather than "free". This header did not exist when the tool
+    # first read it: I wrote against a convention I had invented, so `cost_usd` was always null and
+    # an agent could not report what it spent. Same mistake as the `?next=` redirect.
     spent = r.headers.get("X-Treg-Cost-Micro")
-    if spent:
+    if spent is not None:
         try:
             out["cost_usd"] = round(int(spent) / 1_000_000, 6)
         except ValueError:

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -193,6 +193,20 @@ async def test_tier4_relays_with_the_platform_key_and_charges_the_balance(client
     assert await _balance(clients) == before - EP_MICRO
     kinds = [e["kind"] for e in await _entries(clients)]
     assert kinds[:2] == ["settle", "reserve"], f"reserve→settle, newest first: {kinds}"
+    # The caller is TOLD what it cost. Both llms.txt and skill.md instruct an agent to report the
+    # price it spent, and without this the only way to find out is reading the balance before and
+    # after — which races with any other call and cannot attribute a figure to one request.
+    assert r.headers.get("X-Treg-Cost-Micro") == str(EP_MICRO), dict(r.headers)
+
+
+async def test_an_unmetered_call_carries_NO_cost_header(clients: AsyncClient, platform_on):
+    """A team's own key is never charged, so the header is ABSENT rather than `0` — zero would read
+    as "this was free" when the truth is "this was not ours to bill". Same call as tier 2 above, so
+    the only difference under test is the header."""
+    await clients.post("/secrets", json={"name": "tikhub", "value": "MKKEY"})
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and r.json()["auth"] == "Bearer MKKEY"
+    assert "X-Treg-Cost-Micro" not in r.headers
 
 
 async def test_tier2_shadows_tier4(clients: AsyncClient, platform_on):


### PR DESCRIPTION
Both `llms.txt` and `skill.md` tell an agent to **report the price it spent** — and there was no way
to learn it. The only route was reading the balance before and after, which races with any other call
and cannot attribute a figure to one request.

`mcp.call` has been reading `X-Treg-Cost-Micro` since it was written — **a header I invented and
nothing sets**, so `cost_usd` was always null. The same mistake as the `?next=` redirect: code
written against a convention that existed only in my head. Grepping the name found one occurrence:
the reader.

## The fix

Set on the **metered** path, where the charge is already known. Only there — a team's own key is
never billed, so the header is **absent rather than `0`**: zero would read as *"this was free"* when
the truth is *"this was not ours to bill"*.

## Found how

Verifying the demo call for the launch video on production: a DataForSEO SERP request returned 200
with real results and moved the balance **$0.9755 → $0.9735**, while `cost_usd` came back null.

Two tests: the metered call carries the exact figure; the tier-2 path (org's own key, same endpoint)
carries no header. **1291 pass.**