### PR TITLE
fix(install+login): pin installer Python range; land team-pinned tokens on their baked-in org

### DIFF
--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -52,7 +52,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   user + an org + owner membership and returns a token **once**; the dashboard/CLI login doors do NOT go
   through it (they create the user only, no auto org). `create_org` (`POST /orgs`, `require_identity` so a
   zero-org user can make their first team) + `list_orgs` (`GET /orgs`,
-  each org carries a `tool_count` — one grouped query — so the dashboard can land on the org with tools);
+  each org carries a `tool_count` — one grouped query — so the dashboard can land on the org with tools;
+  its `active` flag follows `require_member`'s precedence — per-org membership token, else `X-Treg-Org`,
+  else a team-pinned identity token's own `org` claim — so `treg login --token <pinned key>` lands on the
+  baked-in team instead of the caller's first membership);
   invites via `create_invite` (`POST /orgs/{id}/invites`, admin+) → one-time code (**emailed** via
   `email.send_invite`, best-effort, along with a separate inbox-only `email_token` sign-in link — the
   token is never in the JSON response; see the invite sign-in link below), `accept_invite`

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -45,7 +45,10 @@ marker on `catalog get`): the catalog is public, and `sys.exit` raises `SystemEx
 read, and tolerates a corrupt file as empty so a half-written config can't brick every command).
 `_save_config` writes atomically (temp + `os.replace`); `login` persists the token **before** the
 best-effort `_pick_active_org` lookup, so a transient `/orgs` failure can't discard a freshly-minted
-token. `call --query` is relayed as a list of pairs (duplicate keys survive) and rejects a value with no
+token. `_pick_active_org` prefers the server's `active` flag, then the org a team-pinned identity token
+bakes into its claim (`_token_org_claim` decodes it locally, unverified — covers older servers that mark
+nothing active for such a token), and only then the first membership — an arbitrary team for a
+multi-team user, so it is the last resort, not the default. `call --query` is relayed as a list of pairs (duplicate keys survive) and rejects a value with no
 `=`; `contract_to_skill_payload`/`load_contract` raise clear errors (naming the entry/file) for a
 stale/malformed `treg.json` instead of a bare traceback. Every "read a file / parse inline JSON the
 user pointed at" path (`oauth connect`, `tool add/update --binding|--health`, `skill push|scaffold|init`,

--- a/docs/context/interface/landing-sandbox.md
+++ b/docs/context/interface/landing-sandbox.md
@@ -139,7 +139,11 @@ files a skill folder is — `SKILL.md` (agent recipe: call the treg proxy, key i
 (so it targets whatever host is live — a dev box or the real domain). The script now installs from
 **PyPI** (`SRC="tools-registry"`, the light CLI package; the FastAPI/DB server stack is the separate
 `tools-registry[server]` extra for self-hosters) via `uv tool install --force` → `pipx install --force` →
-`pip3 install --user --upgrade`, then runs `treg config --base-url {BASE}`. It also installs the official
+`pip3 install --user --upgrade`, then runs `treg config --base-url {BASE}`. The uv/pipx paths pin the
+supported interpreter range (`PYREQ`, kept in sync with `requires-python` in `pyproject.toml`): without
+it uv resolves against its *default* interpreter — its own managed Python first — and a machine whose
+default falls outside the range fails resolution instead of picking (or auto-downloading) a compatible
+one. It also installs the official
 **tools-registry skill** into every detected agent via `treg skill bootstrap` (Claude Code, Cursor, Codex,
 Gemini, Copilot, OpenCode, Windsurf …), falling back on older CLIs to a Claude-only drop that curls
 `{BASE}/skill.md` into `~/.claude/skills/treg`. Because the package is public on PyPI,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.10.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.14"  # keep in sync with PYREQ in src/treg/web/install.sh
 authors = [
     { name = "Unclecode", email = "unclecode@superdesign.dev" },
     { name = "SuperDesign" },

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3201,11 +3201,14 @@ async def list_orgs(
 ) -> list[dict]:
     # "active" = the caller's current org — the token's org (token auth) or X-Treg-Org (session).
     current: int | None = None
-    if x_treg_token:
-        m = await _membership_by_token(x_treg_token, db)
-        current = m.org_id if m else None
-    elif x_treg_org:
-        org = await _resolve_org(x_treg_org, db)
+    if x_treg_token and (m := await _membership_by_token(x_treg_token, db)):
+        current = m.org_id
+    else:
+        # Identity token or session: X-Treg-Org wins, then a team-pinned identity token's own org
+        # claim — the same precedence `require_member` uses to authorize the call. Without the claim
+        # fallback, no org is marked active for a team-pinned token and clients guess (badly).
+        ref = x_treg_org or ((sess.read_claims(x_treg_token) or {}).get("org", "") if x_treg_token else "")
+        org = await _resolve_org(ref, db)
         current = org.id if org else None
     memberships = (
         await db.execute(select(Membership).where(Membership.user_id == user.id))

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -83,6 +83,18 @@ def _save_config(cfg: dict) -> None:
     os.replace(tmp, CONFIG_PATH)
 
 
+def _token_org_claim(token: str | None) -> str | None:
+    """The org slug baked into a team-pinned identity token (`<b64url(claims)>.<sig>`), else None.
+    Decoded WITHOUT verifying the signature — it only picks a local default; the server still
+    authorizes every call against the real membership."""
+    try:
+        payload = token.split(".", 1)[0]
+        claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
+        return claims.get("org") or None
+    except Exception:
+        return None
+
+
 def _pick_active_org(cfg: dict) -> None:
     """Best-effort: set the active org from GET /orgs. The token is already persisted by the
     caller, so a transient failure here (proxy hiccup, cold restart) must never lose it."""
@@ -91,7 +103,14 @@ def _pick_active_org(cfg: dict) -> None:
             r = c.get("/orgs")
         orgs = r.json() if r.status_code == 200 else []
         if orgs:
-            cfg["active_org"] = next((o for o in orgs if o.get("active")), orgs[0])["slug"]
+            # Server's "active" flag first; then the org baked into a team-pinned identity token
+            # (older servers don't mark those active); only then the first membership — which for a
+            # multi-team user is an arbitrary org, the wrong default whenever anything better exists.
+            claimed = _token_org_claim(cfg.get("token"))
+            cfg["active_org"] = next(
+                (o for o in orgs if o.get("active")),
+                next((o for o in orgs if o.get("slug") == claimed), orgs[0]),
+            )["slug"]
             _save_config(cfg)
     except Exception:
         pass

--- a/src/treg/web/install.sh
+++ b/src/treg/web/install.sh
@@ -28,16 +28,33 @@ done
 # light for anyone who wants only the plain CLI.
 SRC="tools-registry[proxy]"
 
+# The supported interpreter range — keep in sync with `requires-python` in pyproject.toml.
+# Passed explicitly because uv otherwise resolves against its DEFAULT interpreter (its own managed
+# Python first), and when that is outside the range — a machine whose uv-managed default is 3.11,
+# or 3.14+ once that ships as the OS default — the install dies on resolution instead of picking
+# (or downloading) a compatible Python. With the constraint, uv fetches one if none is installed.
+PYREQ=">=3.12,<3.14"
+
 printf '\n\033[38;5;173m▚ tools-registry\033[0m - installing the treg CLI…\n\n'
 
 if command -v uv >/dev/null 2>&1; then
-  uv tool install --force "$SRC"
+  uv tool install --force --python "$PYREQ" "$SRC"
 elif command -v pipx >/dev/null 2>&1; then
-  pipx install --force "$SRC"
+  # pipx needs a concrete interpreter, not a range — probe for one inside PYREQ before falling
+  # back to pipx's default (which is pipx's own Python and may be outside the range).
+  PIPX_PY=""
+  for py in python3.13 python3.12; do
+    if command -v "$py" >/dev/null 2>&1; then PIPX_PY="$py"; break; fi
+  done
+  if [ -n "$PIPX_PY" ]; then
+    pipx install --force --python "$PIPX_PY" "$SRC"
+  else
+    pipx install --force "$SRC"
+  fi
 elif command -v pip3 >/dev/null 2>&1; then
   pip3 install --user --upgrade "$SRC"
 else
-  echo "Need Python 3.12+ and one of: uv (recommended), pipx, or pip3." >&2
+  echo "Need Python 3.12 or 3.13 and one of: uv (recommended), pipx, or pip3." >&2
   echo "Install uv:  https://docs.astral.sh/uv/getting-started/installation/" >&2
   exit 1
 fi

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -174,6 +174,27 @@ async def test_cli_token_bakes_the_active_org_and_works_as_a_BARE_bearer(clients
     assert ok.status_code == 200, ok.text
 
 
+async def test_orgs_marks_the_team_pinned_tokens_org_active(gc):
+    """GET /orgs must mark active the org baked into a team-pinned identity token — that flag is how
+    `treg login --token` lands on the right team. Before this, no org was marked active for such a
+    token and the CLI guessed the FIRST membership: for a multi-team user, an arbitrary other team."""
+    async with session_maker() as s:
+        u = User(email="two-teams@x.dev"); s.add(u); await s.flush()
+        first = Org(name="First", slug="first-team"); second = Org(name="Second", slug="second-team")
+        s.add(first); s.add(second); await s.flush()
+        s.add(Membership(user_id=u.id, org_id=first.id, role="owner", token_hash=crypto.hash_token("t1")))
+        s.add(Membership(user_id=u.id, org_id=second.id, role="owner", token_hash=crypto.hash_token("t2")))
+        await s.commit()
+        uid = u.id
+    pinned = sess.make(uid, org="second-team")
+    r = await gc.get("/orgs", headers={"X-Treg-Token": pinned})
+    assert r.status_code == 200, r.text
+    assert [o["slug"] for o in r.json() if o["active"]] == ["second-team"], r.json()
+    # X-Treg-Org still wins over the claim — the same precedence require_member applies
+    r = await gc.get("/orgs", headers={"X-Treg-Token": pinned, "X-Treg-Org": "first-team"})
+    assert [o["slug"] for o in r.json() if o["active"]] == ["first-team"], r.json()
+
+
 async def test_cli_token_refuses_to_pin_a_team_you_are_not_in(clients):
     """The org claim is only baked when the caller is actually a member — a header naming someone
     else's team yields a plain (unpinned) token, never one that pins a team you cannot reach."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,48 @@ def test_load_config_default(tmp_path, monkeypatch):
     assert cfg["token"] is None and cfg["active_org"] is None and cfg["base_url"].startswith("http")
 
 
+def test_token_org_claim_reads_a_team_pinned_token():
+    """`_token_org_claim` decodes the org slug a team-pinned identity token carries — without the
+    signature check (the server still authorizes), and returning None on anything else."""
+    import base64
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"uid": 7, "exp": 9999999999, "tv": 0, "org": "team-b"}).encode()
+    ).decode().rstrip("=")
+    assert cli._token_org_claim(f"{payload}.not-a-real-signature") == "team-b"
+    assert cli._token_org_claim("tok-opaque-per-org") is None      # opaque membership token
+    assert cli._token_org_claim(None) is None
+    assert cli._token_org_claim("") is None
+
+
+def test_pick_active_org_prefers_the_tokens_baked_org(monkeypatch):
+    """Against an older server that marks nothing active for a team-pinned token, `_pick_active_org`
+    must land on the token's own org — not the first membership, which for a multi-team user is an
+    arbitrary other team (`treg login --token <superdesign key>` used to activate `oauth-test`)."""
+    import base64
+
+    class _Resp:
+        status_code = 200
+        def json(self):
+            return [{"slug": "first-team", "active": False}, {"slug": "second-team", "active": False}]
+
+    class _Client:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def get(self, path): return _Resp()
+
+    monkeypatch.setattr(cli, "_client", lambda cfg: _Client())
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"uid": 7, "exp": 9999999999, "tv": 0, "org": "second-team"}).encode()
+    ).decode().rstrip("=")
+    cfg = {"base_url": "http://x", "token": f"{payload}.sig", "active_org": None}
+    cli._pick_active_org(cfg)
+    assert cfg["active_org"] == "second-team"
+    # an opaque token (no claim) still falls back to the first membership
+    cfg = {"base_url": "http://x", "token": "tok-opaque", "active_org": None}
+    cli._pick_active_org(cfg)
+    assert cfg["active_org"] == "first-team"
+
+
 def test_client_sends_token_and_active_org(monkeypatch):
     monkeypatch.setattr(cli, "_ORG_OVERRIDE", None)
     cfg = {"base_url": "http://x", "token": "TK", "active_org": "team-a"}


### PR DESCRIPTION
Two first-minute failures hit while setting up a fresh machine via `curl https://treg.to/install.sh | sh -s -- --token <key>`.

