### PR TITLE
feat: retired/broken catalog markers + versioned-base-URL call note

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -680,6 +680,17 @@ Five rules worth keeping:
   same). Endpoints with evidenced miss behaviour carry a `miss: {status, means}` block in their
   YAML, surfaced through `endpoint_view` — so an agent reads "404 = no match, don't retry" instead
   of treating an expected empty answer as a failure. Only annotate what the wire has demonstrated.
+
+**Retired and broken endpoints are marked, never deleted.** An endpoint verified dead upstream
+(`status: broken`) or moved by its provider (`status: retired`) keeps its YAML entry, gains a
+`status_note` (what happened, with the evidence) and a `superseded_by` (the replacement id), and
+`_parse` drops it from `endpoints` while keeping it in `by_id`. One filter is the whole feature:
+search, platform pages and the census all read `endpoints`, so the row leaves every browse surface
+at once — but a direct id lookup (`/catalog/endpoints/{id}`, `catalog_get` over MCP) still resolves,
+returning the story and the replacement. Deleting the YAML instead would turn an id an agent cached
+yesterday into an unexplained 404, which is exactly the failure that motivated this: ~90 prod errors
+through 2026-08-12 came from endpoints the July sweep had already flagged, still being served by
+search. Calls to a marked id still relay verbatim (the upstream's own answer is the truth).
 - **Below `MIN_SAMPLES` we publish the count and nothing else.** "100% from two calls" is noise
   dressed as evidence, and on a quiet endpoint a rate could expose one org's activity.
 - **Sample size is always visible**, so `100% (8)` cannot beat `99% (121)` by looking rounder.

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -113,8 +113,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   validated by `_validate_bindings`; `host` derived by `_host_of`; optional `examples`; optional `cli`
   local-run profile validated by `_validate_cli_profile`), `list_tools`, `update_tool` (re-derives host on
   base_url change; `cli` set/clear here — this is how the local-run toggle flips `cli.enabled`),
-  `delete_tool`. View via `_tool_view` (now includes `cli`). `delete_secret` refuses a secret referenced by
-  a tool binding **or** a `cli.inject` entry.
+  `delete_tool`. View via `_tool_view` (now includes `cli`, and `call_note` — a server-computed warning
+  when the base URL already ends in an API-version segment, so a caller never composes
+  `/v25.0/v25.0/me`; shown at registration, in listings, and in MCP `my_tools`). `delete_secret`
+  refuses a secret referenced by a tool binding **or** a `cli.inject` entry.
   - **Owner-only binding.** `_validate_bindings` (HTTP bindings) and `_validate_cli_secrets` (local-run
     `cli.inject` entries) require the caller to **own** every secret they bind/inject, via
     `_require_secret_ownership`; only an **admin/owner** may wire up a shared-key tool with a teammate's

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -7742,12 +7742,35 @@ def _secret_view(s: Secret) -> dict:
     return {"id": s.id, "name": s.name, "kind": s.kind, "owner": s.owner, "bundle_id": s.bundle_id}
 
 
