### PR TITLE
feat: idempotent calls — a retry must not bill twice

### DIFF
--- a/docs/IDEMPOTENT-CALLS-PLAN.md
+++ b/docs/IDEMPOTENT-CALLS-PLAN.md
@@ -1,0 +1,143 @@
+# Idempotent calls — a retry must not bill twice
+
+**Status:** planned, awaiting approval. Nothing built.
+
+## The question that prompted it
+
+> "how does result pricing handle retries, agents need idempotent billing before this works"
+
+Asked publicly, and correct. Agents retry far more than humans do, so this is not an edge case for
+treg. It is the main traffic pattern.
+
+## What already works, so we do not rebuild it
+
+Most retries are already free, and this matters because it tells us how narrow the real gap is.
+
+| Outcome | Billed? |
+|---|---|
+| 5xx, 3xx, network error, timeout upstream | never |
+| 4xx | only under `per_call`, where the provider bills for accepting the request |
+| 2xx | yes |
+
+So the common case, where an agent retries *because something failed*, costs nothing extra today.
+`_platform_billable` already draws that line.
+
+Result pricing is also settled on the provider's own reported charge rather than our estimate
+(`_observed_cost_micro`), so a Hunter lookup that finds nothing is free, and the ledger records the
+real number. 1,362 endpoints are `per_success` and 120 are `per_result`, so this is most of the
+catalog.
+
+## The actual gap
+
+One case, and only one:
+
+1. treg calls the provider
+2. the provider succeeds, and bills us
+3. the response is lost on the way back to the agent, or the agent's own client times out
+4. the agent retries
+5. treg calls the provider again and bills again
+
+From treg's side those are two successful calls with nothing linking them. The money is real: we pay
+the provider twice and charge the team twice.
+
+`ledger.topup` already has an idempotency key for exactly this reason (Stripe redelivers webhooks).
+`/call/` has none.
+
+## Not-charging-twice is not enough
+
+The cheap version is to remember that a key was already billed and skip the second charge. It is
+wrong, and it is worth being explicit about why: treg would still make the upstream call, so **we
+still pay the provider**. We would be moving the double cost from the customer onto ourselves rather
+than removing it.
+
+Real idempotency means the second request never reaches the provider. That requires storing the first
+response and replaying it, which is the Stripe model and the only version that actually solves the
+problem.
+
+## Design
+
+### The key comes from the client, or nothing happens
+
+`Idempotency-Key` on `/call/`. No key means today's behaviour exactly: no storage, no lookup, no
+change. This is deliberate. A server-invented key (hashing the URL and body, say) would silently
+collapse two calls a caller genuinely meant to make twice, and "post this twice" is a legitimate
+thing to ask of an API.
+
+### Scope: metered calls only
+
+A team calling on its **own** key is their bill and their relationship with the provider. treg has no
+business caching that, and storing those responses would mean holding other people's data for a
+reason that benefits nobody.
+
+### Only successful, billed responses are stored
+
+Failures are already free, so there is nothing to protect. This is what keeps storage bounded: we
+keep bodies only for calls that actually cost money.
+
+### A 24 hour window
+
+Retries happen within seconds. A day is generous, conventional, and easy to reason about. A row past
+its window is simply absent and the call proceeds normally.
+
+### The table
+
+`IdempotentCall`: `(org_id, key)` unique, plus `endpoint_id`, the request fingerprint, the stored
+status and body, `charged_micro`, and `expires_at`.
+
+`(org_id, key)` and not key alone: keys are client-chosen, two teams will collide eventually, and a
+collision across a tenant boundary would serve one team's data to another. That is the one failure
+here that would be a security incident rather than a billing bug.
+
+### The request fingerprint guards against key reuse
+
+A client that reuses a key for a *different* request has made a mistake, and silently returning the
+old response would hide it. Store a hash of (endpoint, method, body/query) and compare. On mismatch,
+refuse with `422` and say the key was already used for a different request. Stripe does the same, and
+the loud failure is the useful one.
+
+### Concurrency: the database decides
+
+Two retries can arrive at once, and both can miss the lookup. The `(org_id, key)` unique constraint
+is what makes that safe: insert a **placeholder row first**, and the loser of that race waits for the
+winner rather than making a second upstream call.
+
+This is the same reasoning as the conditional UPDATE in `ledger.reserve` and the deleted-before-
+validation authorization code: where two paths can read before either writes, the database has to be
+the arbiter. A check-then-act in Python would leave exactly the window this feature exists to close.
+
+### What the caller sees
+
+A replayed response carries a header saying so, along with the original charge. A retry that silently
+returned a cached body would be indistinguishable from a fresh call, and an agent reporting cost to a
+human should be able to say "this was replayed, it cost nothing extra".
+
+## Order
+
+1. The table, and `(org_id, key)` uniqueness. No behaviour yet.
+2. Lookup and replay on the read path, with the fingerprint check. Storage still off.
+3. Store on the write path, for metered successes only.
+4. The placeholder row and the concurrent-retry race.
+5. Expiry, and a reaper for rows past their window.
+6. **Stop and prove it**: fire the same key twice at a real endpoint and confirm the provider is
+   called once, the ledger moves once, and both callers get the same body.
+
+## What could go wrong, and where I would look first
+
+- **Cross-tenant key collision.** Covered by the compound key, and it is the assertion I would write
+  first, because it is the only failure here that leaks data rather than money.
+- **Storing bodies we should not.** Metered-only and 24 hours are the limits. Anything that widens
+  either should be argued for explicitly.
+- **A replay after the price changed.** The stored `charged_micro` is what was actually taken; a
+  replay charges nothing, so this is consistent by construction. Worth a test anyway.
+- **Size.** SERP and scrape responses are not small. If storage becomes a problem the answer is a
+  size ceiling above which we do not store rather than a shorter window, because a call too large to
+  cache is exactly the one whose retry is most likely to have timed out.
+- **Scope creep into a general cache.** This is a retry guard, not a response cache. It must never
+  serve a request that did not carry the same key, or it stops being a correctness feature and starts
+  being stale data.
+
+## Honest sizing
+
+Smaller than the OAuth work: one table, one lookup, one store, one race. The care goes into the
+tenant boundary and the concurrency, not the volume of code. The existing behaviour stays untouched
+for anyone who does not send a key, which keeps the blast area small.

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -6878,6 +6878,73 @@ async def _enforce_capability_pin(ep: dict, caller: Caller, db: AsyncSession) ->
     })
 
 
