### PR TITLE
feat: BYOK as a first-class path + fix connect rejecting valid API keys

### DIFF
--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -396,7 +396,16 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   provider — a bring-your-own bot token (Slack) or an **API key** (Apollo, Hunter, TikHub, Semrush, …) —
   **verifying the credential against the provider's probe before storing** (a header- OR query-param probe,
   an off-host `probe_url`, tolerating a CSV/text body or a 200-with-false-`token_verify_field` reply), then
-  auto-provisioning its tool with a header or query binding. See
+  auto-provisioning its tool with a header or query binding. Two probe subtleties the code handles
+  because upstreams don't cooperate: a `probe_path` may bake in a required `?query` (PDL, Akta,
+  JustOneAPI, SpyFu), and httpx **replaces** a URL's own query when `params=` is passed — so the path's
+  query is parsed out and **merged into params** (the credential wins a key collision) rather than
+  silently dropped; and the body is parsed as JSON **regardless of content-type**, because ScrapeCreators
+  serves real JSON under `text/plain` and gating on `application/json` left `token_verify_field` unread
+  (a genuinely non-JSON balance still throws → empty payload → the `ERROR`-text branch, unchanged). A
+  base64-encode provider (`token_encode`, DataForSEO/Moz) accepts EITHER a raw `login:password` OR the
+  dashboard's ready-made base64 blob — a blob is detected (strict-decodes to printable text with a `:`)
+  and kept as-is instead of being double-encoded. See
   [auth-secrets](../architecture/auth-secrets.md). `set_extra_credential` (`POST /connections/{id}/extra-credential`) stores
   the second credential a provider needs when treg does NOT hold it centrally (rare) and finishes the
   tool with BOTH bindings. `revoke_connection` (`DELETE /connections/{id}`) deletes the credential and

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -134,7 +134,14 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   (Render/Vercel-style — `pasteEnv` → `parseEnvText`: comments/blanks skipped, `export ` stripped, one
   balanced quote pair removed). A single-line `NAME=value` splits only in the *name* field — a value
   containing `=` (base64 pad, connection strings) pastes untouched into the value field; multi-line
