### PR TITLE
feat: server-side PostHog capture — tool calls (by vendor) + top-ups

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -11,37 +11,50 @@ Regenerate via `scripts/build-map.py`.
 | Source file | Documented in |
 |---|---|
 | `README.md` | foundation/charter.md |
+| `examples/proxy-demo/server.js` | architecture/local-proxy.md |
 | `external:meetings/2026-06-30-jason-tools-registry.md` | foundation/charter.md, reference/glossary.md |
 | `render.yaml` | ops/deploy.md |
 | `src/treg/__main__.py` | ops/deploy.md |
-| `src/treg/api.py` | architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, architecture/money.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md |
-| `src/treg/mcp.py` | architecture/mcp-oauth.md |
-| `src/treg/mcp_oauth.py` | architecture/mcp-oauth.md |
+| `src/treg/agents.py` | interface/cli.md |
+| `src/treg/analytics.py` | architecture/data-model.md |
+| `src/treg/api.py` | architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, guides/expanding-a-category.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md |
 | `src/treg/audit.py` | architecture/data-model.md, ops/deploy.md |
+| `src/treg/billing.py` | architecture/money.md |
+| `src/treg/catalog_store.py` | architecture/catalog.md, interface/api.md |
 | `src/treg/cli.py` | interface/cli.md, interface/onboarding.md, interface/shell.md |
-| `src/treg/config.py` | architecture/super-admin.md, ops/deploy.md |
+| `src/treg/config.py` | architecture/super-admin.md, guides/expanding-a-category.md, ops/deploy.md |
 | `src/treg/convert.py` | interface/cli.md |
 | `src/treg/crypto.py` | architecture/auth-secrets.md |
 | `src/treg/db.py` | architecture/data-model.md, architecture/multi-tenancy.md, ops/deploy.md |
 | `src/treg/demo.py` | interface/onboarding.md |
 | `src/treg/egress.py` | architecture/local-run.md |
 | `src/treg/email.py` | interface/api.md, ops/deploy.md |
+| `src/treg/endpoint_stats.py` | architecture/catalog.md |
 | `src/treg/fsjail.py` | architecture/local-run.md |
 | `src/treg/health.py` | architecture/auth-secrets.md |
 | `src/treg/injectors.py` | architecture/auth-secrets.md |
+| `src/treg/ledger.py` | architecture/money.md |
+| `src/treg/localproxy.py` | architecture/local-proxy.md |
 | `src/treg/localrun.py` | architecture/local-run.md |
+| `src/treg/mcp.py` | architecture/mcp-oauth.md |
+| `src/treg/mcp_oauth.py` | architecture/mcp-oauth.md |
 | `src/treg/models.py` | architecture/data-model.md, architecture/multi-tenancy.md |
 | `src/treg/oauth.py` | architecture/auth-secrets.md |
+| `src/treg/oauth_providers.py` | architecture/auth-secrets.md, guides/expanding-a-category.md |
 | `src/treg/providers.py` | interface/env-import.md |
 | `src/treg/proxy.py` | architecture/proxy-model.md |
+| `src/treg/pubfeed.py` | interface/landing-sandbox.md |
 | `src/treg/ratestore.py` | architecture/data-model.md, interface/api.md |
+| `src/treg/reconcile.py` | architecture/money.md |
 | `src/treg/runner.py` | interface/api.md |
 | `src/treg/sandbox.py` | interface/landing-sandbox.md |
 | `src/treg/session.py` | interface/dashboard.md |
 | `src/treg/shell.py` | interface/shell.md |
 | `src/treg/skills.py` | interface/env-import.md |
+| `src/treg/web/connect-demo.html` | architecture/mcp-oauth.md |
 | `src/treg/web/index.html` | interface/dashboard.md, interface/landing-sandbox.md, interface/onboarding.md |
 | `src/treg/web/install.sh` | interface/landing-sandbox.md |
+| `src/treg/web/selfhost.sh` | ops/deploy.md |
 | `src/treg/web/skill.md` | interface/skill.md |
 | `src/treg/web/tour/index.html` | interface/dashboard.md |
 | `src/treg/web/tour/tour.js` | interface/dashboard.md |
@@ -52,21 +65,26 @@ Regenerate via `scripts/build-map.py`.
 
 | Fragment | Sources |
 |---|---|