+IDEMPOTENCY_WINDOW_S = 24 * 3600   # retries happen in seconds; a day is generous and easy to reason about
+IDEMPOTENCY_HEADER = "idempotency-key"
+_IDEM_MAX_KEY = 200
+
+
+def _idempotency_key(request: Request) -> str:
+    """The caller's label for this request, or "" when they sent none.
+
+    Only ever the client's. A server-invented key — hashing the URL and body, say — would silently
+    collapse two calls a caller genuinely MEANT to make twice, and "do this again" is a legitimate
+    thing to ask of an API. No header means today's behaviour exactly: no lookup, no storage.
+    """
+    return (request.headers.get(IDEMPOTENCY_HEADER) or "").strip()[:_IDEM_MAX_KEY]
+
+
+def _request_fingerprint(method: str, rest: str, body: bytes) -> str:
+    """What the label was used FOR, so reusing it on a different request can be caught.
+
+    A client that reuses one label for two different requests has a bug. Quietly returning the first
+    answer would hide it, and the caller would be left wondering why their second call returned
+    somebody else's data. Refusing loudly is the useful behaviour, and it is what Stripe does.
+    """
+    h = hashlib.sha256()
+    h.update(method.upper().encode())
+    h.update(b"\0")
+    h.update(rest.encode())
+    h.update(b"\0")
+    h.update(body or b"")
+    return h.hexdigest()
+
+
+async def _replay_idempotent(key: str, fingerprint: str, caller: Caller,
+                             db: AsyncSession) -> Response | None:
+    """The stored answer for this caller's label, or None if there is nothing to replay.
+
+    Returns a real response, so the provider is never reached and no money moves. That is the whole
+    point: merely skipping the second CHARGE would still make the second upstream call, which means
+    still paying the provider and simply absorbing the double cost ourselves.
+    """
+    row = (await db.execute(select(IdempotentCall).where(
+        IdempotentCall.membership_id == caller.membership.id,
+        IdempotentCall.key == key))).scalar_one_or_none()
+    if row is None:
+        return None
+    if row.expires_at < datetime.now(timezone.utc).replace(tzinfo=None):
+        # Past its window: the label is free again, and the call proceeds normally.
+        await db.delete(row)
+        await db.commit()
+        return None
+    if row.request_fingerprint and row.request_fingerprint != fingerprint:
+        raise HTTPException(status_code=422, detail=(
+            f"Idempotency-Key {key!r} was already used for a different request. Use a new key, or "
+            f"repeat the original request exactly."))
+    if row.status != "done" or row.response_status is None:
+        # Still in flight. The first call is talking to the provider right now; telling the caller to
+        # retry is honest and cheap, and it is what stops the second one duplicating the spend.
+        raise HTTPException(status_code=409, detail=(
+            f"a call with Idempotency-Key {key!r} is still in progress — retry shortly"))
+    return Response(
+        content=row.response_body or b"",
+        status_code=row.response_status,
+        media_type=row.response_media_type or "application/json",
+        headers={"X-Treg-Idempotent-Replay": "true",
+                 "X-Treg-Cost-Micro": str(row.charged_micro)},
+    )
+
+
 async def _resolve_marketplace_call(
     ep: dict, request: Request, caller: Caller, db: AsyncSession
 ) -> MarketplaceCall:
@@ -7206,6 +7273,18 @@ async def call_tool(
         _, sep, raw_rest = raw_path.decode("ascii", "replace").partition("/call/")
         if sep:
             rest = raw_rest
+    # A retry the caller has labelled: answer it from what we already returned, before resolving
+    # anything or reaching a provider. Nothing happens without the header, so a caller who sends none
+    # sees exactly today's behaviour.
+    idem_key = _idempotency_key(request)
+    idem_fingerprint = ""
+    if idem_key:
+        idem_body = await request.body()
+        idem_fingerprint = _request_fingerprint(request.method, rest, idem_body)
+        replayed = await _replay_idempotent(idem_key, idem_fingerprint, caller, db)
+        if replayed is not None:
+            return replayed
+
     drop_params: set[str] = set()
     mk: MarketplaceCall | None = None
     try:

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -51,9 +51,9 @@ from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
-from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold, Invite,
-                     LedgerEntry, Membership, OAuthClient, OAuthCode, OAuthRefresh, Org,
-                     PendingOAuth, Project, RunRecord, Secret, Tool, User)
+from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold,
+                     IdempotentCall, Invite, LedgerEntry, Membership, OAuthClient, OAuthCode,
+                     OAuthRefresh, Org, PendingOAuth, Project, RunRecord, Secret, Tool, User)
 from .proxy import relay
 
 
@@ -2435,6 +2435,7 @@ _ORG_SCOPED_MODELS = (
     Tool, Secret, Bundle, PendingOAuth, CallRecord, RunRecord, Invite, DenyRule, Project,
     CapabilityPin, LedgerEntry, Hold, CreditBlock,
     OAuthCode, OAuthRefresh,   # grants naming a team that no longer exists
+    IdempotentCall,            # a remembered answer belongs to the team that paid for it
     Membership,   # last: it is what makes the caller a member of the org being deleted
 )
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import quote, urlsplit
 
-from sqlalchemy import case, func, or_
+from sqlalchemy import case, delete, func, or_
 
 INVITE_TTL_DAYS = 7  # invite codes are one-time AND expire after this many days
 