-  splits from either field.
+  splits from either field. The name field carries a **`<datalist>` of pasted-secret provider services**
+  (`keyNameSuggestions` — `auth_kind` `key`/`token`, the names the marketplace ladder's tier 2 matches
+  by `Secret.name == service`), and each row gets a `secretNameHint` line: an exact service name is
+  confirmed ("Apollo.io catalog calls will use this key automatically"), a near miss (`APOLLO_API_KEY`,
+  `tikhub-key` — suffix-stripped, case-folded) gets the exact name plus a one-click **rename** link,
+  and any other name gets silence — most secrets back the org's own tools and can be called anything.
+  Providers are loaded on entering the view (`go('secrets')` also fires `loadConnections` when the
+  list is empty) so the suggestions exist on a cold deep link.
 - **Team** (`view==='orgs'`) — the active team, now split into **tabs** (`orgTab`):
   **Members · Projects · Policy · Team settings**. (The former **My teams** tab is gone — it
   duplicated the sidebar picker; its New team / Join by code / Paste token actions live in Team
@@ -270,9 +277,15 @@ more, and it falls on empty space when the tabs all fit. The rule under the tabs
 **`.mk-tabs-wrap`** parent, because a masked border fades out 26px short of the right edge and reads as a
 rendering fault. Every tab but the last is the **platform axis**
 (which data you want — see the catalog section below); the **last tab, `Platform`, is this integration marketplace**
-(which account you hold), unchanged: providers grouped by category (`providerGroups` computed →
-`shownGroups` filtered by the `mkCat` chip row) as a card grid, the whole card being the click target
-(`openProvider(service)`). Each card shows a **provider logo** served by convention from
+(which account you hold): providers grouped by category (`providerGroups` computed →
+`shownGroups` filtered by the `mkCat` chip row) as a **list** (`.prov-list`, one `.prov-row` per
+provider), not the old card grid — this tab is where "bring your own key" lands, and forty cards put
+every name on a different left edge; a row keeps them in one scannable column (name + truncated summary,
+auth kind, connect state, and an **inline Connect / Add key** action that calls `startConnect(p)` right
+from the row — the `tokenAsk`/`capAsk` modals are global, so the common path is one click). The whole row
+still opens the provider page (`openProvider(service)`); each row has `id="prov-<service>"` so a
+`goByok(service)` jump can scroll to it and flash it (`.prov-row.focus`, `byokFocus` state, self-clearing).
+Rows show the **provider logo** served by convention from
 **`/logos/<service>.svg`** (`.plogo-tile`/`.plogo`, `@error` hides a missing file) — the `StaticFiles`
 mount `_LOGO_DIR` (`src/treg/web/logos/`). `connCount` labels how many accounts are already connected.
 The tab bar itself is `v-if`'d on `plats.list.length` and `mkTabActive` collapses to `'platform'` when
@@ -281,7 +294,9 @@ the catalog is absent, so a build that predates `/catalog` renders exactly the o
 The catalog page's header carries a **Request a tool** button (`reqAsk` modal): a short form —
 what's missing, an optional note, a contact field only when signed out (`!me`) — POSTed to
 `/tool-requests` with `source: web`; the capability input pre-fills from the live search box `q`,
-because the button is most often pressed right after a search found nothing. Next to it sits
+because the button is most often pressed right after a search found nothing. Beside it sit a
+**Bring your own key** button (`goByok()` — the ink-fill primary; it only switches to the Platform
+tab, but naming the action is what makes the tab findable) and
 **List as vendor** (`vendorAsk` modal): a vendor pastes the
 two-sentence prompt (`vendorPromptText`, built on `proxy` = the server's public URL) into their own
 coding agent, which follows the hosted `GET /vendor-listing` instructions and raises the listing PR —
@@ -547,8 +562,12 @@ row below it off the screen.
 The tab bar's right side carries the provider's **docs** (falling back to its pricing page), then the
 two run actions — and which one is primary depends on the provider's `auth_kind` (`mkOauth(service)`).
 For a **key/token** provider, **▶ Try it** (`openEpTry`) is the ink-fill **primary** — trying on treg's
-own key is what most visitors want — and **Bring your own key** (`openProvider`, formerly the ink-filled
-"Connect {provider}") is the secondary ghost beside it. For an **OAuth** provider treg *can't* serve on
+own key is what most visitors want — and **Bring your own key** (`goByok(provider)` — jumps to the
+Catalog's Platform tab with that provider's row scrolled into view and flashed, so the user sees where
+their key lives among the rest; formerly `openProvider` straight to the detail page) is the secondary
+ghost beside it. The same `goByok` jump is offered from a platform page's provider row (passing the
+provider only when the platform has exactly one) and from the Try-it drawer's "can't run this here"
+banner, which now carries a real **Connect** / **Bring your own key** button instead of prose alone. For an **OAuth** provider treg *can't* serve on
 its own key (calls act as your account), so the order flips: **Connect {provider}** is the ink-fill
 primary and Try-it is secondary. Once an account is connected the connect/own-key button is replaced in
 place by the green **`Connected`** chip. Everything here renders identically in a single row's expansion

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -28,7 +28,7 @@ import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote, urlsplit
+from urllib.parse import parse_qsl, quote, urlsplit, urlunsplit
 
 from sqlalchemy import case, delete, func, or_
 
@@ -6274,10 +6274,22 @@ async def connect_with_token(
     if not token:
         raise HTTPException(status_code=422, detail=f"{provider.token_label or 'Token'} is required")
     # HTTP Basic providers (DataForSEO, Moz) take a pasted `login:password`; store the Base64 blob so
-    # `Basic {secret}` renders the same at connect and on every proxy call.
+    # `Basic {secret}` renders the same at connect and on every proxy call. Both dashboards ALSO hand
+    # out a ready-made Base64 credential, and users paste that at least as often as the raw pair —
+    # encoding it again produced a double-encoded blob the provider 401'd. So: if the paste already IS
+    # Base64 of a printable `login:password`, keep it. A raw pair can never be mistaken for one (":"
+    # is not in the Base64 alphabet, so strict decoding refuses it), and a Base64 blob can never be
+    # a working raw pair (it has no ":"), so the branch is unambiguous either way.
     if provider.token_encode == "base64":
         import base64
-        token = base64.b64encode(token.encode()).decode()
+        already = None
+        try:
+            decoded = base64.b64decode(token, validate=True).decode()
+            if ":" in decoded and decoded.isprintable():
+                already = token
+        except Exception:  # noqa: BLE001 — not Base64, or not text: encode it below
+            pass
+        token = already or base64.b64encode(token.encode()).decode()
 
     # The credential rides in a header (default) or a query param (Semrush: ?key=…). The cheapest
     # check may also live on a different host than base_url, so honor an absolute probe_url override,
@@ -6288,6 +6300,14 @@ async def connect_with_token(
     else:
         headers, params = {provider.token_header: rendered}, {}
     probe_url = provider.probe_url or f"{provider.base_url.rstrip('/')}{provider.probe_path}"
+    # httpx REPLACES a URL's own query string when `params=` is passed, so a probe_path like
+    # `/autocomplete?field=title&text=data` (PDL, Akta, JustOneAPI, SpyFu) silently lost its required
+    # params and the probe 400'd — rejecting a perfectly good key. Merge the path's query into params
+    # ourselves (params, i.e. the credential for a query provider, wins on a key collision).
+    split = urlsplit(probe_url)
+    if split.query:
+        params = {**dict(parse_qsl(split.query, keep_blank_values=True)), **params}
+        probe_url = urlunsplit((split.scheme, split.netloc, split.path, "", split.fragment))
     try:
         resp = await request.app.state.http.request(
             provider.probe_method or "GET", probe_url,
@@ -6295,13 +6315,17 @@ async def connect_with_token(
         )
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"could not reach {provider.display_name}: {exc}") from None
-    # Only parse JSON when the response actually is JSON — a key check may answer in CSV/text
-    # (Semrush's balance endpoint), where resp.json() would throw and mask a valid key as unreachable.
+    # Try to parse the body as JSON regardless of the content-type header: ScrapeCreators returns a
+    # real JSON body labelled `text/plain`, and gating on `application/json` left its payload empty so
+    # `token_verify_field` (creditCount) read as false and a valid key was rejected. The parse is
+    # defensive — a genuinely non-JSON key check (Semrush's CSV/number balance) simply throws and
+    # leaves payload empty, falling through to the `text_error` branch exactly as before.
     ctype = resp.headers.get("content-type", "")
     payload: dict = {}
-    if resp.status_code < 500 and ctype.startswith("application/json"):
+    if resp.status_code < 500:
         try:
-            payload = resp.json()
+            parsed = resp.json()
+            payload = parsed if isinstance(parsed, dict) else {}
         except Exception:  # noqa: BLE001
             payload = {}
     # Some providers answer HTTP 200 even for a BAD key and signal validity only in the body: a JSON

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -919,8 +919,10 @@ BRIGHTDATA = OAuthProvider(
     # Web Scraper API (/datasets/v3/…).
     base_url="https://api.brightdata.com",
     docs_url="https://docs.brightdata.com/api-reference/authentication",
-    # Lightweight dataset listing — inferred (medium confidence). Verify with a real token; adjust if it 404s.
-    probe_path="/datasets/v3/datasets",
+    # Account status: free, answers 200 for a valid token and 401 "Invalid credentials" for a bad one
+    # (verified live 2026-08-13). The old inferred /datasets/v3/datasets was not a real route — it
+    # 404'd "Cannot GET" even with a valid token, so every real key was refused at connect.
+    probe_path="/status",
 )
 
 SEMRUSH = OAuthProvider(
@@ -1003,7 +1005,10 @@ JUSTONEAPI = OAuthProvider(
     docs_url="https://docs.justoneapi.com/en/usage",
     # A bad token returns HTTP 401 {"code":100,"message":"TOKEN INVALID/UNACTIVATE"} (verified live), so
     # the standard status check rejects it. A valid token on this endpoint returns code:0 (~1 credit).
-    probe_path="/api/tiktok/get-user-detail/v1?unique_id=tiktok",
+    # The param is camelCase `uniqueId` — with the old snake_case `unique_id` the API answered HTTP 400
+    # "must input one of them (uniqueId or secUid)" and a VALID token was refused at connect
+    # (verified live 2026-08-13).
+    probe_path="/api/tiktok/get-user-detail/v1?uniqueId=tiktok",
 )
 
 SCRAPECREATORS = OAuthProvider(
@@ -1307,7 +1312,9 @@ SPYFU = OAuthProvider(
     setup_url="https://www.spyfu.com/account/api",
     setup_action_label="Get your SpyFu API key",
     setup_steps=("Open SpyFu Account settings → API.", "Copy your Secret Key."),
-    setup_note="API access is included with paid SpyFu plans; paste the Secret Key.",
+    # The SpyFu dashboard shows THREE credentials (API ID, Secret Key, Base64 Key); only the short
+    # Secret Key works here, so the note has to name the other two or users paste them and get a 401.
+    setup_note="Paste ONLY the short Secret Key (e.g. DR…) — not the API ID and not the Base64 key.",
     auth_uri="", token_uri="",
     scopes={},
     client_id_setting="", client_secret_setting="",

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -839,6 +839,29 @@ a:hover{text-decoration-color:var(--muted)}
   box-shadow:var(--shadow-sm);
   transition:box-shadow .24s var(--ease),background-color .2s var(--ease)}
 .mk-card:hover{border-color:transparent;transform:none;box-shadow:var(--shadow-md)}
+/* ---- the Platform tab as a LIST ----
+   One integration per row: name and summary on a shared left edge, auth kind and connect state as
+   quiet columns, the action inline. Cards made every name start somewhere else; a shelf you scan
+   for the one provider you hold an account with wants a column. */
+.prov-list{width:100%}
+/* Outrank the base table rules: .ttable .tn is a nowrap 22% column with a MONO name — right for
+   tool names, wrong for "Google Business Profile" next to a summary. */
+.prov-list .tn{width:34%;white-space:nowrap}
+.prov-list .tn b{font-family:var(--sans)}
+.prov-row{cursor:pointer}
+.prov-row td{transition:background-color .2s var(--ease)}
+.prov-row:hover td{background:var(--hover)}
+.prov-row:focus-visible{outline:0;box-shadow:inset 0 0 0 2px var(--ink)}
+.prov-n-i{display:flex;align-items:center;gap:11px;min-width:0}
+.prov-name{min-width:0}
+.prov-name b{font-family:var(--sans);font-size:13px;font-weight:500;letter-spacing:-.1px;display:block;white-space:nowrap}
+.prov-sum{display:block;font-family:var(--sans);font-size:11.5px;color:var(--muted);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:62ch}
+.prov-auth{font-family:var(--sans);font-size:11.5px;color:var(--muted2);white-space:nowrap}
+.prov-st{white-space:nowrap}
+/* The landing flash after a "Bring your own key" jump: the row you were sent to, then it fades. */
+.prov-row.focus td{background:color-mix(in srgb,var(--teal) 14%,transparent)}
+@media (max-width:760px){.prov-sum{display:none}.prov-auth{display:none}}
 .mk-card:focus-visible{outline:0;
   box-shadow:0 0 0 2px var(--bg),0 0 0 3.5px var(--ink)}
 .mk-chip{border-radius:999px;padding:4px 12px;font-size:11px;font-weight:450;
@@ -1334,6 +1357,9 @@ a:hover{text-decoration-color:var(--muted)}
             <div class="tut-actions">
               <button class="btn sm" @click="openToolRequest()" title="Missing a tool or provider? Tell us — requests steer what gets added next"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><line x1="12" y1="7" x2="12" y2="13"/><line x1="9" y1="10" x2="15" y2="10"/></svg>Request a tool</button>
               <button class="btn sm" @click="vendorAsk=true" title="Sell an API? Get it listed in this catalog"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.83z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>List as vendor</button>
+              <!-- The one header action a paying visitor is actually looking for: where do I put MY
+                   key. It only switches tabs, but naming it makes the Platform tab findable. -->
+              <button class="btn sm primary" @click="goByok()" title="Register your own provider key — your key wins over treg's and those calls are never metered"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777Zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>Bring your own key</button>
             </div>
           </div>
           <div v-if="connErr" class="banner" style="margin-top:12px">{{connErr}}</div>
@@ -1444,30 +1470,38 @@ a:hover{text-decoration-color:var(--muted)}
 
           <div class="tgroup" v-for="g in shownGroups" :key="g.category">
             <div class="tgh">{{g.category}} <span class="tgh-n">{{g.items.length}}</span><span class="tgh-hint">{{g.hint}}</span></div>
-            <div class="mk-grid">
-              <!-- The whole card is the target. A card that only responds on a small "Open" link
-                   makes the grid feel broken, and there is nothing else in it to click. -->
-              <div v-for="p in g.items" :key="p.service" class="mk-card" tabindex="0" role="button"
-                   :aria-label="'Open '+p.display_name"
-                   @click="openProvider(p.service)" @keyup.enter="openProvider(p.service)">
-                <div class="mk-top">
-                  <span class="plogo-tile"><img class="plogo" :src="'/logos/'+p.service+'.svg'" alt="" aria-hidden="true" @error="$event.target.style.visibility='hidden'"></span>
-                  <div style="min-width:0">
-                    <b>{{p.display_name}}</b>
-                    <span class="mk-cat">{{p.category}}</span>
-                  </div>
-                </div>
-                <p class="mk-sum">{{p.summary}}</p>
-                <div class="mk-foot">
-                  <!-- Connected count is the one fact that changes what you'd do next, so it wins
-                       the slot the mockup gives to latency. -->
+            <!-- A LIST, not cards: this tab is where "bring your own key" lands, and the visitor is
+                 scanning forty names for one they hold an account with. One provider per row keeps
+                 every name on the same left edge; the summary rides along muted and truncated. The
+                 whole row opens the provider page; the Connect / Add key action is inline, so the
+                 common path is one click, not two. -->
+            <div class="ttable-wrap"><table class="ttable prov-list">
+              <tr v-for="p in g.items" :key="p.service" :id="'prov-'+p.service" class="prov-row"
+                  :class="{focus:byokFocus===p.service}" tabindex="0" role="button"
+                  :aria-label="'Open '+p.display_name"
+                  @click="openProvider(p.service)" @keyup.enter="openProvider(p.service)">
+                <td class="tn prov-n">
+                  <!-- Flex on a wrapper INSIDE the cell, never on the <td> — see the ledger rows. -->
+                  <span class="prov-n-i">
+                    <span class="plogo-tile"><img class="plogo" :src="'/logos/'+p.service+'.svg'" alt="" aria-hidden="true" @error="$event.target.style.visibility='hidden'"></span>
+                    <span class="prov-name"><b>{{p.display_name}}</b><span class="prov-sum">{{p.summary}}</span></span>
+                  </span>
+                </td>
+                <td class="prov-auth">{{p.auth_kind==='key'?'API key':(p.auth_kind==='token'?'your own bot':'one-click')}}</td>
+                <td class="ta prov-st">
+                  <!-- Connected count is the one fact that changes what you'd do next. -->
                   <span v-if="connCount[p.service]" class="chip ok">{{connCount[p.service]}} connected</span>
                   <span v-else-if="!p.configured" class="chip warn" title="This server has no client credentials for the provider">not configured</span>
-                  <span v-else class="mk-quiet">Not connected</span>
-                  <span class="mk-auth">{{p.auth_kind==='key'?'API key':(p.auth_kind==='token'?'your own bot':'one-click')}}</span>
-                </div>
-              </div>
-            </div>
+                  <span v-else class="mk-quiet">not connected</span>
+                </td>
+                <td class="tx" @click.stop>
+                  <button v-if="p.configured" class="btn sm" :class="{primary:!connCount[p.service]}"
+                          @click="startConnect(p)"
+                          :title="p.auth_kind==='key'||p.auth_kind==='token' ? 'Paste your own '+p.display_name+' credential — treg keeps it server-side' : 'Connect '+p.display_name+' — approve on their site'">
+                    {{connCount[p.service] ? 'Add account' : (p.auth_kind==='key'||p.auth_kind==='token' ? 'Add key' : 'Connect')}}</button>
+                </td>
+              </tr>
+            </table></div>
           </div>
           </template>
 
@@ -1605,6 +1639,8 @@ a:hover{text-decoration-color:var(--muted)}
             <div class="plat-provs" v-if="platProviders.length">
               <span class="plat-provs-l">Providers</span>
               <button v-for="s in platProviders" :key="s" class="btn sm" @click="openProvider(s)">{{provName(s)}} →</button>
+              <button class="btn sm" @click="goByok(platProviders.length===1 ? platProviders[0] : null)"
+                      title="Register your own provider key — your key wins over treg's and those calls are never metered">🔑 Bring your own key</button>
             </div>
           </div>
 
@@ -1763,7 +1799,10 @@ a:hover{text-decoration-color:var(--muted)}
                             <span v-if="catConnected(e.provider)" class="chip go" title="You already have a connected account that can call this"><span class="godot"></span>Connected</span>
                             <button v-else-if="mkOauth(e.provider)" class="btn sm primary" @click.stop="openProvider(e.provider)"
                                     :title="'Connect '+(e.provider_display||e.provider)+' — one-click OAuth, calls act as your account'">Connect {{e.provider_display||e.provider}}</button>
-                            <button v-else-if="mkKnown(e.provider)" class="btn sm" @click.stop="openProvider(e.provider)"
+                            <!-- Lands on the Catalog's Platform tab focused on this provider — the
+                                 whole key shelf in view, not a dead-end detail page — so the user
+                                 sees where their key lives among the rest before they paste it. -->
+                            <button v-else-if="mkKnown(e.provider)" class="btn sm" @click.stop="goByok(e.provider)"
                                     :title="'Register your own '+(e.provider_display||e.provider)+' key — your key wins over treg\'s and those calls are never metered'">Bring your own key</button>
                           </span>
                         </div>
@@ -2039,13 +2078,27 @@ a:hover{text-decoration-color:var(--muted)}
           </table></div>
           <p v-else class="sub">No secrets yet — add one below, or bulk-load everything at once (setup guide under the form).</p>
           <div class="tgh" style="margin-top:6px">Add {{secretRows.length>1?'secrets':'a secret'}}</div>
+          <p class="sub" v-if="keyNameSuggestions.length" style="max-width:660px;margin:0 0 8px;font-size:12px">
+            Name a key after its catalog provider — e.g. <span class="mono">{{keyNameSuggestions.slice(0,3).map(p=>p.service).join(', ')}}</span> —
+            and catalog calls use it automatically. The name field suggests every provider that takes a pasted key.</p>
           <p class="sub" style="margin:2px 0 8px">Tip: paste a whole <span class="mono">.env</span> into the name field — it splits into rows automatically.</p>
           <div v-for="(row,i) in secretRows" :key="i" class="field" style="max-width:660px;flex-wrap:wrap;margin-bottom:8px">
-            <input v-model="row.name" placeholder="name, e.g. openai-key" style="min-width:150px" @paste="pasteEnv($event,i,'name')" @keyup.enter="addSecrets"/>
+            <input v-model="row.name" list="secret-name-suggest" placeholder="name, e.g. apollo" style="min-width:150px" @paste="pasteEnv($event,i,'name')" @keyup.enter="addSecrets"/>
             <input v-model="row.value" :type="row.kind==='param'?'text':'password'" :placeholder="row.kind==='param'?'value, e.g. a project id (not secret)':'value (encrypted server-side)'" style="min-width:190px" @paste="pasteEnv($event,i,'value')" @keyup.enter="addSecrets"/>
             <select v-model="row.kind" class="msel"><option>env</option><option>oauth</option><option>secret_file</option><option value="param">param (non-secret)</option></select>
             <button v-if="secretRows.length>1" class="btn sm ico" @click="secretRows.splice(i,1)" title="Remove row">✕</button>
+            <!-- The ladder matches by NAME EQUALITY, so the hint either confirms a name the catalog
+                 will find, or offers the exact one when the row is a near miss (APOLLO_API_KEY). -->
+            <span v-if="secretNameHint(row)" class="sub" style="flex-basis:100%;font-size:11.5px;margin:-2px 0 0">
+              <template v-if="secretNameHint(row).ok">✓ {{secretNameHint(row).text}}</template>
+              <template v-else>{{secretNameHint(row).text}}
+                <a href="#" @click.prevent="row.name=secretNameHint(row).service">rename to “{{secretNameHint(row).service}}”</a></template>
+            </span>
           </div>
+          <!-- Every provider a key can be pasted into, as native input suggestions on the name field. -->
+          <datalist id="secret-name-suggest">
+            <option v-for="p in keyNameSuggestions" :key="p.service" :value="p.service">{{p.display_name}}</option>
+          </datalist>
           <p class="sub" v-if="secretRows.some(r=>r.kind==='param')" style="margin:2px 0 8px">A param is non-secret config (project id, org id) — injected alongside a credential into CLI env or an HTTP query.</p>
           <div class="field" style="max-width:660px">
             <button class="btn primary" @click="addSecrets" :disabled="secretBusy||!secretRowsReady">{{secretBusy?'…':(secretRowsReady>1?('Add '+secretRowsReady+' secrets'):'Add secret')}}</button>
@@ -3331,7 +3384,11 @@ treg login</pre></div>
                  dead Run button — point them at the tab that DOES work. -->
             <div v-if="epTryAccess && epTryAccess.tier!=='platform' && epTryAccess.tier!=='tool' && epTryAccess.tier!=='credential'"
                  class="banner" style="margin:0">
-              Can't run this here yet — {{mkOauth(epTry.provider) ? 'connect '+(epTry.provider_display||epTry.provider)+' first (Bring your own key), then Run.' : 'this endpoint needs a key. Use the AI Agent / CLI / API tab, or Bring your own key.'}}
+              Can't run this here yet — {{mkOauth(epTry.provider) ? 'connect '+(epTry.provider_display||epTry.provider)+' first, then Run.' : 'this endpoint needs a key. Use the AI Agent / CLI / API tab, or bring your own.'}}
+              <div style="margin-top:10px">
+                <button v-if="mkOauth(epTry.provider)" class="btn sm primary" @click="openProvider(epTry.provider); epTry=null">Connect {{epTry.provider_display||epTry.provider}}</button>
+                <button v-else-if="mkKnown(epTry.provider)" class="btn sm primary" @click="goByok(epTry.provider)">🔑 Bring your own key</button>
+              </div>
             </div>
             <template v-else>
               <div class="field" v-for="p in epTryParams" :key="p.name" style="max-width:520px">
@@ -3408,6 +3465,7 @@ createApp({
       // holds an approved app for; `connections` is what this org has actually connected.
       providers:[], connections:[], connErr:'', connBusy:false, confirmDisc:null, resPick:null,
       mkCat:'', mkService:null,  // marketplace: active category filter, and the open integration
+      byokFocus:null,  // provider row to flash after a "Bring your own key" jump to the Platform tab
       // Marketplace tab bar: 'all' + one key per catalog category, plus 'platform' for the
       // original integration shelves. Data-first is the default view.
       mkTab:'all',
@@ -3915,6 +3973,12 @@ createApp({
     isOwner(){ return this.activeRole==='owner'; },
     canRegister(){ return this.activeRole!=='viewer'; },  // members+ may create secrets/tools
     secretRowsReady(){ return this.secretRows.filter(r=>(r.name||'').trim()&&r.value).length; },
+    // The names the marketplace credential ladder actually matches: tier 2 finds an org secret
+    // NAMED exactly for the provider (Secret.name == service), so these are the names worth
+    // suggesting — a key called APOLLO_API_KEY works as a plain secret but the catalog never sees it.
+    keyNameSuggestions(){ return (this.providers||[])
+      .filter(p=>p.auth_kind==='key'||p.auth_kind==='token')
+      .slice().sort((a,b)=>a.service.localeCompare(b.service)); },
     // ---- detail pages ----
     accessNames(){  // the grantable universe: tool names + recipe-only skill names (an integration
       // skill is reachable through its tool's name; recipe-only bundles need their own entry)
@@ -4384,6 +4448,23 @@ createApp({
         if(v.length>=2&&v[0]===v[v.length-1]&&(v[0]==='"'||v[0]==="'")) v=v.slice(1,-1);
         if(k) out.push({name:k,value:v,kind:'env'}); }
       return out; },
+    // The nudge under a secret row: an exact provider name gets a confirmation, a near miss
+    // (APOLLO_API_KEY, tikhub-key, DATAFORSEO_TOKEN) gets the exact name the ladder matches on.
+    // Anything else — a genuinely custom secret — gets silence, not a warning: most secrets are
+    // for the org's own tools and have every right to any name.
+    secretNameHint(row){
+      const raw=(row.name||'').trim(); if(!raw) return null;
+      const provs=this.keyNameSuggestions;
+      const exact=provs.find(p=>p.service===raw);  // the ladder compares exactly — "Apollo" is a near miss, not a hit
+      if(exact) return {ok:true, service:exact.service,
+        text:(exact.display_name||exact.service)+' catalog calls will use this key automatically'};
+      const norm=raw.toLowerCase().replace(/[^a-z0-9]+/g,'');
+      const near=provs.find(p=>{ const s=p.service.replace(/[^a-z0-9]+/g,'');
+        return norm===s+'apikey'||norm===s+'key'||norm===s+'token'||norm===s+'api'||norm===s; });
+      if(near) return {ok:false, service:near.service,
+        text:(near.display_name||near.service)+' catalog calls only find a key named exactly “'+near.service+'” —'};
+      return null;
+    },
     pasteEnv(e,i,field){ const t=(e.clipboardData||window.clipboardData).getData('text')||'';
       const rows=this.parseEnvText(t);
       if(!rows.length) return;                       // not env-shaped → normal paste
@@ -4858,7 +4939,7 @@ createApp({
       this.go('orgs'); },
     resetConfirms(){ this.confirmDelTool=null; this.confirmDelSecret=null; this.confirmDelBundle=null; this.confirmRemove=null; this.confirmLeave=false; this.confirmDel=''; this.confirmAdmUser=null; this.confirmAdmOrg=null; },
     go(v, fromPop){ this.resetConfirms();  // stale inline "Confirm" states must not survive a view switch (accidental-delete risk)
-      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage(); this.loadBilling();} if(v==='usage')this.loadUsage(); if(v==='secrets')this.loadSecrets(); if(v==='connections')this.loadConnections();
+      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage(); this.loadBilling();} if(v==='usage')this.loadUsage(); if(v==='secrets'){this.loadSecrets(); if(!this.providers.length)this.loadConnections();} if(v==='connections')this.loadConnections();
       // push history so browser Back navigates BETWEEN views instead of leaving the app; the '/app'
       // pathname also walks back from a /app/skills/<x> detail URL so reload doesn't reopen the detail
       if(!fromPop) history.pushState({view:v}, '', '/app#'+v); },
@@ -4869,6 +4950,19 @@ createApp({
     // memory) rather than fetching a detail payload, so they can't share openDetail's loader.
     mkFromPath(path){ const m=/^\/app\/marketplace\/([^/]+)$/.exec(path||'');
       return m ? decodeURIComponent(m[1]) : null; },
+    // "Bring your own key", from anywhere: land on the Catalog's Platform tab — the shelf of every
+    // integration a key can be pasted into — rather than a single provider's detail page. With a
+    // service, the shelf scrolls to that provider's row and flashes it; the flash clears itself so
+    // a later visit to the tab doesn't replay a stale highlight.
+    goByok(service){
+      this.mkTab='platform'; this.mkCat='';
+      this.byokFocus=service||null; this.epTry=null;
+      this.go('connections');
+      if(!service) return;
+      this.$nextTick(()=>{ const el=document.getElementById('prov-'+service);
+        if(el) el.scrollIntoView({block:'center', behavior:'smooth'}); });
+      setTimeout(()=>{ if(this.byokFocus===service) this.byokFocus=null; }, 4000);
+    },
     openProvider(service, fromPop){ this.resetConfirms();
       this.detail=null; this.mkService=service; this.view='provider';
       if(!fromPop) history.pushState({mk:service}, '', '/app/marketplace/'+encodeURIComponent(service));

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,22 @@ def make_upstream(hook_hits: list | None = None) -> FastAPI:
         ok = "good" in request.headers.get("x-api-key", "")
         return {"healthy": True, "is_logged_in": ok}
 
+    @up.get("/credit-json-as-text")
+    async def credit_json_as_text(request: Request):
+        # Emulates ScrapeCreators: a real JSON body served with a text/plain content-type. The probe
+        # must parse it anyway to read token_verify_field, not gate on the mislabelled header.
+        from fastapi.responses import PlainTextResponse
+        return PlainTextResponse('{"success":true,"creditCount":17220}')
+
+    @up.get("/needs-query")
+    async def needs_query(request: Request):
+        # Emulates PDL/Akta/JustOneAPI/SpyFu: a probe_path with a required ?query. httpx drops a URL's
+        # own query when params= is passed, so a valid key 400'd until the query was merged into params.
+        if not request.query_params.get("field"):
+            from fastapi.responses import JSONResponse
+            return JSONResponse({"message": "field is required"}, status_code=400)
+        return {"ok": True}
+
     @up.api_route("/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
     async def echo(request: Request) -> dict:
         body = (await request.body()).decode()

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -119,3 +119,74 @@ async def test_key_connection_lists_and_revokes(clients: AsyncClient, monkeypatc
     listed = [c for c in (await clients.get("/connections")).json() if c["provider"] == "tikhub"]
     assert len(listed) == 1 and listed[0]["kind"] == "env"
     assert (await clients.delete(f"/connections/{listed[0]['id']}")).status_code == 200
+
+
+# ---- HTTP Basic providers: paste a raw pair OR a ready-made Base64 blob ----------------------
+async def test_basic_provider_encodes_a_raw_login_password_once(clients: AsyncClient, monkeypatch):
+    """DataForSEO/Moz take HTTP Basic. Pasting the raw `login:password`, treg Base64s it once and the
+    upstream sees `Basic <b64(login:password)>`."""
+    import base64
+    monkeypatch.setitem(P.REGISTRY, "dataforseo", dataclasses.replace(
+        P.REGISTRY["dataforseo"], base_url="http://upstream", probe_path="/whoami"))
+    r = await clients.post("/connections/token", json={"provider": "dataforseo", "token": "login:pw"})
+    assert r.status_code == 200, r.text
+    echoed = (await clients.get("/call/dataforseo/whoami")).json()["auth"]
+    assert echoed == "Basic " + base64.b64encode(b"login:pw").decode()
+
+
+async def test_basic_provider_accepts_a_ready_made_base64_blob(clients: AsyncClient, monkeypatch):
+    """The DataForSEO and Moz dashboards ALSO hand out a ready-made Base64 credential, and users paste
+    that at least as often as the raw pair. treg must NOT Base64 it a second time — the upstream has to
+    receive exactly `Basic <the pasted blob>`, decoding back to the original `login:password`."""
+    import base64
+    blob = base64.b64encode(b"login:pw").decode()
+    monkeypatch.setitem(P.REGISTRY, "dataforseo", dataclasses.replace(
+        P.REGISTRY["dataforseo"], base_url="http://upstream", probe_path="/whoami"))
+    r = await clients.post("/connections/token", json={"provider": "dataforseo", "token": blob})
+    assert r.status_code == 200, r.text
+    echoed = (await clients.get("/call/dataforseo/whoami")).json()["auth"]
+    assert echoed == "Basic " + blob, "a pasted Base64 blob must not be double-encoded"
+
+
+# ---- corrected probe shapes (regression guards for the 2026-08-13 connect-flow fixes) --------
+def test_brightdata_probe_is_a_real_route():
+    """The old /datasets/v3/datasets 404'd even for a valid token, refusing every real key. /status is
+    the free account check that answers 200 (valid) / 401 (bad)."""
+    assert P.get("brightdata").probe_path == "/status"
+
+
+def test_justoneapi_probe_uses_camelcase_uniqueid():
+    """snake_case unique_id made the API answer HTTP 400 ('must input one of them (uniqueId or
+    secUid)') and a VALID token was refused. The param is camelCase."""
+    assert "uniqueId=" in P.get("justoneapi").probe_path
+    assert "unique_id=" not in P.get("justoneapi").probe_path
+
+
+async def test_probe_parses_json_body_labelled_text_plain(clients: AsyncClient, monkeypatch):
+    """ScrapeCreators answers HTTP 200 with a JSON body but a text/plain content-type; validity lives
+    in creditCount. Gating the parse on application/json left the field unread and refused a good key."""
+    monkeypatch.setitem(P.REGISTRY, "scrapecreators", dataclasses.replace(
+        P.REGISTRY["scrapecreators"], base_url="http://upstream",
+        probe_path="/credit-json-as-text", token_verify_field="creditCount"))
+    r = await clients.post("/connections/token", json={"provider": "scrapecreators", "token": "sc-key"})
+    assert r.status_code == 200, r.text
+
+
+async def test_probe_keeps_a_query_string_baked_into_probe_path(clients: AsyncClient, monkeypatch):
+    """A probe_path like `/autocomplete?field=title` must reach the upstream WITH that query — httpx
+    drops a URL's own query when params= is passed, which used to 400 the probe and refuse the key."""
+    monkeypatch.setitem(P.REGISTRY, "pdl", dataclasses.replace(
+        P.REGISTRY["pdl"], base_url="http://upstream",
+        probe_path="/needs-query?field=title&text=data", token_verify_field=""))
+    r = await clients.post("/connections/token", json={"provider": "pdl", "token": "pdl-key"})
+    assert r.status_code == 200, r.text
+
+
+async def test_query_token_survives_alongside_a_probe_path_query(clients: AsyncClient, monkeypatch):
+    """A query-credential provider (SpyFu: ?api_key=) whose probe_path ALSO carries a required query
+    (?domain=) must send both — the merge keeps the path's params and adds the credential on top."""
+    monkeypatch.setitem(P.REGISTRY, "spyfu", dataclasses.replace(
+        P.REGISTRY["spyfu"], base_url="http://upstream",
+        probe_path="/needs-query?field=title", token_verify_field=""))
+    r = await clients.post("/connections/token", json={"provider": "spyfu", "token": "spyfu-secret"})
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
Two related pieces of work on the bring-your-own-key experience: a UX pass that makes BYOK a first-class path, and a set of bug fixes so pasted keys actually connect.

## 1 — BYOK is now a first-class path (`feat`)

The Catalog's **Platform tab** is the home for "put in my own key", and this makes it findable and usable:

- **Platform tab is a scannable list**, not a card grid. One row per provider (logo, name, truncated summary, auth kind, connected state) with an **inline Connect / Add key** action; the row still opens the provider page.
- **"Bring your own key" on a catalog endpoint jumps to that tab** with the provider's row scrolled into view and flashed, instead of dead-ending on a provider detail page. The Try-it drawer's "can't run this here" banner gets real **Connect / Bring your own key** buttons too.
- A **🔑 Bring your own key** button on the catalog header and platform pages names the action so the tab is discoverable.
- The **add-secret form suggests the names the credential ladder actually matches** (datalist of pasted-key providers) and nudges near misses — `APOLLO_API_KEY` → one-click rename to `apollo`.

## 2 — Stop rejecting valid API keys for 6 providers (`fix`)

Connecting a valid key via `POST /connections/token` failed for **dataforseo, moz, brightdata, justoneapi, scrapecreators, akta, pdl, spyfu**. Four distinct causes, all verified live against each provider's real key:

- **httpx drops a URL's own query string when `params=` is passed** — so a `probe_path` with a required `?query` (PDL, Akta, JustOneAPI, SpyFu) lost it and the probe 400'd. Now the path's query is merged into params.
- **The probe only parsed JSON when content-type was `application/json`** — but ScrapeCreators serves JSON as `text/plain`, so `token_verify_field` (creditCount) read as false. Now parsed regardless of content-type; a genuinely non-JSON balance still falls through to the ERROR-text branch.
- **base64-encode providers double-encoded a ready-made blob** — DataForSEO/Moz dashboards hand out both a raw `login:password` and a base64 blob; pasting the blob got it encoded again. Now an already-base64 pair is detected and kept.
- **Config fixes:** BrightData's probe was a non-existent route (`/datasets/v3/datasets`, a 404) → `/status`; JustOneAPI used snake_case `unique_id` but the API wants `uniqueId`; SpyFu's setup note now says to paste only the short Secret Key.

## Verification

- **19/19 pasted keys connect green** through the live flow (the 8 above plus the 11 already working).
- UI changes verified in a real browser: header button, list layout, endpoint-BYOK jump with provider focus, inline Add key modal, datalist + near-miss rename.
- Full suite green: **1383 passed**. Regression tests added for both probe bugs and the base64-blob path.
- Per-subsystem docs updated in the same commit (`interface/dashboard.md`, `interface/api.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
