### PR TITLE
feat(cli): treg mcp install — headless, header-authed, user-global MCP setup

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -184,3 +184,23 @@ origin check) and that consent failed intermittently on `Origin: null`.
 - **No per-provider MCP tools.** See above.
 - **No routing or failover.** treg publishes facts and calls what it is told; the agent chooses.
 - **No second copy of the enforcement rules.** Everything goes through the API's own routes.
+
+## Two ways to authenticate the MCP server: OAuth, or a header
+
+OAuth (above) is the click-to-connect path. There is also a **headless** path, and it is the default
+the installer uses: a **team-pinned token as an `Authorization: Bearer` header**. `treg mcp install`
+(`mcp_install.py`, sibling of `treg skill bootstrap`) registers the server into every supported agent
+with that header — Claude Code via its own `claude mcp add --scope user` (user-global, not the
+default project scope; it owns its format and redacts the token), Cursor and opencode via their
+documented JSON (`~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`). Codex (TOML +
+`bearer_token_env_var`), Hermes (yaml) and OpenClaw are **reported, not written** — their formats
+aren't safely expressible from the light CLI (no toml writer, yaml is a server-only dep), so we print
+the exact manual step rather than a config we haven't runtime-verified.
+
+Why a header works even though treg advertises OAuth: a client only falls back to OAuth discovery on
+a **401**, and treg returns **200** for a valid header — verified against Claude Code, which
+otherwise prefers OAuth (issue #59467). The determinant is "does the server 200 a valid header," not
+"does it advertise OAuth"; AgentKey behaves the same way. The token is the dashboard's org-baked
+"API key" (see [dashboard](../interface/dashboard.md)), so it carries the team and needs no second
+header. `curl {BASE}/install.sh | sh -s -- --token <key>` runs the whole thing — install, sign in,
+`treg mcp install` — in one paste.

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3327,6 +3327,34 @@ def cmd_skill_install(args, cfg) -> None:
         print(f"  {_M}Overwrites local edits — confirm before you --force.{_R}")
 
 
+def cmd_mcp_install(args, cfg) -> None:
+    """Register the treg MCP server into every supported agent on this machine, header-authed with
+    the logged-in token (which bakes in the team, so no org to pass). The MCP sibling of
+    `treg skill bootstrap` — install.sh calls it after login, and it is runnable by hand. Needs a
+    token: run `treg login` first (or `treg login --token <key>`)."""
+    from . import mcp_install
+    token = os.environ.get("TREG_TOKEN") or cfg.get("token")
+    if not token:
+        sys.exit("no token — run `treg login` first (or `treg login --token <key>`), then retry")
+    base_url = (cfg.get("base_url") or "https://treg.superdesign.dev").rstrip("/")
+    name = getattr(args, "name", None) or "treg"
+    out = mcp_install.install_mcp(base_url=base_url, token=token, server_name=name)
+    ok = 0
+    for display, status, detail in out["results"]:
+        if status == "ok":
+            ok += 1; print(f"  ✓ {display} → {detail}")
+        elif status == "skipped":
+            print(f"  · {display} skipped — {detail}")
+        else:
+            print(f"  ✗ {display}: {detail}")
+    if not out["results"]:
+        print("  (no MCP-capable agents detected — nothing to register)")
+    for display, how in out["manual"]:
+        print(f"  ⚠ {display}: not auto-configured — {how}")
+    print(f"\nRegistered the treg MCP server ({out['mcp_url']}) into {ok} agent(s). "
+          f"Restart an agent to pick it up.")
+
+
 def cmd_skill_bootstrap(args, cfg) -> None:
     """Fetch the official treg skill from the server and drop it into every detected agent's
     skills dir, so whatever agent the user runs already knows how to use treg. install.sh calls this
@@ -5009,6 +5037,14 @@ def build_parser() -> argparse.ArgumentParser:
                      help="every known agent's dir, not just the ones detected on this machine")
     skb.add_argument("--project", action="store_true", help="write into project dirs instead of the per-user global dirs")
     skb.set_defaults(fn=cmd_skill_bootstrap)
+
+    # ---- mcp (register the treg MCP server into detected agents, header-authed) ----
+    mc = mk(sub, "mcp", "Register the treg MCP server into the coding agents on this machine.",
+            "treg mcp install").add_subparsers(dest="sub", required=True, metavar="<subcommand>")
+    mci = mk(mc, "install", "Add treg as a header-authed MCP server in every supported detected agent.",
+             "treg mcp install")
+    mci.add_argument("--name", default="treg", help="the MCP server name to register (default: treg)")
+    mci.set_defaults(fn=cmd_mcp_install)
 
     # ---- agents (which coding agents treg installs skills for) ----
     ag = mk(sub, "agents", "List the coding agents treg can install skills for (and which are detected here).",

--- a/src/treg/mcp_install.py
+++ b/src/treg/mcp_install.py
@@ -1,0 +1,140 @@
+"""Register treg's MCP server into the coding agents on this machine — headless, header-authed.
+
+The sibling of `treg skill bootstrap`. Bootstrap drops a SKILL.md into each agent's skills dir (a
+uniform file-drop). MCP is not uniform: each agent keeps its server list in its OWN file and schema,
+so this writes each format rather than one shared thing.
+
+**Why a static `Authorization` header and not OAuth here.** treg IS an OAuth authorization server,
+and a browser "connect" flow exists — but the whole point of this command is the *headless* path: an
+agent (or install.sh) is handed a team-scoped token and wires every agent up with no browser. A
+client only falls back to OAuth discovery when it gets a 401; treg returns 200 for a valid header, so
+the header is honoured and OAuth never triggers (verified against Claude Code, which otherwise prefers
+OAuth — the determinant is "does the server 200 a valid header", which treg does).
+
+**Kept deliberately small and correct over broad.** Only agents whose MCP format is verified are
+written: Claude Code via its own `claude mcp add` (it owns its format, and redacts the token in its
+output), Cursor and opencode via their documented JSON. CLI-light: stdlib only — no yaml (server-only
+dep) and no toml writer (not in stdlib), which is why Hermes (yaml) and Codex (toml + an env-var
+indirection, not an inline header) are reported as manual rather than half-written wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+HOME = Path.home()
+
+
+def _config_home() -> Path:
+    return Path(os.environ.get("XDG_CONFIG_HOME", HOME / ".config"))
+
+
+# name -> how to register. `marker` mirrors agents.py (existence = installed). `kind` picks the writer.
+MCP_AGENTS: dict[str, dict] = {
+    "claude": {"display": "Claude Code", "kind": "claude_cli",
+               "marker": lambda: (HOME / ".claude").exists() or bool(shutil.which("claude"))},
+    "cursor": {"display": "Cursor", "kind": "json",
+               "path": lambda: HOME / ".cursor" / "mcp.json", "root": "mcpServers",
+               "entry": lambda url, tok: {"url": url, "headers": {"Authorization": f"Bearer {tok}"}},
+               "marker": lambda: (HOME / ".cursor").exists()},
+    "opencode": {"display": "opencode", "kind": "json",
+                 "path": lambda: _config_home() / "opencode" / "opencode.json", "root": "mcp",
+                 "entry": lambda url, tok: {"type": "remote", "url": url, "enabled": True,
+                                            "headers": {"Authorization": f"Bearer {tok}"}},
+                 "marker": lambda: (_config_home() / "opencode").exists()},
+}
+
+# Detected but not auto-written — the format isn't safely expressible from the light CLI. We tell the
+# user exactly how instead of writing a config we haven't runtime-verified.
+MANUAL_AGENTS: dict[str, dict] = {
+    "codex": {"display": "Codex", "marker": lambda: (HOME / ".codex").exists(),
+              "how": "Codex uses ~/.codex/config.toml with `bearer_token_env_var` (a reference to an "
+                     "env var, not an inline header) — set TREG_TOKEN in its environment and add "
+                     "`[mcp_servers.treg]` with url + bearer_token_env_var = \"TREG_TOKEN\"."},
+    "hermes": {"display": "Hermes", "marker": lambda: (HOME / ".hermes").exists(),
+               "how": "add to ~/.hermes/config.yaml under mcp_servers: a `url` + `headers: "
+                      "{Authorization: \"Bearer <token>\"}` entry."},
+    "openclaw": {"display": "OpenClaw", "marker": lambda: (HOME / ".openclaw").exists()
+                 or bool(shutil.which("openclaw")),
+                 "how": "run `openclaw mcp add --transport http treg <url> --header "
+                        "\"Authorization: Bearer <token>\"`."},
+}
+
+
+def _installed(meta: dict) -> bool:
+    try:
+        return bool(meta["marker"]())
+    except Exception:  # noqa: BLE001 — a marker that can't be evaluated is "not installed"
+        return False
+
+
+def _write_json_agent(meta: dict, name: str, url: str, token: str) -> tuple[str, str]:
+    """Merge one server entry into an agent's JSON config, preserving everything else. Returns
+    (status, detail). Idempotent: re-running overwrites just our entry."""
+    path: Path = meta["path"]()
+    try:
+        data = json.loads(path.read_text()) if path.exists() else {}
+        if not isinstance(data, dict):
+            return "error", f"{path} is not a JSON object"
+        root = meta["root"]
+        servers = data.get(root)
+        if not isinstance(servers, dict):
+            servers = {}
+        servers[name] = meta["entry"](url, token)
+        data[root] = servers
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2) + "\n")
+        os.replace(tmp, path)
+        return "ok", str(path)
+    except Exception as exc:  # noqa: BLE001 — report, never crash the whole install
+        return "error", f"{path}: {exc}"
+
+
+def _write_claude(name: str, url: str, token: str) -> tuple[str, str]:
+    """Register with Claude Code through its OWN CLI — it owns its config format and redacts the token
+    in its output. Remove-then-add makes it idempotent (a plain add errors if the name exists)."""
+    claude = shutil.which("claude")
+    if not claude:
+        return "skipped", "the `claude` CLI is not on PATH"
+    try:
+        # `--scope user` = available across ALL the user's projects, not the default `local` (which
+        # pins it to the current directory). This is a per-machine setup, not a per-repo one.
+        subprocess.run([claude, "mcp", "remove", "--scope", "user", name],
+                       capture_output=True, text=True, timeout=30)
+        r = subprocess.run(
+            [claude, "mcp", "add", "--scope", "user", "--transport", "http", name, url,
+             "--header", f"Authorization: Bearer {token}"],
+            capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            return "error", (r.stderr or r.stdout or "claude mcp add failed").strip()[:200]
+        return "ok", "via `claude mcp add --scope user`"
+    except Exception as exc:  # noqa: BLE001
+        return "error", str(exc)
+
+
+def install_mcp(*, base_url: str, token: str, server_name: str = "treg",
+                only: list[str] | None = None) -> dict:
+    """Register the treg MCP server into every supported, installed agent on this machine.
+
+    Returns {results: [(agent_display, status, detail)], manual: [(display, how)], mcp_url}.
+    `status` ∈ ok | skipped | error. `only` restricts to named agents (else all detected)."""
+    url = base_url.rstrip("/") + "/mcp/"
+    results: list[tuple[str, str, str]] = []
+    for key, meta in MCP_AGENTS.items():
+        if only and key not in only:
+            continue
+        if not _installed(meta):
+            continue
+        if meta["kind"] == "claude_cli":
+            status, detail = _write_claude(server_name, url, token)
+        else:
+            status, detail = _write_json_agent(meta, server_name, url, token)
+        results.append((meta["display"], status, detail))
+    manual = [(m["display"], m["how"]) for k, m in MANUAL_AGENTS.items()
+              if (not only or k in only) and _installed(m)]
+    return {"results": results, "manual": manual, "mcp_url": url}

--- a/src/treg/web/install.sh
+++ b/src/treg/web/install.sh
@@ -4,6 +4,20 @@
 set -e
 
 BASE="{BASE}"
+
+# Optional token for a one-shot, fully-authed setup:
+#   curl -fsSL {BASE}/install.sh | sh -s -- --token <key>      (or: TREG_TOKEN=<key> … | sh)
+# With it, this installs the CLI + skill AND signs in + registers the MCP server into every supported
+# agent, header-authed — no browser. The key bakes in the team, so nothing else is needed. Without a
+# token, it installs the CLI + skill and prints the sign-in step (the original behavior, unchanged).
+TOKEN="${TREG_TOKEN:-}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --token) TOKEN="$2"; shift 2 ;;
+    --token=*) TOKEN="${1#--token=}"; shift ;;
+    *) shift ;;
+  esac
+done
 # Install from PyPI (fast, public, no git clone). The base package is the light CLI; the FastAPI/DB
 # server stack is the `tools-registry[server]` extra, which people who self-host install separately.
 #