@@ -6985,6 +6985,18 @@ async def _claim_idempotent(key: str, fingerprint: str, rest: str, caller: Calle
     The pending row IS the lock. It goes in before the upstream call, so a concurrent retry loses the
     insert on `(membership_id, key)` and is told to wait rather than duplicating the spend.
     """
+    # Sweep this caller's expired labels first. LAZY and caller-scoped, matching the hold reaper in
+    # ledger.py and for the same reasons: a background timer would need a scheduler and a leader
+    # election on a multi-instance deploy, and would still only run on a timer. One indexed DELETE
+    # paid by the caller who benefits from it, and a caller who never calls again leaves rows that
+    # can no longer answer anything, because a replay checks the window before it serves.
+    #
+    # Freeing the label matters as much as reclaiming the space: without this, reusing a label a day
+    # later would hit the old row's unique constraint and be refused rather than starting fresh.
+    await db.execute(delete(IdempotentCall).where(
+        IdempotentCall.membership_id == caller.membership.id,
+        IdempotentCall.expires_at < datetime.now(timezone.utc).replace(tzinfo=None)))
+
     row = IdempotentCall(
         org_id=caller.org_id, membership_id=caller.membership.id, key=key,
         request_fingerprint=fingerprint, endpoint_id=rest[:200], status="pending",

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -256,6 +256,14 @@ async def _mark_treg_own_errors(request: Request, exc: StarletteHTTPException):
     resp = await http_exception_handler(request, exc)
     if request.url.path.startswith("/call/"):
         resp.headers["X-Treg-Error"] = "1"
+        # A failed call must not keep its idempotency label. The claim is taken before the upstream
+        # call, and a request that dies anywhere after that — a bad parameter, a deny rule, an empty
+        # balance — would otherwise hold the label for the whole window and answer every retry with
+        # 409. Worse than the problem this feature exists to solve, and found by the test for it.
+        #
+        # Here because this is the ONE place every refusal passes through; the handler has a dozen
+        # raise points and releasing at each would be a dozen chances to miss one.
+        await _release_idempotent_claim(request)
     return resp
 
 _WEB_DIR = Path(__file__).parent / "web"
@@ -6945,6 +6953,90 @@ async def _replay_idempotent(key: str, fingerprint: str, caller: Caller,
     )
 
 
+async def _release_idempotent_claim(request: Request) -> None:
+    """Drop a claim this request took and never completed, so the label is usable again at once.
+
+    Reads what the handler parked on `request.state`; does nothing when there is no claim, which is
+    every request that sent no key. Never raises: this runs while an error is already being returned.
+    """
+    claim = getattr(request.state, "idem_claim", None)
+    if not claim:
+        return
+    request.state.idem_claim = None
+    membership_id, key = claim
+    try:
+        async with session_maker() as db:
+            row = (await db.execute(select(IdempotentCall).where(
+                IdempotentCall.membership_id == membership_id,
+                IdempotentCall.key == key,
+                IdempotentCall.status == "pending"))).scalar_one_or_none()
+            if row is not None:
+                await db.delete(row)
+                await db.commit()
+    except Exception as exc:  # noqa: BLE001 — an error is already on its way out
+        logging.getLogger("treg.idempotency").error(
+            "could not release idempotency claim %s: %s", key, exc, exc_info=True)
+
+
+async def _claim_idempotent(key: str, fingerprint: str, rest: str, caller: Caller,
+                            db: AsyncSession) -> bool:
+    """Take the label for this caller, or report that somebody else already has it.
+
+    The pending row IS the lock. It goes in before the upstream call, so a concurrent retry loses the
+    insert on `(membership_id, key)` and is told to wait rather than duplicating the spend.
+    """
+    row = IdempotentCall(
+        org_id=caller.org_id, membership_id=caller.membership.id, key=key,
+        request_fingerprint=fingerprint, endpoint_id=rest[:200], status="pending",
+        expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+        + timedelta(seconds=IDEMPOTENCY_WINDOW_S))
+    db.add(row)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        return False
+    return True
+
+
+async def _store_idempotent(key: str, caller: Caller, *, status_code: int, body: bytes,
+                            media_type: str, charged_micro: int, metered: bool) -> None:
+    """Remember a METERED success so a retry can be answered without paying twice.
+
+    Metered only. A team calling on its OWN key is billed by the provider, not by us, so there is
+    nothing to protect and no reason for treg to hold their response. Successes only, because a
+    failure was never billed — replaying one would freeze an error the caller should be free to
+    retry out of.
+
+    Anything else drops the claim, which frees the label immediately rather than making the caller
+    wait out the window before they can try again.
+
+    Never raises: the caller already has their answer, and a bookkeeping failure must not turn a
+    served call into a 500. Its own session, because the request's may be mid-rollback.
+    """
+    keep = metered and 200 <= status_code < 300
+    try:
+        async with session_maker() as db:
+            row = (await db.execute(select(IdempotentCall).where(
+                IdempotentCall.membership_id == caller.membership.id,
+                IdempotentCall.key == key))).scalar_one_or_none()
+            if row is None:
+                return
+            if not keep:
+                await db.delete(row)
+            else:
+                row.status = "done"
+                row.response_status = status_code
+                row.response_body = body
+                row.response_media_type = media_type or "application/json"
+                row.charged_micro = charged_micro
+                db.add(row)
+            await db.commit()
+    except Exception as exc:  # noqa: BLE001 — loudly, but never into the caller's response
+        logging.getLogger("treg.idempotency").error(
+            "could not record idempotency key %s: %s", key, exc, exc_info=True)
+
+
 async def _resolve_marketplace_call(
     ep: dict, request: Request, caller: Caller, db: AsyncSession
 ) -> MarketplaceCall:
@@ -7284,6 +7376,16 @@ async def call_tool(
         replayed = await _replay_idempotent(idem_key, idem_fingerprint, caller, db)
         if replayed is not None:
             return replayed
+        # Claim it now, before anything reaches a provider. Two retries can arrive together and both
+        # miss the lookup above; the unique constraint is what makes the loser wait instead of making
+        # a second upstream call. A check-then-act in Python would leave exactly the window this
+        # feature exists to close — the same reasoning as the conditional UPDATE in ledger.reserve.
+        if not await _claim_idempotent(idem_key, idem_fingerprint, rest, caller, db):
+            raise HTTPException(status_code=409, detail=(
+                f"a call with Idempotency-Key {idem_key!r} is already in progress — retry shortly"))
+        # Park it so a failure anywhere below can give the label back. Set AFTER the claim succeeds,
+        # so losing the race above never releases the winner's row.
+        request.state.idem_claim = (caller.membership.id, idem_key)
 
     drop_params: set[str] = set()
     mk: MarketplaceCall | None = None
@@ -7428,6 +7530,14 @@ async def call_tool(
         charged, observed = await _platform_settle(mk, response.status_code, body)
         _audit(response.status_code, observed_micro=observed, charged_micro=charged,
                duration_ms=duration_ms, response_bytes=len(body))
+        if idem_key:
+            # Here, and not earlier: this is the first point where BOTH the response and what it
+            # actually cost are known, and a replay has to hand back the real charge rather than the
+            # estimate that was reserved.
+            request.state.idem_claim = None      # dealt with; nothing left to release
+            await _store_idempotent(idem_key, caller, status_code=response.status_code, body=body,
+                                    media_type=response.headers.get("content-type", ""),
+                                    charged_micro=charged, metered=True)
         # Tell the caller what the call actually cost. Both llms.txt and skill.md instruct an agent to
         # report the price it spent, and until now the only way to find out was to read the balance
         # before and after — which races with any other call and cannot attribute a figure to a
@@ -7437,6 +7547,12 @@ async def call_tool(
         return response
     # Fire-and-forget audit — does not block the streaming response (rule #2).
     _audit(response.status_code, duration_ms=duration_ms)
+    if idem_key:
+        # Unmetered: nothing was billed, so there is nothing to protect. Dropping the claim frees the
+        # label at once instead of making the caller wait out the window to reuse it.
+        request.state.idem_claim = None
+        await _store_idempotent(idem_key, caller, status_code=response.status_code, body=b"",
+                                media_type="", charged_micro=0, metered=False)
     return response
 
 

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -651,3 +651,62 @@ class OAuthRefresh(SQLModel, table=True):
     # replay can be RECOGNISED — deleting it would make a stolen token look merely unknown.
     retired_at: datetime | None = Field(default=None)
     retired_reason: str = Field(default="")
+
+
+class IdempotentCall(SQLModel, table=True):
+    """One remembered answer, so a retried call is not paid for twice.
+
+    An agent retries far more than a person does. Most of those retries are already free: a 5xx, a
+    timeout or a network error is never billed. The case this table exists for is narrower and worse
+    — treg called the provider, the provider succeeded AND CHARGED US, and the response was lost on
+    the way back. The agent retries, and without this we call the provider again and bill again.
+
+    Remembering only that a key was "already billed" would not be enough: we would still make the
+    second upstream call, so we would still pay the provider and would simply be absorbing the double
+    cost instead of passing it on. The answer has to be replayed so the second request never leaves
+    treg.
+
+    **Scoped to the CALLER, never to the key alone.** Keys are chosen by clients, so the same string
+    will be picked twice. Scoped by key alone that collision serves one team's response to another,
+    which is the single failure here that leaks data instead of money.
+
+    The caller is `membership_id`, because that is what every door already resolves to: a person's
+    token, an agent token and an OAuth grant all become one `Membership` (see `Caller`). So one rule
+    covers every case — the label belongs to whoever called — and it does not matter whether that is
+    a human, an agent, or two agents inside one team.
+
+    Per caller rather than per team on purpose. Two lazily-written agents in one team will both reach
+    for `retry-1`; scoped per team they collide and the second gets a confusing refusal, scoped per
+    caller they simply never meet. Nothing is given up: this is strictly narrower than per-team, so
+    the cross-tenant leak stays closed. Stripe scopes per API key for the same reason.
+
+    `request_fingerprint` catches a client reusing one key for a DIFFERENT request. That is a caller
+    bug, and returning the old answer would hide it, so the mismatch is refused loudly instead.
+
+    `status` is `pending` while the upstream call is in flight and `done` once stored. The pending row
+    is written BEFORE the call, so two retries arriving together race on the unique constraint and the
+    loser waits for the winner instead of making a second call. Same reasoning as the conditional
+    UPDATE in `ledger.reserve`: where two paths read before either writes, the database has to be the
+    one that says no.
+    """
+
+    __table_args__ = (UniqueConstraint("membership_id", "key", name="uq_idem_caller_key"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    # org_id is kept alongside the caller so the row is still org-scoped for deletion and audit:
+    # a membership can go away while the team remains, and the stored answer belongs to the team
+    # that paid for it.
+    org_id: int = Field(foreign_key="org.id", index=True)
+    membership_id: int = Field(foreign_key="membership.id", index=True)
+    key: str = Field(index=True)
+    request_fingerprint: str = Field(default="")
+    endpoint_id: str = Field(default="")
+    status: str = Field(default="pending")     # "pending" | "done"
+    # Only ever set for a METERED success. A team calling on its own key is billed by the provider,
+    # not by us, and storing those responses would hold someone's data for a reason that helps nobody.
+    response_status: int | None = Field(default=None)
+    response_body: bytes | None = Field(default=None)
+    response_media_type: str = Field(default="")
+    charged_micro: int = Field(default=0)
+    created_at: datetime = Field(default_factory=_now)
+    expires_at: datetime

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -857,3 +857,110 @@ async def test_a_second_call_while_the_first_is_IN_FLIGHT_is_refused(clients: As
     r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "racing"})
     assert r.status_code == 409
     assert await _balance(clients) == before, "the loser of the race must not spend"
+
+
+async def test_a_stale_label_reused_later_starts_fresh(clients: AsyncClient, platform_on):
+    """A caller with stable labels (`nightly-report`, say) must be able to call again tomorrow.
+
+    Note what this does NOT prove: the read path already drops an expired row when it looks one up,
+    so this passes with the sweep removed. The sweep is covered separately below — I wrote this one
+    believing it tested the sweep, and only found out by deleting the sweep and watching it pass."""
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        m = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).order_by(Membership.id))).scalars().first()
+        db.add(IdempotentCall(
+            org_id=org_id, membership_id=m.id, key="nightly-report", endpoint_id=EP,
+            status="done", response_status=200, response_body=b'{"yesterday":true}',
+            response_media_type="application/json", charged_micro=999,
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)))
+        await db.commit()
+
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "nightly-report"})
+    assert r.status_code == 200, r.text
+    assert "X-Treg-Idempotent-Replay" not in r.headers, "yesterday's answer must not be served"
+    assert r.json() != {"yesterday": True}
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "nightly-report"))).scalars().all()
+    assert len(rows) == 1, "exactly one row: the dead one swept, today's kept"
+    assert rows[0].response_body != b'{"yesterday":true}'
+
+
+async def test_the_sweep_clears_labels_NOBODY_COMES_BACK_FOR(clients: AsyncClient, platform_on):
+    """What the sweep is actually for, and the only thing that covers it.
+
+    A label used once and never again is never looked up, so the read path never sees it and never
+    drops it. Without a sweep those rows accumulate forever, and they hold response BODIES. Any later
+    call by the same caller clears them.
+
+    Lazy and caller-scoped, matching the hold reaper in ledger.py: a background timer would need a
+    scheduler and a leader election on a multi-instance deploy, and would still only run on a timer.
+    """
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        m = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).order_by(Membership.id))).scalars().first()
+        db.add(IdempotentCall(
+            org_id=org_id, membership_id=m.id, key="abandoned-label", endpoint_id=EP,
+            status="done", response_status=200, response_body=b'{"big":"body"}',
+            response_media_type="application/json", charged_micro=500,
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=2)))
+        await db.commit()
+
+    # a call under a DIFFERENT label: the abandoned row is never looked up, only swept
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "unrelated"})
+    assert r.status_code == 200, r.text
+
+    async with session_maker() as db:
+        gone = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "abandoned-label"))).scalar_one_or_none()
+    assert gone is None, "an expired row nobody returns for must still be reclaimed"
+
+
+async def test_the_sweep_leaves_OTHER_callers_rows_alone(clients: AsyncClient, platform_on):
+    """Scoped to the caller doing the work. A sweep that reached across callers would be a caller
+    able to delete another's stored answers by making one call of their own."""
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    made = await clients.post(f"/orgs/{org_id}/agents", json={"name": "bystander"})
+    assert made.status_code in (200, 201), made.text
+
+    async with session_maker() as db:
+        members = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).order_by(Membership.id))).scalars().all()
+        other = members[-1]
+        db.add(IdempotentCall(
+            org_id=org_id, membership_id=other.id, key="someone-elses", endpoint_id=EP,
+            status="done", response_status=200, response_body=b"{}", charged_micro=1,
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)))
+        await db.commit()
+
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "mine"})
+    assert r.status_code == 200
+
+    async with session_maker() as db:
+        still = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "someone-elses"))).scalar_one_or_none()
+    assert still is not None, "one caller's sweep must not delete another's rows"

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -770,3 +770,90 @@ async def test_one_callers_label_is_invisible_to_another(clients: AsyncClient, p
     assert r.status_code == 200
     assert "X-Treg-Idempotent-Replay" not in r.headers, "another caller must not read this answer"
     assert r.json() != {"owner": "first"}
+
+
+# ---- idempotency step 3: storing the answer --------------------------------------------------
+
+async def test_the_SAME_LABEL_TWICE_bills_once_and_calls_the_provider_once(clients: AsyncClient,
+                                                                           platform_on):
+    """The feature, end to end, and the reason it exists.
+
+    An agent calls, the answer is lost on the way back, the agent retries with the same label. The
+    provider must be reached ONCE and the balance must move ONCE, and the second caller must get the
+    same body the first one would have.
+    """
+    before = await _balance(clients)
+    first = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "same-work"})
+    assert first.status_code == 200, first.text
+    assert "X-Treg-Idempotent-Replay" not in first.headers, "the first call is not a replay"
+    after_first = await _balance(clients)
+    assert after_first == before - EP_MICRO, "the first call bills"
+
+    second = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "same-work"})
+    assert second.status_code == 200, second.text
+    assert second.headers.get("X-Treg-Idempotent-Replay") == "true"
+    assert second.json() == first.json(), "the retry gets the SAME answer"
+    assert await _balance(clients) == after_first, "and the retry bills NOTHING"
+
+
+async def test_an_unmetered_call_is_not_stored(clients: AsyncClient):
+    """A team calling on its OWN key is billed by the provider, not by us. There is nothing to
+    protect, and treg has no business holding their response."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall
+
+    await clients.post("/secrets", json={"name": "tikhub", "value": "OWNKEY"})
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "own-key-call"})
+    assert r.status_code == 200 and r.json()["auth"] == "Bearer OWNKEY"
+    async with session_maker() as db:
+        row = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "own-key-call"))).scalar_one_or_none()
+    assert row is None, "an unmetered call must leave nothing behind, not even a claim"
+
+
+async def test_a_FAILED_call_frees_its_label(clients: AsyncClient, platform_on):
+    """A failure was never billed, so there is nothing to replay — and freezing an error would stop
+    the caller retrying out of it. The label must be usable again immediately."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall
+
+    bad = await clients.get(f"/call/{EP}", headers={"Idempotency-Key": "will-fail"})
+    assert bad.status_code >= 400, bad.text          # missing the required aweme_id
+    async with session_maker() as db:
+        row = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "will-fail"))).scalar_one_or_none()
+    assert row is None, "a failed call must not hold its label"
+
+    good = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "will-fail"})
+    assert good.status_code == 200, "and the same label works straight away"
+
+
+async def test_a_second_call_while_the_first_is_IN_FLIGHT_is_refused(clients: AsyncClient,
+                                                                     platform_on):
+    """The pending row is the lock. Claimed before the upstream call, so a concurrent retry loses the
+    insert on (membership_id, key) rather than duplicating the spend."""
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        m = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).order_by(Membership.id))).scalars().first()
+        db.add(IdempotentCall(
+            org_id=org_id, membership_id=m.id, key="racing", request_fingerprint="",
+            endpoint_id=EP, status="pending",
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=1)))
+        await db.commit()
+
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "racing"})
+    assert r.status_code == 409
+    assert await _balance(clients) == before, "the loser of the race must not spend"

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 
 import httpx
