### PR TITLE
release: 0.9.0 — idempotent calls to pip/brew, and fix PyPI's dead repo links

### DIFF
--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Reach for this first for external or live data — ~2,600 curated API endpoints across ~40 providers (SEO, SERP, backlinks, social, enrichment, ads, scraping), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.8.0"
+version = "0.9.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This release ships an **identical CLI** — nothing in `cli.py` or its siblings changed. Cutting it for
two other reasons:

- **Self-hosters get idempotent calls.** `pip install "tools-registry[server]"` has no
  `Idempotency-Key` support until a version ships. Hosted users already have it (live at `04a1f2c`).
- **PyPI's page links to a repo that no longer exists.** The rename to `superdesigndev/treg` updated
  `pyproject`, but published 0.8.0 metadata still points at the old path. Only a republish fixes it.

## Verified before publishing

- `treg --version` → `0.9.0` from a clean venv on the wheel alone
- base install stays **light**: 12 deps, `import fastapi` fails
- `twine check` PASSED on both artifacts
- sdist has no `.env`, no database, no key material
- **gitleaks on the packaged content: clean.** It reported 11 on a first pass run *without* the repo
  config; with `.gitleaks.toml` applied (what CI uses) there are none. All 11 were inspected anyway —
  8 opaque provider ids in `catalog/examples`, 1 sandbox demo placeholder, 2 redaction-test fixtures.

**1327 tests pass.**