### PR TITLE
Add LemMeBuyIt retail data API

### DIFF
--- a/src/treg/catalog/lemmebuyit.yaml
+++ b/src/treg/catalog/lemmebuyit.yaml
@@ -1,0 +1,191 @@
+provider: lemmebuyit
+source:
+  docs: https://www.lemmebuyit.com/docs
+  openapi: https://api.lemmebuyit.com/openapi.yaml
+  curated: 2026-08-12
+limits: "Free: 50,000 requests/month and one API key; higher request allowances are available on paid plans."
+pricing_url: https://www.lemmebuyit.com/pricing
+proposed_capabilities:
+  walmart.retailers.list: "List the retailers available to an API key"
+  walmart.shopping.search.products: "Search shopping-safe Walmart product listings by keyword or identifier"
+  walmart.shopping.product.detail: "Get a shopping-safe Walmart product listing by retailer SKU"
+  walmart.categories.list: "List a retailer's product-category hierarchy"
+  walmart.promotions.list: "List active promotions for a retailer"
+  walmart.product.price_history: "Get weekly price history for a retailer product"
+  amazon.product.price_history: "Get weekly Amazon price history by ASIN"
+endpoints:
+  - id: lemmebuyit.walmart.retailers.list
+    capability: walmart.retailers.list
+    platform: walmart
+    scope: own_account
+    kind: account
+    method: GET
+    path: /retailers
+    name: "List available retailers"
+    summary: "Retrieves the retailers that the authenticated API key can access."
+    input:
+      note: "No parameters. The result is scoped to the API key's retailer permissions."
+    test_request: {queryParams: {}}
+    cost: &unknown_cost
+      type: per_call
+      value: null
+      currency: USD
+      unit: call
+      source: docs
+      checked: '2026-08-12'
+      confidence: unknown
+      note: "Pricing is a monthly request allowance; no per-endpoint rate is published."
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.search.products
+    capability: walmart.search.products
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/products
+    name: "Search Walmart products"
+    summary: "Searches and filters products for a retailer with cursor pagination."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+      queryParams:
+        search_query: {type: string, required: false, note: "Text, SKU, UPC, EAN, GTIN, or MPN query.", example: "Nike socks"}
+        limit: {type: integer, required: false, note: "1–1000; use the smallest value for a cheap request.", example: 1}
+      note: "Use lookup_type=text or gtin only to override automatic detection."
+    test_request:
+      pathParams: {retailer_id: "walmart"}
+      queryParams: {search_query: "Nike socks", limit: 1}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.product.detail
+    capability: walmart.product.detail
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/products/{product_id}
+    name: "Get Walmart product details"
+    summary: "Retrieves detailed product information by retailer SKU."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+        product_id: {type: string, required: true, note: "Retailer-native SKU.", example: "226595547"}
+    test_request:
+      pathParams: {retailer_id: "walmart", product_id: "226595547"}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.shopping.search.products
+    capability: walmart.shopping.search.products
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/shopping/products
+    name: "Search shopping products"
+    summary: "Searches shopping-safe retailer products that include a destination URL."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+      queryParams:
+        search_query: {type: string, required: false, note: "Text, SKU, UPC, EAN, GTIN, or MPN query.", example: "Nike socks"}
+        limit: {type: integer, required: false, note: "1–100.", example: 1}
+      note: "Shopping endpoints reject asin, sales-rank filters, and top_seller_rank_asc sorting."
+    test_request:
+      pathParams: {retailer_id: "walmart"}
+      queryParams: {search_query: "Nike socks", limit: 1}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.shopping.product.detail
+    capability: walmart.shopping.product.detail
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/shopping/products/{product_id}
+    name: "Get shopping product details"
+    summary: "Retrieves a shopping-safe product by retailer SKU, including its destination URL."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+        product_id: {type: string, required: true, note: "Retailer-native SKU.", example: "226595547"}
+    test_request:
+      pathParams: {retailer_id: "walmart", product_id: "226595547"}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.categories.list
+    capability: walmart.categories.list
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/categories
+    name: "List Walmart categories"
+    summary: "Retrieves a retailer's distinct hierarchical product categories."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+    test_request:
+      pathParams: {retailer_id: "walmart"}
+      queryParams: {}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.promotions.list
+    capability: walmart.promotions.list
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/promotions
+    name: "List Walmart promotions"
+    summary: "Lists cursor-paginated promotions for a retailer."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+      queryParams:
+        search_query: {type: string, required: false, example: "Nike"}
+        active: {type: boolean, required: false, note: "Defaults to true.", example: true}
+        limit: {type: integer, required: false, note: "1–1000.", example: 1}
+    test_request:
+      pathParams: {retailer_id: "walmart"}
+      queryParams: {search_query: "Nike", active: true, limit: 1}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.walmart.product.price_history
+    capability: walmart.product.price_history
+    platform: walmart
+    scope: any_account
+    method: GET
+    path: /retailers/{retailer_id}/products/{product_id}/price-history
+    name: "Get Walmart price history"
+    summary: "Returns chart-ready weekly price history for a retailer product."
+    input:
+      pathParams:
+        retailer_id: {type: string, required: true, example: "walmart"}
+        product_id: {type: string, required: true, example: "100000867"}
+      queryParams:
+        weeks: {type: integer, required: false, note: "1–104; defaults to 52.", example: 1}
+    test_request:
+      pathParams: {retailer_id: "walmart", product_id: "100000867"}
+      queryParams: {weeks: 1}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml
+
+  - id: lemmebuyit.amazon.product.price_history
+    capability: amazon.product.price_history
+    platform: amazon
+    scope: any_account
+    method: GET
+    path: /amazon/asins/{asin}/price-history
+    name: "Get Amazon price history"
+    summary: "Returns chart-ready weekly Amazon price history by ASIN."
+    input:
+      pathParams:
+        asin: {type: string, required: true, example: "B082H4RKQQ"}
+      queryParams:
+        weeks: {type: integer, required: false, note: "1–104; defaults to 52.", example: 1}
+    test_request:
+      pathParams: {asin: "B082H4RKQQ"}
+      queryParams: {weeks: 1}
+    cost: *unknown_cost
+    docs_url: https://api.lemmebuyit.com/openapi.yaml

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -873,6 +873,31 @@ HUNTER = OAuthProvider(
     probe_path="/account",  # free — consumes no search/verification/enrichment credits
 )
 
