### PR TITLE
feat: refused_by on CallRecord — every /call refusal leaves a stamped row

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -666,11 +666,20 @@ sample size** per endpoint from `CallRecord` — which has recorded `endpoint_id
 `/catalog/endpoints/{id}`, attached to the endpoint **and every sibling**, because the choice is made
 on that page and an agent will not make a second round-trip to compare reliability.
 
-Four rules worth keeping:
+Five rules worth keeping:
 
 - **A 4xx never counts against the provider.** It usually means the caller sent bad parameters;
   counting it would let one agent's mistake make a healthy endpoint look broken to everyone. Only
   2xx versus 5xx decides the rate.
+- **A treg refusal is not evidence about the endpoint.** Rows with `refused_by` set (a paywall 402,
+  a daily-cap 429 — see the data-model fragment) never reached the provider; they are excluded even
+  from `samples`, or a burst of refused calls dresses itself up as traffic. The 2026-08-12 Hunter
+  incident — 309 refusals next to 488 real calls — is why.
+- **`miss` semantics ride on the endpoint.** Some providers answer "asked and answered: no result"
+  with an error status (PDL 404s a person it has no record of; Hunter's combined-find does the
+  same). Endpoints with evidenced miss behaviour carry a `miss: {status, means}` block in their
+  YAML, surfaced through `endpoint_view` — so an agent reads "404 = no match, don't retry" instead
+  of treating an expected empty answer as a failure. Only annotate what the wire has demonstrated.
 - **Below `MIN_SAMPLES` we publish the count and nothing else.** "100% from two calls" is noise
   dressed as evidence, and on a quiet endpoint a rate could expose one org's activity.
 - **Sample size is always visible**, so `100% (8)` cannot beat `99% (121)` by looking rounder.

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -76,7 +76,15 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   `replaces_secret_id` (which existing connection this consent REPLACES — null = add a new one, so the
   callback no longer has to blanket-replace by provider).
 - **`CallRecord`** — the proxied-call audit row: `org_id`, `user_email`, `tool_name`, `method`, `path`,
-  `status_code`, `kind` (**`call`** = proxy `/call`, **`local_run`** = `/tools/{name}/grant`), `created_at`.
+  `status_code`, `kind` (**`call`** = proxy `/call`, **`local_run`** = `/tools/{name}/grant`), `created_at`,
+  and `refused_by` (migration A29, nullable): set when **treg itself refused the call before anything went
+  upstream** — `auth` | `policy` | `balance` | `cap` | `resolution` | `request` — and NULL whenever the
+  provider actually answered. Every `/call/` refusal now leaves a row: the in-handler audits stamp their own
+  kind, and refusals that raise **before** the handler's audit exists (bad token, unknown tool, ACL, deny
+  rule, daily cap) are recorded by a fallback in the `X-Treg-Error` exception handler — the one place every
+  refusal passes through — using the identity stashed in `request.state` (a bad-token 401 records
+  anonymously). It is what tells "the provider failed" apart from "we said no": a paywall 402 must not read
+  as a provider error, and `endpoint_stats` excludes refused rows entirely.
 - **`RunRecord`** — the **server-side run** audit row (a `treg run --server` CLI execution — the "kind"
   `server_run` in usage rollups): `org_id`, `user_email`, `bundle_name` (holds the **tool** name since the
   tool-side run unification; column name is historical), `argv` (JSON — never carries a secret value;

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -347,7 +347,9 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   registering; `import_skill_folder` (`POST /skills/import`) scans + `build_payload`s + registers the
   selected ones (`_materialize_skill_files` sandboxes the upload). `list_orgs` now carries `tool_count`.
 - **Audit:** `list_calls` (`GET /calls`, limit clamped 1–500; each row carries its `kind` —
-  `call`/`local_run` — for the Activity + Usage views).
+  `call`/`local_run` — for the Activity + Usage views, and `refused_by` — non-null = treg refused
+  pre-relay; see the data-model fragment — so `treg audit` can tell "the provider failed" from
+  "we said no").
 - **OAuth connect + the provider marketplace:** `oauth_start` (`POST /oauth/start`) creates a
   `PendingOAuth` and returns `consent_url` + `state` + `redirect_uri`; `oauth_callback`
   (`GET /oauth/callback`, open) exchanges the code and creates/updates the oauth secret; `oauth_status`

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -246,6 +246,19 @@ async def _id_out_of_range(request: Request, exc: OverflowError) -> JSONResponse
     return JSONResponse({"detail": "identifier out of range"}, status_code=404)
 
 
+def _refusal_kind(status_code: int) -> str | None:
+    """Which gate said no, from the status treg chose for it (models.CallRecord.refused_by).
+
+    Statuses map 1:1 because each gate owns its code on `/call/`: the vendor's own 401/404/429
+    never comes through here — a relayed response is a Response, not an HTTPException. 5xx maps
+    to None: a 502 is the upstream failing to answer, which is a fact about the provider, and
+    must not be counted as a treg refusal."""
+    if status_code >= 500:
+        return None
+    return {401: "auth", 402: "balance", 403: "policy", 404: "resolution",
+            429: "cap"}.get(status_code, "request")
+
+
 @app.exception_handler(StarletteHTTPException)
 async def _mark_treg_own_errors(request: Request, exc: StarletteHTTPException):
     """Tag treg's OWN refusals on `/call/` with `X-Treg-Error`, then answer exactly as before.
@@ -258,6 +271,17 @@ async def _mark_treg_own_errors(request: Request, exc: StarletteHTTPException):
     resp = await http_exception_handler(request, exc)
     if request.url.path.startswith("/call/"):
         resp.headers["X-Treg-Error"] = "1"
+        # Refusals that raised before the handler's own audit ran (bad token, unknown tool, ACL,
+        # deny rule, daily cap) would otherwise leave NO row — the funnel's early friction was
+        # invisible until this. Identity comes from request.state (stashed at handler entry); a
+        # bad-token 401 never had one, and an anonymous row is still the fact that someone knocked.
+        if not getattr(request.state, "call_audited", False):
+            org_id, email = getattr(request.state, "call_identity", (None, ""))
+            rest = request.url.path[len("/call/"):]
+            audit.record_call(
+                org_id=org_id, user_email=email, tool_name=rest.split("/", 1)[0] or "—",
+                method=request.method, path=request.url.path, status_code=exc.status_code,
+                client=_client_of(request), refused_by=_refusal_kind(exc.status_code))
         # A failed call must not keep its idempotency label. The claim is taken before the upstream
         # call, and a request that dies anywhere after that — a bad parameter, a deny rule, an empty
         # balance — would otherwise hold the label for the whole window and answer every retry with
@@ -5530,6 +5554,9 @@ async def list_calls(
             "duration_ms": c.duration_ms,
             "response_bytes": c.response_bytes,
             "params_hash": c.params_hash,
+            # non-null = treg said no before anything went upstream (see models.CallRecord) — the
+            # one field that tells "the provider failed" apart from "we refused" in `treg audit`.
+            "refused_by": c.refused_by,
             "created_at": c.created_at.isoformat(),
         }
         for c in rows
@@ -7419,6 +7446,10 @@ async def call_tool(
     caller: Caller = Depends(require_member),
     db: AsyncSession = Depends(get_session),
 ):
+    # Identity for the refusal fallback in `_mark_treg_own_errors`: a raise anywhere below (unknown
+    # tool, deny rule, daily cap) leaves this handler without an audit row, and the exception handler
+    # is the one place every such refusal passes through — but it has no Caller of its own.
+    request.state.call_identity = (caller.org_id, caller.email)
     # Faithful-relay: use the RAW request path, not Starlette's decoded path param. Decoding is
     # lossy — an encoded slash (`%2f`) in `rest` would become a real `/` and change the upstream
     # route (npm's scoped publish `PUT /@scope%2fname` 404s as `/@scope/name`). httpx preserves
@@ -7465,10 +7496,11 @@ async def call_tool(
         except HTTPException as mkexc:
             # A malformed marketplace call (wrong method, missing param, no credential, 502) must
             # still leave a trace — it's exactly the row the caller will come asking about.
+            request.state.call_audited = True
             audit.record_call(
                 org_id=caller.org_id, user_email=caller.email, tool_name=ep["id"],
                 method=request.method, path=rest, status_code=mkexc.status_code,
-                client=_client_of(request),
+                client=_client_of(request), refused_by=_refusal_kind(mkexc.status_code),
                 telemetry={"endpoint_id": ep["id"], "provider": ep.get("provider")})
             analytics.capture(caller.email, "tool_called",
                 {"tool_name": ep["id"], "status_code": mkexc.status_code,
@@ -7492,10 +7524,12 @@ async def call_tool(
     audit_slug = caller.org.slug  # PostHog group key — must match the browser's posthog.group('team', slug)
 
     def _audit(status_code: int, *, observed_micro: int | None = None, charged_micro: int | None = None,
-               duration_ms: int | None = None, response_bytes: int | None = None) -> None:
+               duration_ms: int | None = None, response_bytes: int | None = None,
+               refused_by: str | None = None) -> None:
         # Audit the attempt too — failures are results worth recording. A marketplace call additionally
         # carries its telemetry (which endpoint, which credential tier, what it cost): still
         # fire-and-forget, because the money itself already landed synchronously in the ledger.
+        request.state.call_audited = True  # the refusal fallback in _mark_treg_own_errors stands down
         telemetry = None
         if mk is not None:
             telemetry = {
@@ -7509,7 +7543,7 @@ async def call_tool(
         audit.record_call(
             org_id=audit_org_id, user_email=audit_email, tool_name=audit_tool,
             method=request.method, path=upstream_url, status_code=status_code,
-            client=_client_of(request), telemetry=telemetry,
+            client=_client_of(request), refused_by=refused_by, telemetry=telemetry,
         )
         # Product analytics mirror of the row above. Deliberately excludes params, bodies, and the
         # full upstream URL (hostname only) — per-call detail beyond what a chart needs stays in the DB.
@@ -7561,7 +7595,8 @@ async def call_tool(
         except HTTPException as exc:
             # A call refused for MONEY (402 empty balance / 429 daily cap) is the event the org will
             # ask about first — it must appear in the activity feed, charged 0.
-            _audit(exc.status_code, charged_micro=0)
+            _audit(exc.status_code, charged_micro=0,
+                   refused_by="balance" if exc.status_code == 402 else "cap")
             raise
     started = _now_ms()
     try:

--- a/src/treg/audit.py
+++ b/src/treg/audit.py
@@ -39,15 +39,16 @@ def _get_sem() -> asyncio.Semaphore:
 
 def record_call(
     *, org_id: int | None = None, user_email: str, tool_name: str, method: str, path: str,
-    status_code: int, client: str = "", telemetry: dict | None = None
+    status_code: int, client: str = "", refused_by: str | None = None, telemetry: dict | None = None
 ) -> None:
     """`telemetry` carries the marketplace/spend columns (endpoint_id, provider, credential_tier,
     cost_*_micro, duration_ms, response_bytes, params_hash) — absent for a plain tool call, where they
     stay NULL. It is still fire-and-forget: the money landed in the ledger synchronously, so losing a
-    row here costs analytics, not accounting."""
+    row here costs analytics, not accounting. `refused_by` marks a call TREG refused before anything
+    went upstream (see models.CallRecord) — NULL whenever the provider actually answered."""
     _schedule(_write(CallRecord,
         org_id=org_id, user_email=user_email, tool_name=tool_name,
-        method=method, path=path, status_code=status_code, client=client,
+        method=method, path=path, status_code=status_code, client=client, refused_by=refused_by,
         **(telemetry or {}),
     ))
 

--- a/src/treg/catalog/hunter.extended.yaml
+++ b/src/treg/catalog/hunter.extended.yaml
@@ -354,6 +354,9 @@ endpoints:
     checked: '2026-07-28'
     confidence: documented
     note: 0.2 credits, billed conditionally (only when the combined record comes back complete); a 404 or partial record is free — same rate as the /people/find and /companies/find enrichment routes
+  miss:
+    status: 404
+    means: "no record for that email — an expected outcome (and free, per the cost note), not an API failure; do not retry"
   docs_url: https://hunter.io/api-documentation/v2#email-enrichment
   verified: '2026-07-28'
   example_response: examples/hunter.x.combined-find.json

--- a/src/treg/catalog/pdl.yaml
+++ b/src/treg/catalog/pdl.yaml
@@ -75,6 +75,9 @@ endpoints:
       checked: '2026-07-31'
       confidence: verified
       note: '1 PDL credit per person returned (HTTP 200); a 404 is free. OBSERVED live 2026-07-31 - the response carried x-call-credits-spent 1 and x-call-credits-type enrich. Enriching the same person twice costs 2 credits, PDL does not de-duplicate. cost.usd stays null because there is no public $/credit - the rate is plan-negotiated - so this is a verified CREDIT count, not a verified dollar figure.'
+    miss:
+      status: 404
+      means: "no person matched (or none above min_likelihood) — an expected outcome (and free, per the cost note), not an API failure; do not retry the same identifiers"
     verified: 2026-07-31
     example_response: examples/pdl.people.enrich.json
     docs_url: https://docs.peopledatalabs.com/docs/reference-person-enrichment-api

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -362,6 +362,10 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # unmarked endpoint as extended would hide it from the platform view entirely.
         "tier": raw.get("tier") or "core",
         "verified": str(verified) if verified else None,
+        # {status, means} — a status the provider uses for "asked and answered: no result" (PDL
+        # 404s a person it has no record of). Only endpoints with evidenced miss semantics carry
+        # it; for everything else an error status means what it says.
+        "miss": raw.get("miss") or None,
         "docs_url": raw.get("docs_url") or "",
         "example_file": _example_file(raw, directory),
     }
@@ -419,6 +423,9 @@ def endpoint_view(ep: dict, provider_display: str, cat: Catalog | None = None) -
         # a fact about the row that decides whether the caller needs a credential at all, so it
         # rides on the row rather than being re-derived per client (see `Catalog.platform_eligible`)
         "platform_eligible": cat.platform_eligible(ep) if cat else None,
+        # "no match" semantics, when the endpoint has them — an agent that reads `miss` stops
+        # treating an expected empty answer as a failed call (and stops retrying it).
+        "miss": ep.get("miss"),
         "verified": ep["verified"],
         "docs_url": ep["docs_url"],
         "has_example": bool(ep["example_file"]),

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -278,6 +278,12 @@ def _migrate_to_orgs(conn) -> None:
             if col not in cols:
                 conn.execute(text(f"ALTER TABLE callrecord ADD COLUMN {col} {ddl}"))
 
+    # (A29) additive: callrecord.refused_by — set when treg itself refused the call pre-relay
+    # (auth/policy/balance/cap/resolution/request; see models.CallRecord). NULLABLE: NULL means the
+    # provider answered, and every pre-existing row that reached upstream is correct as NULL.
+    if "callrecord" in tables and "refused_by" not in {c["name"] for c in insp.get_columns("callrecord")}:
+        conn.execute(text("ALTER TABLE callrecord ADD COLUMN refused_by VARCHAR"))
+
     # (A28) corrective: creditblock.stripe_payment_intent must be UNIQUE (the top-up idempotency
     # key). It sits HERE, above the (B) block, because (B) returns early on a fresh/new-schema DB —
     # and a fresh DB created between the ledger landing and this fix is precisely the one that has

--- a/src/treg/endpoint_stats.py
+++ b/src/treg/endpoint_stats.py
@@ -81,7 +81,11 @@ async def observed(
             func.sum(case((CallRecord.status_code >= 500, 1), else_=0)).label("bad"),
             func.max(CallRecord.created_at).label("last"),
         )
-        .where(CallRecord.endpoint_id.in_(ids), CallRecord.created_at >= since)
+        .where(CallRecord.endpoint_id.in_(ids), CallRecord.created_at >= since,
+               # treg's own refusals (paywall 402s, caps, bad requests never relayed) are facts
+               # about the CALLER's account, not the endpoint — they must not even count as
+               # samples, or a burst of refused calls dresses itself up as evidence.
+               CallRecord.refused_by.is_(None))
         .group_by(CallRecord.endpoint_id)
     )).all()
 

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -203,6 +203,13 @@ class CallRecord(SQLModel, table=True):
     # sha256 of endpoint_id + the canonicalized query + body — an identity for "the same call again".
     # Bodies are NEVER stored; this is the future cache key and the repeat-rate signal (plan phase 5).
     params_hash: str | None = Field(default=None, index=True)
+    # Set when TREG refused the call before a byte went upstream; NULL when the provider answered
+    # (whatever its status). Values: auth (bad/expired token) | policy (ACL/deny rule/suspension) |
+    # balance (402 insufficient prepaid balance) | cap (429 daily caps) | resolution (no such tool
+    # or endpoint) | request (malformed pre-relay: wrong method, missing param, bad body). What
+    # separates "the provider failed" from "we said no" — without it a paywall 402 is
+    # indistinguishable from a provider error, and provider stats absorb our own refusals.
+    refused_by: str | None = Field(default=None, index=True)
     created_at: datetime = Field(default_factory=_now)
 
 

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -61,7 +61,7 @@ async def test_platform_detail_groups_the_same_job_across_providers(clients: Asy
     ep = next(e for e in profile["endpoints"] if e["provider"] == "tikhub")
     assert set(ep) == {"id", "provider", "provider_display", "name", "summary", "method", "path",
                        "scope", "tier", "kind", "domain", "call_template", "cost", "verified", "docs_url",
-                       "has_example", "input", "platform_eligible", "test_request"}
+                       "has_example", "input", "platform_eligible", "test_request", "miss"}
     assert ep["kind"] == "data", "an endpoint with no explicit kind is data (the browse surface)"
     assert ep["provider_display"] == P.get("tikhub").display_name
     assert ep["method"] == "GET" and ep["path"].startswith("/")

--- a/tests/test_endpoint_stats.py
+++ b/tests/test_endpoint_stats.py
@@ -23,10 +23,12 @@ def _now():
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-async def _record(endpoint_id: str, status: int, ms: int = 100, *, days_ago: int = 0, org_id: int = 1):
+async def _record(endpoint_id: str, status: int, ms: int = 100, *, days_ago: int = 0, org_id: int = 1,
+                  refused_by: str | None = None):
     async with session_maker() as db:
         db.add(CallRecord(org_id=org_id, user_email="a@b.c", tool_name=endpoint_id, method="GET",
-                          path="/x", status_code=status, endpoint_id=endpoint_id, duration_ms=ms,
+                          path="/x", status_code=status, endpoint_id=endpoint_id,
+                          duration_ms=None if refused_by else ms, refused_by=refused_by,
                           created_at=_now() - timedelta(days=days_ago)))
         await db.commit()
 
@@ -56,6 +58,20 @@ async def test_a_caller_error_is_not_held_against_the_provider(clients: AsyncCli
     got = (await _observed([EP]))[EP]
     assert got["samples"] == 12         # still counted as traffic…
     assert got["ok_rate"] == 1.0        # …but the rate is decided only by 2xx vs 5xx
+
+
+async def test_a_treg_refusal_is_not_evidence_about_the_endpoint(clients: AsyncClient):
+    """A paywall 402 or a daily-cap 429 never reached the provider — it says the CALLER's account
+    ran dry, nothing about the endpoint. Refused rows must not even count as samples: the Hunter
+    incident (2026-08-12) put 309 refusals next to 488 real calls, and counting them would have
+    made a healthy endpoint look busier and flakier than it was."""
+    for _ in range(6):
+        await _record(EP, 200)
+    for _ in range(9):
+        await _record(EP, 402, refused_by="balance")
+    got = (await _observed([EP]))[EP]
+    assert got["samples"] == 6          # the refusals are not traffic the provider ever saw
+    assert got["ok_rate"] == 1.0
 
 
 async def test_a_provider_failure_does_move_the_rate(clients: AsyncClient):

--- a/tests/test_refusal_audit.py
+++ b/tests/test_refusal_audit.py
@@ -1,0 +1,68 @@
+"""Every `/call/` refusal leaves a CallRecord stamped `refused_by` — the funnel's early friction.
+
+Before this, a call treg refused BEFORE the relay fell into two buckets: money refusals were
+audited (but indistinguishable from a provider's own 402), and everything earlier — bad token,
+unknown tool, ACL, deny rule — left no row at all. The 2026-08-12 Hunter incident is the motivating
+case: 309 pre-relay refusals read as "Hunter is failing" until the rows were re-derived from
+`duration_ms IS NULL`. `refused_by` makes that distinction a column instead of a forensic exercise.
+"""
+
+from __future__ import annotations
+
+from httpx import AsyncClient
+from sqlmodel import select
+
+from treg import audit
+from treg.db import session_maker
+from treg.models import CallRecord
+
+
+async def _rows() -> list[CallRecord]:
+    await audit.drain()  # flush the fire-and-forget writes before reading
+    async with session_maker() as db:
+        return (await db.execute(select(CallRecord).order_by(CallRecord.id))).scalars().all()
+
+
+async def _make_echo_tool(clients: AsyncClient, name: str = "echo-tool") -> None:
+    s = await clients.post("/secrets", json={"name": f"k-{name}", "value": "sek"})
+    await clients.post("/tools", json={"name": name, "base_url": "http://upstream",
+                                       "secret_id": s.json()["id"]})
+
+
+async def test_a_relayed_call_is_not_a_refusal(clients: AsyncClient):
+    await _make_echo_tool(clients)
+    r = await clients.get("/call/echo-tool/echo?x=1")
+    assert r.status_code == 200
+    (rec,) = await _rows()
+    assert rec.refused_by is None
+
+
+async def test_unknown_tool_is_recorded_as_a_resolution_refusal(clients: AsyncClient):
+    """The pre-refused_by blind spot: a 404 for a tool nobody registered raised before the
+    handler's own audit and vanished. The fallback in the exception handler records it."""
+    r = await clients.get("/call/no-such-tool/whatever")
+    assert r.status_code == 404
+    (rec,) = await _rows()
+    assert rec.refused_by == "resolution"
+    assert rec.tool_name == "no-such-tool"
+    assert rec.user_email == "tim@superdesign.dev"  # identity was known — the token was fine
+    assert rec.org_id is not None
+
+
+async def test_bad_token_is_recorded_anonymously_as_an_auth_refusal(clients: AsyncClient):
+    """No Caller ever existed, so the row cannot say who — but an anonymous row is still the
+    fact that someone knocked with a dead token, which zero rows could never say."""
+    r = await clients.get("/call/echo-tool/echo", headers={"X-Treg-Token": "garbage"})
+    assert r.status_code == 401
+    (rec,) = await _rows()
+    assert rec.refused_by == "auth"
+    assert rec.org_id is None and rec.user_email == ""
+
+
+async def test_refusals_reach_the_caller_in_the_audit_log(clients: AsyncClient):
+    """`treg audit` is where an org goes to ask "why did my call fail" — the column must be in
+    the payload, not only in the table."""
+    await clients.get("/call/no-such-tool/whatever")
+    await audit.drain()
+    (row,) = (await clients.get("/calls")).json()
+    assert row["refused_by"] == "resolution"


### PR DESCRIPTION
## What

The 2026-08-12 Hunter incident: 309 pre-relay refusals (paywall 402s, daily-cap 429s) were indistinguishable from Hunter failing — and refusals that raised before the handler's audit (bad token, unknown tool, ACL, deny rule, daily cap) left **no row at all**.

- `CallRecord.refused_by` (migration A29, nullable): `auth | policy | balance | cap | resolution | request` — set when **treg** refused the call before anything went upstream; NULL whenever the provider answered.
- Money refusals and marketplace-resolution failures stamp their kind in the existing in-handler audits; everything earlier is caught by a fallback in the `X-Treg-Error` exception handler (the one place every /call refusal passes through), recording anonymously when no Caller ever existed.
- `endpoint_stats` excludes refused rows even from `samples` — a burst of refused calls must not dress itself up as traffic.
- Catalog `miss: {status, means}` block on endpoints with evidenced no-match semantics (`pdl.people.enrich`, `hunter.x.combined-find`) surfaced through `endpoint_view`, so agents read "404 = no match, don't retry" instead of a failure.
- `GET /calls` now returns `refused_by` for `treg audit`.

## Tests
- `tests/test_refusal_audit.py` (new): relayed call → NULL; unknown tool → `resolution` with identity; bad token → anonymous `auth` row; `/calls` payload carries the column.
- `test_endpoint_stats.py`: refused rows are not samples.
- Full suite: 1348 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)