-| `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `health.py` |
-| `architecture/data-model.md` | `models.py`, `db.py`, `audit.py`, `ratestore.py` |
+| `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
+| `architecture/catalog.md` | `catalog_store.py`, `endpoint_stats.py` |
+| `architecture/data-model.md` | `models.py`, `db.py`, `audit.py`, `analytics.py`, `ratestore.py` |
+| `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
-| `architecture/multi-tenancy.md` | `models.py`, `api.py`, `db.py` |
 | `architecture/mcp-oauth.md` | `mcp.py`, `mcp_oauth.py`, `connect-demo.html` |
+| `architecture/money.md` | `ledger.py`, `billing.py`, `reconcile.py`, `api.py` |
+| `architecture/multi-tenancy.md` | `models.py`, `api.py`, `db.py` |
 | `architecture/proxy-model.md` | `proxy.py`, `api.py` |
 | `architecture/super-admin.md` | `api.py`, `config.py` |
 | `foundation/charter.md` | `2026-06-30-jason-tools-registry.md`, `README.md` |
-| `interface/api.md` | `api.py`, `email.py`, `runner.py`, `ratestore.py` |
-| `interface/cli.md` | `cli.py`, `convert.py` |
+| `guides/expanding-a-category.md` | `oauth_providers.py`, `api.py`, `config.py` |
+| `interface/api.md` | `api.py`, `catalog_store.py`, `email.py`, `runner.py`, `ratestore.py` |
+| `interface/catalog-review-proposal.md` | _(no source files — narrative/reference)_ |
+| `interface/cli.md` | `cli.py`, `convert.py`, `agents.py` |
 | `interface/dashboard.md` | `index.html`, `tutorial.js`, `tutorial.html`, `tour.js`, `index.html`, `api.py`, `session.py` |
 | `interface/env-import.md` | `providers.py`, `skills.py` |
-| `interface/landing-sandbox.md` | `sandbox.py`, `api.py`, `index.html`, `install.sh` |
+| `interface/landing-sandbox.md` | `sandbox.py`, `pubfeed.py`, `api.py`, `index.html`, `install.sh` |
 | `interface/onboarding.md` | `demo.py`, `cli.py`, `index.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md` |
-| `ops/deploy.md` | `__main__.py`, `config.py`, `db.py`, `email.py`, `audit.py`, `render.yaml` |
+| `ops/deploy.md` | `__main__.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -18,11 +18,11 @@ covers (frontmatter `sources:`). Regenerate this index with
 |---|---|---|
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog_store.py, endpoint_stats.py |
-| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, ratestore.py |
+| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, analytics.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |
-| [Money — prepaid balance, the ledger, Stripe, and the reports that check it](architecture/money.md) | shipped | ledger.py, billing.py, reconcile.py |
-| [MCP — the front door for assistants, and treg as an OAuth authorization server](architecture/mcp-oauth.md) | shipped | mcp.py, mcp_oauth.py |
+| [MCP — the front door for assistants, and treg as an OAuth authorization server](architecture/mcp-oauth.md) | shipped | mcp.py, mcp_oauth.py, connect-demo.html |
+| [Money — prepaid balance, the ledger, Stripe, and the reports that check it](architecture/money.md) | shipped | ledger.py, billing.py, reconcile.py, api.py |
 | [Multi-tenancy — orgs, memberships, invites, per-org scoping](architecture/multi-tenancy.md) | shipped | models.py, api.py, db.py |
 | [The proxy — faithful credential-injecting relay + tool resolution](architecture/proxy-model.md) | shipped | proxy.py, api.py |
 | [Super-admin — cross-tenant read + control](architecture/super-admin.md) | shipped | api.py, config.py |
@@ -41,12 +41,6 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [Shell mode (treg shell) — transparent CLI interception](interface/shell.md) | shipped | shell.py, cli.py |
 | [The shippable tools-registry skill (3 personas)](interface/skill.md) | shipped | skill.md |
 
-## Guides (how-to)
-
-| Fragment | Status | Covers |
-|---|---|---|
-| [Expanding a marketplace category — the add-a-provider playbook](guides/expanding-a-category.md) | guide | oauth_providers.py, api.py, config.py |
-
 ## Ops (deploy, scale)
 
 | Fragment | Status | Covers |
@@ -58,4 +52,10 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Glossary](reference/glossary.md) | reference | 2026-06-30-jason-tools-registry.md |
+
+## guides
+
+| Fragment | Status | Covers |
+|---|---|---|
+| [Expanding a marketplace category — the add-a-provider playbook](guides/expanding-a-category.md) | guide | oauth_providers.py, api.py, config.py |
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -5,6 +5,7 @@ sources:
   - src/treg/models.py
   - src/treg/db.py
   - src/treg/audit.py