+LEMMEBUYIT = OAuthProvider(
+    service="lemmebuyit",
+    display_name="LemMeBuyIt",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your LemMeBuyIt API key",
+    token_header="X-API-Key",
+    token_format="{secret}",
+    setup_url="https://www.lemmebuyit.com/sign-up",
+    setup_action_label="Get your free LemMeBuyIt API key",
+    setup_steps=(
+        "Sign up for the free LemMeBuyIt plan.",
+        "Open Settings → API Keys and copy your key.",
+    ),
+    setup_note="The free plan includes one API key and 50,000 requests per month.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Other",
+    summary="Search retail products, shopping listings, categories, promotions and price history across supported retailers.",
+    base_url="https://api.lemmebuyit.com/v1",
+    docs_url="https://api.lemmebuyit.com/openapi.yaml",
+    probe_path="/retailers/walmart/shopping/products?search_query=Nike%20socks&limit=1",
+)
+
 TIKHUB = OAuthProvider(
     service="tikhub",
     display_name="TikHub",
@@ -1484,7 +1509,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         GOOGLE_SEARCH_CONSOLE, GOOGLE_ANALYTICS, GOOGLE_BUSINESS_PROFILE, GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
+        APOLLO, PDL, AKTA, HUNTER, LEMMEBUYIT, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,

--- a/src/treg/web/logos/lemmebuyit.svg
+++ b/src/treg/web/logos/lemmebuyit.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="lemmebuyit">
+  <!-- Neutral placeholder lettermark; not the LemMeBuyIt brand mark. -->
+  <rect width="24" height="24" rx="5" fill="#0F766E"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">L</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
+    for svc in ("apollo", "pdl", "akta", "hunter", "lemmebuyit", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
                 "spyfu", "apify", "meta-ad-library", "serpapi"):

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -43,7 +43,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "apollo", "pdl", "akta", "hunter", "lemmebuyit", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",


### PR DESCRIPTION
## Summary

- Adds LemMeBuyIt as an API-key provider using the `X-API-Key` header.
- Adds a neutral lettermark, required registry coverage, and nine curated retail-data endpoints.
- Includes stable public docs/OpenAPI and pricing sources; per-endpoint rates remain explicitly unknown because pricing is a monthly request allowance, not a published call rate.

## Live verification

- Contact: jsnsdirect@gmail.com
- Bad-key probe: `GET https://api.lemmebuyit.com/v1/retailers/walmart/shopping/products?search_query=Nike%20socks&limit=1` with `X-API-Key: treg-bogus-key` returns `401` with `{"error":"Invalid API key"}`. The treg connection flow was exercised locally and returned `422 LemMeBuyIt rejected that token (Invalid API key)`.
- Pricing: https://www.lemmebuyit.com/pricing — Free includes one API key and 50,000 requests/month; paid plans use monthly request allowances. No machine-readable rate-card endpoint is published.
- Stable OpenAPI: https://api.lemmebuyit.com/openapi.yaml

Please use the contact above to arrange a test credential for the maintainers' live endpoint verification. No credential is included in this PR.

## Checks

- `uv run --frozen python scripts/catalog_validate.py`
- `uv run --frozen python -m pytest -q` (1338 passed)