### PR TITLE
feat: vendor listing funnel — a vendor's own coding agent raises the listing PR

### DIFF
--- a/.claude/skills/vendor-listing/SKILL.md
+++ b/.claude/skills/vendor-listing/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: vendor-listing
+description: >
+  Onboard a vendor who wants their API listed in the treg catalog. Use whenever someone asks
+  "how do we get listed on treg", a vendor sends their API details, or a listing PR/issue needs
+  review. Walks the whole pipeline: eligibility gate → registry entry → logo → tests → LIVE
+  bogus-key test → core catalog YAML → verify → scrub → validate. The vendor-facing doc this
+  skill implements is docs/VENDORS.md.
+---
+
+# Vendor listing — add a provider to the catalog
+
+A listing has **two halves**, and both must ship:
+
+1. **Registry entry** (`src/treg/oauth_providers.py`) — how a team connects a credential for the
+   provider, and how treg verifies that credential is real.
+2. **Core catalog file** (`src/treg/catalog/<service>.yaml`) — what an agent can *do*: 8–15
+   curated endpoints with capability mapping, inputs, cost + provenance, and verified examples.
+
+Deep references (read before non-trivial work; do not duplicate them here):
+- `docs/context/guides/expanding-a-category.md` — the add-a-provider playbook, verify toolbox, traps
+- `docs/context/architecture/catalog.md` — catalog schema, cost provenance, verify pipeline, PII rules
+- `docs/VENDORS.md` — what we told the vendor to prepare (their checklist)
+- `src/treg/web/vendor-listing.md` — the HOSTED instructions (served at `/vendor-listing`) that a
+  vendor's own coding agent follows to raise a listing PR; the dashboard's "List as vendor" modal
+  (connections view, `vendorAsk` in `index.html`) hands vendors a prompt pointing at it. Keep the
+  three vendor-facing surfaces (doc, hosted page, modal prompt) telling one story.
+
+## Step 0 — intake: collect the vendor facts
+
+Before touching code, you need ALL of these. If the vendor's submission is missing any, ask —
+do not guess ("unconfirmed" beats a wrong path shipped):
+
+- **A contact email for the vendor's team** — required in the PR/issue description. It is how a
+  test credential gets arranged for live verification; without it the listing stalls at step 7.
+- `service` id (lowercase slug), display name, one-line summary (what an agent can DO)
+- `base_url` (exact API root)
+- Auth: where the key rides (header name + format, or query param name). Key **in the URL path is
+  not supported** — decline or defer.
+- A **free or near-free probe endpoint** where a valid key returns 2xx and an invalid key does NOT
+  — plus the exact bad-key behavior (status code, or the JSON field that signals invalid)
+- Pricing page URL, per-endpoint prices, and the billing model (`per_call` / `per_success` /
+  `per_result` / credits / quota). Machine-readable rate-card endpoint if they have one.
+- Docs URL; OpenAPI spec URL if published
+- The 8–15 endpoints they consider their core surface, with example parameter *values*
+- A test credential (or credits grant) for verification — read it from env only, never write it
+  into any file
+
+## Step 1 — eligibility gate
+
+Reject decisively, with a recorded reason, when:
+- The key **cannot be validated** (API returns success for garbage keys) — e.g. ScrapeCreators
+- Key rides in the **URL path** (`/v3/{key}/…`) — injectors do header/query only
+- **Sales-gated** signup (no self-serve key breaks the fast path)
+- Legal/shutdown risk, or deprecated/absorbed products
+
+## Step 2 — registry entry
+
+Add an `OAuthProvider(auth_kind="key", …)` in `oauth_providers.py` and append it to `REGISTRY`.
+Model it on `HUNTER` (a clean key provider). Pick the verify fields from the toolbox table in
+`expanding-a-category.md` (`token_header`/`token_format`, `token_location="query"`+`token_param`,
+`probe_url`, `probe_method`+`probe_json`, `token_verify_field`, `token_ok_field`+`token_ok_value`,
+`token_reject_field`, `probe_reject_statuses`, …). Prefer a header over a query key so the secret
+never lands in a logged URL. Set `category` (add to `CATEGORY_ORDER` only if genuinely new),
+`summary`, `base_url`, `docs_url`, `probe_path`, and `setup_url`/`setup_steps` so a user can find
+their key.
+
+## Step 3 — logo
+
+`src/treg/web/logos/<service>.svg` — a **neutral lettermark**, not the real brand mark.
+`test_every_provider_has_a_logo` fails without it.
+
+## Step 4 — tests
+
+- Add the id to `test_every_provider_is_registered` (test_oauth_providers_m3)
+- Add it to the offerable loop in `test_key_providers`
+
+## Step 5 — LIVE bogus-key test (load-bearing; never skip)
+
+Start the server, `POST /connections/token` with a **garbage key** against the real API:
+- `422 "rejected …"` → correct. Ship it.
+- `200` → the probe does not validate the key → fix the verify fields or drop the provider.
+- `404`/`502` in the reason → wrong probe path/host → fix `base_url`/`probe_path`.
+
+**Never ship a key provider you haven't watched reject a bogus key.** Use a throwaway org
+(`e2e-…@treg.local`) and delete it after. Watch for the known traps: trailing-slash 307 (put the
+slash in `probe_path`), 200-with-error-body (read a body field), CSV/text responses.
+
+## Step 6 — core catalog YAML
+
+`src/treg/catalog/<service>.yaml`, following the schema in `catalog.md`. In order:
+
+1. **Ingest** from OpenAPI if published (never hand-transcribe paths); else from docs with
+   `source.openapi: null`.
+2. **Select** ~8–15 endpoints; ALWAYS include ones matching capabilities other providers already
+   implement (overlap enables comparison).
+3. **Map** each to a capability from `capabilities.yaml`; missing jobs go under
+   `proposed_capabilities:` in the provider file, not straight into the shared taxonomy.
+4. **Describe** `input` (param names, types, required, location; constraints into `note`).
+5. **Cost** with full provenance: `type/value/currency/per/unit` + `source/source_url/checked/
+   confidence`. Unknown price → `value: null` + `confidence: unknown` + a note. Prefer a
+   rate-card endpoint (`source: rate_card_api`) over a pricing page.
+6. **test_request** per endpoint — CHEAP: smallest limit, one item, public well-known target.
+   ⚠️ Never probe with empty params "expecting a validation error": a no-required-params endpoint
+   returns its full default result set and bills for it (the Moz quota trap).
+
+## Step 7 — verify, scrub, validate
+
+```bash
+TREG_CATALOG_CRED='<secret>' uv run --frozen python scripts/catalog_verify.py <service>.yaml
+uv run --frozen python scripts/catalog_validate.py    # must exit 0
+uv run --frozen python -m pytest -q
+```
+
+- Stamp `verified:` only on endpoints that PASSED. Docs lie; documented ≠ verified.
+- **Scrub every captured example** (this repo is public): no named private individuals
+  (contact-lookup routes get `untestable:` + no test_request + no example), no third-party
+  emails/phones riding along, no first-party account identity.
+- No credential value anywhere in the diff.
+
+## Step 8 — optional extended tier
+
+If the vendor publishes a stable OpenAPI spec with example parameter values, add an
+`ingest_<service>()` to `scripts/catalog_ingest.py`, register it in `INGESTERS`, and generate
+`<service>.extended.yaml`. Rules: never probe with a real call; platform = what the data is
+ABOUT; normalise platform slugs across providers. Bulk-verify with
+`catalog_verify_extended.py --dry-run` first, then with an explicit `--budget`.
+
+## Step 9 — done means
+
+- Validator exits 0; suite green; bogus-key rejection observed live
+- The PR/issue carries the vendor's contact email (and no credential value anywhere)
+- Every endpoint carries `verified:` + example, or an explicit reason it couldn't be live-tested
+- Docs synced: run `bash .claude/skills/tools-registry-context/scripts/drift.sh`, update touched
+  fragments in the same commit
+- If pricing has `confidence: verified|documented` with a computable USD figure and the endpoints
+  aren't `own_account`/`kind: account`, the vendor is **platform-eligible** — tell them treg can
+  additionally serve their endpoints on its own key once the provider is keyed and allow-listed
+  (`platform_key_for`), which is a separate ops decision, not automatic.

