### PR TITLE
feat(catalog): add Virlo — cross-platform short-form intelligence

### DIFF
--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -46,6 +46,7 @@ platforms:
   apple-music: {label: "Apple Music", category: "Social", summary: "Public artists, albums, tracks and search from Apple Music."}
   soundcloud: {label: "SoundCloud", category: "Social", summary: "Artists, tracks and uploads from SoundCloud."}
   linkinbio: {label: "Link-in-bio pages (Linktree, Komi, Link.me, Pillar…)", category: "Social", summary: "The links a creator lists on their link-in-bio page, across Linktree-style services."}
+  shortform: {label: "Short-form video (cross-platform)", category: "Social", summary: "Cross-platform short-form intelligence — trends, viral videos, sounds and hashtag performance aggregated across TikTok, Instagram Reels and YouTube Shorts."}
 
   # --- Developer: code hosting & developer platforms -------------------------------------------
   github: {label: "GitHub", category: "Developer", summary: "Public repos, users, contributions and trending pages from GitHub."}

--- a/src/treg/catalog/virlo.yaml
+++ b/src/treg/catalog/virlo.yaml
@@ -25,9 +25,6 @@ proposed_capabilities:
   shortform.sounds.trending: "List trending sounds ranked by recent usage"
   shortform.sounds.breakout: "List breakout sounds accelerating in usage"
   shortform.sounds.search: "Search sounds by title"
-  shortform.sounds.detail: "Get a sound's details and metrics"
-  shortform.sounds.usage_history: "Get a sound's daily usage time-series"
-  shortform.sounds.videos: "List videos using a sound"
   shortform.creator.sounds: "List the sounds in a creator's catalog"
 
 endpoints:
@@ -210,67 +207,6 @@ endpoints:
     test_request:
       queryParams: {q: "original sound", limit: 5}
     cost: {type: per_success, value: 0.10, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "10 credits @ $0.01/credit; charged on 2xx only"}
-    docs_url: https://dev.virlo.ai/docs/sounds
-
-  - id: virlo.shortform.sounds.detail
-    capability: shortform.sounds.detail
-    platform: shortform
-    method: GET
-    path: /sounds/{sound_id}
-    name: "Sound details"
-    summary: "A single sound's details and metrics"
-    input:
-      pathParams:
-        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
-      queryParams:
-        resolve: {type: boolean, required: false, note: "true triggers fresh artist resolution and adds 10 credits ($0.10); the base cost below assumes resolve is omitted"}
-      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
-    test_request:
-      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
-    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit base (resolve=true adds 10); charged on 2xx only"}
-    docs_url: https://dev.virlo.ai/docs/sounds
-
-  - id: virlo.shortform.sounds.usage_history
-    capability: shortform.sounds.usage_history
-    platform: shortform
-    method: GET
-    path: /sounds/{sound_id}/usage-history
-    name: "Sound usage history"
-    summary: "Daily usage time-series for a sound"
-    input:
-      pathParams:
-        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
-      queryParams:
-        start_date: {type: string, required: false, example: "2026-08-01"}
-        end_date: {type: string, required: false, example: "2026-08-07"}
-        limit: {type: integer, required: false, example: 30}
-      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
-    test_request:
-      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
-      queryParams: {limit: 30}
-    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit; charged on 2xx only"}
-    docs_url: https://dev.virlo.ai/docs/sounds
-
-  - id: virlo.shortform.sounds.videos
-    capability: shortform.sounds.videos
-    platform: shortform
-    method: GET
-    path: /sounds/{sound_id}/videos
-    name: "Videos using a sound"
-    summary: "Videos that use a given sound"
-    input:
-      pathParams:
-        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
-      queryParams:
-        sort: {type: string, required: false}
-        platform: {type: string, required: false, example: "tiktok"}
-        limit: {type: integer, required: false, example: 5}
-        page: {type: integer, required: false, example: 1}
-      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
-    test_request:
-      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
-      queryParams: {limit: 5}
-    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
     docs_url: https://dev.virlo.ai/docs/sounds
 
   - id: virlo.shortform.creator.sounds