@@ -43,7 +57,20 @@ else
   fi
 fi
 
-printf '\n\033[32m✓\033[0m Installed \033[1mtreg\033[0m. Next:\n'
-printf '    \033[38;5;173mtreg login\033[0m      # sign in (GitHub or email) - first login registers you\n'
-printf '    \033[38;5;173mtreg onboard\033[0m    # optional guided walkthrough\n'
-printf '\nDocs & interactive tutorial:  %s/tutorial\n\n' "$BASE"
+# One-shot authed setup when a token was passed: sign in (the key bakes in the team) and register the
+# MCP server into every supported agent, header-authed. Both are best-effort — a failure here never
+# fails the install, since the CLI + skill are already in place.
+if [ -n "$TOKEN" ]; then
+  if treg login --token "$TOKEN" >/dev/null 2>&1; then
+    printf '\033[32m✓\033[0m Signed in.\n'
+    treg mcp install 2>/dev/null || true
+  else
+    printf '\033[33m!\033[0m That token did not verify — run \033[1mtreg login\033[0m to sign in.\n'
+  fi
+  printf '\n\033[32m✓\033[0m treg is set up. Docs & tutorial:  %s/tutorial\n\n' "$BASE"
+else
+  printf '\n\033[32m✓\033[0m Installed \033[1mtreg\033[0m. Next:\n'
+  printf '    \033[38;5;173mtreg login\033[0m      # sign in (GitHub or email) - first login registers you\n'
+  printf '    \033[38;5;173mtreg mcp install\033[0m  # optional: add treg as an MCP server in your agents\n'
+  printf '\nDocs & interactive tutorial:  %s/tutorial\n\n' "$BASE"
+fi

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -183,6 +183,14 @@ recognizes the catalog CLI and wires the credential, so `treg run` works with no
 Installs the `treg` command (Python 3.12+) and points it at this server. Everything below is
 also doable over raw HTTP (see the call protocol) - the CLI is just a thin client.
 