## 1. Installer dies when uv's default Python is outside the supported range

`install.sh` ran `uv tool install` with no `--python` constraint, so uv resolved against its **default** interpreter — its own managed Python first. On a machine whose managed default is 3.11 (or 3.14+ once that's the OS default), the install fails on resolution instead of picking or downloading a compatible interpreter:

```
× No solution found when resolving dependencies:
╰─▶ Because the current Python version (3.11.11) does not satisfy Python>=3.12,<3.14 …
```

Fix: the uv path now passes `--python "$PYREQ"` (`>=3.12,<3.14`, cross-referenced with `requires-python` in `pyproject.toml` so they can't drift) — uv then selects or auto-downloads a compatible CPython. The pipx path probes for `python3.13`/`python3.12`, and the no-installer error message names the actual supported range.

Follow-up worth its own PR: the full suite passes on Python 3.14 (verified in a 3.14 scratch venv, 1389 green), so the `<3.14` cap is liftable — but that means re-locking `uv.lock`, kept out of scope here.

## 2. `treg login --token <team-pinned key>` activates an arbitrary org

A team-pinned identity token bakes its org into the signed claim, and `require_member` honors that claim — but `GET /orgs` computed its `active` flag only from an opaque per-org membership token or `X-Treg-Org`. For a team-pinned token nothing was marked active, so the CLI's `_pick_active_org` fell back to the caller's **first** membership — for a multi-team user, the wrong team (a `superdesign`-pinned key activated `oauth-test`).

Fix, both sides:
- **Server**: `/orgs` mirrors `require_member`'s precedence exactly — membership token, then `X-Treg-Org`, then the token's own org claim.
- **CLI**: `_pick_active_org` prefers the org baked into the token (`_token_org_claim`, decoded locally without signature verification — it only picks a default; the server still authorizes every call) over the first membership whenever the server marks nothing active, which keeps the fix working against older, not-yet-redeployed servers.

Live-verified: with the patched CLI against current prod (unfixed server), `treg login --token <superdesign key>` now lands on `superdesign`.

## Tests

3 new regression tests (`/orgs` active-flag precedence for pinned tokens incl. header override; `_token_org_claim` decode; `_pick_active_org` claim-over-first-membership fallback). Full suite: **1392 passed**, and separately green on Python 3.14. Doc fragments (`interface/api.md`, `interface/cli.md`, `interface/landing-sandbox.md`) updated in the same commit per repo convention.

Note: the server half only reaches users after a prod redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)