### PR TITLE
docs: the answers the ChatGPT submission form asked for

### DIFF
--- a/docs/PLUGIN-TEST-CASES.md
+++ b/docs/PLUGIN-TEST-CASES.md
@@ -1,0 +1,164 @@
+# Test cases for the ChatGPT plugin submission
+
+Copy each block into its field. Every positive case below was run against production before it was
+written here, so the expected output describes what actually happens rather than what should.
+
+
+## Test Case 1
+
+**Scenario**
+
+Find an API for a task when you have no key for it
+
+**User prompt**
+
+Find a way to get Google search results for a keyword, and show me the options with their prices.
+
+**Tool triggered**
+
+catalog_search
+
+**Expected output**
+
+A short list of catalog endpoints that return search results, each with its provider, its exact price
+per call in USD, and whether it can be called without the user owning an API key. Prices are real,
+not estimates. Nothing is charged, because searching the catalog is free.
+
+
+## Test Case 2
+
+**Scenario**
+
+Check the exact price of one endpoint before spending anything
+
+**User prompt**
+
+Show me the details and exact price for the DataForSEO Google organic search endpoint.
+
+**Tool triggered**
+
+catalog_get
+
+**Expected output**
+
+The full record for that endpoint: its required and optional parameters, the exact cost per call
+(0.004 USD), how that price was sourced, and other providers offering the same capability so the
+model can compare. No call is made and no money is spent.
+
+
+## Test Case 3
+
+**Scenario**
+
+Actually call a third-party API without holding its key, and report the cost
+
+**User prompt**
+
+Get the Google organic results for "payment processing api" and tell me the price first, then what it cost.
+
+**Tool triggered**
+
+catalog_get, then call
+
+**Expected output**
+
+The model states the price (0.004 USD) before calling, then returns real Google search results with
+domains, titles and ranks. The response includes cost_usd with the amount actually charged, and the
+team's prepaid balance drops by that amount. The user never supplies a DataForSEO key: treg injects
+its own server-side and bills the team.
+
+
+## Test Case 4
+
+**Scenario**
+
+Check the prepaid balance
+
+**User prompt**
+
+What is my treg balance right now?
+
+**Tool triggered**
+
+balance
+
+**Expected output**
+
+The team name and the current prepaid balance in USD, plus any spend still in flight. If the previous
+test case ran, the balance is lower by exactly the amount that call cost. Read-only, nothing changes.
+
+
+## Test Case 5
+
+**Scenario**
+
+See which of the team's own registered tools can be called without holding the credential
+
+**User prompt**
+
+What tools has my team registered that I can call without having the API key?
+
+**Tool triggered**
+
+my_tools
+
+**Expected output**
+
+A list of the tools this team registered with treg, each with its name and base URL. Credentials are
+never included, only what can be called. On the demo account this list may be empty, which is the
+correct answer for a team that has registered nothing, and the model should say so rather than invent
+entries.
+
+
+# Negative test cases
+
+Prompts where the model may think treg is relevant and it is not. The plugin should stay out of the
+way for all three.
+
+
+## Negative Test Case 1
+
+**Scenario**
+
+A general knowledge question that needs no API at all
+
+**User prompt**
+
+What is the difference between REST and GraphQL?
+
+**Why it should not trigger**
+
+This is explanatory knowledge the model already has. treg calls third-party APIs and would spend
+money to answer nothing. No tool should be invoked.
+
+
+## Negative Test Case 2
+
+**Scenario**
+
+Writing code that uses an API, rather than calling one
+
+**User prompt**
+
+Write me a Python function that calls the Stripe API to list customers.
+
+**Why it should not trigger**
+
+The user wants source code, not live data. Nothing should be called and no balance should be spent.
+treg is for fetching real data, not for generating examples about APIs.
+
+
+## Negative Test Case 3
+
+**Scenario**
+
+Asking about a personal or local matter with no API behind it
+
+**User prompt**
+
+Help me write a polite reply to my colleague's email about moving our meeting.
+
+**Why it should not trigger**
+
+There is no external data to fetch. The word "email" may look related to treg's people and email
+enrichment endpoints, but the task is composition, which the model does alone.

