### PR TITLE
fix: treg mcp install verifies the token before writing, and only=[] means none

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -248,6 +248,15 @@ documented JSON (`~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`). Code
 aren't safely expressible from the light CLI (no toml writer, yaml is a server-only dep), so we print
 the exact manual step rather than a config we haven't runtime-verified.
 
+The command **verifies the token against `/auth/me` before writing anything** — the same check
+`treg login --token` runs. Learned the hard way: without it, a garbage token fans out silently into
+every agent on the machine and surfaces days later as per-provider "invalid token" errors inside
+whichever agent tries a call — catalog reads still work (they don't validate the token downstream),
+which makes it look like a provider outage rather than a setup problem. The garbage in question was
+the test suite's own dummy: `install_mcp(only=[])` read an empty list as "no filter" and wrote
+`Bearer K` into the developer's real configs on every suite run — `only=[]` now means *none*, and
+the test isolates HOME.
+
 Why a header works even though treg advertises OAuth: a client only falls back to OAuth discovery on
 a **401**, and treg returns **200** for a valid header — verified against Claude Code, which
 otherwise prefers OAuth (issue #59467). The determinant is "does the server 200 a valid header," not

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3336,6 +3336,23 @@ def cmd_mcp_install(args, cfg) -> None:
     token = os.environ.get("TREG_TOKEN") or cfg.get("token")
     if not token:
         sys.exit("no token — run `treg login` first (or `treg login --token <key>`), then retry")
+    # VERIFY before fanning the token out into every agent config on this machine — the same check
+    # `treg login --token` runs. Without it, a garbage token (a stale TREG_TOKEN, a mangled paste)
+    # is written silently into Claude/Cursor/opencode, and the failure surfaces days later inside
+    # whichever agent tries a call — looking like a provider problem, not a setup one. `_client`
+    # applies the same TREG_TOKEN-beats-config precedence used above, so this validates exactly the
+    # token that would be written.
+    try:
+        with _client(cfg) as c:
+            who = c.get("/auth/me")
+    except Exception as exc:  # noqa: BLE001 — network/DNS: report, don't write a maybe-bad token
+        sys.exit(f"Could not reach {cfg['base_url']} to verify the token: {exc}")
+    if who.status_code == 401:
+        sys.exit("That token was rejected (401 invalid token) — nothing was written. It's expired "
+                 "or from a different server; run `treg login` (or copy a fresh token from the "
+                 "dashboard), then retry.")
+    if who.status_code >= 400:
+        sys.exit(f"Token check failed ({who.status_code}): {who.text[:120]} — nothing was written.")
     base_url = (cfg.get("base_url") or "https://treg.superdesign.dev").rstrip("/")
     name = getattr(args, "name", None) or "treg"
     out = mcp_install.install_mcp(base_url=base_url, token=token, server_name=name)

--- a/src/treg/mcp_install.py
+++ b/src/treg/mcp_install.py
@@ -122,11 +122,17 @@ def install_mcp(*, base_url: str, token: str, server_name: str = "treg",
     """Register the treg MCP server into every supported, installed agent on this machine.
 
     Returns {results: [(agent_display, status, detail)], manual: [(display, how)], mcp_url}.
-    `status` ∈ ok | skipped | error. `only` restricts to named agents (else all detected)."""
+    `status` ∈ ok | skipped | error. `only` restricts to named agents; None means all detected.
+
+    `only=[]` means NONE, not all. The original `if only and …` guard read an empty list as "no
+    filter", so a test that passed `only=[]` expecting a no-op wrote its dummy token into the
+    developer's REAL Claude/Cursor/opencode configs on every suite run — which is exactly how a
+    literal `Bearer K` ended up breaking every MCP call on a dev machine, days later, looking like
+    a provider outage."""
     url = base_url.rstrip("/") + "/mcp/"
     results: list[tuple[str, str, str]] = []
     for key, meta in MCP_AGENTS.items():
-        if only and key not in only:
+        if only is not None and key not in only:
             continue
         if not _installed(meta):
             continue
@@ -136,5 +142,5 @@ def install_mcp(*, base_url: str, token: str, server_name: str = "treg",
             status, detail = _write_json_agent(meta, server_name, url, token)
         results.append((meta["display"], status, detail))
     manual = [(m["display"], m["how"]) for k, m in MANUAL_AGENTS.items()
-              if (not only or k in only) and _installed(m)]
+              if (only is None or k in only) and _installed(m)]
     return {"results": results, "manual": manual, "mcp_url": url}

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -52,8 +52,66 @@ def test_uninstalled_agents_are_skipped_not_written(tmp_path, monkeypatch):
     assert not (tmp_path / ".cursor").exists()
 
 
-def test_the_mcp_url_carries_the_trailing_slash():
+def test_the_mcp_url_carries_the_trailing_slash(tmp_path, monkeypatch):
     """The resource identifier is `/mcp/` — the transport is served there, and a client that resolves
-    metadata uses that exact form."""
+    metadata uses that exact form.
+
+    HOME is isolated even though `only=[]` writes nothing: this exact test once ran against the
+    REAL home (empty list read as "no filter" by the old `if only and …` guard), so every suite run
+    silently rewrote the developer's actual Claude/Cursor/opencode configs with `Bearer K` — and
+    every MCP call on the machine failed days later with "invalid token". A test must never be one
+    guard away from writing outside its sandbox."""
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
     out = mcp_install.install_mcp(base_url="https://treg.superdesign.dev/", token="K", only=[])
     assert out["mcp_url"] == "https://treg.superdesign.dev/mcp/"
+
+
+def test_only_empty_means_NONE_not_all(tmp_path, monkeypatch):
+    """`only=[]` writes nothing anywhere — an empty restriction is "no agents", not "no filter".
+    The old falsy check made [] behave like None, which is how the suite's dummy token reached
+    real configs (see test above)."""
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    (tmp_path / ".cursor").mkdir()                       # cursor IS "installed" in this home…
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+    out = mcp_install.install_mcp(base_url="https://treg.superdesign.dev", token="K", only=[])
+    assert out["results"] == [] and out["manual"] == []  # …and still nothing is written
+    assert not (tmp_path / ".cursor" / "mcp.json").exists()
+    assert not (tmp_path / ".config" / "opencode" / "opencode.json").exists()
+
+
+def test_cmd_mcp_install_REFUSES_a_bad_token_before_writing(tmp_path, monkeypatch):
+    """The command validates the token against /auth/me before touching any agent config — the same
+    check `treg login --token` runs. Without it a garbage token (stale TREG_TOKEN, mangled paste)
+    fans out silently into every agent on the machine and surfaces days later as per-provider
+    "invalid token" errors inside whichever agent tries a call."""
+    from types import SimpleNamespace
+
+    import httpx
+    import pytest
+
+    from treg import cli
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url):
+            assert url == "/auth/me"
+            return httpx.Response(401, json={"detail": "invalid token"},
+                                  request=httpx.Request("GET", "http://t/auth/me"))
+
+    monkeypatch.setattr(cli, "_client", lambda cfg, **k: FakeClient())
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    (tmp_path / ".config" / "opencode").mkdir(parents=True)
+
+    with pytest.raises(SystemExit) as e:
+        cli.cmd_mcp_install(SimpleNamespace(name=None),
+                            {"token": "K", "base_url": "https://treg.superdesign.dev"})
+    assert "rejected" in str(e.value)
+    assert not (tmp_path / ".config" / "opencode" / "opencode.json").exists()  # nothing written


### PR DESCRIPTION
Closes the loop on the "Bearer K" incident (context in #93's investigation): every MCP call on a dev machine failed with "invalid token" while catalog search kept working, looking exactly like a provider outage.

## Where the garbage token actually came from

`install_mcp`'s guard was `if only and key not in only` — an **empty list is falsy**, so `only=[]` meant "no filter" = all agents. `test_the_mcp_url_carries_the_trailing_slash` called `install_mcp(token="K", only=[])` expecting a no-op, **without isolating HOME** — so every full-suite run since Aug 11 rewrote the developer's real `~/.claude.json`, `~/.cursor/mcp.json` and `~/.config/opencode/opencode.json` with `Bearer K`. A healthy install from Aug 11 11:12 was silently clobbered by the next `pytest -q`.

Fixes:
- `only=[]` now means **none** (`only is not None` guards, both for writers and the manual list)
- the test isolates HOME, and a new test locks the `only=[]` semantics with an installed agent present
- **`cmd_mcp_install` verifies the token against `/auth/me` before writing anything** — the same check `treg login --token` runs — and refuses loudly (`nothing was written`) on 401/4xx/unreachable. `_client` applies the same TREG_TOKEN-beats-config precedence, so it validates exactly the token that would be fanned out. New test proves a 401 writes no config.

## Verification

- Full suite: 1,342 passed — and the real machine configs verified untouched after the run (the incident's reproducer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)