### PR TITLE
fix: gzip /mcp/ responses at the origin — the edge ignores no-transform

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -88,15 +88,25 @@ provider sent, and `catalog_get.example_response` is a dict for most endpoints b
 providers whose response is a list of records (brightdata datasets) — typing it `dict` made the
 server's own outbound validation refuse the whole catalog entry.
 
-## Responses forbid edge transforms
+## Responses are gzip-compressed at the origin — the edge must find nothing to do
 
-Every `/mcp/` response carries `Cache-Control: no-store, no-transform` (the `NoTransformResponses`
-ASGI wrapper, outermost so 401 challenges carry it too). Production sits behind Render's Cloudflare
-edge — no account or dashboard of ours — which otherwise Brotli-compresses large responses; at least
-one real client stack (httpx + brotlicffi, issue #93) dies mid-decode and then hangs to its own
-timeout, minutes after the upstream answered in seconds. `no-transform` is the origin's standard
-"do not re-encode" (RFC 9111) and Cloudflare honours it; `no-store` rides along because these
-responses are per-caller and priced.
+Production sits behind Render's managed edge — no account or dashboard of ours — which
+Brotli-compresses large responses on the way out. At least one real client stack (httpx +
+brotlicffi, issue #93) dies mid-decode on that output and then hangs to its own timeout, minutes
+after the upstream answered in seconds.
+
+The first fix was `Cache-Control: no-store, no-transform` (the `NoTransformResponses` wrapper,
+outermost so 401 challenges carry it too) — the origin's standard "do not re-encode" (RFC 9111).
+**Render's edge ignores it** (issue #100: `content-encoding: br` arrived in production right next to
+the header). The header stays because it is correct and free, but the working fix is different: the
+MCP app gzips its own responses (`GZipMiddleware` inside `build_mcp_app`, ≥1KB). An edge only
+compresses what arrives uncompressed — a response already carrying `Content-Encoding: gzip` passes
+through — and gzip decodes via zlib on every mainstream client, sidestepping the brotli decoder
+entirely. Only a client accepting br-but-not-gzip (no mainstream stack does this) would still meet
+the edge's Brotli.
+
+Post-deploy check, any time this path changes: a large authenticated `catalog_get` over `/mcp/` with
+`Accept-Encoding: br, gzip` must come back `content-encoding: gzip`, not `br`.
 
 ## Authentication: eager, every request
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -767,15 +767,19 @@ class RequireAuthForProtectedTools:
 class NoTransformResponses:
     """Stamp `Cache-Control: no-store, no-transform` on every MCP response.
 
-    Production sits behind Render's Cloudflare edge — not an account of ours, and there is no
+    Production sits behind Render's managed edge — not an account of ours, and there is no
     dashboard to configure — and that edge Brotli-compresses responses on the way out. A compliant
     client decodes `br` fine, but at least one real MCP client stack (httpx + brotlicffi, issue #93)
     dies mid-decode on large compressed bodies, and the failure mode is the worst one available: the
     RPC hangs until the client's own timeout, minutes after the upstream answered in seconds.
 
     `no-transform` is the standard way for an origin to tell an intermediary "do not re-encode this"
-    (RFC 9111 §5.2.2.6), and Cloudflare honours it. `no-store` rides along because these responses
-    are per-caller and priced — nothing on this path should ever be served from a cache.
+    (RFC 9111 §5.2.2.6) — and Render's edge IGNORES it (issue #100: `content-encoding: br` arrived
+    right next to this header in production). The header stays because it is correct and costs
+    nothing, but the fix that actually works is compressing at the origin — see `build_mcp_app`:
+    an edge does not re-encode a response that already carries `Content-Encoding`. `no-store` rides
+    along because these responses are per-caller and priced — nothing on this path should ever be
+    served from a cache.
 
     An ASGI wrapper rather than a header in api.py's middleware so that WHEREVER this app is mounted
     — production, or a test building its own transport — the header ships. Same lesson as the auth
@@ -824,8 +828,22 @@ def build_mcp_app():
     # Wrapped HERE, not around the module-level value, so a caller that builds its own app gets the
     # same thing production runs. The first version wrapped only the module-level app, and the tests
     # — which build a fresh transport per test — silently exercised an unprotected server.
-    # NoTransformResponses is outermost so the auth wrapper's own 401 challenges carry it too.
-    return NoTransformResponses(RequireAuthForProtectedTools(transport))
+    #
+    # GZip at the ORIGIN is the fix for edge re-compression (issue #100, the second half of #93).
+    # Render's edge ignored `Cache-Control: no-transform` and kept Brotli-compressing large
+    # responses, which a real client stack (httpx + brotlicffi) fails to decode and then hangs on.
+    # An edge only compresses what arrives UNCOMPRESSED — a response already carrying
+    # `Content-Encoding: gzip` passes through, and gzip is decoded by zlib on every mainstream
+    # client, which sidesteps the brotli decoder entirely. A client that does not accept gzip gets
+    # identity from us (GZipMiddleware respects Accept-Encoding); only a client accepting br-and-
+    # not-gzip — no mainstream stack — would still meet the edge's Brotli.
+    #
+    # NoTransformResponses is outermost so the auth wrapper's own 401 challenges carry the header
+    # too; gzip sits between so challenges and answers alike are origin-encoded.
+    from starlette.middleware.gzip import GZipMiddleware
+
+    return NoTransformResponses(GZipMiddleware(RequireAuthForProtectedTools(transport),
+                                               minimum_size=1024))
 
 
 mcp_app = build_mcp_app()

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -443,6 +443,52 @@ async def test_structured_content_VALIDATES_against_the_advertised_schema(client
             jsonschema.validate(structured, schemas[tool])  # raises on any mismatch
 
 
+async def test_large_mcp_responses_are_gzipped_AT_THE_ORIGIN(clients):
+    """The fix that actually works for edge re-compression (issue #100). Render's edge ignored
+    `no-transform` and kept Brotli-compressing large responses — which a real client stack
+    (httpx + brotlicffi) fails to decode and then hangs on. An edge only compresses what arrives
+    UNCOMPRESSED, so the origin gzips its own responses: the edge passes them through, and gzip
+    decodes via zlib everywhere.
+
+    Asserted the way the field report arrived: a large catalog_get with `Accept-Encoding: br, gzip`
+    (what httpx sends) must come back gzip — OUR encoding — not unencoded (which the edge would
+    Brotli) and not br."""
+    import json as _json
+
+    token = (await clients.post("/users", json={"email": "gz@superdesign.dev"})).json()["token"]
+    async with mcp_session(clients) as c:
+        await _rpc(c, "initialize", {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "clientInfo": {"name": "gz", "version": "1"}}, token)
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "catalog_get",
+                       "arguments": {"endpoint_id": "brightdata.linkedin.user.profile"}}},
+            headers={**MCP_HEADERS, "Authorization": f"Bearer {token}",
+                     "Accept-Encoding": "br, gzip"})
+    assert r.status_code == 200
+    assert r.headers.get("content-encoding") == "gzip", dict(r.headers)
+    # httpx transparently gunzips `.content` — that it parses is the end-to-end decode proof,
+    # through the exact client library the field reports used.
+    body = _json.loads(r.content)
+    assert body.get("result"), body
+
+    # And a client that does NOT accept gzip gets identity from us — GZipMiddleware respects
+    # Accept-Encoding rather than forcing an encoding the client cannot decode.
+    async with mcp_session(clients) as c:
+        await _rpc(c, "initialize", {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "clientInfo": {"name": "gz2", "version": "1"}}, token)
+        r = await c.post("http://localhost/mcp/", json={
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "catalog_get",
+                       "arguments": {"endpoint_id": "brightdata.linkedin.user.profile"}}},
+            headers={**MCP_HEADERS, "Authorization": f"Bearer {token}",
+                     "Accept-Encoding": "identity"})
+    assert r.status_code == 200
+    assert "content-encoding" not in r.headers, dict(r.headers)
+
+
 async def test_mcp_responses_forbid_edge_TRANSFORMS(clients):
     """Production sits behind Render's Cloudflare edge, which Brotli-compresses responses unless the
     origin says not to. At least one real client stack (httpx + brotlicffi, issue #93) dies decoding


### PR DESCRIPTION
Fixes #100 (the remaining half of #93).

## Why no-transform wasn't enough

`Cache-Control: no-store, no-transform` (#98) is the origin's standard "do not re-encode" (RFC 9111) — and Render's managed edge ignores it: reproduced in prod, `content-encoding: br` arriving right next to the header. There is no Render dashboard knob for per-path compression.

## The fix that doesn't need the edge to cooperate

An edge only compresses what arrives **uncompressed**. The MCP app now gzips its own responses (`GZipMiddleware` inside `build_mcp_app`, ≥1KB, respects `Accept-Encoding`):

- the reporter's stack (httpx sends `gzip, deflate, br`) gets **gzip from our origin**, decoded by zlib — the brotlicffi decoder never runs
- the edge sees `Content-Encoding` already set and passes the body through
- a client that doesn't accept gzip gets identity from us; only a br-but-not-gzip client (no mainstream stack) would still meet the edge's Brotli
- `no-transform` stays — correct and free, just not sufficient

## Verification

- New test: a large `catalog_get` with `Accept-Encoding: br, gzip` comes back `content-encoding: gzip` and parses through httpx end-to-end; a client sending `identity` gets no encoding. Full suite: 1,343 passed.
- Live local server: same curl → `content-encoding: gzip`; the strict `mcp`-client run from the #93 investigation still passes.

## Post-deploy check (the part local tests cannot reach)

```
curl -s -X POST https://treg.superdesign.dev/mcp/ \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -H "Authorization: Bearer $TREG_TOKEN" -H 'Accept-Encoding: br, gzip' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"catalog_get","arguments":{"endpoint_id":"dataforseo.account.usage"}}}' \
  -D - -o /dev/null | grep -i content-encoding
```

Must print `content-encoding: gzip`. If the edge transcodes gzip→br anyway (not expected — pass-through of pre-encoded bodies is Render's documented behavior), the fallback is routing `/mcp/` off Render's edge, per the reporter's suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)