+**One-shot, fully authed (recommended when you were handed a token):**
+
+    curl -fsSL {BASE}/install.sh | sh -s -- --token <TOKEN>
+
+That installs the CLI + skill, signs in, and registers the treg MCP server into every supported agent
+(Claude Code, Cursor, opencode; others reported) — header-authed, no browser. The token bakes in the
+team, so nothing else is needed. `TREG_TOKEN=<TOKEN> …| sh` works too.
+
 ## Get a token
 
 Three human sign-in doors (email is the identity; the door just proves it):
@@ -191,15 +199,22 @@ Three human sign-in doors (email is the identity; the door just proves it):
 - **Email one-time code** - `treg login --email you@company.com` (a 6-digit code is emailed).
 - **Invite code** - `treg org join <code> --email you@company.com` (creates you + joins a team).
 
-Agents/CI use a **per-org token** directly: `treg login --token <token>`. Get one from
-`treg org create` / `treg org join` (returned once), or ask a team owner. The token goes
-in the `X-Treg-Token` header on every call. Never share the upstream key - share access.
+Agents/CI use a token directly: `treg login --token <token>`. A dashboard "API key" bakes in the
+team (so it needs no `X-Treg-Org` — it works as a bare bearer, including as an MCP `Authorization`
+header); a per-org token from `treg org create` / `treg org join` does too. Never share the upstream
+key - share access.
 