+  - src/treg/analytics.py
   - src/treg/ratestore.py
 related:
   - architecture/proxy-model.md
@@ -138,7 +139,21 @@ the small pool shared with the request path, so a loop-bound semaphore caps conc
 `_MAX_CONCURRENT_WRITES`, and under an extreme burst `_schedule` **sheds** load — it drops any row past
 `_MAX_PENDING` rather than grow unbounded — so best-effort logging can never starve real calls. `drain()`
 **loops until quiescent** (a call finishing during shutdown enqueues a new task
-after a one-shot snapshot would have gathered) on shutdown and in tests. The engine adds Postgres pool
+after a one-shot snapshot would have gathered) on shutdown and in tests.
+
+## Product analytics writer (`analytics.py`)
+The same lossy discipline as `audit.py`, but the sink is PostHog's `/batch/` endpoint, not the DB.
+`capture(distinct_id, event, properties, groups=)` is synchronous and **never raises** (call sites sit
+inside the Stripe webhook, where an exception would 500 and trigger a retry of an already-credited
+payment); it queues up to `_MAX_PENDING` events (drop-newest past the bound) and one flusher task
+micro-batches them (`_BATCH_MAX` per POST, at most every `_FLUSH_INTERVAL_S`) via a per-flush httpx
+client — no semaphore, because HTTP to PostHog never touches the DB pool. **Empty `posthog_key` = the
+module is off** (self-hosters and the test suite send nothing). `$groups: {team: org_slug}` mirrors the
+browser's `posthog.group('team', slug)` and `distinct_id` is the user email, so server events join the
+same PostHog person/group the SPA identifies. Emitters: `call_tool`'s `_audit` funnel (`tool_called`,
+with the catalog `provider` as vendor or the upstream host for own tools), `billing_topup`
+(`topup_started`), and `billing._credit` (`topup_completed`, gated on `fresh`). Drained in the lifespan
+`finally` after `audit.drain()`. The engine adds Postgres pool
 hygiene (`pool_pre_ping`/`pool_recycle`/sizing) for non-SQLite URLs, and `init_db` refuses to start with
 no `TREG_SECRET_KEY` on a real DB (an ephemeral key would lose every stored secret on restart).
 

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -42,7 +42,8 @@ Tools reach the rest of treg through `httpx.ASGITransport` against our own app â
 through the real routes, without a socket. That matters because the enforcement rules (deny rules,
 capability pins, per-member tool access, the credential ladder, metering) live in those routes. A
 second path that "just read the database" would be a second implementation of every one of them,
-drifting quietly.
+drifting quietly. The in-process client stamps `X-Treg-Client: mcp` (attribution, never a gate), so
+MCP traffic is distinguishable from unreported CLI traffic in the audit trail and analytics.
 
 The catalog is the one exception: read straight from `catalog_store`, which is already parsed in
 memory, so a search answers in about a millisecond. That is a **speed** choice, not a permission one.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -112,6 +112,13 @@ returns 500 **on purpose**: that is how Stripe is told to retry.
 The Stripe SDK is synchronous, so every call goes through `_sdk()` onto a worker thread — a blocking
 network call on the event loop would stall every in-flight request, including the proxy's hot path.
 
+`_credit` also emits the `topup_completed` product-analytics event (`analytics.capture`, PostHog),
+riding the same `fresh` flag as the receipt email so a redelivery re-emits nothing. `capture` is
+synchronous and swallowing by construction — analytics is the one side effect in the webhook that is
+allowed to fail, and it must fail silently, because a raise here would 500 the handler and make Stripe
+retry a payment that already credited. Amounts travel as canonical integer `amount_micro`; the
+`amount_usd` on the event is display-only.
+
 **Auto-top-up is guarded in depth**, because it is the part that can go wrong expensively: recorded
 consent (the PSD2/SCA mandate, a compliance requirement rather than a checkbox), a monthly cap, a
 cooldown stamped in the DB *before* the charge so a second web worker sees it, a consecutive-failure

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -112,7 +112,9 @@ response.
 
 `call_tool()` loads every bound secret (running `oauth.ensure_fresh` on oauth secrets first — see
 [auth-secrets](auth-secrets.md)), calls `relay()`, then fires `audit.record_call(...)` off the response
