### PR TITLE
release: 0.8.0

### DIFF
--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Call ~2,600 curated API endpoints across ~40 providers without owning the keys — treg holds the credential and meters each call from your team's prepaid balance.",
   "author": {
     "name": "superdesign",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.7.1"
+version = "0.8.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Version bump so `treg mcp install` (merged in #82) reaches pip / brew / install.sh users.

- `pyproject.toml` `0.7.1 → 0.8.0`
- `plugin/.codex-plugin/plugin.json` version tracked in lockstep (test_plugin enforces this)

No new deps (mcp_install.py is stdlib-only) → Homebrew formula needs only a url + sha256 bump. Full suite green (1307).

🤖 Generated with [Claude Code](https://claude.com/claude-code)