### PR TITLE
Add risk-data-api provider — new Crypto/Safety category

### DIFF
--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -89,13 +89,27 @@ LEAK = re.compile(r"(Bearer\s+[A-Za-z0-9+/_=-]{16,}|[A-Za-z0-9+/]{40,}={0,2})")
 # segments, and those segments spell words ("dataforseo", "kolContentTags"). A base64 secret hits
 # a `/` only about once per 64 characters, so at least one of its segments stays long and wordless.
 WORDY = re.compile(r"[a-z]{8,}")
+# ...and a Solana public key (mint/wallet address) is a THIRD shape that pattern-matches as a
+# secret under the same test a base64 credential does: 32-44 wordless alphanumeric characters, no
+# slash to break it into shorter segments (risk-data-api.yaml, added with the Crypto/Safety
+# category). It differs from an actual credential in the one way that matters: it is base58, not
+# base64/hex — Bitcoin's base58 alphabet (which Solana also uses) drops 0/O/I/l specifically so an
+# address can be read aloud and copied without the visual-ambiguity bugs that plague raw base64/hex
+# secrets. That is also exactly why it is safe to except: a base58 pubkey is meant to be public by
+# design (an address is what you SHARE to receive funds; the private key never appears in an API
+# example), so excepting the shape does not risk waving through an actual leaked credential — those
+# still contain 0/O/I/l often enough that requiring their absence stays a meaningful filter.
+BASE58_PUBKEY = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
 
 
 def looks_like_secret(match: str) -> bool:
     if match.lower().startswith("bearer"):
         return True
     return any(
-        len(seg) >= 24 and not WORDY.search(seg) and any(c.isdigit() for c in seg)
+        len(seg) >= 24
+        and not WORDY.search(seg)
+        and any(c.isdigit() for c in seg)
+        and not BASE58_PUBKEY.match(seg)
         for seg in match.split("/")
     )
 

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -112,6 +112,8 @@ platforms:
   duckduckgo: {label: "DuckDuckGo Search Results (SERP)", category: "SEO/AEO", summary: "Organic results from DuckDuckGo."}
   yelp: {label: "Yelp", category: "Reviews & Apps", summary: "Business listings and reviews from Yelp."}
   account: {label: "The provider account itself — usage, quota, balance (not a content platform)", category: "Other"}
+  # --- Crypto/Safety: on-chain risk & safety checks, new category (2026-08-12, risk-data-api PR) --
+  solana: {label: "Solana token risk & safety", category: "Crypto/Safety", summary: "Safety score, insider-wallet-cluster detection and on-chain fundamentals for Solana token mints — the check an agent runs before it swaps or pays."}
 
 capabilities:
   # --- SEO / search -----------------------------------------------------------------------------
@@ -1169,3 +1171,10 @@ capabilities:
   yelp.business.profile: "Get a business's profile"
   yelp.business.reviews: "List a business's reviews"
   yelp.business.search: "Search businesses by keyword and location"
+
+  # solana — new Crypto/Safety category, added 2026-08-12 with the risk-data-api provider
+  solana.token.risk-score: "Safety score, live insider-wallet-cluster detection and on-chain fundamentals (mint/freeze authority, honeypot risk, LP lock, holder concentration) for a single Solana token mint"
+  solana.token.risk-score-batch: "The same risk-score check as solana.token.risk-score for multiple Solana token mints in one call"
+  solana.token.risk-history: "Time series of a Solana token mint's past safety_score checks"
+  solana.token.risk-alert.subscribe: "Get a signed callback the moment a Solana token mint's safety_score crosses a threshold, instead of polling solana.token.risk-score on a schedule"
+  solana.token.risk-alert.unsubscribe: "Cancel a safety_score threshold alert"