-path. Methods allowed: GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
+path — and, when a PostHog key is configured, mirrors the same funnel as a `tool_called` product-analytics
+event (`analytics.capture`, see [data-model](data-model.md)): vendor = the catalog provider slug, or the
+upstream host for own tools. Methods allowed: GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
 
 **Resolution + error hardening:** the URL-passthrough prefix match respects a **path-segment boundary**
 (`norm == base` or `base + "/"`), so `.../v1` no longer matches `.../v10/...` and inject the wrong

--- a/src/treg/analytics.py
+++ b/src/treg/analytics.py
@@ -1,0 +1,117 @@
+"""Server-side product analytics (PostHog) — batched, bounded, droppable.
+
+Same discipline as audit.py (rule #2: never block a proxied response), but the sink is
+PostHog's /batch/ endpoint instead of the DB. Losing an event here costs a chart, never
+money or a response, so every failure mode is a drop: queue full → drop newest, POST
+fails → drop the batch, no running loop → drop the event. `capture()` is synchronous and
+never raises — call sites stay one line and can sit inside the Stripe webhook handler
+(where an exception would 500 and make Stripe retry a payment that already credited).
+
+Gate: an empty `posthog_key` turns the whole module off — self-hosted instances send
+nothing, and the test suite (no key set) stays inert. The key is the same PUBLIC ingestion
+key the browser uses; /batch/ accepts it.
+
+Unlike audit.py there is no semaphore: that cap exists to protect the shared DB pool,
+which HTTP traffic to PostHog never touches. One flusher task micro-batches the queue
+(≤ _BATCH_MAX per POST, at most every _FLUSH_INTERVAL_S) so outbound requests stay ~0.5/s
+no matter how hot /call runs. The client is opened per flush, not cached at module level —
+a loop-bound client is exactly the footgun audit._get_sem() exists to dodge, and at one
+flush per two seconds keepalive buys nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+
+from .config import get_settings
+
+_queue: list[dict] = []
+_MAX_PENDING = 2000        # shed load past this: drop the event rather than grow unbounded
+_BATCH_MAX = 100           # events per /batch/ POST
+_FLUSH_INTERVAL_S = 2.0    # max staleness before a flush
+
+_flusher: asyncio.Task | None = None
+
+
+def enabled() -> bool:
+    """Empty posthog_key = OFF (self-hosters and tests send nothing)."""
+    return bool(get_settings().posthog_key)
+
+
+def capture(distinct_id: str, event: str, properties: dict | None = None,
+            *, groups: dict[str, str] | None = None) -> None:
+    """Queue one event. Synchronous, non-blocking, never raises.
+
+    `groups` lands as $groups (e.g. {"team": org_slug}) so server events aggregate on the
+    same PostHog group the browser stamps via posthog.group('team', slug).
+    """
+    try:
+        if not enabled() or len(_queue) >= _MAX_PENDING:
+            return
+        props = dict(properties or {})
+        if groups:
+            props["$groups"] = groups
+        props["$lib"] = "treg-server"
+        _queue.append({
+            "event": event,
+            "distinct_id": distinct_id,
+            "properties": props,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
+        _ensure_flusher()
+    except Exception:  # noqa: BLE001 — analytics must never surface into a caller's path
+        pass
+
+
+def _ensure_flusher() -> None:
+    """Start (or restart) the flusher on the CURRENT loop. No loop → drop-by-doing-nothing:
+    the event stays queued and the next capture from a loop context picks it up."""
+    global _flusher
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    if _flusher is None or _flusher.done() or _flusher.get_loop() is not loop:
+        _flusher = loop.create_task(_flush_loop())
+
+
+async def _flush_loop() -> None:
+    while _queue:
+        await asyncio.sleep(_FLUSH_INTERVAL_S)
+        while _queue:
+            batch, _queue[:_BATCH_MAX] = _queue[:_BATCH_MAX], []
+            try:
+                await _post(batch)
+            except Exception:  # noqa: BLE001 — a failed batch is dropped, the loop survives
+                pass
+
+
+async def _post(batch: list[dict]) -> None:
+    s = get_settings()
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            await client.post(f"{s.posthog_host.rstrip('/')}/batch/",
+                              json={"api_key": s.posthog_key, "batch": batch})
+    except Exception:  # noqa: BLE001 — a PostHog hiccup costs this batch, nothing else
+        pass
+
+
+async def drain() -> None:
+    """Best-effort flush of whatever is queued (shutdown / tests). One attempt per batch."""
+    global _flusher
+    if _flusher is not None and not _flusher.done():
+        _flusher.cancel()
+        try:
+            await _flusher
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+    _flusher = None
+    while _queue:
+        batch, _queue[:_BATCH_MAX] = _queue[:_BATCH_MAX], []
+        try:
+            await _post(batch)
+        except Exception:  # noqa: BLE001 — drain runs in lifespan shutdown; never mask teardown
+            pass

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -47,7 +47,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from . import audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
+from . import analytics, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
 from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import get_settings, platform_setting_name
@@ -151,6 +151,7 @@ async def lifespan(app: FastAPI):
                 yield
     finally:
         await audit.drain()  # flush pending audit writes before tearing down
+        await analytics.drain()  # best-effort flush of queued analytics events
         await app.state.http.aclose()
 
 
@@ -3728,6 +3729,10 @@ async def billing_topup(
         raise HTTPException(status_code=503, detail=str(e))
     except billing.TopupRejected as e:
         raise HTTPException(status_code=422, detail=str(e))
+    # The one place the actual payer's identity exists — the webhook that later credits the
+    # balance is org-scoped, so the started/completed funnel joins on the team group.
+    analytics.capture(caller.email, "topup_started",
+                      {"amount_usd": amount, "org": org.slug}, groups={"team": org.slug})
     return out
 
 
@@ -7457,6 +7462,11 @@ async def call_tool(
                 method=request.method, path=rest, status_code=mkexc.status_code,
                 client=_client_of(request),
                 telemetry={"endpoint_id": ep["id"], "provider": ep.get("provider")})
+            analytics.capture(caller.email, "tool_called",
+                {"tool_name": ep["id"], "status_code": mkexc.status_code,
+                 "client": _client_of(request), "method": request.method,
+                 "own_tool": False, "provider": ep.get("provider"), "endpoint_id": ep["id"]},
+                groups={"team": caller.org.slug})
             raise
         tool, upstream_url, drop_params = mk.tool, mk.upstream, mk.consumed
     _require_tool_use(caller, tool)  # per-member tool + project ACL (NULL access = all; admins exempt)
@@ -7471,6 +7481,7 @@ async def call_tool(
     # Snapshot the audit identity NOW: a failed reserve rolls the session back, expiring the ORM
     # instances behind `caller` — reading them inside a later _audit would raise MissingGreenlet.
     audit_org_id, audit_email, audit_tool = caller.org_id, caller.email, tool.name
+    audit_slug = caller.org.slug  # PostHog group key — must match the browser's posthog.group('team', slug)
 
     def _audit(status_code: int, *, observed_micro: int | None = None, charged_micro: int | None = None,
                duration_ms: int | None = None, response_bytes: int | None = None) -> None:
@@ -7492,6 +7503,18 @@ async def call_tool(
             method=request.method, path=upstream_url, status_code=status_code,
             client=_client_of(request), telemetry=telemetry,
         )
+        # Product analytics mirror of the row above. Deliberately excludes params, bodies, and the
+        # full upstream URL (hostname only) — per-call detail beyond what a chart needs stays in the DB.
+        props = {"tool_name": audit_tool, "status_code": status_code,
+                 "client": _client_of(request), "method": request.method,
+                 "own_tool": mk is None, "duration_ms": duration_ms}
+        if mk is not None:
+            props |= {"provider": mk.provider, "endpoint_id": mk.endpoint_id,
+                      "tier": mk.tier, "metered": mk.metered, "cost_type": mk.cost_type,
+                      "charged_micro": charged_micro, "observed_micro": observed_micro}
+        else:
+            props["provider"] = urlsplit(upstream_url).hostname or ""
+        analytics.capture(audit_email, "tool_called", props, groups={"team": audit_slug})
 
     # Landing-page sandbox: never touch the network — EXCEPT the one live wire. A call to the
     # exact seeded stripe tool (fingerprint-matched; see sandbox.is_live_tool) relays to the real

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -42,6 +42,7 @@ import stripe
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from . import analytics
 from . import email as email_mod
 from . import ledger
 from .config import get_settings
@@ -633,6 +634,16 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
         if to:
             await email_mod.send_topup_receipt(to, (org.name or org.slug) if org else "", amount_micro,
                                               after, auto=auto)
+        # Rides `fresh` like the receipt above, so a webhook redelivery re-emits nothing. The webhook
+        # is org-scoped, so the owner's email is the best available person (the payer may differ);
+        # the `team` group is what makes org-level revenue exact. capture() never raises — an
+        # exception here would 500 the webhook and make Stripe retry an already-credited payment.
+        analytics.capture(to or f"org:{org_id}", "topup_completed",
+                          {"amount_micro": amount_micro,
+                           "amount_usd": amount_micro / 1_000_000,  # display-only, never computed against
+                           "auto": auto, "balance_after_micro": after,
+                           "org": org.slug if org else ""},
+                          groups={"team": org.slug if org else ""})
     return {"handled": True, "credited": fresh, "block_id": block.id,
             "amount_micro": amount_micro, "balance_micro": after}
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -292,7 +292,9 @@ async def _api(token: str):
         transport=httpx.ASGITransport(app=app),
         base_url=_INTERNAL_BASE,
         timeout=_TIMEOUT,
-        headers=await _internal_auth(token),
+        # X-Treg-Client is attribution, not auth: without it every MCP-originated call lands
+        # in the audit trail as client="", indistinguishable from unreported CLI traffic.
+        headers={**await _internal_auth(token), "X-Treg-Client": "mcp"},
     ) as client:
         yield client
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4237,6 +4237,9 @@ createApp({
         this.autoAmount=Math.round(this.billing.autotopup.amount_usd);
         this.autoThreshold=Math.round(this.billing.autotopup.threshold_usd); } },
     async addFunds(amount){ this.billingBusy=true; this.topupAmount=amount; this.err='';
+      // Named differently from the server's topup_started (same click, two vantage points —
+      // a shared name would double-count in trends); this one exists to link session replays.
+      this.track('topup_checkout_opened',{amount_usd:amount});
       try{ const out=await this.api('/billing/topup',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({amount_usd:amount})});
         // Stripe's own hosted page does the payment; the balance moves when its webhook lands, never
         // on the return redirect (which a payer could simply type). Same tab, so the return lands here.

--- a/tests/test_agent_capture.py
+++ b/tests/test_agent_capture.py
@@ -204,6 +204,41 @@ async def test_promotion_link_survives_a_rotate(env):
     assert me["promoted_from"] == "m@x.dev|codex", "a rotate must not unlink the promotion"
 
 
+# ---- product analytics mirror ------------------------------------------------------------------
+async def test_call_emits_one_tool_called_event(env, monkeypatch):
+    """The audit funnel also mirrors each /call to PostHog (when a key is set): one `tool_called`
+    per call, carrying the runtime attribution and — for own tools — the upstream host as vendor."""
+    from treg import analytics
+    from treg.config import get_settings
+    monkeypatch.setattr(get_settings(), "posthog_key", "phc_test_suite", raising=False)
+
+    async def _no_post(batch):  # the flusher must not reach the real PostHog host
+        pass
+    monkeypatch.setattr(analytics, "_post", _no_post)
+    analytics._queue.clear()
+
+    r = await env.c.get("/call/alpha/ok", headers=_h(env.member, "claude-code"))
+    assert r.status_code == 200
+    events = [e for e in analytics._queue if e["event"] == "tool_called"]
+    assert len(events) == 1
+    e = events[0]
+    assert e["distinct_id"] == "m@x.dev"
+    p = e["properties"]
+    assert p["client"] == "claude-code" and p["status_code"] == 200
+    assert p["own_tool"] is True and p["tool_name"] == "alpha"
+    assert p["provider"] == "upstream"  # own tool → vendor falls back to the upstream host
+    assert p["$groups"] == {"team": "team"}
+    await analytics.drain()
+    analytics._queue.clear()
+
+
+async def test_no_key_no_tool_called_events(env):
+    from treg import analytics
+    analytics._queue.clear()  # default settings: no key
+    assert (await env.c.get("/call/alpha/ok", headers=_h(env.member, "codex"))).status_code == 200
+    assert analytics._queue == []
+
+
 # ---- the check-in handshake ---------------------------------------------------------------------
 async def test_checkin_flips_connected(env):
     made = await env.c.post(f"/orgs/{env.org_id}/agents", headers=_h(env.owner), json={"name": "ci-bot"})

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,94 @@
+"""analytics.py — bounded, batched, droppable, and OFF by default.
+
+The module's whole contract is negative space: with no posthog_key it must do nothing, and
+with one it must never raise, never block, and never grow without bound. Each test pins one
+of those guarantees; the event payload shape (distinct_id / $groups / $lib) is pinned once.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from treg import analytics
+from treg.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+async def _clean():
+    analytics._queue.clear()
+    analytics._flusher = None
+    yield
+    await analytics.drain()
+    analytics._queue.clear()
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setattr(get_settings(), "posthog_key", "phc_test_suite", raising=False)
+
+
+@pytest.fixture
+def posts(monkeypatch):
+    """Record batches instead of talking to PostHog."""
+    sent: list[list[dict]] = []
+
+    async def _fake_post(batch):
+        sent.append(batch)
+
+    monkeypatch.setattr(analytics, "_post", _fake_post)
+    return sent
+
+
+async def test_disabled_is_a_noop():
+    # default settings: no key → capture must not even queue (self-hosters send nothing)
+    analytics.capture("a@b.c", "tool_called", {"x": 1})
+    assert analytics._queue == []
+    assert analytics._flusher is None
+
+
+async def test_batch_shape_and_drain(enabled, posts):
+    analytics.capture("a@b.c", "tool_called", {"provider": "tikhub"}, groups={"team": "acme"})
+    analytics.capture("a@b.c", "tool_called", {"provider": "dataforseo"})
+    await analytics.drain()
+    assert len(posts) == 1
+    batch = posts[0]
+    assert [e["event"] for e in batch] == ["tool_called", "tool_called"]
+    first = batch[0]
+    assert first["distinct_id"] == "a@b.c"
+    assert first["properties"]["provider"] == "tikhub"
+    assert first["properties"]["$groups"] == {"team": "acme"}
+    assert first["properties"]["$lib"] == "treg-server"
+    assert "$groups" not in batch[1]["properties"]  # no groups passed → no key at all
+
+
+async def test_queue_is_bounded(enabled, monkeypatch):
+    monkeypatch.setattr(analytics, "_MAX_PENDING", 10)
+    for i in range(25):
+        analytics.capture("a@b.c", "e", {"i": i})
+    assert len(analytics._queue) == 10  # newest dropped past the bound, no growth
+
+
+async def test_oversized_drain_splits_batches(enabled, posts, monkeypatch):
+    monkeypatch.setattr(analytics, "_BATCH_MAX", 100)
+    for i in range(150):
+        analytics.capture("a@b.c", "e", {"i": i})
+    await analytics.drain()
+    assert [len(b) for b in posts] == [100, 50]
+
+
+async def test_post_failure_is_swallowed_and_capture_never_raises(enabled, monkeypatch):
+    async def _boom(batch):
+        raise RuntimeError("posthog is down")
+
+    monkeypatch.setattr(analytics, "_post", _boom)
+    analytics.capture("a@b.c", "e")
+    await analytics.drain()  # must return, not raise
+    assert analytics._queue == []  # the batch was dropped, not retried
+
+    # capture() itself swallows internal failures — the never-raise contract call sites
+    # (the Stripe webhook above all) depend on
+    def _explode():
+        raise RuntimeError("scheduling broke")
+
+    monkeypatch.setattr(analytics, "_ensure_flusher", _explode)
+    analytics.capture("a@b.c", "e")  # must not raise

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -629,3 +629,62 @@ async def _no_sdk(fn, /, **kw):
     """A Stripe call the test did not expect. Anything reaching here is a code path that would have
     hit the network in production."""
     raise AssertionError(f"unexpected Stripe call: {fn} {kw}")
