### PR TITLE
feat(billing): downloadable invoices, payment history, and the Stripe portal

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -119,6 +119,36 @@ allowed to fail, and it must fail silently, because a raise here would 500 the h
 retry a payment that already credited. Amounts travel as canonical integer `amount_micro`; the
 `amount_usd` on the event is display-only.
 
+**Invoices exist on the manual path only.** The top-up Checkout sets `invoice_creation`, so a
+one-off purchase produces a real Stripe Invoice — number, PDF, billing address, tax ID — which is the
+document a finance team accepts; Stripe's card receipt is not. Auto-top-up charges a bare off-session
+PaymentIntent and therefore has **no** invoice, only a receipt: attaching one would mean rebuilding
+the automatic charge as InvoiceItem + Invoice paid off-session, rewriting the money path and its
+idempotency guarantees for the minority of payments. Say "invoice" only about the manual path.
+
+Turning `invoice_creation` on makes Stripe emit `invoice.created` / `invoice.paid` for every top-up.
+`handle_webhook_event` drops them, deliberately: crediting on an invoice event as well as on the
+PaymentIntent would be a second door onto the same money. The invoice is a document; the
+PaymentIntent is the payment. Note also that `invoice_creation` on one-time Checkout is **priced
+separately** by Stripe, and invoice emails only go out with Customer emails → Successful payments
+enabled in the dashboard.
+
+**`list_payments` reads rows from us and documents from Stripe.** The payment list is built from our
+own `CreditBlock` rows — the same table the balance is computed from, so the history can never show a
+payment the balance disagrees with, and amounts and dates need no network call. Stripe is asked only
+for the links, in two list calls (`Charge.list` + `Invoice.list`, joined in memory) rather than two
+per row; a failure degrades to rows without links and reports `stripe_ok: false`, because a Stripe
+hiccup should cost the payer a download button, not their payment history. Both Stripe windows cap at
+100 payments, so a very old top-up on a busy account comes back link-less — the portal is the
+unbounded archive.
+
+**`create_portal_session` is the self-serve surface** for card, billing address, tax ID and the full
+invoice archive: hosted, because every one of those is a form we would otherwise own and the tax-ID
+rules go stale per country. It requires a portal configuration saved in the Stripe dashboard, and it
+refuses an org with no `stripe_customer_id` rather than minting one — a customer exists once someone
+has paid, and an empty portal has nothing to show. `billing_state.portal` is the flag the UI hides
+the button on, so a new team never sees a button that would 422.
+
 **Auto-top-up is guarded in depth**, because it is the part that can go wrong expensively: recorded
 consent (the PSD2/SCA mandate, a compliance requirement rather than a checkbox), a monthly cap, a
 cooldown stamped in the DB *before* the charge so a second web worker sees it, a consecutive-failure
@@ -126,8 +156,8 @@ limit, and an idempotency key derived from the threshold crossing — so a burst
 that all notice the low balance produces exactly ONE charge.
 
 Authorization splits by WHAT, not by who. `_billing_org` (the `/billing/*` routes — cards, top-ups,
-auto-top-up policy) requires **admin or owner**: a card and a spend policy are the org's money, not a
-member's preference.
+auto-top-up policy, payment history, the portal) requires **admin or owner**: a card, a spend policy
+and an invoice archive are the org's money, not a member's preference.
 
 `GET /orgs/{id}/balance` is different, and deliberately so. Any **member** sees the figure and the
 in-flight holds; the **funding detail** (credit blocks, the ledger) stays admin+. It used to be

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -152,7 +152,7 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
   Providers are loaded on entering the view (`go('secrets')` also fires `loadConnections` when the
   list is empty) so the suggestions exist on a cold deep link.
 - **Team** (`view==='orgs'`) — the active team, now split into **tabs** (`orgTab`):