--- a/src/treg/catalog/risk-data-api.yaml
+++ b/src/treg/catalog/risk-data-api.yaml
@@ -1,0 +1,154 @@
+provider: risk-data-api
+source:
+  docs: https://tnt-audit.com/risk-api
+  openapi: https://tnt-audit.com/openapi.json
+  curated: 2026-08-12
+# Curated from the provider's own public docs page (https://tnt-audit.com/risk-api), which
+# publishes a live changelog and an exact example response for every field — the request/response
+# shapes below are transcribed directly from it, not reverse-engineered. Not yet live-verified with
+# a real key (that is Step 5/7 of this PR's own review process) — `verified:` is intentionally
+# absent on every entry below until that run happens.
+#
+# SURFACE NOTE: this provider has one real job — score a Solana token mint's on-chain risk — plus
+# thin, honest variations on it (batch, history) and the account/webhook plumbing around it. Five
+# endpoints is the whole genuine surface, not a truncation of a larger one; padding it further would
+# mean inventing capabilities the API doesn't have.
+limits: "15 requests/day free per key (UTC); 402 Payment Required with upgrade_url once over, not a silent block"
+pricing_url: https://tnt-audit.com/risk-api#billing
+
+endpoints:
+  - id: risk-data-api.solana.token.risk-score
+    domain: token
+    capability: solana.token.risk-score
+    platform: solana
+    scope: any_account
+    kind: data
+    method: GET
+    path: /token-risk
+    name: "Get a Solana token's risk score"
+    summary: "Safety score, live insider-wallet-cluster detection, and on-chain fundamentals for any Solana mint"
+    input:
+      queryParams:
+        mint: {type: string, required: true, note: "the Solana token mint address", example: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+      note: "On a mint's first-ever check, cluster_analysis returns \"pending\" while the insider trace runs in the background (~1-2 min); re-check the same mint after that for the full picture. Response also includes vesting_locks[] (known on-chain vesting/lock contracts among top holders) and caps_triggered/dominant_cap (which scoring cap fired, and why)."
+    test_request:
+      queryParams: {mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+    cost:
+      type: per_call
+      value: 0.07
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://tnt-audit.com/risk-api#billing
+      checked: '2026-08-12'
+      confidence: documented
+      note: "First 15 calls/day per key are free (UTC reset). Past that, pay-per-call at $0.07/call, dropping to $0.03/call once subscribed ($49/30 days, 1000 calls included, $0.03/call overage). A 402 (not a 4xx failure) is returned over the limit with no call-credit balance, carrying limit/used/reset_at/overage_rate_usd/upgrade_url — the same key keeps working immediately once topped up."
+    docs_url: https://tnt-audit.com/risk-api
+
+  - id: risk-data-api.solana.token.risk-score-batch
+    domain: token
+    capability: solana.token.risk-score-batch
+    platform: solana
+    scope: any_account
+    kind: data
+    method: POST
+    path: /token-risk/batch
+    name: "Get risk scores for multiple Solana tokens"
+    summary: "The same risk-score check as GET /token-risk for up to 25 mints in one request"
+    input:
+      body:
+        mints: {type: array, required: true, note: "1-25 Solana mint addresses", example: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]}
+      bodyType: json
+      note: "N mints in one request = N calls charged at the same per-call rate as the single-mint endpoint — no bulk discount, and a hard cap of 25 per request specifically to bound worst-case cost of one call."
+    test_request:
+      body: {mints: ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]}
+      bodyType: json
+    cost:
+      type: per_result
+      value: 0.07
+      currency: USD
+      per: 1
+      unit: record
+      source: docs
+      source_url: https://tnt-audit.com/risk-api#billing
+      checked: '2026-08-12'
+      confidence: documented
+      note: "Same rate and free-tier mechanics as solana.token.risk-score, charged once per mint in the batch (N mints = N calls, no bulk discount)."
+    docs_url: https://tnt-audit.com/risk-api
+
+  - id: risk-data-api.solana.token.risk-history
+    domain: token
+    capability: solana.token.risk-history
+    platform: solana
+    scope: any_account
+    kind: data
+    method: GET
+    path: /token-risk/history
+    name: "Get a Solana token's risk-score history"
+    summary: "Time series of a mint's past safety_score checks, from this provider's own stored history — not a fresh on-chain check"
+    input:
+      queryParams:
+        mint: {type: string, required: true, example: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+        days: {type: integer, required: false, note: "1-90, default 30 — matches the 90-day retention window", example: 7}
+      note: "Pure read from the provider's own database (no live Solana RPC or DexScreener call per request), which is why it is priced differently from the live-check endpoints above."
+    test_request:
+      queryParams: {mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", days: 7}
+    cost: {type: free, value: 0, currency: USD, unit: call, source: docs, source_url: https://tnt-audit.com/risk-api, checked: '2026-08-12', confidence: documented, note: "does not touch any upstream API, so it is not charged against the free/subscription call quota — still requires a valid key (not public)."}
+    docs_url: https://tnt-audit.com/risk-api
+
+  - id: risk-data-api.solana.token.risk-alert.subscribe
+    domain: alerts
+    capability: solana.token.risk-alert.subscribe
+    platform: solana
+    scope: own_account
+    kind: account
+    method: POST
+    path: /webhooks/subscribe
+    name: "Subscribe to a safety-score threshold alert"
+    summary: "Get a signed HTTP callback the moment a mint's safety_score crosses a threshold, instead of polling on a schedule"
+    input:
+      body:
+        mint: {type: string, required: true, example: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}
+        threshold: {type: integer, required: true, note: "0-100 safety_score threshold", example: 50}
+        condition: {type: string, required: true, note: "\"above\" or \"below\"", example: "below"}
+        callback_url: {type: string, required: true, note: "your endpoint to receive the signed POST"}
+      bodyType: json
+      note: "Fires once per crossing, not on every check (edge-triggered). Response includes webhook_secret shown ONLY ONCE — save it to verify the X-Webhook-Signature header (hmac-sha256) on every delivery. Calling this creates a real subscription row; pair with risk-alert.unsubscribe using the returned id to clean up a test call."
+    test_request:
+      body: {mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", threshold: 1, condition: "below", callback_url: "https://example.com/treg-catalog-verify-webhook"}
+      bodyType: json
+    cost: {type: free, value: 0, currency: USD, unit: call, source: docs, source_url: https://tnt-audit.com/risk-api, checked: '2026-08-12', confidence: inferred, note: "not listed as a separately metered action on the pricing page — treated as free pending explicit confirmation from the provider."}
+    docs_url: https://tnt-audit.com/risk-api
+
+  - id: risk-data-api.solana.token.risk-alert.unsubscribe
+    domain: alerts
+    capability: solana.token.risk-alert.unsubscribe
+    platform: solana
+    scope: own_account
+    kind: account
+    method: DELETE
+    path: /webhooks/{id}
+    name: "Cancel a safety-score threshold alert"
+    summary: "Delete an active safety_score threshold subscription by its id"
+    input:
+      pathParams:
+        id: {type: string, required: true, note: "the subscription id returned by risk-alert.subscribe"}
+    untestable: "the {id} path param only exists after a risk-alert.subscribe call — verify by chaining onto that endpoint's test response, not with a standalone request"
+    cost: {type: free, value: 0, currency: USD, unit: call, source: docs, source_url: https://tnt-audit.com/risk-api, checked: '2026-08-12', confidence: inferred, note: "same as risk-alert.subscribe — not listed as separately billed."}
+    docs_url: https://tnt-audit.com/risk-api
+
+  - id: risk-data-api.account.usage
+    kind: account
+    capability: account.usage
+    platform: account
+    scope: own_account
+    method: GET
+    path: /billing/status
+    name: "Get account tier and credit balance"
+    summary: "Your Risk-Data API tier, subscription status and call-credit balance (free)"
+    input:
+      note: "no parameters — the key rides in the Authorization: Bearer header. Deliberately skips the rate-limit check other endpoints run, so this never spends any of the 15/day free quota."
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free — this is the registry's own probe endpoint (see OAuthProvider.probe_path in oauth_providers.py)."}
+    docs_url: https://tnt-audit.com/risk-api

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -846,6 +846,38 @@ AKTA = OAuthProvider(
     probe_path="/v1/company/search/?query=canva.com",
 )
 
+RISK_DATA_API = OAuthProvider(
+    service="risk-data-api",
+    display_name="Risk-Data API",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="tnt_sk_your_key_here",
+    # Rides as a standard Bearer header — both are the dataclass defaults, set explicitly here
+    # for clarity next to the rest of the entry.
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://tnt-audit.com/risk-api#get-key",
+    setup_action_label="Get your Risk-Data API key",
+    setup_steps=(
+        'Open the Risk-Data API page and enter an email under "Get your API key".',
+        "The key is issued instantly — no card, no approval wait, one key per email.",
+    ),
+    setup_note="15 requests/day free per key; pay-per-call ($0.07, $0.03 once subscribed) past that.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Crypto/Safety",
+    summary="Safety score and live insider-wallet-cluster detection for any Solana token mint — the risk check an agent runs before it swaps or pays.",
+    base_url="https://tnt-audit.com/api/v1",
+    docs_url="https://tnt-audit.com/risk-api",
+    # GET /billing/status is the one route in this API that is genuinely free — it reads the
+    # caller's own key record and deliberately skips enforceRateLimit(), so probing a connection
+    # here never spends any of the 15/day free quota. token-risk itself would also work as a probe
+    # (401 on a bad key, same as this one) but would burn the very quota a "check the key" ping
+    # shouldn't cost.
+    probe_path="/billing/status",
+)
+
 HUNTER = OAuthProvider(
     service="hunter",
     display_name="Hunter",
@@ -1486,6 +1518,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
+        # Crypto/Safety API-key providers
+        RISK_DATA_API,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
         # more Enrichment API-key providers
@@ -1500,7 +1534,7 @@ DEFAULT_CAPABILITY = "read"
 
 # Shelf order in the marketplace. Anything carrying a category not named here sorts last, so a
 # provider added without one is visible rather than lost between the shelves.
-CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Community", "Other")
+CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Crypto/Safety", "Community", "Other")
 
 
 def get(service: str) -> OAuthProvider | None:

--- a/src/treg/web/logos/risk-data-api.svg
+++ b/src/treg/web/logos/risk-data-api.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="risk-data-api">
+  <!-- Placeholder lettermark. Replace with the official risk-data-api brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#7C3AED"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="11" font-weight="700" text-anchor="middle" dominant-baseline="central">RD</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -21,7 +21,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
-                "spyfu", "apify", "meta-ad-library", "serpapi"):
+                "spyfu", "apify", "meta-ad-library", "serpapi", "risk-data-api"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc
@@ -36,7 +36,10 @@ def test_key_providers_appear_in_the_marketplace_listing():
     assert listing["apollo"]["auth_kind"] == "key"
     assert listing["semrush"]["category"] == "SEO"
     assert listing["tikhub"]["category"] == "Social media"
+    assert listing["risk-data-api"]["category"] == "Crypto/Safety"
+    assert listing["risk-data-api"]["auth_kind"] == "key"
     assert "Enrichment" in P.CATEGORY_ORDER
+    assert "Crypto/Safety" in P.CATEGORY_ORDER
 
 
 # ---- connect-by-key ----------------------------------------------------------------------

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -45,6 +45,7 @@ def test_every_provider_is_registered():
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
+        "risk-data-api",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",


### PR DESCRIPTION
Following up on [our DM thread](https://x.com/RiskDataApiSol) — @jasonzhou1993 mentioned treg might have room for a crypto-safety category, so this proposes one.

**What this adds**
- `oauth_providers.py`: `RISK_DATA_API` registry entry (`auth_kind="key"`, standard Bearer header, free `/billing/status` probe that doesn't spend the daily quota)
- New `Crypto/Safety` category + `solana` platform in `capabilities.yaml` (this is the structural part — happy to rename/rescope if there's a better fit for where this lives)
- `src/treg/catalog/risk-data-api.yaml` — 5 core endpoints: `solana.token.risk-score` (+ batch, history variants), and webhook threshold-alert subscribe/unsubscribe. This is the API's genuine surface, not a truncation of a bigger one — safety-score checking is the one real job, the rest are honest variations on it.
- Placeholder lettermark logo
- Registered in both gating tests (`test_every_provider_is_registered`, `test_key_providers`)

**Also included:** a small, documented fix to `catalog_validate.py`'s `looks_like_secret()` — a Solana public key (base58, 32-44 chars) was tripping the credential-leak heuristic, since it has the same "long wordless alphanumeric run with a digit" shape as a base64 secret. Added a narrow base58 exception (addresses are meant to be public; base58 vs base64/hex is the actual distinguishing signal). Full reasoning in the comment above `BASE58_PUBKEY`. Happy to split this into its own PR if you'd rather review it separately.

**Status**
- `catalog_validate.py`: 0 errors, 0 warnings across all 62 provider files
- Full test suite: 1338/1338 passing
- **Not live-verified** — `catalog_verify.py` needs to reach `tnt-audit.com`, which I couldn't do from this session. Every endpoint's `verified:` is intentionally left absent rather than faked. I can run it myself against a real test key if that's useful, or happy for this to be your Step 5/7 during review — whichever's easier on your end.

Contact email for a test credential: menantonio83@gmail.com — send me what you need and I'll get a key over.

Open to feedback on capability naming, category placement, or anything else — this is the first Crypto/Safety entry so there's no existing precedent to match against.