+
+
+# ---- product analytics (PostHog) ----------------------------------------------------------------
+async def test_topup_completed_fires_once_across_redelivery(c: AsyncClient, monkeypatch):
+    """One PostHog `topup_completed` per PaymentIntent — a webhook redelivery re-credits nothing
+    and must re-emit nothing (same `fresh` guard as the receipt email)."""
+    from treg import analytics
+    org_id, _owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    monkeypatch.setattr(get_settings(), "posthog_key", "phc_test_suite", raising=False)
+
+    async def _no_post(batch):  # the flusher must not reach the real PostHog host
+        pass
+    monkeypatch.setattr(analytics, "_post", _no_post)
+    analytics._queue.clear()
+
+    event = _pi_event(org_id, pi="pi_analytics_once", cents=1500)
+    assert (await _deliver(c, event)).json()["credited"] is True
+    assert (await _deliver(c, event)).json()["credited"] is False
+
+    done = [e for e in analytics._queue if e["event"] == "topup_completed"]
+    assert len(done) == 1, "a redelivered webhook emitted a second revenue event"
+    props = done[0]["properties"]
+    assert props["amount_micro"] == 15_000_000  # canonical integer micro-USD
+    assert props["auto"] is False
+    assert props["balance_after_micro"] == get_settings().promo_grant_micro + 15_000_000
+    assert props["$groups"] == {"team": props["org"]}
+    assert done[0]["distinct_id"] == "billing@superdesign.dev"
+    analytics._queue.clear()
+
+
+async def test_analytics_outage_cannot_500_the_webhook(c: AsyncClient, monkeypatch):
+    """A handler exception returns 500 ON PURPOSE (Stripe retries) — so analytics must be
+    incapable of causing one, even when its own machinery breaks."""
+    from treg import analytics
+    org_id, _owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    monkeypatch.setattr(get_settings(), "posthog_key", "phc_test_suite", raising=False)
+
+    async def _no_post(batch):
+        pass
+    monkeypatch.setattr(analytics, "_post", _no_post)
+
+    def _explode():
+        raise RuntimeError("flusher scheduling broke")
+    monkeypatch.setattr(analytics, "_ensure_flusher", _explode)
+
+    r = await _deliver(c, _pi_event(org_id, pi="pi_analytics_broken", cents=500))
+    assert r.status_code == 200 and r.json()["credited"] is True
+    analytics._queue.clear()
+
+
+async def test_no_posthog_key_means_no_events(c: AsyncClient, monkeypatch):
+    from treg import analytics
+    org_id, _owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    analytics._queue.clear()  # default settings: no key
+    assert (await _deliver(c, _pi_event(org_id, pi="pi_no_key", cents=500))).status_code == 200
+    assert analytics._queue == []