-## MCP — connect an assistant instead of copying a token
+## MCP — connect an assistant
 
-treg is also an **MCP server** at `{BASE}/mcp/`. Any client that speaks the MCP authorization spec
-— ChatGPT, Claude Code, Cursor — connects with a link and a consent screen rather than a pasted
-token. Choose **OAuth** when the client asks; there is no API-key option to look for.
+treg is also an **MCP server** at `{BASE}/mcp/`, two ways to authenticate it:
+
+- **Header (headless, no browser):** `treg mcp install` registers it into every supported agent
+  (Claude Code at user scope, Cursor, opencode) with your token as an `Authorization: Bearer` header
+  — this is what the one-shot installer above runs for you. treg 200s a valid header, so the client
+  uses it directly and never falls back to OAuth.
+- **OAuth (click to connect):** any client that speaks the MCP authorization spec — ChatGPT, Claude
+  Code, Cursor — can instead connect with a link + consent screen. Choose **OAuth** when the client
+  asks; the token is issued to the team you pick.
 
 Five tools, the same ones for every client:
 
@@ -272,6 +287,8 @@ are both supported; you do not need to pre-arrange anything with us.
       [--no-egress] [--refresh-egress]            runs under a dedicated treg-run user + egress allow-list
 
     treg skill init --dir D | skill add --dir D | skill ls | skill rm <id>