--- a/docs/PLUGIN-TOOL-JUSTIFICATIONS.md
+++ b/docs/PLUGIN-TOOL-JUSTIFICATIONS.md
@@ -1,0 +1,93 @@
+# Tool justifications for the ChatGPT plugin submission
+
+One block per form field. Copy the paragraph under each heading exactly as it is.
+
+Taken from what the server actually declares (`tools/list` on production), not from what the code
+intends. Those agreed when this was written, and the claim under review is what the server sends.
+
+Four of the five tools are read-only and closed-world. `call` is none of those, and its
+justifications are the ones a reviewer should read closely, because they explain a deliberately
+cautious labelling rather than a convenient one.
+
+
+## catalog_search
+
+### Read Only is True
+
+It searches treg's own catalog of API endpoints and returns names, descriptions and prices. It creates nothing, changes nothing, and spends nothing. Running it a hundred times leaves the account exactly as it was.
+
+### Open World is False
+
+It reads only treg's internal catalog, which is a fixed dataset we curate and ship. It does not reach any third-party API, follow any URL, or accept a host from the caller. Nothing outside our own service is contacted.
+
+### Destructive is False
+
+It performs no write of any kind. There is nothing for it to delete, overwrite or cancel, because the catalog is read-only data and the tool has no write path to it.
+
+
+## catalog_get
+
+### Read Only is True
+
+It returns the full detail of one catalog entry: parameters, exact price per call, documentation links, and the reliability we have observed. It is a lookup with no side effect, and no money moves.
+
+### Open World is False
+
+It reads the same fixed internal catalog as catalog_search. The caller supplies an endpoint ID we already publish, not a URL, so there is no way to point it at an arbitrary host.
+
+### Destructive is False
+
+It is a read-only lookup. It has no write path and cannot remove or modify anything.
+
+
+## call
+
+These four are the deliberately cautious ones. treg relays to a third-party API on the user's behalf.
+We do not model what that API does, and we would rather over-warn than let a client assume safety we
+cannot promise.
+
+### Read Only is False
+
+It performs a real API call to a third-party provider and can spend money from the team's prepaid balance. Two things change: the upstream provider does whatever that endpoint does, and the balance is debited. Neither is a read.
+
+### Open World is True
+
+This is the tool's whole purpose. It calls external APIs across roughly 2,600 catalogued endpoints from many independent providers, and it can also call an endpoint the user's own team registered at any URL. The set of systems it can reach is open by design and is not bounded by us.
+
+### Destructive is True
+
+We label it destructive because treg cannot see inside the endpoint being called. The catalog includes endpoints that create, update, cancel and delete on third-party systems, and treg relays whatever the caller asks for. Claiming otherwise would be a guess presented as a fact, so we take the cautious label and let the client ask the user first. treg itself never deletes user data. The risk being flagged is the upstream API's, which is exactly the risk the caller cannot otherwise see.
+
+### Idempotent is False
+
+Repeating a call can charge again and can repeat a side effect upstream. Some catalog endpoints are plain lookups, but many are not, and treg has no reliable way to tell them apart, so it does not claim safety it cannot verify.
+
+
+## balance
+
+### Read Only is True
+
+It reports the team's prepaid balance and any spend currently in flight. It reads the ledger and writes nothing. It cannot add, move or refund funds.
+
+### Open World is False
+
+It reads treg's own database only. No third-party system is contacted.
+
+### Destructive is False
+
+Reporting a number changes nothing. There is no write path from this tool to the ledger.
+
+
+## my_tools
+
+### Read Only is True
+
+It lists the API tools the user's team has already registered with treg, so the model knows what it may call. It is a directory listing. Nothing is created, changed or removed, and no credential is revealed, only names and base URLs.
+
+### Open World is False
+
+It reads treg's own database only, scoped to the team the user chose when authorizing. No external system is contacted.
+
+### Destructive is False
+
+It is a read-only listing with no write path. It cannot unregister a tool or alter a credential.


### PR DESCRIPTION
Two files, written to be copied field by field rather than read.

**`PLUGIN-TOOL-JUSTIFICATIONS.md`** covers all 16 annotation fields across the five tools, taken from
what `tools/list` actually returns on production rather than what the code intends.

Four tools are read-only and closed-world. `call` is the one that matters, labelled destructive,
open-world and non-idempotent on purpose. The reasoning given to the reviewer is the honest one: treg
cannot see inside the endpoint being called, and claiming safety we cannot verify would be a guess
presented as a fact. It also states that treg itself never deletes user data, since the flagged risk
belongs to the upstream API.

**`PLUGIN-TEST-CASES.md`** has the 5 positive and 3 negative cases. Every positive case was run
against production first, so "expected output" describes what happens rather than what should. Test 5
notes the demo team's tool list may be **empty** and that saying so is the correct answer, so a
reviewer does not read it as a failure.

The negative cases target the three ways a model over-triggers here: general knowledge, a request to
*write* code that calls an API, and a task that merely contains the word "email".

Also recorded for next time: the form wants username/password credentials and **treg has no
passwords**. Every door needs an inbox we cannot share, and the one mechanism that fits
(`/auth/invite-signin?t=`) is deliberately one-time and never returns its token through the API.