-  **Members · Projects · Policy · Team settings**. (The former **My teams** tab is gone — it
+  **Members · Projects · Policy · Billing · Team settings**. (The former **My teams** tab is gone — it
   duplicated the sidebar picker; its New team / Join by code / Paste token actions live in Team
   settings now.) Header reads `Team: {activeName} — you are {activeRole}` and points at the sidebar
   picker for switching.
@@ -174,6 +174,14 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
     argv deny patterns with their source (skill vs catalog), under a line naming all three deny
     layers — HTTP rules, argv patterns, OS sandbox — so the whole "what is blocked" picture is one
     screen.
+  - **Billing** (admin+) — balance, the top-up presets, the auto-top-up toggle with its verbatim
+    PSD2/SCA mandate text, and below them **Payment history**: date, amount, an `auto` marker, and one
+    link per row — *Invoice* when Stripe issued one (manual top-ups do; automatic ones can't), else
+    *Receipt*, else an em dash. Amounts come from our own ledger and the links from Stripe, so when
+    Stripe is unreachable the table still renders and a line under it says the links, not the numbers,
+    are missing. A **Manage billing** button opens Stripe's hosted portal (card, billing address, tax
+    ID, the full invoice archive); it is hidden until `billing.portal` is true, which needs a Stripe
+    customer, which a team gets on its first payment — so a new team never sees a button that errors.
   - **Team settings** — deliberately JUST the **Danger zone** (leave / delete), visible to EVERY role
     (leaving is self-service, and `loadOrgAdmin` lands a non-admin here). New team / Join by code /
     Paste token live only in the sidebar picker — cut from this tab on founder review; a personal

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3966,6 +3966,39 @@ async def billing_autotopup(
     return state
 
 
+@app.get("/billing/history")
+async def billing_history(
+    limit: int = Query(24, ge=1, le=100),
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """This team's completed top-ups, newest first, each with its invoice PDF or card receipt.
+
+    Read-only in both directions: it moves no money, and the amounts come from our own credit blocks
+    rather than from Stripe, so the history can never contradict the balance. Stripe is asked only for
+    the document links, and `stripe_ok: false` says they were unavailable — the payments listed are
+    still correct.
+    """
+    org = _billing_org(caller)
+    return await billing.list_payments(db, org, limit=limit)
+
+
+@app.post("/billing/portal")
+async def billing_portal(
+    request: Request,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """A one-time link into Stripe's hosted billing portal — card, billing address, tax ID, and the
+    full invoice archive. 422 until the team has a Stripe customer, which it gets on its first
+    payment; `billing_state`'s `portal` flag is what the UI hides the button on."""
+    org = _billing_org(caller)
+    try:
+        return await billing.create_portal_session(db, org, return_base=_return_base(request))
+    except billing.BillingNotConfigured as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except billing.TopupRejected as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
 @app.post("/billing/stripe/webhook", include_in_schema=False)
 async def billing_stripe_webhook(request: Request, db: AsyncSession = Depends(get_session)) -> dict:
     """Stripe → treg: the ONLY door through which a payment becomes balance.

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -261,6 +261,11 @@ async def create_topup_checkout(
     WITH the mandate signals PSD2/SCA requires for an unattended charge. Asking for it at purchase
     time costs the payer nothing; retrofitting consent afterwards costs them a second card entry.
 
+    `invoice_creation` is what makes the payment expensable. Stripe's card receipt proves a card was
+    charged; an invoice is the document with an invoice number, a billing address and a tax ID on it,
+    which is what a finance team actually accepts. It is post-purchase — the invoice appears once the
+    payment succeeds, not when the session opens — so nothing here changes what the payer sees.
+
     Currency is pinned to USD explicitly — the Stripe account's own default is AUD, and inheriting it
     would charge a number the ledger would then credit as dollars.
     """
@@ -292,6 +297,15 @@ async def create_topup_checkout(
             "setup_future_usage": "off_session",
             "metadata": {"treg_org_id": str(org.id), "treg_kind": "topup", "treg_auto": "0"},
             **({"receipt_email": email} if email else {}),
+        },
+        # The expensable document (see docstring). `invoice_data` carries the same org identity as the
+        # session so an invoice found in the Stripe dashboard resolves to a team without a lookup.
+        invoice_creation={
+            "enabled": True,
+            "invoice_data": {
+                "description": f"Prepaid API call balance for {org.name or org.slug}",
+                "metadata": {"treg_org_id": str(org.id), "treg_kind": "topup"},
+            },
         },
         # Idempotent per (org, amount, minute): a double-clicked "Add funds" reuses the same session
         # instead of opening a second one the payer might also complete.
@@ -328,6 +342,127 @@ async def create_setup_checkout(db: AsyncSession, org: Org, *, return_base: str 
         cancel_url=f"{base}/app?card=cancelled#billing",
     )
     return {"url": session["url"], "session_id": session["id"], "mode": "setup"}
+
+
+# ---- the hosted billing portal -----------------------------------------------------------------
+async def create_portal_session(db: AsyncSession, org: Org, *, return_base: str = "") -> dict:
+    """A one-time link into Stripe's hosted Customer Portal, where the payer manages their own
+    billing details: card, billing address, tax ID, and the invoice history with its PDFs.
+
+    Hosted rather than rebuilt here for the same reason Checkout is: every one of those fields is a
+    form we would otherwise own, and the tax-ID one carries validation rules per country that go
+    stale. The portal also renders the invoice archive we now generate, so "download an old invoice"
+    needs no page of ours at all.
+
+    Requires a portal CONFIGURATION saved in the Stripe dashboard (Settings → Billing → Customer
+    portal); without one Stripe rejects the call, which surfaces here as the usual Stripe error.
+
+    Refuses an org with no Stripe customer instead of creating one. A customer exists once someone has
+    paid or saved a card; minting one to open an empty portal would fill the Stripe account with
+    customers that never bought anything, and the portal would have nothing to show anyway.
+    """
+    _require_configured()
+    if not org.stripe_customer_id:
+        raise TopupRejected("no billing details yet — add funds once and the portal opens after that")
+    base = (return_base or get_settings().public_url).rstrip("/")
+    session = await _sdk(
+        stripe.billing_portal.Session.create,
+        customer=org.stripe_customer_id,
+        return_url=f"{base}/app#billing",
+    )
+    return {"url": session["url"]}
+
+
+# ---- payment history ---------------------------------------------------------------------------
+async def list_payments(db: AsyncSession, org: Org, *, limit: int = 24) -> dict:
+    """The org's completed top-ups, newest first, each with a link to its invoice or receipt.
+
+    The ROWS come from our own `CreditBlock` table, not from Stripe. That table is what the balance is
+    computed from, so a history built on it can never show a payment the balance disagrees with — and
+    it needs no network call to render amounts and dates.
+
+    Stripe is asked only for the DOCUMENTS, in two list calls rather than two per row: charges (which
+    carry `receipt_url` and point at the invoice) and invoices (which carry the PDF). A failure there
+    degrades to rows without links — a Stripe hiccup should cost the payer their download button, not
+    their payment history. `stripe_ok` says which happened so the UI can tell them.
+
+    Both Stripe windows cap at 100 payments, so a very old top-up on a heavily-used account can come
+    back link-less; the portal (`create_portal_session`) is the unbounded archive.
+
+    Read-only: nothing here moves money or writes to the ledger.
+    """
+    blocks = (await db.execute(
+        select(CreditBlock)
+        .where(CreditBlock.org_id == org.id, CreditBlock.kind == "purchased",
+               CreditBlock.stripe_payment_intent.is_not(None))
+        .order_by(CreditBlock.created_at.desc())
+        .limit(max(1, min(int(limit), 100)))
+    )).scalars().all()
+
+    # Which of these top-ups were automatic. The flag lives in the ledger entry's JSON meta, and JSON
+    # containment isn't portable across SQLite and Postgres — so the rows are narrowed by block id
+    # (exactly the page we're rendering) and the flag is read in Python, the same shape as
+    # `monthly_autotopup_spend`.
+    auto: set[str] = set()
+    if blocks:
+        rows = (await db.execute(
+            select(LedgerEntry.block_id, LedgerEntry.meta).where(
+                LedgerEntry.org_id == org.id, LedgerEntry.kind == "topup",
+                LedgerEntry.block_id.in_([b.id for b in blocks]),
+            )
+        )).all()
+        auto = {str(bid) for bid, meta in rows if isinstance(meta, dict) and meta.get("auto")}
+
+    docs, stripe_ok = await _payment_documents(org, len(blocks))
+    items = []
+    for b in blocks:
+        d = docs.get(b.stripe_payment_intent or "", {})
+        items.append({
+            "payment_intent": b.stripe_payment_intent,
+            "amount_micro": int(b.amount_micro),
+            "amount_usd": ledger.usd(int(b.amount_micro)),
+            "created_at": b.created_at.isoformat() if b.created_at else None,
+            "auto": b.id in auto,
+            "invoice_number": d.get("number") or "",
+            "invoice_pdf": d.get("invoice_pdf") or "",
+            "hosted_invoice_url": d.get("hosted_invoice_url") or "",
+            "receipt_url": d.get("receipt_url") or "",
+        })
+    return {"items": items, "stripe_ok": stripe_ok}
+
+
+async def _payment_documents(org: Org, wanted: int) -> tuple[dict[str, dict], bool]:
+    """`{payment_intent_id: {receipt_url, number, invoice_pdf, hosted_invoice_url}}` for one customer.
+
+    Two list calls, joined in memory through the charge's `invoice` field. Returns `({}, False)` on
+    any Stripe failure — the caller renders amounts without links rather than a 500.
+    """
+    if not (org.stripe_customer_id and wanted and configured()):
+        return {}, bool(configured())
+    window = max(wanted, 100)
+    try:
+        charges = await _sdk(stripe.Charge.list, customer=org.stripe_customer_id, limit=window)
+        invoices = await _sdk(stripe.Invoice.list, customer=org.stripe_customer_id, limit=window)
+    except Exception as e:  # noqa: BLE001 — see docstring: links are optional, the history is not
+        log.warning("billing: could not load payment documents for org %s: %s", org.id, e)
+        return {}, False
+
+    by_invoice = {}
+    for inv in (invoices.get("data") or []):
+        if inv.get("id"):
+            by_invoice[inv["id"]] = {"number": inv.get("number") or "",
+                                     "invoice_pdf": inv.get("invoice_pdf") or "",
+                                     "hosted_invoice_url": inv.get("hosted_invoice_url") or ""}
+    out: dict[str, dict] = {}
+    for ch in (charges.get("data") or []):
+        pi = ch.get("payment_intent")
+        pi = pi if isinstance(pi, str) else (pi or {}).get("id")
+        if not pi:
+            continue
+        inv = ch.get("invoice")
+        inv = inv if isinstance(inv, str) else (inv or {}).get("id")
+        out[pi] = {"receipt_url": ch.get("receipt_url") or "", **by_invoice.get(inv or "", {})}
+    return out, True
 
 
 # ---- auto top-up -------------------------------------------------------------------------------
@@ -606,6 +741,10 @@ async def handle_webhook_event(db: AsyncSession, event: dict) -> dict:
         return await _on_payment_failed(db, obj)
     if kind == "setup_intent.succeeded":
         return await _on_setup_succeeded(db, obj)
+    # Everything else acknowledged and dropped — deliberately, not by omission. `invoice_creation` on
+    # the top-up Checkout makes Stripe emit `invoice.created` / `invoice.paid` for every purchase, and
+    # crediting on those too would be a second door onto the same money. The invoice is a document; the
+    # PaymentIntent is the payment.
     return {"handled": False, "type": kind}
 
 
@@ -760,6 +899,9 @@ async def billing_state(db: AsyncSession, org: Org) -> dict:
         "balance_usd": ledger.usd(int(org.balance_micro or 0)),
         "customer": bool(org.stripe_customer_id),
         "card_on_file": bool(org.stripe_default_pm),
+        # Whether the hosted portal can be opened at all. It hangs off the Stripe customer, which only
+        # exists once someone has paid — so the button stays hidden rather than 422-ing a new team.
+        "portal": configured() and bool(org.stripe_customer_id),
         "topup": {"min_usd": s.topup_min_usd, "default_usd": s.topup_default_usd,
                   "presets": list(s.topup_presets)},
         "autotopup": {

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2325,10 +2325,18 @@ a:hover{text-decoration-color:var(--muted)}
             <template v-if="canAdmin && orgTab==='billing'">
               <div v-if="billing" style="margin-top:4px">
                 <div class="card" style="padding:16px">
-                  <div>
-                    <div class="lbl">Balance</div>
-                    <div style="font-size:28px;font-weight:700;color:var(--accent);font-family:var(--mono)">{{money(billing.balance_micro)}}</div>
-                    <p class="sub" style="margin:4px 0 0">Prepaid credit. Calls draw from it - <code>treg balance</code> shows the ledger.</p>
+                  <div style="display:flex;gap:12px;align-items:flex-start;flex-wrap:wrap">
+                    <div style="flex:1;min-width:220px">
+                      <div class="lbl">Balance</div>
+                      <div style="font-size:28px;font-weight:700;color:var(--accent);font-family:var(--mono)">{{money(billing.balance_micro)}}</div>
+                      <p class="sub" style="margin:4px 0 0">Prepaid credit. Calls draw from it - <code>treg balance</code> shows the ledger.</p>
+                    </div>
+                    <!-- Stripe's hosted portal: card, billing address, tax ID and the invoice archive.
+                         Hidden until the team has a Stripe customer, which its first payment creates. -->
+                    <button v-if="billing.portal" class="btn sm" :disabled="billingBusy" @click="openPortal()"
+                            title="Update your card, billing address and tax ID, and download past invoices">
+                      {{billingBusy?'Opening…':'Manage billing'}}
+                    </button>
                   </div>
                   <p v-if="!billing.configured" class="sub" style="margin:12px 0 0">Top-ups aren't configured on this deployment.</p>
 
@@ -2373,6 +2381,28 @@ a:hover{text-decoration-color:var(--muted)}
                           <button class="btn primary" :disabled="!autoConsent||billingBusy" @click="setAuto(true)">{{billingBusy?'…':'Turn on auto top-up'}}</button>
                         </div>
                       </div>
+                    </div>
+
+                    <div style="margin-top:16px;border-top:1px solid var(--line);padding-top:14px">
+                      <div class="lbl">Payment history</div>
+                      <p v-if="bhist.loading" class="sub" style="margin:8px 0 0">Loading…</p>
+                      <p v-else-if="!bhist.items.length" class="sub" style="margin:8px 0 0">No top-ups yet. Once you add funds, every payment shows up here with its invoice.</p>
+                      <template v-else>
+                        <!-- Amounts come from our own ledger, so this list always agrees with the
+                             balance above. Only the links come from Stripe — hence the notice below. -->
+                        <table style="width:100%;margin-top:8px;border-collapse:collapse;max-width:560px">
+                          <tr v-for="i in bhist.items" :key="i.payment_intent" style="border-top:1px solid var(--line)">
+                            <td style="padding:8px 10px 8px 0;white-space:nowrap">{{bhistDate(i.created_at)}}</td>
+                            <td style="padding:8px 10px 8px 0;font-family:var(--mono);white-space:nowrap">{{money(i.amount_micro)}}</td>
+                            <td style="padding:8px 10px 8px 0" class="sub">{{i.auto?'auto':''}}</td>
+                            <td style="padding:8px 0;text-align:right;white-space:nowrap">
+                              <a v-if="bhistLink(i)" :href="bhistLink(i)" target="_blank" rel="noopener">{{bhistLabel(i)}}</a>
+                              <span v-else class="muted">—</span>
+                            </td>
+                          </tr>
+                        </table>
+                        <p v-if="!bhist.ok" class="sub" style="margin:8px 0 0">Invoice links are temporarily unavailable — the amounts above are correct. Try again shortly, or use <b>Manage billing</b> for the full archive.</p>
+                      </template>
                     </div>
                   </template>
                 </div>
@@ -3455,6 +3485,7 @@ createApp({
       // Billing (Stripe top-ups). `billing` null = not loaded / not an admin; billing.configured
       // false = this deployment sells no balance, so the whole block stays hidden.
       billing:null, billingBusy:false, topupAmount:10, autoAmount:10, autoThreshold:5, autoConsent:false, autoOpen:false,
+      bhist:{items:[],loading:false,ok:true},   // past top-ups + their invoice/receipt links; ok=false means Stripe was unreachable, amounts are still right
       confirmDel:'', confirmLeave:false, confirmRemove:null,
       showJoin:false, joinCode:'', joinBusy:false, joinErr:'',
       secrets:[], showSecrets:false, secretRows:[{name:'',value:'',kind:'env'}], secretBusy:false, secretErr:'', runNote:'',
@@ -4355,7 +4386,27 @@ createApp({
       this.billing=await this.api('/billing').catch(()=>null);
       if(this.billing){ this.topupAmount=this.billing.topup.default_usd;
         this.autoAmount=Math.round(this.billing.autotopup.amount_usd);
-        this.autoThreshold=Math.round(this.billing.autotopup.threshold_usd); } },
+        this.autoThreshold=Math.round(this.billing.autotopup.threshold_usd);
+        this.loadBillingHistory(); } },
+    // Amounts come from our own credit blocks, so this list can never disagree with the balance above
+    // it; Stripe supplies only the document links, and bhist.ok===false means those were unavailable.
+    async loadBillingHistory(){ if(!this.canAdmin || !this.billing || !this.billing.configured){ this.bhist={items:[],loading:false,ok:true}; return; }
+      this.bhist={items:[],loading:true,ok:true};
+      const out=await this.api('/billing/history').catch(()=>null);
+      this.bhist={items:(out&&out.items)||[], loading:false, ok:!out||out.stripe_ok!==false}; },
+    async openPortal(){ this.billingBusy=true; this.err='';
+      try{ const out=await this.api('/billing/portal',{method:'POST'});
+        // Stripe's hosted portal owns card, billing address, tax ID and the full invoice archive. Its
+        // return_url comes back to #billing, so the same tab is right here as it is for Checkout.
+        window.location.href=out.url; }
+      catch(e){ this.err='Could not open the billing portal: '+(e.detail||e.status); this.billingBusy=false; } },
+    bhistLink(i){ return i.invoice_pdf || i.hosted_invoice_url || i.receipt_url || ''; },
+    bhistLabel(i){ return (i.invoice_pdf||i.hosted_invoice_url) ? 'Invoice' : (i.receipt_url ? 'Receipt' : ''); },
+    // created_at is naive UTC (the models._now convention), so it needs the Z that isoformat omits —
+    // without it the browser reads it as local time and a late-evening top-up shows the wrong day.
+    bhistDate(iso){ if(!iso) return '';
+      const d=new Date(/(Z|[+-]\d{2}:?\d{2})$/.test(iso) ? iso : iso+'Z');
+      return isNaN(d)?'':d.toLocaleDateString(undefined,{year:'numeric',month:'short',day:'numeric'}); },
     async addFunds(amount){ this.billingBusy=true; this.topupAmount=amount; this.err='';
       // Named differently from the server's topup_started (same click, two vantage points —
       // a shared name would double-count in trends); this one exists to link session replays.

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -223,6 +223,190 @@ async def test_topup_reuses_the_org_stripe_customer(c: AsyncClient, monkeypatch)
         assert (await db.get(Org, org_id)).stripe_customer_id == "cus_test_1"
 
 
+async def test_topup_checkout_asks_stripe_for_an_invoice(c: AsyncClient, monkeypatch):
+    """A card receipt proves a charge; an invoice is the document a finance team accepts. The second
+    half of this test is the real guard: the invoice must not cost us `setup_future_usage`, because
+    that is the saved card and the SCA mandate every later auto-top-up charge runs on."""
+    org_id, owner = await _org(c)
+    calls: list[tuple] = []
+
+    async def fake_sdk(fn, /, **kw):
+        calls.append((getattr(fn, "__qualname__", str(fn)), kw))
+        if "Customer" in str(fn):
+            return {"id": "cus_test_1"}
+        return {"id": "cs_1", "url": "https://checkout.stripe.com/c/pay/cs_1"}
+
+    monkeypatch.setattr(billing, "_sdk", fake_sdk)
+    r = await c.post("/billing/topup", json={"amount_usd": 10}, headers=_h(owner))
+    assert r.status_code == 200, r.text
+    session_kw = [kw for name, kw in calls if "Session" in name][0]
+    assert session_kw["invoice_creation"]["enabled"] is True
+    # The org travels onto the invoice too, so one found in the Stripe dashboard resolves to a team.
+    assert session_kw["invoice_creation"]["invoice_data"]["metadata"]["treg_org_id"] == str(org_id)
+    assert session_kw["payment_intent_data"]["setup_future_usage"] == "off_session"
+
+
+async def test_invoice_events_are_acknowledged_but_never_credit(c: AsyncClient):
+    """`invoice_creation` makes Stripe emit invoice.* for every top-up. Crediting on those as well as
+    on the PaymentIntent would be a second door onto the same money."""
+    org_id, owner = await _org(c)
+    before = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()["balance_micro"]
+    event = {"id": "evt_inv_1", "type": "invoice.paid", "data": {"object": {
+        "id": "in_test_1", "object": "invoice", "amount_paid": 100_000, "currency": "usd",
+        "metadata": {"treg_org_id": str(org_id), "treg_kind": "topup"}}}}
+    r = await _deliver(c, event)
+    assert r.status_code == 200, r.text
+    assert r.json().get("handled") is False
+    after = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()["balance_micro"]
+    assert after == before
+
+
+# ---- the hosted portal --------------------------------------------------------------------------
+async def test_portal_returns_a_one_time_url_for_a_paying_org(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    calls: list[tuple] = []
+
+    async def fake_sdk(fn, /, **kw):
+        calls.append((getattr(fn, "__qualname__", str(fn)), kw))
+        return {"id": "bps_1", "url": "https://billing.stripe.com/p/session/bps_1"}
+
+    monkeypatch.setattr(billing, "_sdk", fake_sdk)
+    r = await c.post("/billing/portal", headers=_h(owner))
+    assert r.status_code == 200, r.text
+    assert r.json()["url"].startswith("https://billing.stripe.com/")
+    name, kw = calls[0]
+    assert "billing_portal" in name.lower() or "Session" in name
+    assert kw["customer"] == "cus_test_1"
+    assert kw["return_url"].endswith("/app#billing")
+
+
+async def test_portal_refuses_an_org_with_no_stripe_customer(c: AsyncClient, monkeypatch):
+    """Minting a Customer just to open an empty portal would fill the Stripe account with teams that
+    never bought anything — and the portal would have nothing to show them."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", lambda *a, **k: pytest.fail("must not reach Stripe"))
+    r = await c.post("/billing/portal", headers=_h(owner))
+    assert r.status_code == 422
+    assert (await c.get("/billing", headers=_h(owner))).json()["portal"] is False
+
+
+async def test_portal_is_advertised_once_the_org_has_a_customer(c: AsyncClient):
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    assert (await c.get("/billing", headers=_h(owner))).json()["portal"] is True
+
+
+async def test_portal_is_503_when_stripe_is_not_configured(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    monkeypatch.setattr(get_settings(), "stripe_secret_key", "", raising=False)
+    assert (await c.post("/billing/portal", headers=_h(owner))).status_code == 503
+
+
+# ---- payment history ----------------------------------------------------------------------------
+def _charge(pi: str, *, invoice: str | None = None, receipt: str = "https://pay.stripe.com/r/1") -> dict:
+    return {"id": f"ch_{pi}", "payment_intent": pi, "receipt_url": receipt, "invoice": invoice}
+
+
+def _invoice(iid: str, *, number: str = "TREG-0001") -> dict:
+    return {"id": iid, "number": number,
+            "invoice_pdf": f"https://pay.stripe.com/invoice/{iid}/pdf",
+            "hosted_invoice_url": f"https://invoice.stripe.com/i/{iid}"}
+
+
+def _docs_sdk(charges: list[dict], invoices: list[dict]):
+    async def fake_sdk(fn, /, **kw):
+        return {"data": invoices if "Invoice" in str(fn) else charges}
+    return fake_sdk
+
+
+async def test_history_links_each_purchase_to_its_invoice(c: AsyncClient, monkeypatch):
+    """Rows come from our own credit blocks so the history can never contradict the balance; Stripe is
+    asked only for the documents. A payment with no invoice still gets its receipt."""
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    async with session_maker() as db:
+        await ledger.topup(db, org_id, 10_000_000, "pi_manual", meta={"source": "stripe"})
+        await ledger.topup(db, org_id, 25_000_000, "pi_auto", meta={"auto": True, "source": "stripe"})
+
+    monkeypatch.setattr(billing, "_sdk", _docs_sdk(
+        [_charge("pi_manual", invoice="in_1"), _charge("pi_auto")], [_invoice("in_1")]))
+    r = await c.get("/billing/history", headers=_h(owner))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["stripe_ok"] is True
+    rows = {i["payment_intent"]: i for i in body["items"]}
+    assert rows["pi_manual"]["amount_micro"] == 10_000_000
+    assert rows["pi_manual"]["invoice_pdf"].endswith("/pdf")
+    assert rows["pi_manual"]["invoice_number"] == "TREG-0001"
+    assert rows["pi_manual"]["auto"] is False
+    # The auto charge is a bare PaymentIntent — no invoice exists for it, so the receipt is the link.
+    assert rows["pi_auto"]["invoice_pdf"] == ""
+    assert rows["pi_auto"]["receipt_url"].startswith("https://pay.stripe.com/")
+    assert rows["pi_auto"]["auto"] is True
+    # Newest first.
+    assert [i["payment_intent"] for i in body["items"]] == ["pi_auto", "pi_manual"]
+
+
+async def test_history_excludes_the_signup_promo(c: AsyncClient, monkeypatch):
+    """The free grant is balance, not a payment — listing it would offer an invoice for money nobody
+    paid."""
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    monkeypatch.setattr(billing, "_sdk", _docs_sdk([], []))
+    assert (await c.get("/billing/history", headers=_h(owner))).json()["items"] == []
+
+
+async def test_history_survives_a_stripe_outage(c: AsyncClient, monkeypatch):
+    """A Stripe hiccup should cost the payer their download button, not their payment history."""
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    async with session_maker() as db:
+        await ledger.topup(db, org_id, 10_000_000, "pi_manual", meta={"source": "stripe"})
+
+    async def boom(fn, /, **kw):
+        raise stripe.APIConnectionError("stripe is down")
+
+    monkeypatch.setattr(billing, "_sdk", boom)
+    r = await c.get("/billing/history", headers=_h(owner))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["stripe_ok"] is False
+    assert body["items"][0]["amount_micro"] == 10_000_000  # the amount is still right
+    assert body["items"][0]["invoice_pdf"] == "" and body["items"][0]["receipt_url"] == ""
+
+
+async def test_history_never_moves_money(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    await _set_org(org_id, stripe_customer_id="cus_test_1")
+    async with session_maker() as db:
+        await ledger.topup(db, org_id, 10_000_000, "pi_manual", meta={"source": "stripe"})
+    monkeypatch.setattr(billing, "_sdk", _docs_sdk([_charge("pi_manual", invoice="in_1")], [_invoice("in_1")]))
+    before = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()["balance_micro"]
+    await c.get("/billing/history", headers=_h(owner))
+    after = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()["balance_micro"]
+    assert after == before
+
+
+async def test_history_and_portal_need_admin_of_this_org(c: AsyncClient, monkeypatch):
+    """A card and an invoice archive are the org's money, not a member's business — the same gate as
+    the rest of /billing."""
+    org_id, owner = await _org(c)
+    member = await _member(c, org_id, owner, "grunt@superdesign.dev")
+    monkeypatch.setattr(billing, "_sdk", lambda *a, **k: pytest.fail("must not reach Stripe"))
+    for method, path in (("GET", "/billing/history"), ("POST", "/billing/portal")):
+        assert (await c.request(method, path, headers=_h(member))).status_code == 403
+        assert (await c.request(method, path)).status_code in (401, 403)
+
+
+async def test_history_of_a_team_that_never_paid_is_empty_not_an_error(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", lambda *a, **k: pytest.fail("no customer — must not ask Stripe"))
+    r = await c.get("/billing/history", headers=_h(owner))
+    assert r.status_code == 200 and r.json()["items"] == []
+
+
 # ---- webhook: signature ------------------------------------------------------------------------
 async def test_webhook_rejects_a_bad_signature(c: AsyncClient):
     org_id, _ = await _org(c)


### PR DESCRIPTION
## Why

Top-ups produced a Stripe **card receipt** and nothing else. Anyone who needed to expense treg had no document to hand their finance team, and no way to get a company name or VAT number onto it. There was also no Customer Portal anywhere in the repo, so a payer couldn't update their card, billing address or tax ID without emailing us.

## What changed

**Real invoices on the manual path.** `create_topup_checkout` now sets `invoice_creation`, so every one-off top-up produces a Stripe Invoice — number, PDF, billing address, tax ID.

Auto top-up deliberately does **not** get one. It charges a bare off-session PaymentIntent; attaching an invoice would mean rebuilding it as InvoiceItem + Invoice paid off-session, rewriting the money path and its idempotency guarantees for a minority of payments. Those rows keep their receipt link and are documented as receipt-only.

**`GET /billing/history`.** Rows come from our own `CreditBlock` table — the same table the balance is computed from — so the list can never show a payment the balance disagrees with, and amounts/dates need no network call. Stripe is asked only for the document links, in two list calls (`Charge.list` + `Invoice.list`, joined in memory) rather than two per row. A Stripe failure degrades to rows without links and reports `stripe_ok: false`; a hiccup should cost the payer a download button, not their payment history.

**`POST /billing/portal`.** Stripe's hosted portal — card, billing address, tax ID, and the unbounded invoice archive. Refuses an org with no `stripe_customer_id` rather than minting one: a customer exists once someone starts a top-up, and an empty portal has nothing to show. `billing_state.portal` is the flag the UI hides the button on, so a new team never sees a button that would 422.

**Billing tab.** A **Manage billing** button and a **Payment history** table — date, amount, an `auto` marker, and one link per row: *Invoice* → *Receipt* → em dash.

**Webhook unchanged, on purpose.** `invoice_creation` makes Stripe emit `invoice.created` / `invoice.paid` for every top-up. `handle_webhook_event` keeps dropping them — crediting on an invoice event as well as on the PaymentIntent would be a second door onto the same money. There's a test pinning that.

## Testing

- 12 new tests in `tests/test_billing.py`; full suite **1415 passed**.
- The load-bearing regression guard is `test_topup_checkout_asks_stripe_for_an_invoice`: it asserts `invoice_creation.enabled` **and** that `payment_intent_data.setup_future_usage` survives — the invoice must not cost us the saved card and SCA mandate every auto-top-up runs on.
- Billing tab verified in a browser in both light and dark themes, with all three link states rendering.

## Before merging / deploying

Two Stripe **dashboard** prerequisites — neither is code, and the first makes the portal 400 until it's done:

1. **Settings → Billing → Customer portal** — save a configuration with invoice history on.
2. **Settings → Business → Customer emails → Successful payments** — on, or invoices never email out.

Do both in test first, then live.

Also worth a decision before this goes live: **`invoice_creation` on one-time Checkout is priced separately by Stripe** — it is not part of Invoicing. Worth checking the rate against top-up volume.

## Known gap

I could not run the live Stripe probe (no key in the dev environment): confirming against the real API that `invoice_creation` and `payment_intent_data.setup_future_usage` coexist on one Checkout Session. Stripe's docs list no conflict between them — the only documented `setup_future_usage` conflict is with `payment_method_save_usage`, which we don't use — and a test pins both fields. But that is documentary evidence, not a live 200. **One $5 test-mode top-up settles it**; if the Checkout page opens, they coexist.

## Docs

`docs/context/architecture/money.md` and `docs/context/interface/dashboard.md`, in the same commit. `interface/api.md` needed no change — it doesn't cover billing routes; `money.md` owns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SUgGnwegexjJtYCDN3wrb