### PR TITLE
feat(catalog): add Linkup web search provider

### DIFF
--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -114,7 +114,7 @@ module symbols:
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,
   Akta, Hunter, Crunchbase, Lusha, Coresignal, Diffbot, The Companies API, LeadMagic on a new
   **Enrichment** shelf, TikHub + Bright Data + Just One API under
-  Social, under **SEO** Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat, and under
+  Social, under **SEO** Linkup + Semrush + DataForSEO, SE Ranking, Moz, Majestic, Serpstat, and under
   **Advertising** the ad-intel keys SpyFu, Apify, Meta Ad Library, SerpApi — alongside the OAuth ad
   platforms Google Ads + Meta Ads and the **unconfigured** Microsoft Ads, Snapchat Ads, Pinterest Ads
   (standard OAuth, live once this deployment sets their client credentials) and TikTok Ads (a

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -424,6 +424,11 @@ Success criteria for a provider PR: validator exits 0; every endpoint either car
 date + example file or an explicit comment why it could not be live-tested; no credential value
 appears anywhere in the diff.
 
+Linkup is the first agentic open-web provider curated here: its core catalog keeps Search's raw,
+sourced-answer and structured response shapes separate, plus Fetch. Their documented prices vary
+with body parameters, so the static test-request price is marked `inferred` and is not eligible for
+treg's platform key until reservation can price `depth`, `outputType` and `renderJs`.
+
 ## Process — bulk-ingesting the extended tier
 
 ```

--- a/docs/context/interface/env-import.md
+++ b/docs/context/interface/env-import.md
@@ -23,7 +23,8 @@ Bare `treg upload` does **both** sides of the dir; `treg upload env` / `treg upl
   each as a tool (+ recipe) or a recipe-only bundle — see "Skill directories" below.
 
 ## The provider catalog (`CATALOG`)
-~80 curated providers (`CATALOG_VERSION`, now **9** — added `probe` = a cheap authenticated GET path per
+~80 curated providers (`CATALOG_VERSION`, now **10** — added Linkup web search/fetch with a free
+authenticated balance probe; `probe` = a cheap authenticated GET path per
 provider so an imported tool self-validates, then a wave of `cli` local-run blocks plus the CLI-only
 providers Google Cloud, Azure, and Supabase, and per-CLI `deny` rules for leaky subcommands — see the `cli`
 block below),
@@ -55,7 +56,7 @@ real machine test (docs lie — Vercel ships an env var it ignores, so it inject
 verified); `beta` marks an unverified entry. Several entries now carry **`deny`** patterns for subcommands
 that would print the injected key or run member code as the isolated runner (`gh extension`/`alias`/`auth
 token`/`--show-token`, `flyctl|turso auth token`, `doppler|infisical run`, …) — enforced by `check_deny` at
-grant (see [local-run](../architecture/local-run.md)). `CATALOG_VERSION` is now **9**. An `unsupported:true` block is first-class: it tells the analyzer
+grant (see [local-run](../architecture/local-run.md)). `CATALOG_VERSION` is now **10**. An `unsupported:true` block is first-class: it tells the analyzer
 WHY and what to do instead (e.g. **Azure** — device-login only → register a service principal as an HTTP tool).
 The catalog can never ENABLE a local run — only the owner's `tool.cli.enabled` does.
 

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -217,6 +217,10 @@ capabilities:
   web.scrape.job.start: "Start a scraping job over many URLs"
   web.scrape.job.status: "Check if a scraping job has finished"
   web.scrape.structured: "Scrape a URL into structured records"
+  web.search.results: "Search the live web for sources and snippets"
+  web.search.answer: "Answer a question from cited live web sources"
+  web.search.structured: "Search the live web into a JSON schema"
+  web.page.fetch: "Fetch a public page as clean Markdown"
 
   # merged from ad-provider proposed_capabilities (2026-07-28)
   meta-ads.library.advertiser: "Ads a specific Page is running now"

--- a/src/treg/catalog/linkup.yaml
+++ b/src/treg/catalog/linkup.yaml
@@ -1,0 +1,165 @@
+provider: linkup
+source:
+  docs: https://docs.linkup.so/
+  openapi: https://api.linkup.so/v1/openapi.json
+  curated: 2026-08-12
+
+# UNVERIFIED — no Linkup credential was available while curating this file. The request shapes,
+# constraints and prices below come from Linkup's live OpenAPI document and official pricing page.
+# Credential behavior was checked live on 2026-08-12: a bogus Bearer token returns HTTP 401 from
+# both POST /search and GET /credits/balance. Run:
+#   TREG_CATALOG_CRED='<key>' uv run python scripts/catalog_verify.py linkup --write
+# to capture examples and stamp only the endpoints that pass.
+#
+# Search and fetch prices vary with request parameters. Each cost below is the documented price for
+# its test_request, but is deliberately `confidence: inferred`: callers can change `depth`,
+# `outputType` or `renderJs`, so the static amount is only a floor for the route. This keeps the
+# endpoints off treg's own prepaid key until parameter-aware reservation exists.
+
+limits: "10 requests/second per organization for Search and Fetch"
+pricing_url: https://docs.linkup.so/pages/documentation/platform/pricing
+endpoints:
+  - id: linkup.web.search.results
+    capability: web.search.results
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search the live web"
+    summary: "Retrieve live web sources with titles, URLs, snippets and optional images"
+    input:
+      bodyType: json
+      body:
+        q: {type: string, required: true, note: "natural-language retrieval instruction", example: "Find the official Linkup API documentation"}
+        depth: {type: string, required: true, note: "fast | standard | deep; fast and standard cost $0.005, deep costs $0.05", example: "fast"}
+        outputType: {type: string, required: true, note: "must be searchResults for this response shape", example: "searchResults"}
+        includeDomains: {type: array, required: false, note: "hard allow-list of up to 100 domains"}
+        excludeDomains: {type: array, required: false, note: "hard domain block-list"}
+        fromDate: {type: string, required: false, note: "ISO date YYYY-MM-DD; must be before toDate"}
+        toDate: {type: string, required: false, note: "ISO date YYYY-MM-DD"}
+        includeImages: {type: boolean, required: false, note: "include image results; default false"}
+        maxResults: {type: number, required: false, note: "maximum results, at least 1"}
+      note: "Results arrive in results[]; text rows contain name, url, content and favicon. Errors and no-result searches are not charged."
+    test_request:
+      body: {q: "Find the official Linkup API documentation", depth: "fast", outputType: "searchResults", maxResults: 2}
+    cost:
+      type: per_success
+      value: 0.005
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.linkup.so/pages/documentation/platform/pricing
+      checked: '2026-08-12'
+      confidence: inferred
+      note: "$0.005 for fast/standard searchResults, as used by the test request; deep searchResults costs $0.05. Errors and no-result searches are free."
+    docs_url: https://docs.linkup.so/pages/documentation/endpoints/search/reference
+
+  - id: linkup.web.search.answer
+    capability: web.search.answer
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Answer from cited web sources"
+    summary: "Generate a sourced answer from live web results"
+    input:
+      bodyType: json
+      body:
+        q: {type: string, required: true, note: "question or retrieval instruction", example: "Where is the official Linkup API documentation?"}
+        depth: {type: string, required: true, note: "fast | standard | deep; deep enables iterative search and scraping", example: "standard"}
+        outputType: {type: string, required: true, note: "must be sourcedAnswer for this response shape", example: "sourcedAnswer"}
+        includeInlineCitations: {type: boolean, required: false, note: "add inline citations to the answer; default false"}
+        includeDomains: {type: array, required: false, note: "hard allow-list of up to 100 domains"}
+        excludeDomains: {type: array, required: false, note: "hard domain block-list"}
+        fromDate: {type: string, required: false, note: "ISO date YYYY-MM-DD; must be before toDate"}
+        toDate: {type: string, required: false, note: "ISO date YYYY-MM-DD"}
+      note: "Returns answer plus sources[] with name, URL, favicon and supporting snippet. Errors and no-result searches are not charged."
+    test_request:
+      body: {q: "Where is the official Linkup API documentation?", depth: "standard", outputType: "sourcedAnswer"}
+    cost:
+      type: per_success
+      value: 0.006
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.linkup.so/pages/documentation/platform/pricing
+      checked: '2026-08-12'
+      confidence: inferred
+      note: "$0.006 for fast/standard sourcedAnswer, as used by the test request; deep sourcedAnswer costs $0.055. Errors and no-result searches are free."
+    docs_url: https://docs.linkup.so/pages/documentation/endpoints/search/reference
+
+  - id: linkup.web.search.structured
+    capability: web.search.structured
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search into structured JSON"
+    summary: "Return live web research as JSON matching a caller-provided schema"
+    input:
+      bodyType: json
+      body:
+        q: {type: string, required: true, note: "instruction naming the exact fields to retrieve", example: "Find Linkup's API documentation title and URL"}
+        depth: {type: string, required: true, note: "fast | standard | deep", example: "standard"}
+        outputType: {type: string, required: true, note: "must be structured", example: "structured"}
+        structuredOutputSchema: {type: object, required: true, note: "JSON Schema with type object at the root"}
+        includeSources: {type: boolean, required: false, note: "return sources alongside data; changes the response envelope"}
+        includeDomains: {type: array, required: false, note: "hard allow-list of up to 100 domains"}
+        excludeDomains: {type: array, required: false, note: "hard domain block-list"}
+      note: "Without includeSources, the response is the schema-shaped object itself; with it, the response is {data, sources}."
+    test_request:
+      body:
+        q: "Find Linkup's API documentation title and URL"
+        depth: "standard"
+        outputType: "structured"
+        structuredOutputSchema:
+          type: object
+          properties:
+            title: {type: string}
+            url: {type: string}
+          required: [title, url]
+    cost:
+      type: per_success
+      value: 0.006
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.linkup.so/pages/documentation/platform/pricing
+      checked: '2026-08-12'
+      confidence: inferred
+      note: "$0.006 for fast/standard structured output, as used by the test request; deep structured output costs $0.055. Errors and no-result searches are free."
+    docs_url: https://docs.linkup.so/pages/documentation/endpoints/search/reference
+
+  - id: linkup.web.page.fetch
+    capability: web.page.fetch
+    platform: web
+    scope: any_account
+    method: POST
+    path: /fetch
+    name: "Fetch a page as Markdown"
+    summary: "Fetch one public URL as clean Markdown, with optional JavaScript rendering and images"
+    input:
+      bodyType: json
+      body:
+        url: {type: string, required: true, note: "public webpage or PDF URL", example: "https://docs.linkup.so"}
+        renderJs: {type: boolean, required: false, note: "render client-side JavaScript; default false; raises cost from $0.001 to $0.005"}
+        extractImages: {type: boolean, required: false, note: "include extracted image URLs and alt text"}
+        includeRawContent: {type: boolean, required: false, note: "include the raw page content and content type"}
+      note: "Returns markdown and favicon; images and rawContent appear only when requested. includeRawHtml is deprecated in favor of includeRawContent."
+    test_request:
+      body: {url: "https://docs.linkup.so", renderJs: false}
+    cost:
+      type: per_success
+      value: 0.001
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.linkup.so/pages/documentation/platform/pricing
+      checked: '2026-08-12'
+      confidence: inferred
+      note: "$0.001 without JavaScript rendering, as used by the test request; renderJs=true costs $0.005. Errors are free."
+    docs_url: https://docs.linkup.so/pages/documentation/endpoints/fetch/reference

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1035,6 +1035,34 @@ SCRAPECREATORS = OAuthProvider(
     token_verify_field="creditCount",
 )
 
+# ---- web search API-key providers -------------------------------------------------------------
+
+LINKUP = OAuthProvider(
+    service="linkup",
+    display_name="Linkup",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Linkup API key",
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://app.linkup.so/",
+    setup_action_label="Get your Linkup API key",
+    setup_steps=(
+        "Sign in to Linkup and open your organization settings.",
+        "Create an API key and copy it.",
+    ),
+    setup_note="New eligible accounts receive monthly credits; successful calls use the prepaid balance.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary="Agentic web search, sourced answers, structured results and page fetching.",
+    base_url="https://api.linkup.so/v1",
+    docs_url="https://docs.linkup.so/",
+    # Free balance read. Live checked 2026-08-12: a bogus Bearer token returns HTTP 401.
+    probe_path="/credits/balance",
+)
+
 # ---- SEO API-key providers -------------------------------------------------------------------
 
 DATAFORSEO = OAuthProvider(
@@ -1485,7 +1513,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
-        SCRAPECREATORS,
+        SCRAPECREATORS, LINKUP,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
         # more Enrichment API-key providers

--- a/src/treg/providers.py
+++ b/src/treg/providers.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 # `auth` is the provider's DEFAULT shape; a per-variable form (CLIENT_ID/SECRET → oauth2) can override
 # it. Served at GET /providers.json so the CLI can refresh centrally (bundled copy = offline fallback);
 # bump CATALOG_VERSION whenever entries change so a cache can tell it's stale.
-CATALOG_VERSION = 9
+CATALOG_VERSION = 10
 # `skills` (optional) matches a SKILL FOLDER name for file-credential skills that have no env var to
 # key on (OAuth token files etc.) — see `match_skill`. Such providers carry `tokens: []` so the env
 # scanner never mis-detects them as a simple bearer key (their real auth is OAuth + extra headers).
@@ -157,6 +157,7 @@ CATALOG: list[dict] = [
     {"provider": "Serper",      "tokens": ["SERPER"],              "base_url": "https://google.serper.dev",                       "auth": {"shape": "api_key_header", "header": "X-API-KEY"}},
     {"provider": "SerpAPI",     "tokens": ["SERPAPI"],             "base_url": "https://serpapi.com",                             "auth": {"shape": "query", "param": "api_key"}},
     {"provider": "Brave Search","tokens": ["BRAVE"],               "base_url": "https://api.search.brave.com/res/v1",             "auth": {"shape": "api_key_header", "header": "X-Subscription-Token"}},
+    {"provider": "Linkup",      "tokens": ["LINKUP"],               "base_url": "https://api.linkup.so/v1",                        "auth": {"shape": "bearer"}, "probe": "credits/balance"},
     {"provider": "ScrapingBee", "tokens": ["SCRAPINGBEE"],         "base_url": "https://app.scrapingbee.com/api/v1",              "auth": {"shape": "query", "param": "api_key"}},
     {"provider": "NewsAPI",     "tokens": ["NEWSAPI"],             "base_url": "https://newsapi.org/v2",                          "auth": {"shape": "api_key_header", "header": "X-Api-Key"}},
     # --- dev / infra / cloud ---

--- a/src/treg/web/logos/linkup.svg
+++ b/src/treg/web/logos/linkup.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="linkup">
+  <!-- Placeholder lettermark. Replace with the official Linkup brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#2563EB"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="9" font-weight="700" text-anchor="middle" dominant-baseline="central">Li</text>
+</svg>

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -32,7 +32,7 @@ async def test_platforms_lists_the_curated_shelves_busiest_first(clients: AsyncC
     assert 0 < tiktok["capabilities"] <= tiktok["endpoints"]
     assert 0 < tiktok["verified"] <= tiktok["endpoints"]
     assert {"tikhub", "justoneapi"} <= set(tiktok["providers"]), "the social overlap pair is the point"
-    assert {"dataforseo", "moz"} <= set(rows["web"]["providers"]), "the SEO overlap pair is the point"
+    assert {"dataforseo", "moz", "linkup"} <= set(rows["web"]["providers"])
 
     counts = [p["endpoints"] for p in body["platforms"]]
     assert counts == sorted(counts, reverse=True)
@@ -41,6 +41,25 @@ async def test_platforms_lists_the_curated_shelves_busiest_first(clients: AsyncC
 async def test_platform_listing_hides_taxonomy_entries_nobody_implements(clients: AsyncClient):
     rows = (await clients.get("/catalog/platforms")).json()["platforms"]
     assert all(p["endpoints"] > 0 for p in rows)
+
+
+async def test_linkup_exposes_search_answer_structured_and_fetch(clients: AsyncClient):
+    body = (await clients.get("/catalog/platforms/web")).json()
+    caps = {c["id"]: c for c in body["capabilities"]}
+    assert {
+        "web.search.results", "web.search.answer", "web.search.structured", "web.page.fetch",
+    } <= set(caps)
+    endpoints = {
+        e["id"]: e for capability in caps.values() for e in capability["endpoints"]
+        if e["provider"] == "linkup"
+    }
+    assert set(endpoints) == {
+        "linkup.web.search.results",
+        "linkup.web.search.answer",
+        "linkup.web.search.structured",
+        "linkup.web.page.fetch",
+    }
+    assert all(e["platform_eligible"] is False for e in endpoints.values())
 
 
 # ---- platform detail ---------------------------------------------------------------------

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -21,7 +21,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
-                "spyfu", "apify", "meta-ad-library", "serpapi"):
+                "spyfu", "apify", "meta-ad-library", "serpapi", "linkup"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc
@@ -35,6 +35,7 @@ def test_key_providers_appear_in_the_marketplace_listing():
     assert listing["apollo"]["category"] == "Enrichment"
     assert listing["apollo"]["auth_kind"] == "key"
     assert listing["semrush"]["category"] == "SEO"
+    assert listing["linkup"]["category"] == "SEO"
     assert listing["tikhub"]["category"] == "Social media"
     assert "Enrichment" in P.CATEGORY_ORDER
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -44,7 +44,7 @@ def test_every_provider_is_registered():
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
-        "scrapecreators",
+        "scrapecreators", "linkup",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -178,6 +178,13 @@ def test_query_provider_auto_registers(tmp_path):
     assert a.supported and a.binding["location"] == "query" and a.binding["name"] == "api_key"
 
 
+def test_linkup_key_auto_registers_as_bearer(tmp_path):
+    env = _write_env(tmp_path, "LINKUP_API_KEY=x\n")
+    [a] = prov.plan_actions(prov.scan_env(env))
+    assert a.supported and a.tool_name == "linkup"
+    assert a.binding["location"] == "header" and a.binding["format"] == "Bearer {secret}"
+
+
 def test_catalog_grew_and_versioned():
     assert prov.CATALOG_VERSION >= 2 and len(prov.CATALOG) >= 80
     # tokens stay distinct enough: no duplicate provider names


### PR DESCRIPTION
## Summary
- add Linkup as a bring-your-own-key provider with Bearer auth, env-key discovery, and a free balance probe
- curate Search results, sourced answers, structured search, and Fetch with documented inputs and parameter-sensitive pricing
- add web-search capabilities, marketplace coverage, tests, docs, and a placeholder logo

Contact: support@linkup.so

## Vendor details
- **Probe:** `GET https://api.linkup.so/v1/credits/balance`; an invalid Bearer key returns HTTP 401 (live-checked on 2026-08-12). `POST /v1/search` also returned 401 for the bogus key.
- **Pricing:** https://docs.linkup.so/pages/documentation/platform/pricing — prepaid USD balance, billed per successful call. Search varies by `depth` and `outputType`; Fetch varies by `renderJs`; errors and no-result searches are free.
- **OpenAPI:** https://api.linkup.so/v1/openapi.json (stable public spec).
- **Verification:** no Linkup key or example responses are included in this PR. Maintainers can arrange a test credential through the contact above.

Pricing is marked `inferred` because callers can change `depth`, `outputType`, and `renderJs`; this intentionally keeps Linkup off treg's platform-funded key until reservation is parameter-aware.

## Test plan
- [x] `.venv/bin/python scripts/catalog_validate.py` — 62 providers, 2,594 endpoints, 0 errors/warnings
- [x] `.venv/bin/pytest -q tests/test_providers.py tests/test_key_providers.py tests/test_oauth_providers_m3.py tests/test_catalog_api.py` — 126 passed
- [x] full `pytest -q` — 1,340 passed