### PR TITLE
feat(scripts): add Apollo to provider_balances reconciliation

### DIFF
--- a/scripts/provider_balances.py
+++ b/scripts/provider_balances.py
@@ -159,7 +159,18 @@ async def _thecompaniesapi(c, key):
     return {"value": team.get("credits"), "unit": "credits", "note": ""}
 
 
+async def _apollo(c, key):
+    # api_profile with include_credit_usage returns the caller's remaining balances directly;
+    # num_credits_remaining is the (lead) credit pool the search/enrich endpoints draw from.
+    d = await _get(c, "https://api.apollo.io/api/v1/users/api_profile",
+                   params={"include_credit_usage": "true"}, headers={"X-Api-Key": key})
+    return {"value": d.get("num_credits_remaining"), "unit": "credits",
+            "note": f"direct-dial {d.get('effective_num_direct_dial_credits')} left, "
+                    f"ai {d.get('effective_num_ai_credits')} left"}
+
+
 BALANCE_ROUTES = {
+    "apollo": _apollo,
     "dataforseo": _dataforseo,
     "tikhub": _tikhub,
     "scrapecreators": _scrapecreators,


### PR DESCRIPTION
## What

Adds an `_apollo` balance route to `scripts/provider_balances.py` (the maintainer's reconciliation tool), and registers it in `BALANCE_ROUTES`. One self-contained function — no server or request-path changes.

## Why

`provider_balances.py` prints what each provider's own account says is left, next to what treg's ledger billed for platform-key calls — the two only agree if the catalog's `$/credit` prices are true. Now that Apollo is a live tier-4 platform provider (PRs #111/#117/#118), it should be in that loop. This is the tool you'd run to confirm the `$0.026/credit` Apollo rate against real spend.

## How

Calls Apollo's free account-profile endpoint:
```
GET https://api.apollo.io/api/v1/users/api_profile?include_credit_usage=true   (X-Api-Key)
```
and reports `num_credits_remaining` (the lead-credit pool the search/enrich routes draw from), with direct-dial and AI credit counts in the note. It meters nothing, so it's safe to run on any schedule like the other routes.

## Verification

- `python -m py_compile` passes.
- Live call returns HTTP 200 with all three fields the function reads present (`num_credits_remaining`, `effective_num_direct_dial_credits`, `effective_num_ai_credits`). The 2,500-credit pool it reports corroborates the `$65 / 2,500 = $0.026` rate.

Note: Coresignal stays dashboard-only (no balance API — a live check returns `402 Insufficient credits`), so it can't join this reconciliation the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)