+    treg mcp install                              register treg as a header-authed MCP server in
+                                                  every supported agent (Claude Code/Cursor/opencode)
     treg skill install <name> [--all] [--dir D]   pull a shared skill's recipe into .claude/skills/
     treg scan [env|skills] [--dir D]              read-only preview: list the keys & skills upload
                                                   would register (nothing leaves the machine)

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -1,0 +1,59 @@
+"""`treg mcp install` — registering the treg MCP server into agents, header-authed, user-global.
+
+The header path is deliberate: treg 200s a valid Authorization header, so a client never falls back
+to OAuth discovery (verified against Claude Code). These tests lock the config each agent actually
+writes and the user-global scope — a project-scoped MCP entry is a per-repo surprise, not a setup.
+"""
+from __future__ import annotations
+
+import json
+
+from treg import mcp_install
+
+
+def test_json_agents_write_user_global_header_config(tmp_path, monkeypatch):
+    """Cursor + opencode: a header-authed entry in the per-USER config file (not a project ./ file),
+    merged so anything already there survives, and idempotent on re-run."""
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    # pre-existing unrelated servers must be preserved
+    cur = tmp_path / ".cursor"; cur.mkdir()
+    (cur / "mcp.json").write_text(json.dumps({"mcpServers": {"other": {"url": "http://x"}}}))
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+
+    out = mcp_install.install_mcp(base_url="https://treg.superdesign.dev", token="TESTKEY",
+                                  only=["cursor", "opencode"])
+    got = {d: (s, detail) for d, s, detail in out["results"]}
+    assert got["Cursor"][0] == "ok" and got["opencode"][0] == "ok", out
+
+    cursor = json.loads((cur / "mcp.json").read_text())
+    assert cursor["mcpServers"]["other"] == {"url": "http://x"}          # untouched
+    treg = cursor["mcpServers"]["treg"]
+    assert treg["url"] == "https://treg.superdesign.dev/mcp/"
+    assert treg["headers"]["Authorization"] == "Bearer TESTKEY"
+
+    oc = json.loads((tmp_path / ".config" / "opencode" / "opencode.json").read_text())
+    assert oc["mcp"]["treg"]["type"] == "remote" and oc["mcp"]["treg"]["enabled"] is True
+    assert oc["mcp"]["treg"]["headers"]["Authorization"] == "Bearer TESTKEY"
+
+    # idempotent: a second run leaves exactly one entry, still correct
+    mcp_install.install_mcp(base_url="https://treg.superdesign.dev", token="TESTKEY", only=["cursor"])
+    again = json.loads((cur / "mcp.json").read_text())
+    assert list(again["mcpServers"].keys()) == ["other", "treg"]
+
+
+def test_uninstalled_agents_are_skipped_not_written(tmp_path, monkeypatch):
+    """No marker dir → the agent isn't touched (no stray config created for something not installed)."""
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    out = mcp_install.install_mcp(base_url="https://treg.superdesign.dev", token="K",
+                                  only=["cursor", "opencode"])
+    assert out["results"] == []                       # nothing installed → nothing written
+    assert not (tmp_path / ".cursor").exists()
+
+
+def test_the_mcp_url_carries_the_trailing_slash():
+    """The resource identifier is `/mcp/` — the transport is served there, and a client that resolves
+    metadata uses that exact form."""
+    out = mcp_install.install_mcp(base_url="https://treg.superdesign.dev/", token="K", only=[])
+    assert out["mcp_url"] == "https://treg.superdesign.dev/mcp/"

