### PR TITLE
cutover: flip production to treg.to (URL + email)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -34,20 +34,21 @@ services:
           name: treg-db
           property: connectionString
       # Public base URL — drives the OAuth callback, /meta, /llms.txt, /install.sh, all {BASE} links.
-      # STAGED CUTOVER (treg.superdesign.dev → treg.to): this deliberately still names the OLD
-      # domain so the migration code deploys INERT — behavior byte-identical to pre-migration.
-      # The flip to https://treg.to is its own later one-line PR, and setting this back IS the
-      # complete rollback (PUBLIC_HOST_ALIASES keeps both names valid in both directions).
+      # CUTOVER (treg.superdesign.dev → treg.to, 2026-08): setting this back to
+      # https://treg.superdesign.dev is the complete, lossless rollback — PUBLIC_HOST_ALIASES
+      # keeps both names valid in both directions, and the old domain must stay attached on
+      # Render forever (installed clients hold tokens against it).
       - key: TREG_PUBLIC_URL
-        value: https://treg.superdesign.dev
+        value: https://treg.to
       # Never return OTP codes in prod responses (account-takeover vector); email them via Resend.
       - key: TREG_EMAIL_DEV_MODE
         value: "false"
-      # Flips to no-reply@treg.to in its own PR, AFTER the URL flip soaks AND a real canary send
-      # from the Resend-verified treg.to domain — send failures are swallowed by design, so an
-      # unverified sender silently kills OTP login.
+      # treg.to is Resend-verified (DKIM + SPF). Deliverability canary after every change to this
+      # value: sign in via email OTP and confirm the code ARRIVES — send failures are swallowed by
+      # design, so a broken sender silently kills OTP login. Rollback: the old sender stays
+      # verified in Resend forever.
       - key: TREG_EMAIL_FROM
-        value: tools-registry <no-reply@treg.superdesign.dev>
+        value: tools-registry <no-reply@treg.to>
       - key: PYTHON_VERSION
         value: "3.12.7"
       # Dashboard-managed secrets (paste values in Render; sync:false keeps them out of git).


### PR DESCRIPTION
**The cutover switch.** Stacked on #106 (base auto-retargets to `main` when it merges). Merging this PR = flipping production to treg.to. Draft until cutover minute.

## Diff
- `TREG_PUBLIC_URL` → `https://treg.to`
- `TREG_EMAIL_FROM` → `tools-registry <no-reply@treg.to>` (Resend shows treg.to **Verified**; combined because the two lines revert independently)

## Cutover-minute checklist
1. Confirm #106 merged, deployed inert, and `bash scripts/smoke-domain.sh pre` passed
2. Merge this PR → Render deploys
3. **Same minutes** — GitHub OAuth App (github.com → Settings → Developer settings → OAuth Apps → treg): set *Authorization callback URL* to `https://treg.to/auth/github/callback`
4. `bash scripts/smoke-domain.sh post` (and once with `TREG_SMOKE_TOKEN=<token>` for the authed /mcp/ proof)
5. Canary: sign out, sign in on https://treg.to via **email OTP** — code must arrive from `no-reply@treg.to`; plus one GitHub and one Google login
6. Soak 24–48h (PostHog dashboard 892238 both `$host`s, Resend sends, support) before Phase 4 client releases

## Rollback (lossless, by design)
- URL: revert `TREG_PUBLIC_URL` to `https://treg.superdesign.dev` (+ paste back the GitHub callback field). Everything minted on treg.to keeps working — `PUBLIC_HOST_ALIASES` is symmetric.
- Email alone: revert `TREG_EMAIL_FROM` to `tools-registry <no-reply@treg.superdesign.dev>` (old sender stays Resend-verified).
- Never detach `treg.superdesign.dev` from Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)