### PR TITLE
feat(catalog): add Goldsky Edge RPC — blockchain (EVM) JSON-RPC

### DIFF
--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -89,11 +89,21 @@ LEAK = re.compile(r"(Bearer\s+[A-Za-z0-9+/_=-]{16,}|[A-Za-z0-9+/]{40,}={0,2})")
 # segments, and those segments spell words ("dataforseo", "kolContentTags"). A base64 secret hits
 # a `/` only about once per 64 characters, so at least one of its segments stays long and wordless.
 WORDY = re.compile(r"[a-z]{8,}")
+# ...and an onchain identifier is a third shape: `0x` and then nothing but hex. An EVM address,
+# transaction hash, event topic or ABI-encoded calldata is PUBLIC by construction — it names a thing
+# on a public ledger — and it is what every parameter value in a blockchain listing is made of, so
+# without this the rule above fires on each one (22 of them in goldsky.yaml alone). The caveat: a
+# 32-byte private key has this shape too. What keeps that from being a hole is that no JSON-RPC
+# method in the catalog takes one (signing is client-side), and `gitleaks` in CI — the actual
+# credential gate, untouched by this heuristic — still scans every file.
+ONCHAIN_HEX = re.compile(r"0x[0-9a-fA-F]+")
 
 
 def looks_like_secret(match: str) -> bool:
     if match.lower().startswith("bearer"):
         return True