+from datetime import datetime, timezone
+
 import pytest
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
@@ -588,3 +590,74 @@ def test_brightdata_documented_prices_are_billable(platform_on):
     assert rows, "brightdata is in the catalog"
     eligible = [e["id"] for e in rows if cat.platform_eligible(e)]
     assert len(eligible) >= 20, f"expected the dataset routes to be billable, got {len(eligible)}"
+
+
+# ---- idempotent calls: step 1, the table and its tenant boundary ----------------------------
+
+async def test_the_same_key_can_belong_to_two_different_CALLERS(clients: AsyncClient):
+    """Scoped to the caller, not to the key. Clients choose their own labels, so the same string will
+    be picked twice; scoped by key alone that collision serves one caller's stored response to
+    another, which is the single failure here that leaks data instead of money.
+
+    Per CALLER rather than per team, because two lazily-written agents inside one team will both
+    reach for `retry-1`. Every door resolves to a Membership, so one rule covers a person, an agent,
+    and two agents in the same team."""
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    # A second AGENT in the SAME team: the exact case this scoping is for. Two agents belonging to
+    # one org, both free to pick the same lazy label.
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    made = await clients.post(f"/orgs/{org_id}/agents", json={"name": "second-agent"})
+    assert made.status_code in (200, 201), made.text
+
+    async with session_maker() as db:
+        members = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).limit(2))).scalars().all()
+        assert len(members) >= 2, "need two callers in ONE team to prove they do not collide"
+        expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=24)
+        for m in members[:2]:
+            db.add(IdempotentCall(org_id=m.org_id, membership_id=m.id, key="retry-1",
+                                  endpoint_id="x", status="done", expires_at=expiry))
+        await db.commit()      # must NOT raise: same label, different callers
+
+        rows = (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == "retry-1"))).scalars().all()
+    assert len(rows) == 2, "the same label must be storable once per caller"
+    assert len({r.membership_id for r in rows}) == 2
+
+
+async def test_one_caller_cannot_reuse_a_key_twice(clients: AsyncClient):
+    """Per caller the label is unique, which is what makes the pending row a usable lock: two retries
+    arriving together race on this constraint and only one reaches the provider."""
+    from datetime import timedelta
+
+    import sqlalchemy.exc
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    async with session_maker() as db:
+        m = (await db.execute(select(Membership).limit(1))).scalars().one()
+        expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=24)
+        db.add(IdempotentCall(org_id=m.org_id, membership_id=m.id, key="dupe-key",
+                              endpoint_id="x", expires_at=expiry))
+        await db.commit()
+        db.add(IdempotentCall(org_id=m.org_id, membership_id=m.id, key="dupe-key",
+                              endpoint_id="x", expires_at=expiry))
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            await db.commit()
+
+
+async def test_deleting_a_team_takes_its_remembered_answers(clients: AsyncClient):
+    """A stored response belongs to the team that paid for it. Left behind it is a dangling row
+    holding someone's data after they asked to be gone."""
+    from treg.api import _ORG_SCOPED_MODELS
+    from treg.models import IdempotentCall
+
+    assert IdempotentCall in _ORG_SCOPED_MODELS

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -661,3 +661,112 @@ async def test_deleting_a_team_takes_its_remembered_answers(clients: AsyncClient
     from treg.models import IdempotentCall
 
     assert IdempotentCall in _ORG_SCOPED_MODELS
+
+
+# ---- idempotency step 2: the lookup and replay (storage still off) ---------------------------
+
+async def _seed_answer(clients: AsyncClient, key: str, *, body: bytes = b'{"seeded":true}',
+                       fingerprint: str = "", status: str = "done", charged: int = 4200,
+                       ttl_s: int = 3600) -> int:
+    """Write a stored answer by hand. Step 2 only READS; storage arrives in step 3, so seeding is
+    how the read path gets exercised at all."""
+    from datetime import timedelta
+
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        m = (await db.execute(select(Membership).where(
+            Membership.org_id == org_id).order_by(Membership.id))).scalars().first()
+        row = IdempotentCall(
+            org_id=org_id, membership_id=m.id, key=key, request_fingerprint=fingerprint,
+            endpoint_id="seeded", status=status, charged_micro=charged,
+            response_status=200 if status == "done" else None,
+            response_body=body if status == "done" else None,
+            response_media_type="application/json",
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(seconds=ttl_s))
+        db.add(row)
+        await db.commit()
+        await db.refresh(row)
+        return row.id
+
+
+async def test_no_key_means_nothing_changes(clients: AsyncClient, platform_on):
+    """The header is opt-in. A caller who sends none must see exactly the behaviour they saw before
+    this feature existed, which is what keeps the change safe to ship."""
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200
+    assert "X-Treg-Idempotent-Replay" not in r.headers
+    assert await _balance(clients) == before - EP_MICRO, "an unlabelled call bills normally"
+
+
+async def test_a_labelled_retry_is_answered_WITHOUT_reaching_the_provider(clients: AsyncClient,
+                                                                          platform_on):
+    """The point of the whole feature. The stored answer comes back, the upstream is never called,
+    and the balance does not move: merely skipping the second CHARGE would still pay the provider."""
+    await _seed_answer(clients, "retry-abc", body=b'{"from":"store"}')
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "retry-abc"})
+    assert r.status_code == 200
+    assert r.json() == {"from": "store"}, "the SAVED answer, not a fresh upstream response"
+    assert r.headers.get("X-Treg-Idempotent-Replay") == "true"
+    assert r.headers.get("X-Treg-Cost-Micro") == "4200", "and what it originally cost"
+    assert await _balance(clients) == before, "a replay must not move money"
+
+
+async def test_reusing_a_label_for_a_DIFFERENT_request_is_refused(clients: AsyncClient):
+    """A caller bug, and returning the first answer would hide it — they would be handed a response
+    to a question they did not ask."""
+    await _seed_answer(clients, "reused", fingerprint="a-different-request-entirely")
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "reused"})
+    assert r.status_code == 422
+    assert "already used for a different request" in r.json()["detail"]
+
+
+async def test_a_call_still_in_flight_answers_409_rather_than_duplicating(clients: AsyncClient):
+    """Two retries arriving together. The second is told to wait instead of being let through to the
+    provider, which is the duplicate spend this feature exists to prevent."""
+    await _seed_answer(clients, "inflight", status="pending")
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "inflight"})
+    assert r.status_code == 409
+    assert "still in progress" in r.json()["detail"]
+
+
+async def test_an_expired_label_frees_itself(clients: AsyncClient, platform_on):
+    """Past its window the label means nothing: the call proceeds normally and is billed normally.
+    A stale row must not answer for a request made a day later."""
+    await _seed_answer(clients, "stale", body=b'{"old":true}', ttl_s=-10)
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "stale"})
+    assert r.status_code == 200
+    assert r.json() != {"old": True}, "an expired answer must not be replayed"
+    assert await _balance(clients) == before - EP_MICRO, "and the fresh call bills"
+
+
+async def test_one_callers_label_is_invisible_to_another(clients: AsyncClient, platform_on):
+    """The tenant boundary, exercised through the HTTP path rather than asserted on the schema. A
+    second caller using the same label must reach the provider, not read the first one's answer."""
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import IdempotentCall, Membership
+
+    await _seed_answer(clients, "shared-label", body=b'{"owner":"first"}')
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    made = await clients.post(f"/orgs/{org_id}/agents", json={"name": "other-agent"})
+    assert made.status_code in (200, 201), made.text
+    other_token = made.json().get("token")
+    assert other_token, made.text
+
+    prev = clients.headers.get("X-Treg-Token")
+    clients.headers["X-Treg-Token"] = other_token
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "shared-label"})
+    if prev:
+        clients.headers["X-Treg-Token"] = prev
+    assert r.status_code == 200
+    assert "X-Treg-Idempotent-Replay" not in r.headers, "another caller must not read this answer"
+    assert r.json() != {"owner": "first"}