--- a/tests/test_skill_md.py
+++ b/tests/test_skill_md.py
@@ -21,3 +21,12 @@ async def test_skill_md_served_and_templated(clients):
 def test_install_sh_installs_the_skill():
     sh = (Path(api_mod.__file__).parent / "web" / "install.sh").read_text()
     assert "$BASE/skill.md" in sh and ".claude/skills/treg" in sh
+
+
+def test_install_sh_supports_the_one_shot_authed_setup():
+    """`… | sh -s -- --token <key>` (or TREG_TOKEN=) → sign in + register MCP in one go; the key
+    bakes in the team, so no org is passed. Without a token the flow is unchanged."""
+    sh = (Path(api_mod.__file__).parent / "web" / "install.sh").read_text()
+    assert "--token" in sh and "TREG_TOKEN" in sh
+    assert "treg login --token" in sh
+    assert "treg mcp install" in sh


### PR DESCRIPTION
Re-targets #81 to `main`. #81 was based on `feat/org-scoped-api-key` and got merged **into that branch** right after #80 had already merged it to main — so the mcp-install commit never reached main. Rebased onto current main; this is the clean single-commit delta.

The `treg skill bootstrap` sibling for MCP. Registers the treg MCP server into every supported agent using the org-baked token as an `Authorization: Bearer` header — headless, no browser.

## Why header auth works (verified, not assumed)
A client only falls back to OAuth discovery on a **401**; treg returns **200** for a valid header, so the header is honoured and OAuth never triggers. Confirmed live against **Claude Code** (which otherwise prefers OAuth, issue #59467) — returned a real balance via the header. AgentKey behaves identically.

## User-global, not project
- **Claude Code** → `claude mcp add --scope user` (its own CLI owns the format + redacts the token). Verified: `claude mcp get treg` → *"Scope: User config (available in all your projects)."*
- **Cursor** → `~/.cursor/mcp.json` · **opencode** → `~/.config/opencode/opencode.json` (per-user, merged, idempotent).
- **Codex / Hermes / OpenClaw** → *reported with the exact manual step, not written* — their formats (TOML + `bearer_token_env_var` indirection; YAML) aren't safely expressible from the light CLI (no stdlib TOML writer; PyYAML is a server-only dep).

## One-shot installer
```
curl -fsSL https://treg.superdesign.dev/install.sh | sh -s -- --token <key>
```
→ install CLI + skill, sign in, `treg mcp install` — the whole authed setup in one paste. Without a token, unchanged.

## Verified
- Full suite green earlier (1302); `test_mcp_install.py` + `test_skill_md.py` green on the rebased branch.
- Docs fragment (`mcp-oauth.md`) updated in the same commit, per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)