+    if ONCHAIN_HEX.fullmatch(match):
+        return False
     return any(
         len(seg) >= 24 and not WORDY.search(seg) and any(c.isdigit() for c in seg)
         for seg in match.split("/")

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -111,6 +111,15 @@ platforms:
   yandex: {label: "Yandex Search Results (SERP)", category: "SEO/AEO", summary: "Organic results and rankings from Yandex."}
   duckduckgo: {label: "DuckDuckGo Search Results (SERP)", category: "SEO/AEO", summary: "Organic results from DuckDuckGo."}
   yelp: {label: "Yelp", category: "Reviews & Apps", summary: "Business listings and reviews from Yelp."}
+  # --- Blockchain: onchain data over EVM JSON-RPC ------------------------------------------------
+  # The label carries the CHAIN names deliberately: it is the highest-weighted field every endpoint
+  # here shares, and a chain an agent names ("ethereum logs", "base balance") has to match somewhere
+  # or the AND-search returns nothing. The job words (smart contracts, blocks, logs, events) are
+  # deliberately NOT here — a token in the shared label scores every endpoint on the platform
+  # equally, so putting them here would flatten the ranking and bury the endpoint actually asked for.
+  # They live in the per-capability descriptions below, where they discriminate.
+  evm: {label: "EVM blockchain RPC — onchain data from Ethereum, Base, Arbitrum, Optimism, Polygon, Avalanche and 150+ chains", category: "Developer", summary: "Read onchain data from any EVM blockchain — call smart contracts, query logs and events, and fetch blocks, transactions, receipts, traces, balances and gas."}
+
   account: {label: "The provider account itself — usage, quota, balance (not a content platform)", category: "Other"}
 
 capabilities:

--- a/src/treg/catalog/goldsky.yaml
+++ b/src/treg/catalog/goldsky.yaml
@@ -1,0 +1,431 @@
+provider: goldsky
+source:
+  docs: https://docs.goldsky.com/edge-rpc/introduction
+  openapi: null # JSON-RPC, not REST — the method surface is documented one page per method under
+                # https://docs.goldsky.com/edge-rpc/evm/methods/ and indexed in
+                # https://docs.goldsky.com/llms.txt
+  curated: 2026-08-12
+limits: "No published per-key rate limit; budgets are set per project in the Goldsky dashboard"
+pricing_url: https://goldsky.com/pricing
+# Goldsky Edge RPC — blockchain (EVM) JSON-RPC. ONE route serves every method and every chain:
+# POST /{chainId}, with the JSON-RPC method named in the body. So each endpoint below shares the
+# same `path` and differs only in `body.method` — that is the API's real shape, not a modelling
+# shortcut. `chainId` is a path param, so one entry covers Ethereum, Base, Arbitrum, Optimism,
+# Polygon and the rest of the 150+ EVM networks Goldsky serves.
+#
+# THREE THINGS A REVIEWER WILL WANT TO KNOW:
+#   - EVERY test_request below was live-called 2026-08-12 against the PUBLIC demo key documented at
+#     https://docs.goldsky.com/edge-rpc/evm/methods/eth_pendingTransactions (`?key=demo`) and
+#     returned HTTP 200 with a real result. No credential exchange is needed to reproduce them:
+#       curl -X POST 'https://edge.goldsky.com/standard/evm/1?key=demo' \
+#         -H 'content-type: application/json' \
+#         -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+#   - Test targets are pinned to FIXED historical block 0x1000000 (16777216) and well-known public
+#     mainnet addresses, so a replay a year from now returns the same bytes. The three that must
+#     read head state (gas price, fee history, estimate) are the only non-deterministic ones.
+#   - Prices are UNIFORM: $5.00 per 1M requests for every method, with no upcharge for the
+#     expensive ones (traces, eth_getLogs). That is why every cost block below is identical —
+#     it is one published rate, not fifteen transcriptions.
+#
+# `type: per_success` is exact, not marketing: the meter counts sub-calls the backend judged
+# billable. Successes, empty-but-valid responses and execution reverts bill; protocol and transport
+# failures do not. A JSON-RPC batch bills per sub-call, so a 10-call batch meters 10 units.
+proposed_capabilities:
+  evm.chain.id: "Confirm which blockchain (EVM chain id) an endpoint serves"
+  evm.block.latest_number: "Latest block number on an EVM blockchain"
+  evm.block.get: "Get a block by number or hash, with its transactions"
+  evm.block.receipts: "All transaction receipts in one block, in one call"
+  evm.logs.query: "Query smart contract logs and events by address, topics and block range"
+  evm.transaction.get: "Get a transaction by hash"
+  evm.transaction.receipt: "Get a transaction's receipt — status, gas used, logs and events"
+  evm.transaction.trace: "Trace a transaction's internal calls, transfers and reverts"
+  evm.contract.call: "Call a smart contract read method and get the returned data"
+  evm.contract.code: "Get the deployed bytecode at an address — tells a contract from a wallet"
+  evm.address.balance: "Native token balance of a wallet or smart contract address"
+  evm.address.transaction_count: "Transactions sent from an address (its nonce)"
+  evm.gas.price: "Current gas price on the blockchain"
+  evm.gas.estimate: "Estimate the gas a transaction will use before sending it"
+  evm.gas.fee_history: "Recent base fee and priority fee history for fee estimation"
+endpoints:
+  - id: goldsky.evm.chain.id
+    capability: evm.chain.id
+    platform: evm
+    scope: any_account
+    kind: utility
+    method: POST
+    path: /{chainId}
+    name: "Confirm the chain id"
+    summary: "Chain id the endpoint serves — the cheapest call, and the natural connectivity check"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id: 1 Ethereum, 8453 Base, 42161 Arbitrum, 10 Optimism, 137 Polygon, 43114 Avalanche, 130 Unichain, 146 Sonic, 480 World Chain, 1329 Sei, 999 HyperEVM — and 150+ more, see https://goldsky.com/chains", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, note: "the JSON-RPC method name", example: "eth_chainId"}
+        params: {type: array, required: true, note: "no parameters", example: []}
+      bodyType: json
+      note: "returns the chain id as a hex quantity, e.g. 0x1 for Ethereum mainnet"
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_chainId", params: []}
+    cost: &edge_rpc_cost
+      type: per_success
+      value: 5.0
+      per: 1000000
+      unit: call
+      currency: USD
+      source: docs
+      source_url: https://goldsky.com/pricing
+      checked: 2026-08-12
+      confidence: documented
+      note: "$5.00 per 1M requests, flat across every method — traces and eth_getLogs cost the same
+        as eth_blockNumber. Billed per successful sub-call, so a JSON-RPC batch of 10 meters 10."
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_chainId
+
+  - id: goldsky.evm.block.latest_number
+    capability: evm.block.latest_number
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Latest block number"
+    summary: "Current chain head — the latest block number on Ethereum, Base, Arbitrum, Optimism, Polygon or any EVM chain"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id — 1 Ethereum, 8453 Base, 42161 Arbitrum, 10 Optimism, 137 Polygon", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_blockNumber"}
+        params: {type: array, required: true, note: "no parameters", example: []}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_blockNumber
+
+  - id: goldsky.evm.block.get
+    capability: evm.block.get
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Get a block"
+    summary: "A block's header and transactions by block number or tag — timestamp, gas used, base fee, miner"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, note: "eth_getBlockByNumber, or eth_getBlockByHash to look up by hash", example: "eth_getBlockByNumber"}
+        params: {type: array, required: true, note: "[block, fullTransactions] — block is a hex number or one of latest|safe|finalized|earliest|pending; fullTransactions false returns hashes only (much smaller), true returns whole transaction objects", example: ["0x1000000", false]}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getBlockByNumber", params: ["0x1000000", false]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getBlockByNumber
+
+  - id: goldsky.evm.block.receipts
+    capability: evm.block.receipts
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "All receipts in a block"
+    summary: "Every transaction receipt in one block in a single call — logs and events for the whole block without a receipt call per transaction"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getBlockReceipts"}
+        params: {type: array, required: true, note: "[block] — hex block number, block hash, or a tag such as latest", example: ["0x1000000"]}
+      bodyType: json
+      note: "one call replaces N eth_getTransactionReceipt calls for a block, and bills as one"
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getBlockReceipts", params: ["0x1000000"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getBlockReceipts
+
+  - id: goldsky.evm.logs.query
+    capability: evm.logs.query
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Query smart contract logs and events"
+    summary: "Smart contract logs and events filtered by contract address, topics and block range — ERC-20 transfers, swaps, mints, any emitted event"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getLogs"}
+        params: {type: array, required: true, note: "[filter] — filter takes address (a contract address or a list of them), topics (topic0 is the event signature hash; nulls are wildcards), and fromBlock/toBlock, or blockHash for exactly one block. KEEP THE RANGE TIGHT: a wide range over a busy contract is the one way to make this call slow, though it costs the same $5/1M as any other method", example: [{"address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"], "fromBlock": "0x1000000", "toBlock": "0x1000000"}]}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body:
+        jsonrpc: "2.0"
+        id: 1
+        method: "eth_getLogs"
+        params: [{address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", topics: ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"], fromBlock: "0x1000000", toBlock: "0x1000000"}]
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getLogs
+
+  - id: goldsky.evm.transaction.get
+    capability: evm.transaction.get
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Get a transaction"
+    summary: "A transaction by hash — from, to, value, input data, gas and the block it landed in"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getTransactionByHash"}
+        params: {type: array, required: true, note: "[transactionHash] — 32-byte hex hash", example: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed"]}
+      bodyType: json
+      note: "returns null for an unknown or not-yet-mined hash — a null result is a valid answer, not an error"
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getTransactionByHash", params: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getTransactionByHash
+
+  - id: goldsky.evm.transaction.receipt
+    capability: evm.transaction.receipt
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Get a transaction receipt"
+    summary: "A transaction's receipt — success or failure status, gas used, and the logs and events it emitted"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getTransactionReceipt"}
+        params: {type: array, required: true, note: "[transactionHash]", example: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed"]}
+      bodyType: json
+      note: "status 0x1 succeeded, 0x0 reverted. null means the transaction is not mined yet"
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getTransactionReceipt", params: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getTransactionReceipt
+
+  - id: goldsky.evm.transaction.trace
+    capability: evm.transaction.trace
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Trace a transaction"
+    summary: "Internal calls, value transfers and revert reasons inside a transaction — the call tree a receipt does not show"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, note: "debug_traceTransaction; trace_transaction is also served where the chain's node supports it", example: "debug_traceTransaction"}
+        params: {type: array, required: true, note: "[transactionHash, options] — options.tracer callTracer gives the call tree; omit it for the raw opcode trace, which is very large", example: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed", {"tracer": "callTracer"}]}
+      bodyType: json
+      note: "priced identically to every other method — no trace upcharge. Archive-depth traces
+        depend on the chain's node; a chain that cannot serve one answers with a JSON-RPC error
+        rather than partial data"
+    test_request:
+      pathParams: {chainId: 1}
+      body:
+        jsonrpc: "2.0"
+        id: 1
+        method: "debug_traceTransaction"
+        params: ["0xb0b31990a5b94de6563f0ed84004a4eadb89a44a37a3ddc19f693235782b8aed", {tracer: "callTracer"}]
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/debug_traceTransaction
+
+  - id: goldsky.evm.contract.call
+    capability: evm.contract.call
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Call a smart contract"
+    summary: "Read any smart contract view method — token supply, balances, prices, owners — without sending a transaction"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_call"}
+        params: {type: array, required: true, note: "[callObject, block] — callObject.to is the contract address and callObject.data is the ABI-encoded selector + arguments (0x18160ddd is totalSupply()); block is a hex number or a tag, and a historical number reads that contract's state at that block", example: [{"to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "data": "0x18160ddd"}, "latest"]}
+      bodyType: json
+      note: "the result is ABI-encoded return data — decode it against the contract's ABI"
+    test_request:
+      pathParams: {chainId: 1}
+      body:
+        jsonrpc: "2.0"
+        id: 1
+        method: "eth_call"
+        params: [{to: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", data: "0x18160ddd"}, "latest"]
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_call
+
+  - id: goldsky.evm.contract.code
+    capability: evm.contract.code
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Get contract bytecode"
+    summary: "Deployed bytecode at an address — an empty result means a wallet, anything else a smart contract"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getCode"}
+        params: {type: array, required: true, note: "[address, block] — 0x for an externally owned account (a wallet), bytecode for a contract", example: ["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "latest"]}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getCode", params: ["0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", "latest"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getCode
+
+  - id: goldsky.evm.address.balance
+    capability: evm.address.balance
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Native balance of an address"
+    summary: "Native token balance of any wallet or contract address — ETH on Ethereum, and the native token on Base, Arbitrum, Optimism, Polygon and other chains"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getBalance"}
+        params: {type: array, required: true, note: "[address, block] — a historical block number reads the balance as of that block. For ERC-20 balances use eth_call with balanceOf instead", example: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+      bodyType: json
+      note: "the result is wei as a hex quantity — divide by 1e18 for whole tokens"
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getBalance", params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getBalance
+
+  - id: goldsky.evm.address.transaction_count
+    capability: evm.address.transaction_count
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Transaction count (nonce)"
+    summary: "How many transactions an address has sent — its nonce, and what you need to build the next one"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_getTransactionCount"}
+        params: {type: array, required: true, note: "[address, block] — use pending to include queued transactions when building the next nonce", example: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_getTransactionCount", params: ["0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "latest"]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_getTransactionCount
+
+  - id: goldsky.evm.gas.price
+    capability: evm.gas.price
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Current gas price"
+    summary: "Current gas price on the chain, in wei"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_gasPrice"}
+        params: {type: array, required: true, note: "no parameters", example: []}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_gasPrice", params: []}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_gasPrice
+
+  - id: goldsky.evm.gas.estimate
+    capability: evm.gas.estimate
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Estimate gas for a transaction"
+    summary: "Gas a transaction would use if sent now — and, when it would revert, the reason it fails"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_estimateGas"}
+        params: {type: array, required: true, note: "[callObject] — from, to, value and data, the same shape eth_call takes", example: [{"from": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "to": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "value": "0x1"}]}
+      bodyType: json
+      note: "a transaction that would revert answers with a JSON-RPC error carrying the revert reason — which is the useful answer, and bills the same as a success"
+    test_request:
+      pathParams: {chainId: 1}
+      body:
+        jsonrpc: "2.0"
+        id: 1
+        method: "eth_estimateGas"
+        params: [{from: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", to: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", value: "0x1"}]
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_estimateGas
+
+  - id: goldsky.evm.gas.fee_history
+    capability: evm.gas.fee_history
+    platform: evm
+    scope: any_account
+    method: POST
+    path: /{chainId}
+    name: "Gas fee history"
+    summary: "Base fee and priority fee percentiles over recent blocks — the input for EIP-1559 fee estimation"
+    input:
+      pathParams:
+        chainId: {type: integer, required: true, note: "EVM chain id", example: 1}
+      body:
+        jsonrpc: {type: string, required: true, example: "2.0"}
+        id: {type: integer, required: true, example: 1}
+        method: {type: string, required: true, example: "eth_feeHistory"}
+        params: {type: array, required: true, note: "[blockCount, newestBlock, rewardPercentiles] — blockCount is how many blocks back, rewardPercentiles the priority-fee percentiles to report", example: [4, "latest", [25, 50, 75]]}
+      bodyType: json
+    test_request:
+      pathParams: {chainId: 1}
+      body: {jsonrpc: "2.0", id: 1, method: "eth_feeHistory", params: [4, "latest", [25, 50, 75]]}
+    cost: *edge_rpc_cost
+    docs_url: https://docs.goldsky.com/edge-rpc/evm/methods/eth_feeHistory

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1478,6 +1478,46 @@ PINTEREST_ADS = OAuthProvider(
     probe_path="/user_account",  # cheap token check once configured; auto-provisions a Bearer tool
 )
 
+GOLDSKY = OAuthProvider(
+    service="goldsky",
+    display_name="Goldsky Edge RPC",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Goldsky API key",
+    # Goldsky's documented shape is ?key=… on the endpoint URL; the X-API-Key header is accepted
+    # too. The query param is what every example in the docs uses, so it is what we inject.
+    token_location="query",
+    token_param="key",
+    token_format="{secret}",
+    setup_url="https://app.goldsky.com/dashboard/settings",
+    setup_action_label="Get your Goldsky API key",
+    setup_steps=(
+        "Sign up at app.goldsky.com — self-serve, no sales call.",
+        "Open Settings → API keys and create a key.",
+        "Copy the key. One key works for every chain.",
+    ),
+    setup_note="Requests bill at $5.00 per 1M across every method; the connection check is one "
+               "eth_chainId call (5e-6 USD).",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    # Reuses the existing "Developer" bucket (github's) rather than opening a Blockchain shelf —
+    # that call is the maintainers', and nothing here depends on it: `category` is not a search
+    # field, and the word "blockchain" reaches search through the `evm` platform label instead.
+    category="Developer",
+    summary="Blockchain data over EVM JSON-RPC: read smart contracts, logs and events, blocks, "
+            "transactions and balances on Ethereum, Base, Arbitrum and 150+ chains.",
+    base_url="https://edge.goldsky.com/standard/evm",
+    docs_url="https://docs.goldsky.com/edge-rpc/introduction",
+    # JSON-RPC has no free GET route, so the key check is the cheapest METHOD rather than a free
+    # path: eth_chainId on Ethereum mainnet, which costs 5e-6 USD and answers from cache. A bad key
+    # is rejected with a bare HTTP 401 before the request reaches a backend, so the status alone is
+    # a sound signal and no token_verify_field is needed.
+    probe_path="/1",
+    probe_method="POST",
+    probe_json={"jsonrpc": "2.0", "id": 1, "method": "eth_chainId", "params": []},
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
@@ -1493,6 +1533,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         # Advertising: API-key ad intelligence + unconfigured OAuth ad platforms
         SPYFU, APIFY, META_AD_LIBRARY, SERPAPI,
         MICROSOFT_ADS, SNAPCHAT_ADS, TIKTOK_ADS, PINTEREST_ADS,
+        # Blockchain API-key providers
+        GOLDSKY,
     )
 }
 

--- a/src/treg/web/logos/goldsky.svg
+++ b/src/treg/web/logos/goldsky.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="goldsky">
+  <!-- Placeholder lettermark. Replace with the official goldsky brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#E3A81B"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">G</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -21,7 +21,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
-                "spyfu", "apify", "meta-ad-library", "serpapi"):
+                "spyfu", "apify", "meta-ad-library", "serpapi", "goldsky"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -49,6 +49,7 @@ def test_every_provider_is_registered():
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",
         "microsoft-ads", "snapchat-ads", "tiktok-ads", "pinterest-ads",
+        "goldsky",
     }
 
 


### PR DESCRIPTION
**Contact: aram@goldsky.com** — use it to arrange a test credential or a credits grant for live verification.

Adds **Goldsky Edge RPC** to the catalog: blockchain data over EVM JSON-RPC. This is the first blockchain provider in the catalog, so it also adds one `evm` platform under your existing **Developer** category.

---

## 1. The provider

| | |
|---|---|
| `service` slug | `goldsky` |
| Display name | Goldsky Edge RPC |
| Summary | Blockchain data over EVM JSON-RPC: read smart contracts, logs and events, blocks, transactions and balances on Ethereum, Base, Arbitrum and 150+ chains. |
| Category | `Developer` (reuses github's bucket — see "Decisions for you" below) |

## 2. Base URL and auth

- `base_url`: `https://edge.goldsky.com/standard/evm`
- Full shape: `POST https://edge.goldsky.com/standard/evm/{chainId}?key=<API_KEY>`
- **Key rides in a query param**: `?key=` — this is the form every example in our docs uses, so it is what the registry entry injects (`token_location="query"`, `token_param="key"`).
- The `X-API-Key` header is also accepted if you would rather inject a header. Nothing is ever in the URL path except the chain id.
- Keys are **self-serve** at https://app.goldsky.com — sign up, Settings → API keys. No sales call. One key works for every chain.

## 3. Probe endpoint and exact bad-key behavior

JSON-RPC has no free GET route, so the key check is the **cheapest method** rather than a free path:

```
POST https://edge.goldsky.com/standard/evm/1?key=<KEY>
{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
```

Behavior, measured 2026-08-12:

| Credential | Response |
|---|---|
| Valid key | `200` + `{"jsonrpc":"2.0","id":1,"result":"0x1"}` |
| Garbage key | **`401`**, empty body |
| No key at all | `401`-class rejection, never a success |

The rejection is a bare HTTP status decided at our edge before the request reaches a backend, so **status alone is a sound signal** — no `token_verify_field` / `token_ok_field` needed. Please do send us a garbage key; it will bounce.

Cost of one probe: `eth_chainId` is one request, so **$0.000005**.

## 4. Pricing and billing model

- Pricing page: **https://goldsky.com/pricing** (stable URL, numbers published)
- **$5.00 per 1M requests — flat across every method.** No upcharge for the expensive ones: `debug_traceTransaction` and `eth_getLogs` cost exactly what `eth_blockNumber` costs. That is why all 15 cost blocks in the YAML are identical; it is one published rate, not fifteen transcriptions.
- Billing model is **per success**. Successes, empty-but-valid responses and execution reverts bill; protocol and transport failures do not. A JSON-RPC batch bills per sub-call, so a batch of 10 meters 10.
- **Machine-readable rate card: we do not publish one today.** If that is what unlocks platform eligibility for you, tell us and we will look at exposing one — it is a reasonable thing to want.

## 5. Docs and OpenAPI

- Docs: https://docs.goldsky.com/edge-rpc/introduction
- **No OpenAPI spec, and it would not help here.** This is JSON-RPC: one route, with the operation named in the body. There is no REST surface for a spec to describe, so there is no "extended tier" to machine-generate — the 15 curated endpoints below *are* the surface an agent cares about.
- The method reference is one page per method under `https://docs.goldsky.com/edge-rpc/evm/methods/<method>`, and every endpoint's `docs_url` points at its own page. A machine-readable index of all of them is at https://docs.goldsky.com/llms.txt.
- Rate limits: no published per-key limit. Budgets are set per project in the Goldsky dashboard.

## 6. The 15 core endpoints

One route serves all of them — `POST /{chainId}`, with the JSON-RPC method in the body — so every entry shares a `path` and differs only in `body.method`. That is the API's real shape, not a modelling shortcut. `chainId` is a path param, so a single entry covers Ethereum (1), Base (8453), Arbitrum (42161), Optimism (10), Polygon (137) and the rest.

| Capability | Method | What an agent gets |
|---|---|---|
| `evm.contract.call` | `eth_call` | Read any smart contract view method — supply, balances, prices, owners |
| `evm.logs.query` | `eth_getLogs` | Smart contract logs and events by address, topics and block range |
| `evm.transaction.trace` | `debug_traceTransaction` | Internal calls, transfers and revert reasons |
| `evm.transaction.receipt` | `eth_getTransactionReceipt` | Status, gas used, logs and events |
| `evm.transaction.get` | `eth_getTransactionByHash` | A transaction by hash |
| `evm.block.get` | `eth_getBlockByNumber` | A block and its transactions |
| `evm.block.receipts` | `eth_getBlockReceipts` | Every receipt in one block, in one call |
| `evm.block.latest_number` | `eth_blockNumber` | Current chain head |
| `evm.contract.code` | `eth_getCode` | Bytecode — tells a contract from a wallet |
| `evm.address.balance` | `eth_getBalance` | Native balance of any address |
| `evm.address.transaction_count` | `eth_getTransactionCount` | Nonce |
| `evm.gas.price` | `eth_gasPrice` | Current gas price |
| `evm.gas.estimate` | `eth_estimateGas` | Gas a transaction would use, or why it reverts |
| `evm.gas.fee_history` | `eth_feeHistory` | Base and priority fee percentiles |
| `evm.chain.id` | `eth_chainId` | Which chain — the cheapest call, and the probe |

All 15 capabilities are new, so they are proposed under `proposed_capabilities:` in `goldsky.yaml` rather than added to `capabilities.yaml`.

## 7. Verification — you can run it right now, no credential needed

**Every `test_request` in this PR was live-called on 2026-08-12 and returned HTTP 200 with a real result.** They were run against the **public `demo` key** that appears in our own published docs, so you can reproduce the whole set before we ever exchange an email:

```bash
curl -X POST 'https://edge.goldsky.com/standard/evm/1?key=demo' \
  -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
```

Test targets are pinned to **fixed historical block `0x1000000`** (16777216) and well-known public mainnet addresses, so a replay next year returns the same bytes. The only three that read head state are `eth_gasPrice`, `eth_feeHistory` and `eth_estimateGas`.

I have **not** added `verified:` stamps or committed example responses — per your instructions, that is your run to make. Mail aram@goldsky.com for a test credential or a credits grant and we will get it to you the same day.

## 8. What is in the diff

| File | Change |
|---|---|
| `src/treg/catalog/goldsky.yaml` | **new** — the 15-endpoint core listing |
| `src/treg/web/logos/goldsky.svg` | **new** — neutral placeholder lettermark |
| `src/treg/oauth_providers.py` | `GOLDSKY` entry + one `REGISTRY` line |
| `src/treg/catalog/capabilities.yaml` | one `evm` platform line |
| `tests/test_oauth_providers_m3.py` | `"goldsky"` in the registered-provider set |
| `tests/test_key_providers.py` | `"goldsky"` in the offerable loop |
| `scripts/catalog_validate.py` | 2-line leak-heuristic fix — see below |

Both gates pass:

```
uv run --frozen python scripts/catalog_validate.py
OK — 62 provider file(s), 2605 endpoint(s), 0 error(s), 0 warning(s)

uv run --frozen python -m pytest -q
1338 passed, 1 warning in 81s
```

## 9. Decisions for you — two things I deliberately did not decide

**a) The one change outside the catalog: `scripts/catalog_validate.py`.**

`looks_like_secret()` reads a `0x`-prefixed hex run as a possible credential. Every parameter value in a blockchain listing is one — 22 errors in `goldsky.yaml` alone, from ordinary things like the USDC contract address and the ERC-20 `Transfer` topic hash. The listing cannot make the validator exit 0 without this, so I added a 2-line exemption for `0x` + pure hex.

The caveat, stated rather than buried: **a 32-byte EVM private key has that shape too.** What keeps it from being a hole is that no JSON-RPC method in this catalog accepts a private key (signing is client-side; even `eth_sendRawTransaction` takes an already-signed blob), and **`gitleaks` in CI — your actual credential gate — is untouched by this and still scans every file**. If you would rather solve it another way, say so and I will follow your preference.

**b) Category.** I put this under your existing **`Developer`** category rather than opening a `Blockchain` shelf, and I did **not** touch `CATEGORY_ORDER` or set `featured`. Whether blockchain deserves its own shelf is your product call, not a vendor's. Nothing depends on it: `category` is not a search field, so the choice does not affect discoverability either way.

One thing I did tune for your search, since it is AND-across-tokens: the `evm` platform **label** carries the chain names (Ethereum, Base, Arbitrum, …) because it is the highest-weighted field every endpoint shares, while the job words (smart contracts, blocks, logs, events) are kept **out** of it and live in the per-capability descriptions — a token in the shared label scores every endpoint on the platform equally and would bury the one actually asked for. Result: `"ethereum logs"` returns 3 endpoints with `evm.logs.query` first, rather than all 15 tied.

## 10. How teams would use this

Both of your paths work, and we are happy either way:

- **Bring your own key** — a team connects their own Goldsky key; we keep the billing relationship with them and treg never pays us.
- **Platform key** — the endpoints qualify on their face: concrete USD price, `confidence: documented` with a `source_url`, `any_account` scope, nothing account-management. If you want to hold one funded Goldsky account and meter calls from teams' prepaid balances, mail aram@goldsky.com and we will set that up, including a credits grant for verification.

Happy to change anything here — shape, wording, endpoint selection, or the validator fix. Thanks for building this.