### PR DESCRIPTION
## Why

The PostHog project only receives six browser events (onboarding/try-it). The core action — an API call through the `/call` proxy — and revenue — a top-up — were invisible, so activation, real-usage retention, vendor mix, and signup→paid conversion couldn't be measured. Call data existed only in the internal `CallRecord` table; payments only in Stripe + the ledger.

## What

**New `src/treg/analytics.py`** — a PostHog capture sibling of `audit.py`: same bounded fire-and-forget discipline (drop-newest past 2000 queued, failures swallowed, drained in lifespan), but micro-batched to `{posthog_host}/batch/` (≤100 events per POST, ≥2s apart) instead of the DB, and with no semaphore — HTTP to PostHog never touches the DB pool. **Empty `TREG_POSTHOG_KEY` = the module is off** (self-hosters and the test suite send nothing). `capture()` is synchronous and never raises.

**Events** (distinct_id = user email, `$groups.team` = org slug — joining the SPA's `identify(email)` + `group('team', slug)` exactly):

- `tool_called` — from `call_tool`'s `_audit` funnel, so every outcome is one event (success, upstream error, 402/429, sandbox, and the malformed-marketplace early exit). Vendor = catalog `provider` slug for marketplace calls, upstream host + `own_tool: true` for a team's own tools; plus client runtime, tier, metered, status, duration, integer-micro costs. Params, bodies, and full URLs deliberately excluded.
- `topup_started` — at checkout creation, the only place the payer's own email exists.
- `topup_completed` — in `billing._credit`, riding the same `fresh` flag as the receipt email, so a Stripe webhook redelivery re-emits nothing. `capture()` being unable to raise preserves the 500-means-retry webhook contract.

**Attribution fix**: the MCP in-process client now stamps `X-Treg-Client: mcp` — previously all MCP-originated calls landed as `client=""`, indistinguishable from unreported CLI traffic.

**Web**: one `track('topup_checkout_opened')` in `addFunds` for session-replay linkage (named differently from the server event to avoid double-counting).

## Tests

`tests/test_analytics.py` (off-by-default, bounds, batch shape/split, never-raise) plus webhook redelivery emits-once, analytics-breakage-cannot-500-the-webhook, and a real `/call` → one `tool_called` assertion in the existing harnesses. Full suite: **1338 passed**.

## Docs

`data-model.md` (new analytics writer section), `money.md`, `proxy-model.md`, `mcp-oauth.md` updated; MAP.md rebuilt; drift.sh maps every changed source.

## After deploy

Set/verify `TREG_POSTHOG_KEY` in prod, then the PostHog dashboard gets: calls by vendor, activation funnel (team created → first call), payer funnel, and revenue trend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)