--- a/docs/VENDORS.md
+++ b/docs/VENDORS.md
@@ -1,0 +1,195 @@
+# List your API on treg
+
+treg is the tool catalog for AI agents: ~2,600 endpoints across ~40 providers, discoverable by
+*capability* ("get a domain's backlink summary") rather than by vendor name. Agents search the
+catalog, compare providers side by side on price / measured success rate / speed, and call your
+API through treg's proxy with the credential injected server-side.
+
+**What listing gets you:**
+
+- **Discovery** — every agent connected to a treg deployment can find your endpoints when they
+  search for the job your API does, next to (and compared against) your competitors.
+- **Zero-friction customers** — teams that connect their own key to your API call you directly;
+  you keep the billing relationship. treg never sits between you and your customer's account.
+- **Metered platform traffic (optional)** — if your pricing is published and machine-checkable,
+  treg can serve your endpoints on *its own* key, metered per call from teams' prepaid balances.
+  That means paid usage from teams that never signed up with you. See "Platform-eligible" below.
+
+## Eligibility
+
+You need ALL of these. They exist because every listing is *live-tested*, not transcribed:
+
+| Requirement | Why |
+|---|---|
+| **Self-serve API keys** — sign up, get a key, no sales call | The whole listing pipeline runs in one session; sales-gated APIs can't be verified |
+| **Key rides in a header or query param** | treg injects credentials as a header (preferred) or query param. Keys embedded in the URL path are not supported |
+| **A free (or near-free) probe endpoint** that returns 2xx for a valid key and a distinguishable failure for an invalid one | Connect-time verification. We will literally send your API a garbage key and watch it get rejected — **an API that accepts any key cannot be listed** |
+| **Published pricing** with a stable URL | Costs in the catalog carry provenance (`source_url`, `checked`, `confidence`); "contact sales" prices can't be listed as numbers |
+| **Accurate docs** for your core endpoints: param names, types, required flags, and example *values* | Every listed endpoint gets a real test call; docs without example values can't be verified |
+
+Strongly preferred (each one directly improves your listing):
+
+- **An OpenAPI spec at a stable URL** — lets us machine-generate your *full* endpoint surface as
+  an "extended tier" (hundreds of routes), not just the hand-curated core 8–15.
+- **A machine-readable rate card endpoint** (an API route that returns your current per-endpoint
+  prices) — the strongest cost provenance we have, and the fastest route to platform eligibility.
+- **Per-success billing** (errors free) — makes verification and retries cheap, and means broken
+  calls never bill treg users.
+- **Documented rate limits**, including per-route limits, not just the account-wide one.
+
+## What to send us
+
+The fastest route: paste the prompt from the **"List as vendor"** button on the dashboard's
+Catalog page into your coding agent — it follows the hosted instructions at
+[`/vendor-listing`](https://treg.superdesign.dev/vendor-listing) and opens the PR for you.
+Or open an issue or PR on this repo yourself, with:
+
+0. **A contact email in the PR/issue description** (e.g. `Contact: partnerships@yourapi.com`) —
+   we use it to arrange a test credential for live verification; a PR without one cannot be
+   verified or merged
+
+1. `service` slug (lowercase), display name, and a one-line summary of what an agent can DO
+2. `base_url`, auth mechanics (header name + format, or query param name)
+3. Probe endpoint path + exact bad-key behavior (status code, or the JSON field that flips)
+4. Pricing page URL + billing model; rate-card endpoint if you have one
+5. Docs URL; OpenAPI spec URL if published
+6. Your 8–15 core endpoints, each with example parameter values and a cheap test target
+7. A test credential (or a small credits grant) sent privately once we reach out — **never in
+   the issue/PR** — so we can run live verification
+
+The example below is the complete shape of a listing.
+
+## Example implementation — "Acme SEO"
+
+A fictional vendor: Acme SEO sells backlink data at `https://api.acmeseo.example/v1`, key in an
+`X-Api-Key` header, free `/account` route, $0.002 per successful request, pricing at
+`https://acmeseo.example/pricing`.
+
+### 1. Registry entry — `src/treg/oauth_providers.py`
+
+How a team connects a key, and how treg verifies it is real:
+
+```python
+ACMESEO = OAuthProvider(
+    service="acmeseo",
+    display_name="Acme SEO",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Acme SEO API key",
+    token_header="X-Api-Key",
+    token_format="{secret}",
+    setup_url="https://acmeseo.example/dashboard/api-keys",
+    setup_action_label="Get your Acme SEO API key",
+    setup_steps=(
+        "Sign in to Acme SEO and open Settings → API Keys.",
+        "Copy your API key.",
+    ),
+    setup_note="Backlink queries are billed per successful request; the account check is free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Backlink profiles, referring domains and anchor texts for any domain or URL.",
+    base_url="https://api.acmeseo.example/v1",
+    docs_url="https://docs.acmeseo.example",
+    probe_path="/account",  # free — a bad key gets a 401 here
+)
+```
+
+…added to the `REGISTRY` tuple, plus a neutral lettermark at `src/treg/web/logos/acmeseo.svg`
+and the two test-list additions (`test_every_provider_is_registered`, `test_key_providers`).
+
+If your API answers HTTP 200 even for a bad key, the entry instead names the body field that
+distinguishes them (`token_verify_field`, `token_ok_field`/`token_ok_value`, or
+`token_reject_field`) — tell us the exact behavior and we pick the right one.
+
+### 2. Core catalog file — `src/treg/catalog/acmeseo.yaml`
+
+What an agent can do, priced and verifiable:
+
+```yaml
+provider: acmeseo                  # must equal the registry entry's `service`
+source:
+  docs: https://docs.acmeseo.example
+  openapi: https://api.acmeseo.example/v1/openapi.json
+  curated: 2026-08-12
+limits: "60 requests/minute per key"
+pricing_url: https://acmeseo.example/pricing
+endpoints:
+  - id: acmeseo.web.backlinks.summary
+    capability: web.backlinks.summary     # the cross-provider join key, from capabilities.yaml
+    platform: web
+    scope: any_account                     # data about anything, not the caller's own account
+    method: GET
+    path: /backlinks/summary
+    name: "Backlink summary"
+    summary: "Aggregate backlink profile of a domain or URL"   # vendor's wording, verbatim
+    input:
+      queryParams:
+        target: {type: string, required: true, note: "domain or full URL", example: "moz.com"}
+        mode:   {type: string, required: false, note: "one of domain | url", example: "domain"}
+    test_request:                          # the CHEAP call verification replays
+      queryParams: {target: "moz.com", mode: "domain"}
+    cost:
+      type: per_success                    # errors free
+      value: 0.002
+      currency: USD
+      source: docs
+      source_url: https://acmeseo.example/pricing
+      checked: 2026-08-12
+      confidence: documented
+    docs_url: https://docs.acmeseo.example/backlinks-summary
+  # …7–14 more endpoints, same shape
+```
+
+The `capability` field is what puts you on the comparison shelf: an agent asking for
+`web.backlinks.summary` sees every provider that implements it, with prices side by side. If
+your API does a job the taxonomy lacks, the file proposes it under `proposed_capabilities:`.
+
+### 3. What we run before it merges
+
+```bash
+# 1. Live bogus-key test: a garbage key POSTed to /connections/token must come back rejected
+# 2. Live verification of every endpoint's test_request (with the test credential, from env)
+TREG_CATALOG_CRED='<key>' uv run python scripts/catalog_verify.py acmeseo.yaml
+# 3. Schema + referential integrity
+uv run python scripts/catalog_validate.py     # must exit 0
+# 4. The full test suite
+uv run --frozen python -m pytest -q
+```
+
+Endpoints that pass get a `verified:` date and a truncated, PII-scrubbed real example response
+committed to `src/treg/catalog/examples/` — that example is what convinces an agent choosing
+between providers, so passing verification is the listing's main asset.
+
+## Platform-eligible — getting paid calls from treg's own key
+
+Beyond discovery, treg can serve your endpoints on its **own** key, charging the calling team's
+prepaid balance per call. An endpoint qualifies when:
+
+- its cost is machine-computable in USD (a concrete `value`, or a convertible credit/unit rate),
+- the price's `confidence` is `verified` (observed billed, or read from your live rate card) or
+  `documented` (transcribed from your published pricing), and
+- it isn't an own-account or account-management route.
+
+Eligibility is necessary but not sufficient — treg also has to hold a funded account with you
+and allow-list your service, which is an ops decision made per provider. The fastest way to get
+there: publish a rate-card endpoint, bill per success, and give us a verification credit grant.
+
+## What gets declined
+
+Recorded reasons from past reviews, so nobody wastes a cycle:
+
+- API accepts any key (no way to validate a connection)
+- Key embedded in the URL path
+- Sales-gated / enterprise-only access
+- Legal or shutdown risk; deprecated or absorbed products
+- UI-only products with no API
+
+## Keeping your listing healthy
+
+- **Prices moved?** Tell us or PR the `cost` blocks — stale prices are flagged after 90 days.
+- **Routes changed?** If you publish OpenAPI, a re-ingest regenerates your extended tier from
+  the spec; the curated core file is updated by hand, so breaking changes there need a heads-up.
+- **Success rates are public.** treg aggregates observed success rate and latency per endpoint
+  across all callers and shows them next to your price. Reliability is your ranking.

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -299,6 +299,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `_serve_md` backs `quickstart_md` (`GET /quickstart.md`) + `tutorial_md` (`GET /tutorial.md`) —
   `{BASE}`-templated markdown served as inline `text/plain` (so "open in new tab" shows it, not a
   download); the docs pages' **Copy markdown** dropdowns (copy / open-in-tab) fetch these.
+  `vendor_listing_md` (`GET /vendor-listing`, alias `/vendor-listing.md`) serves the same way: the
+  instructions a VENDOR's own coding agent follows to raise a listing PR on the repo (the dashboard's
+  "List as vendor" modal hands vendors a prompt naming this URL; the repo-side counterpart is
+  `docs/VENDORS.md`).
   Browser-facing auth pages (GitHub callback, OAuth-connect result) render via `_auth_page` (brand card).
 - **Landing sandbox + hosted skills:** `demo_sandbox_mint` (`POST /demo/sandbox`, open, per-IP
   rate-limited) mints an anonymous throwaway team (its response now carries `live` = whether the seeded

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -37,7 +37,10 @@ each team carries its own **⚙ Settings** (`orgSettings` → switch into it, th
 **Switch** (`switchTo`) button (long names truncate, actions pinned right; the click-outside handler
 keys on `.orgblock`); (middle) the nav — Tools · **Secrets** (member+) · **Marketplace** (member+, the
 OAuth-connect view — `go('connections')`) · Activity · **Usage** (admin/owner) · Team · Getting
-started · Tutorial · Admin; (bottom)
+started · Admin, then a Help group of two external links (**Open source** (the GitHub repo) ·
+**Discord community**) —
+the Tutorial nav entry was removed 2026-08-12 in their favor; the `help` view itself survives and
+is still reachable (welcome flow, in-app links); (bottom)
 the **account** block — avatar · email · theme · sign out. The old top-bar org dropdown and top-right
 account controls are gone.
 
@@ -243,7 +246,7 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   `/?invite_expired=1`. Neither path consumes the invite (still `pending`); the accept modal does. `loadAll`
   short-circuits the org-scoped fetches while `myOrgs` is empty so no error banner flashes behind it. The
   old demo/guided stepper (`onb.*`) is removed entirely. A `demo` chip marks a sandbox org.
-- **Help → Tutorial** — the full interactive walkthrough, rendered natively (Vue) from the shared
+- **Tutorial (`view==='help'`; no nav entry since 2026-08-12)** — the full interactive walkthrough, rendered natively (Vue) from the shared
   `window.TREG_TUTORIAL` data (`tutGo`/`tutHL`/`tutCopy`, syntax-highlighted command + output blocks,
   persona chips, and four toggle panels — **Concepts · Roles · Auth shapes · Skills**). The standalone
   `/tutorial` mirrors it and opens a panel from the URL hash (`/tutorial#auth`, `#skills`). See below.
@@ -274,6 +277,11 @@ rendering fault. Every tab but the last is the **platform axis**
 mount `_LOGO_DIR` (`src/treg/web/logos/`). `connCount` labels how many accounts are already connected.
 The tab bar itself is `v-if`'d on `plats.list.length` and `mkTabActive` collapses to `'platform'` when
 the catalog is absent, so a build that predates `/catalog` renders exactly the old marketplace.
+
+The catalog page's header carries a **List as vendor** button (`vendorAsk` modal): a vendor pastes the
+two-sentence prompt (`vendorPromptText`, built on `proxy` = the server's public URL) into their own
+coding agent, which follows the hosted `GET /vendor-listing` instructions and raises the listing PR —
+including the vendor's contact email, which is how a test credential gets arranged.
 
 **One integration** is its own view (`view==='provider'`, `mkProvider`/`mkConns` keyed on `mkService`) at a
 shareable path **`/app/marketplace/<service>`** (server route `dashboard_marketplace` — plain SPA, **no**
@@ -658,7 +666,7 @@ the prose walkthrough is `docs/TUTORIAL.md`. Editing steps means editing `tutori
 
 **Two focused tutorials as cards** — **Import & shell** (`importShell`, auto-import + shell mode + the
 local-run sandbox) and **Team access control** (`access`, per-member tool access + the local-run dial)
-are cards on the Help → Tutorial chooser, rendered by **one shared stepper template** in `index.html`
+are cards on the tutorial chooser (`view==='help'`), rendered by **one shared stepper template** in `index.html`
 (`helpMode === 'import-shell' || 'access'`), with its own `xtut*`-prefixed state/computed/method names
 (`xtut.i`, `xtutSteps`, `xtutStep`, `xtutTitle`, `xtutGo`) so they never collide with the CLI tutorial's
 `tut*` names. Two extra persona chips: `you` (green) and `sam` (amber). Each also has a **prose twin**
@@ -667,7 +675,8 @@ served as markdown: `web/tutorial-import-shell.md` at `/tutorial-import-shell.md
 agent-friendly versions; the main tutorial (`tutorial.md` + `docs/TUTORIAL.md`) links them near the top
 and `tutorial.js` ends with a "Further tutorials" step pointing at the cards + URLs.
 
-**Dashboard tour** (the web-UI walkthrough — screenshots, not commands): the **Help** nav (`◫ Tutorial`)
+**Dashboard tour** (the web-UI walkthrough — screenshots, not commands): the tutorial view
+(`go('help')` — no side-nav entry anymore)
 opens a **chooser** (`helpMode` = `cli` | `dashboard` | `import-shell` | `access`, plus the Guided-setup
 replay) with five cards; the dashboard card renders a native
 stepper (`tourGo` via `tourI`, `personaTour`, per-Part `tourMatColor` mats) from **`window.TREG_TOUR`**

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1487,6 +1487,14 @@ async def tutorial_access_md():
     return _serve_md("tutorial-access.md")
 
 
+@app.get("/vendor-listing", include_in_schema=False)
+@app.get("/vendor-listing.md", include_in_schema=False)
+async def vendor_listing_md():
+    """Vendor listing instructions — what a vendor's coding agent reads before raising a PR that
+    adds their API to the catalog. Linked from the dashboard's "List your API" modal."""
+    return _serve_md("vendor-listing.md")
+
+
 @app.get("/skill.md", include_in_schema=False)
 async def skill_md():
     """The OFFICIAL treg Claude skill (3 personas), {BASE}-templated to this server.

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1296,7 +1296,8 @@ a:hover{text-decoration-color:var(--muted)}
           <button class="nav" :class="{active:view==='orgs'}" @click="go('orgs')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>Team</button>
           <div v-if="isAdmin"><div class="grp">Platform</div><button class="nav" :class="{active:view==='admin'}" @click="go('admin')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>Admin</button></div>
           <div class="grp" style="margin-top:auto">Help</div>
-          <button class="nav" :class="{active:view==='help'}" @click="helpMode=null; go('help')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>Tutorial</button>
+          <a class="nav" href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener" style="gap:6px;text-decoration:none"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.17-.02-2.12-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.75 2.69 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.18a10.9 10.9 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.59.23 2.76.11 3.05.73.81 1.18 1.83 1.18 3.09 0 4.41-2.69 5.38-5.25 5.67.41.35.77 1.04.77 2.1 0 1.52-.01 2.74-.01 3.11 0 .3.2.66.8.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>Open source</a>
+          <a class="nav" href="https://discord.gg/6mQYYfFMAn" target="_blank" rel="noopener" style="gap:6px;text-decoration:none"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.3 18.3 0 0 0-5.49 0 12.6 12.6 0 0 0-.61-1.25.08.08 0 0 0-.08-.04 19.7 19.7 0 0 0-4.88 1.52.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06c0 .02.01.04.03.05a19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.22-2a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.89.08.08 0 0 1-.01-.13c.13-.09.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.24.2.37.29a.08.08 0 0 1-.01.13c-.6.35-1.22.64-1.87.89a.08.08 0 0 0-.04.11c.36.7.77 1.36 1.22 2a.08.08 0 0 0 .08.03 19.8 19.8 0 0 0 6.02-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.95 2.42-2.16 2.42z"/></svg>Discord community</a>
         </div>
 
         <!-- Prepaid balance (admins; /billing is admin-gated) — pinned above the account block.
@@ -1330,6 +1331,7 @@ a:hover{text-decoration-color:var(--muted)}
           <div class="tut-head">
             <div><h1>2,600+ tools for agents</h1><p class="sub" style="margin:0">Connect an account once. treg holds the credential server-side and injects it on every call — nothing lands on your machine.</p></div>
             <!-- (The balance pill lives in the side nav, above the account block.) -->
+            <div class="tut-actions"><button class="btn sm" @click="vendorAsk=true" title="Sell an API? Get it listed in this catalog">List as vendor</button></div>
           </div>
           <div v-if="connErr" class="banner" style="margin-top:12px">{{connErr}}</div>
           <div v-for="c in needSecondCred" :key="'n'+c.id" class="banner" style="margin-top:12px">
@@ -3137,6 +3139,21 @@ a:hover{text-decoration-color:var(--muted)}
         </div></div>
     </div>
 
+    <!-- LIST AS VENDOR (an instruction the vendor pastes into THEIR coding agent; it raises the PR) -->
+    <div class="scrim" role="dialog" aria-modal="true" v-if="vendorAsk" @click.self="vendorAsk=false">
+      <div class="modal" style="width:min(620px,95vw)"><div class="hd"><b>List your API in this catalog</b><button class="btn sm ico" @click="vendorAsk=false" aria-label="Close">✕</button></div>
+        <div style="padding:16px 18px">
+          <p class="explain">Sell an API? This is an <b>instruction for your coding agent</b>, not for you — paste it into Claude Code, Codex or any coding agent. The agent reads the hosted instructions, prepares the listing files, and opens a pull request on the treg repo — with your contact email so we can arrange live verification.</p>
+          <div class="lbl">Agent instruction — paste into your coding agent</div>
+          <pre class="code" style="white-space:pre-wrap">{{vendorPromptText}}</pre>
+          <div style="margin-top:12px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+            <button class="btn primary" style="display:inline-flex;align-items:center;gap:7px" @click="copyVendorPrompt">
+              <img :src="agentIconInv('claudecode-color')" alt="Claude Code" style="width:15px;height:15px" onerror="this.style.display='none'"/><img :src="agentIconInv('codex-color')" alt="Codex" style="width:15px;height:15px" onerror="this.style.display='none'"/>{{vendorCopied?'Copied!':'Copy agent instruction'}}</button>
+            <a class="sub" style="font-size:12px;margin:0" :href="proxy+'/vendor-listing'" target="_blank" rel="noopener">Read the instructions yourself →</a>
+          </div>
+        </div></div>
+    </div>
+
     <!-- SHARE A DETAIL PAGE (invite someone new; they land right here after sign-in) -->
     <div class="scrim" role="dialog" aria-modal="true" v-if="share.on && detail" @click.self="share.on=false">
       <div class="modal" style="width:min(560px,95vw)"><div class="hd"><b>Share “{{detail.name}}”</b><button class="btn sm ico" @click="share.on=false" aria-label="Close">✕</button></div>
@@ -3405,6 +3422,7 @@ createApp({
       useMode:'call', runArgsStr:'', running:false, runOut:null,
       startCopied:'', startTab:'access', startAgentOpen:false, startTokenShow:false, mdMenu:false, llmsCopied:false, myToken:null, _myTokenOrg:null, tokenCopied:false,
       agentGuide:null, agentGuideCopied:false, agentRowCopied:null,
+      vendorAsk:false, vendorCopied:false,
       demo:{
         token:null, org_slug:'', ttl:60, busy:false, err:'', copied:'', signin:false,
         view:'endpoints', secrets:[], tools:[], maxSecrets:3, maxTools:3,
@@ -3727,6 +3745,9 @@ createApp({
     activeOrgId(){ return this.activeOrg ? this.activeOrg.org_id : null; },
     canAdmin(){ return ['admin','owner'].includes(this.activeRole); },
     agentPromptText(){ return this.buildAgentPrompt(this.agentGuide); },
+    // The whole vendor pitch is two sentences: the hosted /vendor-listing page carries the real
+    // instructions, so this prompt only has to name the repo, the page, and the contact email.
+    vendorPromptText(){ return `Help me create a PR to treg (https://github.com/superdesigndev/treg) that adds our API to its tool catalog. Follow the instructions at ${this.proxy}/vendor-listing — and include our contact email in the PR description so the maintainers can reach us to arrange live verification.`; },
     // first-run welcome: the agent picker (step 1) and the per-agent setup line (step 2)
     welcomeAgents(){ return [
       {id:'openclaw', name:'OpenClaw', icon:'openclaw-color'},
@@ -4584,6 +4605,9 @@ createApp({
     welcomeFinish(){ this.track('onboarding_finished',{agent:this.welcome.agent, step:this.welcome.step}); this.welcome.on=false; this.go('start');
       this.orgMsg='Team created. Send your agent the setup line any time — it lives on Getting started.'; },
     agentIcon(icon){ return 'https://unpkg.com/@lobehub/icons-static-png@latest/'+(this.theme==='dark'?'dark':'light')+'/'+icon+'.png'; },
+    // For logos that sit ON a .btn.primary: its background is the theme's INVERSE, so the icon
+    // variant has to flip too or a dark glyph lands on a dark button.
+    agentIconInv(icon){ return 'https://unpkg.com/@lobehub/icons-static-png@latest/'+(this.theme==='dark'?'light':'dark')+'/'+icon+'.png'; },
     // Product analytics — only when this deployment opted in (meta.posthog_key present); self-hosters send nothing.
     initAnalytics(){
       const key=this.meta && this.meta.posthog_key; if(!key || window.__phInit) return; window.__phInit=true;
@@ -4779,6 +4803,7 @@ createApp({
       return `set up treg — ${this.proxy}/llms.txt`;
     },
     async copyAgentPrompt(){ if(!(await this.toClipboard(this.agentPromptText))) return; this.agentGuideCopied=true; setTimeout(()=>this.agentGuideCopied=false,1500); },
+    async copyVendorPrompt(){ if(!(await this.toClipboard(this.vendorPromptText))) return; this.vendorCopied=true; setTimeout(()=>this.vendorCopied=false,1500); },
     async copyAgentGuide(kind){ if(!(await this.toClipboard(this.buildAgentPrompt(kind, true)))) return; this.agentRowCopied=kind; setTimeout(()=>{ if(this.agentRowCopied===kind) this.agentRowCopied=null; },1500); },
     switchTo(o){ this.switchOrg(o); },  // dropdown "Switch" button - just switch, stay where you are
     orgSettings(o){ this.orgMenu=false;  // dropdown ⚙ - go INTO that team, then open its settings

--- a/src/treg/web/vendor-listing.md
+++ b/src/treg/web/vendor-listing.md
@@ -1,0 +1,68 @@
+# List your API in the treg catalog — instructions for a coding agent
+
+You are helping an API vendor get listed in treg's tool catalog ({BASE}). The deliverable is a
+**pull request to https://github.com/superdesigndev/treg** containing the listing, plus a way for
+the maintainers to reach your team.
+
+## Before you write anything
+
+Clone the repo and read these two files — they are the authority, this page is only the summary:
+
+- `docs/VENDORS.md` — eligibility rules, the vendor checklist, and a complete worked example
+  (a fictional provider "Acme SEO" showing every file a listing needs).
+- `.claude/skills/vendor-listing/SKILL.md` — the exact review pipeline your PR will be run
+  through, including the live bogus-key test.
+
+Confirm eligibility first. Hard requirements: self-serve API keys (no sales call), the key rides
+in a **header or query param** (never the URL path), a free or near-free probe endpoint that
+**rejects an invalid key** with a distinguishable response, a published pricing page, and docs
+with example parameter values. If any of these fail, stop and tell your user which one — a PR
+that fails them will be declined.
+
+## What the PR contains
+
+1. **Registry entry** — an `OAuthProvider(auth_kind="key", …)` in `src/treg/oauth_providers.py`,
+   appended to `REGISTRY`: service slug, display name, `base_url`, auth mechanics
+   (`token_header`/`token_format` or `token_location="query"`+`token_param`), `category`,
+   one-line `summary`, `docs_url`, `probe_path`, and `setup_url`/`setup_steps` so users can find
+   their key. Copy the shape of the `HUNTER` entry.
+2. **Logo** — `src/treg/web/logos/<service>.svg`, a **neutral lettermark** (do not reproduce the
+   real brand mark).
+3. **Tests** — add the service id to `test_every_provider_is_registered`
+   (tests/test_oauth_providers_m3.py) and the offerable loop in tests/test_key_providers.py.
+4. **Core catalog file** — `src/treg/catalog/<service>.yaml` with the 8–15 endpoints an agent
+   would actually reach for, each with: a `capability` from `src/treg/catalog/capabilities.yaml`
+   (propose missing ones under `proposed_capabilities:`), typed `input` params, a **cheap**
+   `test_request` (smallest limit, public well-known target), and a `cost` block with provenance
+   (`value`, `currency`, `type`, `source`, `source_url`, `checked`, `confidence`). Follow the
+   schema in the worked example.
+
+## Verify before opening the PR
+
+```bash
+uv run --frozen python scripts/catalog_validate.py   # must exit 0
+uv run --frozen python -m pytest -q                  # must pass
+```
+
+Do NOT stamp `verified:` on any endpoint and do NOT commit example responses — live verification
+runs on the maintainers' side with a test credential. And **never put a credential value anywhere
+in the diff**: no API keys in the YAML, the tests, the PR description, or commit messages.
+
+## The PR description — required
+
+- **A contact email** for your team, stated plainly (e.g. `Contact: partnerships@yourapi.com`).
+  The maintainers reach out on this address to arrange a test credential for live verification —
+  a PR without it cannot be verified or merged.
+- Your probe endpoint's exact bad-key behavior (status code, or the JSON field that flips).
+- Your pricing page URL and billing model; a machine-readable rate-card endpoint if you have one
+  (that is the fastest path to treg serving your endpoints on its own key, metered).
+- Whether you publish an OpenAPI spec at a stable URL (enables a machine-generated "extended
+  tier" listing of your full endpoint surface).
+
+## What happens next
+
+Maintainers run the live checks: a garbage key POSTed at your probe must come back rejected, and
+every endpoint's `test_request` is called with the test credential you arrange over email.
+Endpoints that pass get `verified:` stamps and captured example responses; then the PR merges and
+your API is discoverable by every agent using the catalog — compared side by side with other
+providers on price, measured success rate, and speed.


### PR DESCRIPTION
## What

Vendors keep asking how to get listed. This makes the answer self-serve, end to end — a vendor's **own coding agent** raises the listing PR:

1. **"List as vendor" button** on the Catalog page header opens a modal with a copyable **agent instruction** (labeled as such; the copy button carries the Claude Code + Codex marks). The prompt names the repo and the hosted instructions URL, and requires the vendor's contact email in the PR description.
2. **`GET /vendor-listing`** (+ `.md` alias, `_serve_md`/`{BASE}`-templated) hosts the instructions the agent follows: eligibility gate, the four PR artifacts (registry entry, lettermark logo, tests, core catalog YAML), pre-PR checks, and what happens maintainer-side.
3. **`docs/VENDORS.md`** — the human-facing pitch + requirements with reasons, a complete worked example (fictional "Acme SEO"), platform-eligibility (what earns metered traffic on treg's own key), and recorded decline reasons.
4. **`.claude/skills/vendor-listing/SKILL.md`** — the maintainer-side review pipeline (intake → eligibility → registry entry → logo → tests → live bogus-key test → catalog YAML → verify/scrub/validate). Force-added past the `/.claude/` ignore because the hosted page names it, so it must exist in the public repo.

Also: the side nav's **Tutorial** entry gives way to **Open source** (repo) and **Discord community** links; the help view survives and stays reachable from the welcome flow and in-app links.

## Why the contact email is load-bearing

Live verification runs maintainer-side with a test credential the vendor arranges over email — a PR without a contact can't be verified or merged, so all three surfaces (modal prompt, hosted page, doc) state it.

## Verification

- Full suite: **1328 passed**; markup tests re-run after every UI edit.
- Verified in a real browser: signed-in dashboard, modal opened and screenshotted, nav links checked, `/vendor-listing` fetched with `{BASE}` templated.
- Doc fragments (`interface/api.md`, `interface/dashboard.md`) updated in the same commit, including the four stale Tutorial-nav references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