+_VERSION_SEGMENT = re.compile(r"/v\d+(?:[._]\d+)*/?$")
+
+
+def _base_url_call_note(base_url: str) -> str | None:
+    """A one-line warning when the base URL already ends in an API-version segment.
+
+    The single most common self-inflicted call failure in prod (2026-08-12: 24 errors on one
+    Facebook tool alone) is `graph.facebook.com/v25.0/v25.0/me` — the version lives in the base
+    URL AND the caller prepends it again. The registry relays verbatim by design, so the fix is
+    to say it where every caller looks (tool listings + the moment of registration), not to
+    second-guess the path at relay time."""
+    from urllib.parse import urlsplit
+    m = _VERSION_SEGMENT.search(urlsplit(base_url).path)
+    if not m:
+        return None
+    v = m.group(0).strip("/")
+    return (f"base URL already ends in /{v} — start paths at the resource "
+            f"(use `{v}/me` → wrong: it becomes /{v}/{v}/me; right: `me`)")
+
+
 def _tool_view(t: Tool) -> dict:
     return {
         "id": t.id,
         "name": t.name,
         "owner": t.owner,
         "base_url": t.base_url,
+        # non-null only when the base URL carries an API version: the one line that prevents the
+        # doubled-version path (`/v25.0/v25.0/…`) — shown at registration and in every listing.
+        "call_note": _base_url_call_note(t.base_url),
         "host": t.host,
         "bindings": t.bindings,
         "health_check": t.health_check,

--- a/src/treg/catalog/tikhub.extended.yaml
+++ b/src/treg/catalog/tikhub.extended.yaml
@@ -19292,6 +19292,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-ads.json
   capability: linkedin.search.ads
 - id: tikhub.x.linkedin-web-search-jobs
+  status: retired
+  status_note: "TikHub retired the linkedin/web/* routes (they answer 404 — 19 recorded in prod through 2026-08-12); the web_v2 family replaced them"
+  superseded_by: tikhub.x.linkedin-web-v2-search-jobs
   tier: extended
   platform: linkedin
   method: GET
@@ -19405,6 +19408,9 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.linkedin-web-search-location.json
 - id: tikhub.x.linkedin-web-search-people
+  status: retired
+  status_note: "TikHub retired the linkedin/web/* routes (they answer 404 — 14 recorded in prod through 2026-08-12); the web_v2 family replaced them"
+  superseded_by: tikhub.x.linkedin-web-v2-search-users
   tier: extended
   platform: linkedin
   method: GET
@@ -27634,6 +27640,9 @@ endpoints:
   example_response: examples/tikhub.x.tiktok-shop-web-fetch-product-detail.json
   capability: tiktok-shop.product.detail
 - id: tikhub.x.tiktok-shop-web-fetch-product-reviews
+  status: broken
+  status_note: "upstream-broken since the 2026-07-30 catalog sweep (TikHub returns 400 regardless of parameters — 37 recorded in prod through 2026-08-12); V2 works"
+  superseded_by: tikhub.x.tiktok-shop-web-fetch-product-reviews-v2
   tier: extended
   platform: tiktok-shop
   method: GET

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -211,7 +211,13 @@ def _parse(directory: Path) -> Catalog:
             if ep["id"] in by_id:  # first file wins; ids are unique by validator contract
                 continue
             by_id[ep["id"]] = ep
-            endpoints.append(ep)
+            # A retired/broken endpoint resolves by id (an agent holding the old id gets the story
+            # and the replacement, and a call still relays verbatim) but leaves every browse
+            # surface: search, platform pages and the census all read `endpoints`, so one filter
+            # here is the whole feature. Deleting the YAML instead would turn a cached id into an
+            # unexplained 404 — the exact failure the marker exists to prevent.
+            if not ep["status"]:
+                endpoints.append(ep)
 
     for ep in endpoints:  # a platform seen only in provider files still deserves a label
         platforms.setdefault(ep["platform"], {"label": ep["platform"], "category": "Other"})
@@ -366,6 +372,13 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # 404s a person it has no record of). Only endpoints with evidenced miss semantics carry
         # it; for everything else an error status means what it says.
         "miss": raw.get("miss") or None,
+        # "" = live (the default). "retired" (the provider moved/removed the route) or "broken"
+        # (verified dead upstream) pulls the endpoint off every browse surface while keeping it
+        # resolvable by id — see the filter in `_parse`. `status_note` says what happened and
+        # `superseded_by` names the replacement id, so the marker is a migration path, not a wall.
+        "status": str(raw.get("status") or "").strip().lower(),
+        "status_note": str(raw.get("status_note") or "").strip(),
+        "superseded_by": str(raw.get("superseded_by") or "").strip(),
         "docs_url": raw.get("docs_url") or "",
         "example_file": _example_file(raw, directory),
     }
