### PR TITLE
feat(catalog): make apollo.people.enrich platform-eligible

### DIFF
--- a/src/treg/catalog/apollo.yaml
+++ b/src/treg/catalog/apollo.yaml
@@ -66,9 +66,9 @@ endpoints:
       unit: record
       source: docs
       source_url: https://www.apollo.io/pricing
-      checked: '2026-07-28'
-      confidence: inferred
-      note: '1-9 credits per person, charged only when credit-consuming data is returned: 1 credit for demographics or an email, plus 8 credits if a mobile phone comes back (reveal_phone_number defaults off). No match, no charge. Waterfall vendors may bill even on a miss. No public $/credit.'
+      checked: '2026-08-13'
+      confidence: documented
+      note: 'Metered at the 1-credit baseline treg calls with: reveal_phone_number and reveal_personal_emails both default false, so a default enrich consumes 1 credit for demographics or an email, charged only when credit-consuming data comes back (no match, no charge) — the same documented Basic-plan rate (fx.yaml credit_rates_usd.apollo) as apollo.companies.enrich. CAVEAT: a caller that sets reveal_phone_number=true consumes up to 9 credits (a mobile is +8, returned async to webhook_url) and is under-metered by the extra 8. Waterfall vendors may bill even on a miss.'
     docs_url: https://docs.apollo.io/reference/people-enrichment
 
   - id: apollo.people.search


### PR DESCRIPTION
## What

Flips `apollo.people.enrich`'s cost `confidence` from `inferred` → `documented` so tier 4 can serve it on treg's own Apollo platform key. One-line data change to `src/treg/catalog/apollo.yaml` (plus its cost `note`).

## Why

`catalog_store.platform_eligible` refuses any priced endpoint whose confidence is below `documented`. Post-#111 (which added the Apollo platform key + `fx.yaml` credit rate), `apollo.companies.enrich` / `companies.search` are `documented` and serve on tier 4, but `people.enrich` was left `inferred` — so it 404'd `no apollo credential in this org` even with the platform key configured. This was verified live: the company endpoints served on the key while `people.enrich` was refused purely on eligibility.

## Justification for `documented`

At the settings treg calls with — `reveal_phone_number` and `reveal_personal_emails` both default `false` — a default enrich consumes **1 credit** (demographics or an email), the same documented Basic-plan rate (`fx.yaml credit_rates_usd.apollo` = $65 / 2,500 = **$0.026**) as `companies.enrich`. Confirmed against the team's own Apollo plan and a direct API call.

**Caveat (recorded in the note):** a caller that overrides `reveal_phone_number=true` consumes up to 9 credits (a mobile is +8, returned async to `webhook_url`) and is under-metered by the extra 8. Given the default-off flag and the async return, the 1-credit baseline is the right meter — matching how `companies.enrich` is already treated.

## Scope

- ✅ `people.enrich` → eligible at $0.026
- ⬜ `people.bulk_enrich` left `inferred`/ineligible (same pricing basis; excluded to keep this PR single-purpose — easy follow-up if wanted)
- `people.search` stays free; `account.usage` stays excluded (own-account)

## Test

Full catalog/pricing/eligibility suite passes (119 selected). No test changes needed — main's pricing test already covers Apollo conversion, and the eligibility predicate is exercised by existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)