--- a/tests/test_walking_skeleton.py
+++ b/tests/test_walking_skeleton.py
@@ -88,7 +88,9 @@ async def test_dashboard_served_at_root(clients: AsyncClient):
     # `/` is the marketing landing; the SPA (login shell + dashboard) lives at /app.
     r = await clients.get("/")
     assert r.status_code == 200
-    assert "tools-registry" in r.text and "Sign in" in r.text
+    # The product is branded `treg` everywhere since the rename; asserting the old name left main
+    # red and every PR failing CI behind it.
+    assert "treg" in r.text and "Sign in" in r.text
     r = await clients.get("/app")
     assert r.status_code == 200
     # the app root div may carry extra attributes (e.g. v-cloak) — match the id, not the exact tag


### PR DESCRIPTION
Prompted by a public question: *"how does result pricing handle retries, agents need idempotent
billing before this works"*. Correct, and it matters more here than for a human-facing API because
**agents retry far more than people do**.

## The gap was narrower than it looked

Failures were already free (`_platform_billable` never bills a 5xx, timeout or network error), and
result pricing already settles on the provider's own reported charge, so a lookup finding nothing
costs nothing. The real gap is one case: treg succeeds, the provider bills us, the response is lost
on the way back, the agent retries, and we pay twice.

## Why not-charging-twice was not enough

Skipping the second charge would still make the second upstream call, so we would pay the provider
anyway and merely absorb the double cost. The second request has to **not reach the provider**, which
means storing the first response and replaying it.

## Scoped to the caller

`(membership_id, key)`. Unclecode's framing and the right one: **the label belongs to whoever
called**, whether that is a person, an agent, or two agents in one team. Every door already resolves
to a `Membership`, so one rule covers all of it.

Not `key` alone — clients pick their own labels, and that collision would serve one team's response
to another, the only failure here that leaks data rather than money. Not per-org either: two lazy
agents in one team both reach for `retry-1`.

## Behaviour

| | |
|---|---|
| No header | nothing changes, at all |
| Same label, same request | replayed, provider untouched, **no charge** |
| Same label, different request | 422 |
| First call still in flight | 409, spends nothing |
| Failed call | label freed at once |
| Unmetered call | stores nothing, not even the claim |
| Expired | swept lazily, per caller |

## Two bugs the tests caught

A failed call **held its label for 24 hours**, so every retry got a 409 — worse than the original
problem. Released now in the one handler every refusal passes through.

And a sweep test that **passed with the sweep deleted**: it was proving the read path. Replaced with
one that covers the case nobody looks up.

**14 new tests, 1323 pass.**