@@ -426,6 +439,11 @@ def endpoint_view(ep: dict, provider_display: str, cat: Catalog | None = None) -
         # "no match" semantics, when the endpoint has them — an agent that reads `miss` stops
         # treating an expected empty answer as a failed call (and stops retrying it).
         "miss": ep.get("miss"),
+        # retired/broken marker (browse surfaces never serve these rows, so a non-empty value is
+        # only ever seen on a direct id lookup — where the note + replacement ARE the answer)
+        "status": ep.get("status") or None,
+        "status_note": ep.get("status_note") or None,
+        "superseded_by": ep.get("superseded_by") or None,
         "verified": ep["verified"],
         "docs_url": ep["docs_url"],
         "has_example": bool(ep["example_file"]),

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -166,6 +166,7 @@ class TeamTool(TypedDict, total=False):
     name: str | None
     base_url: str | None
     description: str | None
+    call_note: str | None  # e.g. "base URL already ends in /v25.0 — start paths at the resource"
 
 
 class MyToolsOut(TypedDict, total=False):
@@ -581,8 +582,11 @@ async def my_tools(ctx: Context) -> MyToolsOut:
     return {
         "team": slug,
         "count": len(tools),
+        # call_note rides along when present — e.g. "base URL already ends in /v25.0 — start
+        # paths at the resource": the agent about to compose a path is exactly who must read it.
         "tools": [{"name": t.get("name"), "base_url": t.get("base_url"),
-                   "description": t.get("description")} for t in tools],
+                   "description": t.get("description"), "call_note": t.get("call_note")}
+                  for t in tools],
     }
 
 

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -61,7 +61,8 @@ async def test_platform_detail_groups_the_same_job_across_providers(clients: Asy
     ep = next(e for e in profile["endpoints"] if e["provider"] == "tikhub")
     assert set(ep) == {"id", "provider", "provider_display", "name", "summary", "method", "path",
                        "scope", "tier", "kind", "domain", "call_template", "cost", "verified", "docs_url",
-                       "has_example", "input", "platform_eligible", "test_request", "miss"}
+                       "has_example", "input", "platform_eligible", "test_request", "miss",
+                       "status", "status_note", "superseded_by"}
     assert ep["kind"] == "data", "an endpoint with no explicit kind is data (the browse surface)"
     assert ep["provider_display"] == P.get("tikhub").display_name
     assert ep["method"] == "GET" and ep["path"].startswith("/")
@@ -616,3 +617,39 @@ def test_an_unpriced_route_is_still_refused():
     ep = {"cost": {"type": "per_call", "currency": "credit", "unit": "credit"},
           "provider": "pdl", "scope": "any_account", "kind": "data"}
     assert not cat.platform_eligible(ep)
+
+
+# ---- retired/broken endpoints -----------------------------------------------------------------
+RETIRED = "tikhub.x.linkedin-web-search-jobs"          # TikHub retired the web/* family
+BROKEN = "tikhub.x.tiktok-shop-web-fetch-product-reviews"   # verified dead upstream
+
+
+async def test_a_retired_endpoint_leaves_every_browse_surface(clients: AsyncClient):
+    """~90 prod errors through 2026-08-12 came from endpoints the July sweep already knew were
+    dead — because search kept serving them. A status marker must pull the row from search and
+    the platform page in one move."""
+    hits = (await clients.get("/catalog/search", params={"q": "linkedin search jobs", "limit": 100})).json()
+    assert RETIRED not in {r["id"] for r in hits["results"]}
+    # the replacement IS still served — retiring the old id must not orphan the capability
+    assert "tikhub.x.linkedin-web-v2-search-jobs" in {r["id"] for r in hits["results"]}
+
+    page = (await clients.get("/catalog/platforms/tiktok-shop", params={"include_hidden": 1})).json()
+    listed = {e["id"] for row in page["domains"] for grp in row.get("rows", [row]) for e in grp.get("endpoints", [])} if page.get("domains") else set()
+    assert BROKEN not in listed
+
+
+async def test_a_retired_id_still_resolves_with_the_story_and_the_replacement(clients: AsyncClient):
+    """An agent holding the old id from a cached answer must get a migration path, not a bare 404 —
+    that unexplained 404 is exactly the failure the marker exists to prevent."""
+    r = await clients.get(f"/catalog/endpoints/{RETIRED}")
+    assert r.status_code == 200
+    ep = r.json()["endpoint"]
+    assert ep["status"] == "retired"
+    assert "web_v2" in ep["status_note"] or "retired" in ep["status_note"]
+    assert ep["superseded_by"] == "tikhub.x.linkedin-web-v2-search-jobs"
+
+
+async def test_a_live_endpoint_carries_no_status(clients: AsyncClient):
+    r = await clients.get("/catalog/endpoints/tikhub.x.linkedin-web-v2-search-jobs")
+    assert r.status_code == 200
+    assert r.json()["endpoint"]["status"] is None

