### PR TITLE
fix: catalog_get.example_response accepts any shape — brightdata examples are arrays

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -83,6 +83,11 @@ Two independent field reports arrived the same day (issue #93 and one on X) befo
 FastMCP's own client is lenient, so nothing local ever tripped it. The suite now validates real
 `structuredContent` against the advertised schema with `jsonschema` playing the strict client.
 
+A field whose real payloads vary in shape is `Any`, not a union: `call.body` relays whatever the
+provider sent, and `catalog_get.example_response` is a dict for most endpoints but an ARRAY for
+providers whose response is a list of records (brightdata datasets) — typing it `dict` made the
+server's own outbound validation refuse the whole catalog entry.
+
 ## Responses forbid edge transforms
 
 Every `/mcp/` response carries `Cache-Control: no-store, no-transform` (the `NoTransformResponses`

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -132,7 +132,8 @@ class CatalogGetOut(TypedDict, total=False):
     provider: dict[str, Any] | None
     siblings: list[dict[str, Any]] | None  # other providers of the same capability, for comparison
     call_template: str | None
-    example_response: dict[str, Any] | None
+    example_response: Any                  # a dict for most endpoints, an ARRAY for providers whose
+                                           # response is a list of records (brightdata datasets)
     hints: list[str] | None
     error: str | None
     detail: str | None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -429,6 +429,9 @@ async def test_structured_content_VALIDATES_against_the_advertised_schema(client
         # tools whose error shape carries teams/hint — plus a catalog_get error path.
         for tool, args in [("catalog_search", {"query": "backlinks"}),
                            ("catalog_get", {"endpoint_id": "no.such.endpoint"}),
+                           # its example_response is an ARRAY of records, which a dict-typed field
+                           # refused server-side — the third null/shape mismatch found in the wild
+                           ("catalog_get", {"endpoint_id": "brightdata.linkedin.user.profile"}),
                            ("balance", {}),
                            ("my_tools", {})]:
             await _rpc(c, "initialize", {


### PR DESCRIPTION
Follow-up to #98 (this commit was pushed to that branch minutes after it merged, so it never landed on main).

Found by re-running the exact flow from the #93 / X reports after the nullable fix: `catalog_get(brightdata.linkedin.user.profile)` failed treg's **own outbound validation** — that endpoint's `example_response` is an ARRAY of records, while `CatalogGetOut` typed it `dict`. Nullability doesn't cover it; fields whose real payloads vary in shape are now `Any` (the treatment `call.body` already had).

The end-to-end schema test now includes that exact endpoint, validating real `structuredContent` against the advertised schema.

MCP suite: 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)