--- a/src/treg/catalog/virlo.yaml
+++ b/src/treg/catalog/virlo.yaml
@@ -1,0 +1,295 @@
+provider: virlo                     # must equal the OAuthProvider.service in oauth_providers.py
+source:
+  docs: https://dev.virlo.ai/docs
+  openapi: https://api.virlo.ai/openapi.json   # public spec (admin paths stripped)
+  curated: 2026-08-13
+limits: "Per-key rate limits apply; every response carries X-RateLimit-Limit / -Remaining / -Reset."
+pricing_url: https://dev.virlo.ai/docs/credits
+
+# UNVERIFIED — no endpoint below has been live-called yet. Virlo bills in credits at a fixed,
+# published rate of 1 credit = $0.01 (dev.virlo.ai/docs/credits), so the USD figures here are that
+# rate transcribed, hence `confidence: documented`. Charges are deducted on 2xx only (per_success);
+# the real per-call charge for any request is echoed in the `X-Cost` / `X-Credits-Used` response
+# headers. Only the synchronous, fixed-price discovery surface is listed — Virlo's asynchronous
+# Content Research Agents, Satellite lookups and Tracking jobs are poll-based and priced
+# dynamically, so they are intentionally out of scope for the catalog's per-call model.
+
+proposed_capabilities:
+  shortform.trends.regions: "List the regions short-form trends can be requested for"
+  shortform.trends.list: "List ranked short-form content trends for a region and time window"
+  shortform.trends.digest: "Get today's short-form trend digest for a region"
+  shortform.trends.emerging: "List early-stage short-form trends gaining momentum"
+  shortform.videos.trending: "List the top trending short-form videos across platforms"
+  shortform.hashtags.performance: "List hashtag performance (uses & views) over a date range"
+  shortform.hashtag.detail: "Get one hashtag's aggregated performance metrics"
+  shortform.sounds.trending: "List trending sounds ranked by recent usage"
+  shortform.sounds.breakout: "List breakout sounds accelerating in usage"
+  shortform.sounds.search: "Search sounds by title"
+  shortform.sounds.detail: "Get a sound's details and metrics"
+  shortform.sounds.usage_history: "Get a sound's daily usage time-series"
+  shortform.sounds.videos: "List videos using a sound"
+  shortform.creator.sounds: "List the sounds in a creator's catalog"
+
+endpoints:
+  # --- Trends -----------------------------------------------------------------------------------
+  - id: virlo.shortform.trends.regions
+    capability: shortform.trends.regions
+    platform: shortform
+    kind: utility
+    method: GET
+    path: /trends/regions
+    name: "List trend regions"
+    summary: "The region codes short-form trends can be queried for"
+    input: {}
+    test_request: {}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://dev.virlo.ai/docs/trends
+
+  - id: virlo.shortform.trends.list
+    capability: shortform.trends.list
+    platform: shortform
+    method: GET
+    path: /trends
+    name: "List short-form trends"
+    summary: "Trend groups in a date range, with exemplar videos, across TikTok, Reels and Shorts"
+    input:
+      queryParams:
+        region: {type: string, required: false, note: "region code from /trends/regions; default global", example: "global"}
+        start_date: {type: string, required: false, note: "ISO date; default last 24h"}
+        end_date: {type: string, required: false, note: "ISO date"}
+        limit: {type: integer, required: false, note: "trend groups to return (default 50, max 100)", example: 5}
+        top_exemplars: {type: integer, required: false, note: "example videos per group (default 5, max 20)", example: 3}
+    test_request:
+      queryParams: {region: "global", limit: 5, top_exemplars: 3}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/trends
+
+  - id: virlo.shortform.trends.digest
+    capability: shortform.trends.digest
+    platform: shortform
+    method: GET
+    path: /trends/digest
+    name: "Today's trend digest"
+    summary: "Today's trend group for a region"
+    input:
+      queryParams:
+        region: {type: string, required: false, note: "region code; default global", example: "global"}
+        limit: {type: integer, required: false, example: 5}
+        top_exemplars: {type: integer, required: false, example: 3}
+    test_request:
+      queryParams: {region: "global", limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/trends
+
+  - id: virlo.shortform.trends.emerging
+    capability: shortform.trends.emerging
+    platform: shortform
+    method: GET
+    path: /trends/emerging
+    name: "List emerging trends"
+    summary: "Early-stage trends ranked by momentum"
+    input:
+      queryParams:
+        region: {type: string, required: false, note: "region code; default global", example: "global"}
+        limit: {type: integer, required: false, note: "default 20", example: 5}
+        top_exemplars: {type: integer, required: false, example: 3}
+    test_request:
+      queryParams: {region: "global", limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/trends
+
+  # --- Videos -----------------------------------------------------------------------------------
+  - id: virlo.shortform.videos.trending
+    capability: shortform.videos.trending
+    platform: shortform
+    method: GET
+    path: /videos/digest
+    name: "Top trending videos"
+    summary: "Top recent videos across all platforms (per-platform variants exist at /tiktok, /youtube, /instagram)"
+    input:
+      queryParams:
+        limit: {type: integer, required: false, note: "default 50, max 100", example: 5}
+    test_request:
+      queryParams: {limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/videos
+
+  # --- Hashtags ---------------------------------------------------------------------------------
+  - id: virlo.shortform.hashtags.performance
+    capability: shortform.hashtags.performance
+    platform: shortform
+    method: GET
+    path: /hashtags
+    name: "Hashtag performance"
+    summary: "Hashtag stats (uses & views) in a date range (per-platform variants at /tiktok, /youtube, /instagram)"
+    input:
+      queryParams:
+        start_date: {type: string, required: true, note: "ISO date; window max 90 days", example: "2026-08-01"}
+        end_date: {type: string, required: true, note: "ISO date", example: "2026-08-07"}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+        order_by: {type: string, required: false, note: "count | views"}
+        sort: {type: string, required: false, note: "asc | desc"}
+    test_request:
+      queryParams: {start_date: "2026-08-01", end_date: "2026-08-07", limit: 5}
+    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/hashtags
+
+  - id: virlo.shortform.hashtag.detail
+    capability: shortform.hashtag.detail
+    platform: shortform
+    method: GET
+    path: /hashtags/{hashtag}/performance
+    name: "One hashtag's performance"
+    summary: "Aggregated metrics for a single hashtag"
+    input:
+      pathParams:
+        hashtag: {type: string, required: true, note: "hashtag without the '#'", example: "fyp"}
+      queryParams:
+        start_date: {type: string, required: false, example: "2026-08-01"}
+        end_date: {type: string, required: false, example: "2026-08-07"}
+    test_request:
+      pathParams: {hashtag: "fyp"}
+      queryParams: {start_date: "2026-08-01", end_date: "2026-08-07"}
+    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/hashtags
+
+  # --- Sounds -----------------------------------------------------------------------------------
+  - id: virlo.shortform.sounds.trending
+    capability: shortform.sounds.trending
+    platform: shortform
+    method: GET
+    path: /sounds/trending
+    name: "Trending sounds"
+    summary: "Sounds ranked by recent usage"
+    input:
+      queryParams:
+        platform: {type: string, required: false, note: "tiktok | instagram | youtube; omit for all", example: "tiktok"}
+        sort: {type: string, required: false, note: "default videos_7d"}
+        commerce_only: {type: boolean, required: false}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+    test_request:
+      queryParams: {platform: "tiktok", limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.sounds.breakout
+    capability: shortform.sounds.breakout
+    platform: shortform
+    method: GET
+    path: /sounds/breakout
+    name: "Breakout sounds"
+    summary: "Sounds accelerating in usage (recent vs baseline)"
+    input:
+      queryParams:
+        platform: {type: string, required: false, note: "tiktok | instagram | youtube; omit for all", example: "tiktok"}
+        commerce_only: {type: boolean, required: false}
+        min_recent: {type: integer, required: false}
+        min_baseline: {type: integer, required: false}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+    test_request:
+      queryParams: {platform: "tiktok", limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.sounds.search
+    capability: shortform.sounds.search
+    platform: shortform
+    method: GET
+    path: /sounds/search
+    name: "Search sounds"
+    summary: "Fuzzy title search across the sound catalog"
+    input:
+      queryParams:
+        q: {type: string, required: true, note: "search term", example: "original sound"}
+        platform: {type: string, required: false, example: "tiktok"}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+    test_request:
+      queryParams: {q: "original sound", limit: 5}
+    cost: {type: per_success, value: 0.10, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "10 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.sounds.detail
+    capability: shortform.sounds.detail
+    platform: shortform
+    method: GET
+    path: /sounds/{sound_id}
+    name: "Sound details"
+    summary: "A single sound's details and metrics"
+    input:
+      pathParams:
+        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
+      queryParams:
+        resolve: {type: boolean, required: false, note: "true triggers fresh artist resolution and adds 10 credits ($0.10); the base cost below assumes resolve is omitted"}
+      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
+    test_request:
+      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
+    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit base (resolve=true adds 10); charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.sounds.usage_history
+    capability: shortform.sounds.usage_history
+    platform: shortform
+    method: GET
+    path: /sounds/{sound_id}/usage-history
+    name: "Sound usage history"
+    summary: "Daily usage time-series for a sound"
+    input:
+      pathParams:
+        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
+      queryParams:
+        start_date: {type: string, required: false, example: "2026-08-01"}
+        end_date: {type: string, required: false, example: "2026-08-07"}
+        limit: {type: integer, required: false, example: 30}
+      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
+    test_request:
+      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
+      queryParams: {limit: 30}
+    cost: {type: per_success, value: 0.05, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "5 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.sounds.videos
+    capability: shortform.sounds.videos
+    platform: shortform
+    method: GET
+    path: /sounds/{sound_id}/videos
+    name: "Videos using a sound"
+    summary: "Videos that use a given sound"
+    input:
+      pathParams:
+        sound_id: {type: string, required: true, note: "id from shortform.sounds.trending / .search (chained id)"}
+      queryParams:
+        sort: {type: string, required: false}
+        platform: {type: string, required: false, example: "tiktok"}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+      note: "sound_id must be harvested from a trending/search response first — replace the test id with a live one at verify time"
+    test_request:
+      pathParams: {sound_id: "REPLACE_WITH_LIVE_SOUND_ID"}
+      queryParams: {limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds
+
+  - id: virlo.shortform.creator.sounds
+    capability: shortform.creator.sounds
+    platform: shortform
+    method: GET
+    path: /sounds/by-creator/{platform}/{handle}
+    name: "A creator's sounds"
+    summary: "The sound catalog for a creator handle on a platform"
+    input:
+      pathParams:
+        platform: {type: string, required: true, note: "tiktok | instagram | youtube", example: "tiktok"}
+        handle: {type: string, required: true, note: "creator handle without the '@'", example: "tiktok"}
+      queryParams:
+        sort: {type: string, required: false}
+        limit: {type: integer, required: false, example: 5}
+        page: {type: integer, required: false, example: 1}
+    test_request:
+      pathParams: {platform: "tiktok", handle: "tiktok"}
+      queryParams: {limit: 5}
+    cost: {type: per_success, value: 0.25, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://dev.virlo.ai/docs/credits', checked: '2026-08-13', confidence: documented, note: "25 credits @ $0.01/credit; charged on 2xx only"}
+    docs_url: https://dev.virlo.ai/docs/sounds

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -897,6 +897,32 @@ TIKHUB = OAuthProvider(
     probe_path="/api/v1/tikhub/user/get_user_info",  # account info — the natural key check
 )
 
+VIRLO = OAuthProvider(
+    service="virlo",
+    display_name="Virlo",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Virlo API key (virlo_tkn_…)",
+    # token_header / token_format default to Authorization: Bearer {secret} — Virlo's exact scheme.
+    setup_url="https://dev.virlo.ai/dashboard",
+    setup_action_label="Get your Virlo API key",
+    setup_steps=(
+        "Sign in to Virlo and open the dashboard.",
+        "Create an API key (it looks like virlo_tkn_…) and copy it.",
+    ),
+    setup_note="Discovery reads are billed per successful request; the balance check is free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Social media",
+    summary="Cross-platform short-form intelligence: trends, viral videos, sounds and hashtag "
+            "performance across TikTok, Instagram Reels and YouTube Shorts.",
+    base_url="https://api.virlo.ai/v1",
+    docs_url="https://dev.virlo.ai/docs",
+    # A valid key → 200 with the team's balance; a missing/invalid key → 401. Costs 0 credits.
+    probe_path="/account/balance",
+)
+
 BRIGHTDATA = OAuthProvider(
     service="brightdata",
     display_name="Bright Data",
@@ -1492,7 +1518,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
-        SCRAPECREATORS,
+        SCRAPECREATORS, VIRLO,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
         # more Enrichment API-key providers

--- a/src/treg/web/logos/virlo.svg
+++ b/src/treg/web/logos/virlo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="virlo">
+  <!-- Placeholder lettermark. Replace with the official virlo brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111827"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">V</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -19,7 +19,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
-                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
+                "justoneapi", "virlo", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
                 "spyfu", "apify", "meta-ad-library", "serpapi"):
         p = P.get(svc)

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -44,7 +44,7 @@ def test_every_provider_is_registered():
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
-        "scrapecreators",
+        "scrapecreators", "virlo",
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",


### PR DESCRIPTION
Adds **Virlo** — cross-platform short-form intelligence (TikTok, Instagram Reels, YouTube Shorts) — to the catalog.

**Contact:** info@virlo.ai

## Scope
11 synchronous, fixed-price discovery endpoints under a new `shortform` platform: trends (list/digest/emerging), trending videos, hashtag performance (cross-platform + per-hashtag), and sounds (trending/breakout/search/by-creator). Virlo's asynchronous Content Research Agents, Satellite lookups and Tracking jobs are poll-based and dynamically priced, so they're intentionally excluded from the per-call proxy model.

## Auth & probe
- Key rides in `Authorization: Bearer virlo_tkn_…` (treg's default injector).
- Probe: `GET /v1/account/balance` → `200` for a valid key, `401` for a missing/invalid one (`{ "code": "missing_api_key" | "invalid_api_key" }`). Costs 0 credits.

## Pricing & billing
- Published at https://dev.virlo.ai/docs/credits. Fixed rate: **1 credit = $0.01**.
- Billed **per success** (deducted on 2xx only). The exact per-call charge is echoed in the `X-Cost` / `X-Credits-Used` response headers.
- No dedicated rate-card endpoint today, but we're happy to expose one — we're open to **platform-eligibility** (treg serving these on its own key).

## OpenAPI
Published at https://api.virlo.ai/openapi.json (admin paths stripped).

## Notes for verification
- `scripts/catalog_validate.py` exits 0 locally.
- No `verified:` stamps or example responses committed — awaiting your live verification.
- Every endpoint's `test_request` uses public inputs (a region, keyword, or hashtag) — no chained ids or placeholders.
- Signup is self-serve (add a balance, then generate a key — no sales call). Happy to send a **funded** test credential privately over email so paid endpoints don't 402.