--- a/tests/test_step3_crud_auth_audit.py
+++ b/tests/test_step3_crud_auth_audit.py
@@ -92,3 +92,24 @@ async def test_call_is_audited(clients: AsyncClient):
     assert rec["user_email"] == "tim@superdesign.dev"
     assert rec["method"] == "GET"
     assert rec["status_code"] == 200
+
+
+async def test_a_versioned_base_url_warns_at_registration_and_in_listings(clients: AsyncClient):
+    """The doubled-version path (`graph.facebook.com/v25.0/v25.0/me` — 24 prod errors on one tool,
+    2026-08-12) happens because nothing told the caller the version was already in the base URL.
+    The registry relays verbatim by design, so the fix is a note where every caller looks."""
+    s = await clients.post("/secrets", json={"name": "fb", "value": "sek"})
+    r = await clients.post("/tools", json={"name": "fb", "base_url": "https://graph.facebook.com/v25.0",
+                                           "secret_id": s.json()["id"]})
+    assert r.status_code == 200
+    assert "already ends in /v25.0" in r.json()["call_note"]
+
+    listed = {t["name"]: t for t in (await clients.get("/tools")).json()}
+    assert "v25.0" in listed["fb"]["call_note"]
+
+
+async def test_an_unversioned_base_url_carries_no_note(clients: AsyncClient):
+    s = await clients.post("/secrets", json={"name": "p", "value": "sek"})
+    r = await clients.post("/tools", json={"name": "plain", "base_url": "https://api.example.com",
+                                           "secret_id": s.json()["id"]})
+    assert r.json()["call_note"] is None


### PR DESCRIPTION
Stacked on #104 (merge that first; this PR's base is its branch).

## What

The other half of the 2026-08-12 error analysis — the two caller-facing fixes:

- **Retired/broken endpoints are marked, never deleted.** `status: retired|broken` + `status_note` + `superseded_by` in the catalog YAML; `_parse` keeps the row in `by_id` but drops it from `endpoints`, so search, platform pages and the census lose it in one move while a direct id lookup still answers with the story and the replacement. Marked now (with prod evidence in the notes): `tikhub.x.linkedin-web-search-jobs` / `-people` (retired → web_v2) and `tikhub.x.tiktok-shop-web-fetch-product-reviews` (broken → v2). ~90 prod errors through Aug 12 came from these three.
- **`call_note` on tools whose base URL ends in a version segment** (`graph.facebook.com/v25.0` → "base URL already ends in /v25.0 — start paths at the resource"). Server-computed in `_tool_view`, so it shows at registration, in `GET /tools`, and in MCP `my_tools` — the doubled `/v25.0/v25.0/me` path was 24 prod errors on one tool alone. Deliberately a note, not relay-time dedup: the registry never second-guesses the path it relays.

## Tests
- Retired id absent from search/platform page, still resolves by id with note + replacement; live sibling unaffected.
- `call_note` present for versioned base URL (registration + listing), absent otherwise.
- Full suite: 1353 passed; `catalog_validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)