### PR TITLE
feat(auth): team-pin the dashboard API key so it works as a bare MCP bearer

### DIFF
--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -53,9 +53,16 @@ Two are **session** (cookie) paths, one is a token fallback:
   dashboard just `location.reload()`s into session mode — identical to GitHub.
 - Either way the dashboard authenticates with the **cookie** (`credentials:'include'`) + picks the org
   with **`X-Treg-Org`**, detected via `/auth/me` on load. Cookie `Secure` only on HTTPS (`_is_https`).
-  For copy-paste convenience it also fetches `GET /auth/cli-token` on load into `myToken` (a minted
-  identity token) — the per-tool snippets embed it + `X-Treg-Org` so a copied curl runs as-is, and a
-  **"Copy API token"** button (`copyToken`) puts it on the clipboard.
+  For copy-paste convenience it also fetches `GET /auth/cli-token` on load into `myToken` — sent WITH
+  the active-org header, so the minted identity token is **team-pinned** (`sess.make(..., org=slug)`,
+  a stateless `org` claim; the endpoint only pins a team the caller is a member of). That is the point:
+  the "API key" then works as a **bare bearer** — pasted into an MCP server's `Authorization` header,
+  where no `X-Treg-Org` can travel, it still resolves to that team (fixing the "several teams, none
+  active" wall a multi-team user hit). `require_member` uses the token's org claim when no header is
+  sent (the header still overrides), and the MCP layer surfaces it via `_internal_auth`. `myToken` is
+  re-minted whenever the active org changes (`_myTokenOrg` guard) so it always names the shown team.
+  The per-tool snippets embed it (+ `X-Treg-Org`, now redundant but harmless), and **"Copy API token"**
+  (`copyToken`) puts it on the clipboard.
 - **"For your agents" sidebar** — ONE copyable **agent instruction** (a prompt to paste into Claude
   Code / Codex), built client-side by `buildAgentPrompt(kind, inclToken)` with the caller's minted
   token + active org slug baked in. It was two prompts (admin "Setup" / consumer "Connect"), each

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -2274,12 +2274,31 @@ async def require_identity(
 
 
 @app.get("/auth/cli-token")
-async def auth_cli_token(user: User = Depends(require_identity)) -> dict:
+async def auth_cli_token(
+    user: User = Depends(require_identity),
+    x_treg_org: str = Header(default=""),
+    db: AsyncSession = Depends(get_session),
+) -> dict:
     """Mint a fresh CLI/bearer token for the authenticated caller (session cookie OR token). Identity
     tokens are stateless (`sess.make`), so handing one out rotates/invalidates nothing — it just lets
     the dashboard embed a working token in copy-paste snippets + a 'copy token' button, so a human
-    doesn't have to hunt for it in `~/.treg/config.json`. Pair it with `X-Treg-Org` to pick the org."""
-    return {"token": sess.make(user.id, CLI_TOKEN_TTL, user.token_version), "email": user.email}
+    doesn't have to hunt for it in `~/.treg/config.json`.
+
+    When the caller names a team (the dashboard sends `X-Treg-Org` for the active org, and only after
+    confirming membership), the org slug is BAKED into the token. That is what makes the dashboard's
+    "your API key" work as a bare bearer where no `X-Treg-Org` header can travel — pasted into an MCP
+    server's Authorization it resolves to that team, no header, no per-org agent token to manage. A
+    caller in one team who sends no header still gets a plain token (MCP auto-selects the sole team)."""
+    org_slug = None
+    if x_treg_org:
+        org = await _resolve_org(x_treg_org, db)
+        if org is not None:
+            m = (await db.execute(select(Membership).where(
+                Membership.user_id == user.id, Membership.org_id == org.id))).scalar_one_or_none()
+            if m is not None:               # only pin a team the caller actually belongs to
+                org_slug = org.slug
+    return {"token": sess.make(user.id, CLI_TOKEN_TTL, user.token_version, org=org_slug),
+            "email": user.email, "org": org_slug}
 
 
 @app.post("/auth/revoke-tokens")
@@ -2336,7 +2355,13 @@ async def require_member(
         user = (await _user_from_identity_token(x_treg_token, db)) if x_treg_token else await _user_from_session(treg_session, db)
         if user is None:
             raise HTTPException(status_code=401, detail="invalid token" if x_treg_token else "not authenticated")
-        org = await _resolve_org(x_treg_org, db)
+        # The X-Treg-Org header wins; a team-pinned identity token (org baked into its claim) is the
+        # fallback, so a copyable "API key" resolves as a BARE bearer where no header can travel — an
+        # MCP server's Authorization. The header still overrides, so one token can act on another team
+        # when the caller can set it (the CLI does). Only the token owner could sign it, so trusting
+        # its own org claim grants nothing they could not already reach.
+        org_ref = x_treg_org or ((sess.read_claims(x_treg_token) or {}).get("org", "") if x_treg_token else "")
+        org = await _resolve_org(org_ref, db)
         if org is None:
             raise HTTPException(status_code=400, detail="choose an org (send X-Treg-Org)")
         membership = (

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -254,7 +254,14 @@ async def _internal_auth(token: str) -> dict[str, str]:
     """
     claims = _oauth_claims(token)
     if claims is None:
-        return {"X-Treg-Token": token}
+        # Not an OAuth access token — a per-org or identity token, forwarded as-is. But an identity
+        # token may PIN a team in its own claim (the dashboard's org-scoped "API key", so it works as
+        # a bare MCP bearer where no X-Treg-Org header can travel). If it does, surface that as
+        # X-Treg-Org so `_resolve_org` takes its "pinned" path instead of asking "which team?" — the
+        # exact failure a multi-team user hit pasting their key into an MCP client.
+        from . import session as _session
+        pinned = (_session.read_claims(token) or {}).get("org")
+        return {"X-Treg-Token": token, "X-Treg-Org": pinned} if pinned else {"X-Treg-Token": token}
 
     from sqlmodel import select
 

--- a/src/treg/session.py
+++ b/src/treg/session.py
@@ -41,19 +41,29 @@ def _unb64(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
-def make(user_id: int, ttl: int = TTL_SECONDS, token_version: int = 0) -> str:
+def make(user_id: int, ttl: int = TTL_SECONDS, token_version: int = 0,
+         org: str | None = None) -> str:
     # `tv` binds the token to the user's current token_version; bumping that row invalidates every
     # token minted at an older version (see api._revoke path). Callers pass user.token_version.
-    raw = json.dumps({"uid": user_id, "exp": int(time.time()) + ttl, "tv": token_version},
-                     separators=(",", ":")).encode()
+    #
+    # `org` is optional and stateless like the rest of the claim: an identity token that PINS a team.
+    # It exists so a copyable "API key" works as a bare bearer where no `X-Treg-Org` header can travel
+    # (an MCP server's Authorization header). Omitted → today's org-less token, unchanged. Baking the
+    # slug in costs nothing to store and needs no rotation, because the whole token is re-derivable
+    # from (uid, tv, org) — the same reason the org-less one can be re-minted on every dashboard load.
+    claims = {"uid": user_id, "exp": int(time.time()) + ttl, "tv": token_version}
+    if org:
+        claims["org"] = org
+    raw = json.dumps(claims, separators=(",", ":")).encode()
     sig = hmac.new(_key(), raw, hashlib.sha256).digest()
     return f"{_b64(raw)}.{_b64(sig)}"
 
 
 def read_claims(cookie: str) -> dict | None:
-    """Return the token's claims ({uid, exp, tv}) if it is validly signed and unexpired, else None.
+    """Return the token's claims ({uid, exp, tv, org?}) if validly signed and unexpired, else None.
     `tv` defaults to 0 for tokens minted before token_version existed, so old tokens stay valid
-    against a user whose token_version is still 0 (no forced logout on deploy)."""
+    against a user whose token_version is still 0 (no forced logout on deploy). `org` is present only
+    on a team-pinned identity token (see `make`); absent for a plain one."""
     if not cookie or "." not in cookie:
         return None
     try:
@@ -65,7 +75,10 @@ def read_claims(cookie: str) -> dict | None:
         data = json.loads(raw)
         if int(data.get("exp", 0)) < time.time():
             return None
-        return {"uid": int(data["uid"]), "exp": int(data["exp"]), "tv": int(data.get("tv", 0))}
+        out = {"uid": int(data["uid"]), "exp": int(data["exp"]), "tv": int(data.get("tv", 0))}
+        if data.get("org"):
+            out["org"] = str(data["org"])
+        return out
     except Exception:  # noqa: BLE001 — any malformed cookie is simply "no session"
         return None
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -3403,7 +3403,7 @@ createApp({
       exPath:'<PATH>', exMethod:'GET',
       tryTool:null, tryMethod:'GET', tryPath:'', tryBody:'', trying:false, tryResp:null, tryStatus:0, tryMs:0,
       useMode:'call', runArgsStr:'', running:false, runOut:null,
-      startCopied:'', startTab:'access', startAgentOpen:false, startTokenShow:false, mdMenu:false, llmsCopied:false, myToken:null, tokenCopied:false,
+      startCopied:'', startTab:'access', startAgentOpen:false, startTokenShow:false, mdMenu:false, llmsCopied:false, myToken:null, _myTokenOrg:null, tokenCopied:false,
       agentGuide:null, agentGuideCopied:false, agentRowCopied:null,
       demo:{
         token:null, org_slug:'', ttl:60, busy:false, err:'', copied:'', signin:false,
@@ -5148,7 +5148,13 @@ createApp({
       try{
         this.myOrgs=await this.api('/orgs');
         if(!this.sessionMode && !this.me){ const who=await this.api('/auth/me').catch(()=>null); if(who){ this.me=who.email; this.isAdmin=!!who.is_superadmin; } }  // token mode: learn our own email + superadmin flag (isPersonal / join-by-code)
-        if(this.myToken===null){ this.myToken=(await this.api('/auth/cli-token').catch(()=>null)||{}).token||null; }  // a real bearer token to embed in copy snippets + the "copy token" button (works in session AND token mode)
+        // Re-mint the bearer whenever the ACTIVE org changes: the token now bakes the org slug in
+        // (so it works as a bare MCP Authorization bearer), and a stale one would name the old team.
+        // Stateless mint — cheap, nothing stored, nothing rotated.
+        if(this.myToken===null || this._myTokenOrg!==this.activeSlugNow){
+          this.myToken=(await this.api('/auth/cli-token').catch(()=>null)||{}).token||null;
+          this._myTokenOrg=this.activeSlugNow;
+        }
         if(this.sessionMode){ this.pendingInvites=await this.api('/invites/mine').catch(()=>[]); }  // BEFORE the no-orgs early return: an invited user has 0 orgs but DOES have a pending invite — maybeOnboard needs it to offer joining instead of forcing create-team
         if(!this.myOrgs.length){ this.tools=[]; this.bundles=[]; this.health={}; return; }  // brand-new user: no team yet → the mandatory welcome (maybeOnboard) creates the first one; skip org-scoped fetches (they'd 400). finally{} clears loading.
         if(this.sessionMode && (!this.activeSlug || !this.myOrgs.some(o=>o.slug===this.activeSlug)) && this.myOrgs.length){

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -45,6 +45,19 @@ def test_session_sign_roundtrip_tamper_expiry():
     assert sess.read(sess.make(1, ttl=-1)) is None  # expired
 
 
+def test_token_can_carry_an_org_claim_statelessly():
+    """A team-pinned identity token: same stateless HMAC, plus an `org` slug. Omitting org keeps the
+    plain shape (backward-compatible); passing it round-trips — and the signature still covers it, so
+    a tampered org is rejected like any other tampered claim."""
+    plain = sess.read_claims(sess.make(7))
+    assert plain is not None and "org" not in plain          # unchanged when no org given
+    pinned = sess.read_claims(sess.make(7, org="acme"))
+    assert pinned is not None and pinned["org"] == "acme" and pinned["uid"] == 7
+    # tampering the payload to inject/forge an org breaks the signature
+    good = sess.make(7, org="acme")
+    assert sess.read_claims(good + "x") is None
+
+
 @pytest.fixture
 async def gc(monkeypatch):
     monkeypatch.setenv("TREG_GITHUB_CLIENT_ID", "cid")
@@ -145,6 +158,30 @@ async def test_cli_token_mints_a_usable_identity_token(clients):
 async def test_cli_token_requires_auth(clients):
     r = await clients.get("/auth/cli-token", headers={"X-Treg-Token": "nope"})
     assert r.status_code == 401
+
+
+async def test_cli_token_bakes_the_active_org_and_works_as_a_BARE_bearer(clients):
+    """The point of this whole change: when the dashboard asks for its API key WITH the active team
+    (X-Treg-Org), the returned token pins that team — so it authenticates a call as a BARE bearer,
+    no X-Treg-Org header. That is what lets it be pasted into an MCP server's Authorization, where no
+    second header can travel, and still resolve to the right team."""
+    slug = (await clients.get("/orgs")).json()[0]["slug"]
+    r = await clients.get("/auth/cli-token", headers={"X-Treg-Org": slug})
+    assert r.status_code == 200 and r.json().get("org") == slug, r.text
+    baked = r.json()["token"]
+    # the baked token works with NO X-Treg-Org — the org rides on the token
+    ok = await clients.get("/tools", headers={"X-Treg-Token": baked, "X-Treg-Org": ""})
+    assert ok.status_code == 200, ok.text
+
+
+async def test_cli_token_refuses_to_pin_a_team_you_are_not_in(clients):
+    """The org claim is only baked when the caller is actually a member — a header naming someone
+    else's team yields a plain (unpinned) token, never one that pins a team you cannot reach."""
+    r = await clients.get("/auth/cli-token", headers={"X-Treg-Org": "some-other-teams-slug"})
+    assert r.status_code == 200 and r.json().get("org") is None, r.text
+    # and the plain token still needs X-Treg-Org, proving it wasn't silently pinned
+    plain = r.json()["token"]
+    assert (await clients.get("/tools", headers={"X-Treg-Token": plain, "X-Treg-Org": ""})).status_code == 400
 
 
 # ---- Google OAuth (a parallel login door) -------------------------------------------------


### PR DESCRIPTION
## Why
The dashboard's **"YOUR API KEY"** was an org-**less** identity token. Pasted into an MCP server's `Authorization` header — where no `X-Treg-Org` can travel — a **multi-team** user got `"several teams, none active"`, so the key looked broken. To match the AgentKey-style "paste a key, no browser" setup, the org has to ride *on* the key.

## What
A minimal, backward-compatible change: the identity token gains an optional **stateless `org` claim**.
- `session.make(..., org=slug)` — same HMAC construction, nothing stored, **no rotation** (so it's still re-minted on every dashboard load, exactly like today).
- `GET /auth/cli-token` bakes in the **active org** (sent via `X-Treg-Org`), and only a team the caller is actually a member of.
- `require_member` falls back to the token's `org` claim when no `X-Treg-Org` header is sent — **the header still overrides**, so the CLI can still act on another team.
- The MCP layer surfaces the claim through `_internal_auth`, so `_resolve_org` takes its "pinned" path instead of asking "which team?".
- Dashboard re-mints `myToken` on org switch (`_myTokenOrg` guard).

## Result
```
claude mcp add --transport http treg https://treg.superdesign.dev/mcp/ \
  --header "Authorization: Bearer <the dashboard's API key>"
```
→ tools work, **single-team AND multi-team**, no browser, no second header. Same key still works in curl (org-less header now redundant but harmless).

## Verified
- Full suite green (1298), incl. new tests: `org` claim round-trips + tamper-rejects; `/auth/cli-token` bakes the active org and the baked token works as a bare bearer; refuses to pin a team you're not in.
- **Live, multi-team**: created a 2-team user → dashboard key baked `org: beta-2` → pasted as a bare MCP bearer (no `X-Treg-Org`) → `balance` resolved to `beta-2` ($1.00). Dashboard-side confirmed the displayed key carries the claim.

Server change → ships with the next prod deploy. Complements the OAuth flow in #79 (this is the no-browser alternative; both hit `/mcp/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)