### PR TITLE
docs(plugin): ClawHub is live — and publishing skills is a two-phase flow nobody documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Discover what your team has shared: `treg tool ls` · check credential health: `
 
 Installs with no token and no configuration. The skill loads as `treg:treg` and, on its first run,
 walks your agent through the rest — the CLI, sign-in, then `treg mcp install` — so you end up with
-the command line **and** treg's tools. Other agents: `npx skills add superdesigndev/treg`.
+the command line **and** treg's tools. Other agents: `npx skills add superdesigndev/treg -s treg`
+(the `-s` matters — without it you also get this repo's internal dev skills).
 See [docs/CLAUDE-PLUGIN.md](docs/CLAUDE-PLUGIN.md).
 
 ## Call a tool you don't have a key for

--- a/docs/CLAUDE-PLUGIN.md
+++ b/docs/CLAUDE-PLUGIN.md
@@ -93,11 +93,37 @@ The live path is the npm CLI:
 
 ```bash
 npm i -g clawhub
-clawhub login                                   # GitHub account must be ≥1 week old
-clawhub skill publish ./skills/treg --dry-run   # always dry-run first
-clawhub skill publish ./skills/treg --slug treg --name "treg" \
-  --version 0.11.0 --changelog "..." --tags latest
+clawhub login                     # device flow; opens a browser (--no-browser prints a URL + code)
+clawhub whoami                    # confirm before publishing
+
+clawhub skill publish "$PWD/skills/treg" \
+  --slug treg --name "treg" --version 0.11.0 \
+  --changelog "..." \
+  --topics "api,seo,serp,backlinks,enrichment,scraping,agent-tools,web-search" \
+  --source-repo superdesigndev/treg \
+  --source-commit "$(git rev-parse HEAD)" \
+  --source-ref main --source-path skills/treg \
+  --dry-run                       # drop --dry-run to publish for real
 ```
+
+Verified against clawhub CLI **v0.23.3** — the published docs are thinner than the real `--help`,
+so read the CLI:
+
+- **Pass an ABSOLUTE path.** A relative `./skills/treg` fails with `Path must be a folder`, because
+  paths resolve against `--workdir` + `--dir` (which defaults to `skills`), so it looks for
+  `skills/skills/treg`. `"$PWD/skills/treg"` is the reliable form.
+- **The `--source-*` flags are worth filling in.** They link the listing back to a GitHub repo,
+  commit and path. That is the one provenance signal available on a registry whose own vetting
+  history is the reason Hermes marks every ClawHub skill `community` trust.
+- **`--categories` takes slugs the public API does not enumerate** (`/api/v1/categories` 404s and
+  listings come back with empty `categories`). Do not invent one — use `--topics`, which is
+  free-form, until a real category slug can be read off a live listing.
+- `--dry-run --json` prints the resolved slug, version, file count and fingerprint without
+  publishing. `latestVersion: null` means the slug is unclaimed.
+- Publishing is not irreversible: `clawhub delete` soft-deletes a skill or withdraws one version,
+  and `clawhub hide` / `undelete` exist too. Ownership can move later with
+  `--owner <handle> --migrate-owner`, so publishing under a personal handle now does not lock the
+  skill out of a `superdesigndev` org later.
 
 Requirements the generated skill already satisfies: frontmatter `name` + `description` + semver
 `version`, with `name` matching the parent directory (`treg`). A security scan runs post-publish;

--- a/docs/CLAUDE-PLUGIN.md
+++ b/docs/CLAUDE-PLUGIN.md
@@ -86,7 +86,17 @@ Nothing to submit. Merging to `main` publishes it; the install lines above start
 Bump `version` in `pyproject.toml` and both manifests together — `test_plugin_version_tracks_the_package`
 pins all of them to one value.
 
-### 2. ClawHub (clawhub.ai) — self-serve, CLI-based
+### 2. ClawHub (clawhub.ai) — ✅ LIVE, self-serve, CLI-based
+
+**Published 2026-08-14: [clawhub.ai/superdesigndev](https://clawhub.ai/superdesigndev) · `treg@0.11.0`
+· owner `@superdesigndev` · MIT-0.** Verified by installing it back out of the registry into a scratch
+dir — the delivered `SKILL.md` is byte-identical to `skills/treg/SKILL.md` in this repo.
+
+The publisher org was created with
+`clawhub publisher create superdesigndev --display-name "Superdesign dev, Inc."`. Publishing under a
+personal handle would also have worked — `--owner <handle> --migrate-owner` moves a skill later — but
+a company handle reads as a product listing rather than a side project.
+
 
 `https://clawhub.ai/submit` **404s** (Hermes' CLI still points there; its `--to clawhub` is a stub).
 The live path is the npm CLI:
@@ -104,7 +114,32 @@ clawhub skill publish "$PWD/skills/treg" \
   --source-commit "$(git rev-parse HEAD)" \
   --source-ref main --source-path skills/treg \
   --dry-run                       # drop --dry-run to publish for real
+
+# Publishing is TWO PHASES. The command above only SUBMITS — the version sits at
+# `pending.publication`, invisible on every public surface, until a scan is attached to it:
+clawhub scan --slug treg --version 0.11.0 --update    # took ~37 minutes; let it run
 ```
+
+**Do not skip that second command, and do not conclude the publish failed while it runs.** This is
+the single least obvious thing about ClawHub and it is not in their docs. `clawhub skill publish`
+reports `"status": "pending-publication"` and exits; nothing else happens on its own. `scan --update`
+("write published scan results back to the selected version") is not a convenience — it is the step
+that completes publication. Watch the moderation record flip:
+
+```bash
+curl -s -H "Authorization: Bearer $(clawhub token)" \
+  https://clawhub.ai/api/v1/skills/treg/moderation
+```
+
+| | before `scan --update` | after |
+|---|---|---|
+| `legacyReason` | `pending.publication` | `scanner.llm.review` |
+| `reasonCodes` | `[]` | `["review.llm_review"]` |
+| public `GET /api/v1/skills/treg` | 403, hidden | returns the skill |
+
+Note `package publish` has a `--wait` flag that polls to a definitive state; **`skill publish` does
+not**, and `/api/v1/publish/attempts/<attemptId>` 404s for skill attempts. So for skills there is no
+progress indicator at all — run `scan --update` and wait it out.
 
 Verified against clawhub CLI **v0.23.3** — the published docs are thinner than the real `--help`,
 so read the CLI:
@@ -138,6 +173,31 @@ server code.
 Listing here also feeds Hermes' Skills Hub automatically. Note Hermes hard-codes every ClawHub skill
 to `community` trust after the Feb 2026 "ClawHavoc" incident (341 malicious skills), so this is a
 discovery channel, not a trust signal.
+
+#### Two verdicts, and only one of them gates visibility
+
+Do not confuse these — one costs a day if you do:
+
+- **Moderation** (`/api/v1/skills/treg/moderation`) is what hides or shows a skill. Ours is
+  `verdict: "clean"`, `isSuspicious: false`, `isMalwareBlocked: false`, empty `reasonCodes`. Reading
+  the CLI source: `isSuspicious` only prints an install-time warning that `--force` bypasses; only
+  `isMalwareBlocked` hard-blocks.
+- **`clawscan`** (`clawhub scan`) is an LLM review published as an **advisory on the listing**. It
+  rated treg `suspicious` — and that changed nothing about visibility.
+
+The v0.11.0 advisory raised four findings against `SKILL.md`. Three restate deliberate product
+decisions; **one is worth weighing on its own merits, independent of ClawHub**:
+
+| id | sev | what it says |
+|---|---|---|
+| `PE3` | **HIGH** | `cli_auth` consumes material from a CLI's keychain and relays it — "expands the agent's credential-access surface … without a strong, explicit consent boundary". Remediation suggested: per-tool opt-in before using keychain-derived credentials, and prefer scoped service tokens. |
+| `SQP-1` | MEDIUM | the frontmatter `description` is broad enough to get the skill selected for loosely-related tasks |
+| `SQP-2` | MEDIUM | `curl … \| sh` executes remote code with no checksum or signature |
+| `EA2` | MEDIUM | the "ask once, not per command" guidance discourages per-command approval |
+
+`EA2` and `SQP-2` are the trade-offs treg made knowingly. **`PE3` is a real description of a real
+feature** and deserves a decision rather than a dismissal — see `docs/context/architecture/` for how
+`cli_auth` binds. Static analysis and VirusTotal both came back clean.
 
 ### 3. aiskillstore/marketplace + skills.sh
 

--- a/docs/CLAUDE-PLUGIN.md
+++ b/docs/CLAUDE-PLUGIN.md
@@ -199,12 +199,36 @@ decisions; **one is worth weighing on its own merits, independent of ClawHub**:
 feature** and deserves a decision rather than a dismissal — see `docs/context/architecture/` for how
 `cli_auth` binds. Static analysis and VirusTotal both came back clean.
 
-### 3. aiskillstore/marketplace + skills.sh
+### 3. Skill Store (aiskillstore/marketplace) + skills.sh
 
-`aiskillstore/marketplace` is one of only two repos in Hermes' `KNOWN_MARKETPLACES`, so a PR there is
-the cheapest route into Hermes' `claude-marketplace` source. For skills.sh, verify on a scratch
-machine that `npx skills add superdesigndev/treg` resolves `skills/treg/` — that one command covers
-70+ coding agents beyond Claude Code.
+**Do NOT open a pull request against `aiskillstore/marketplace`.** Its README is explicit — *"PRs
+adding skills will be closed"*; the repo is written to by the platform's own review pipeline, not by
+contributors. Submit through the form instead:
+
+> <https://skillstore.io/submit> — one required field, and it accepts a **directory**, so give it:
+> `https://github.com/superdesigndev/treg/tree/main/skills/treg`
+
+GitHub auth is optional (it only adds review notifications); anonymous submissions are allowed. The
+audit there is **report-only** — a risk finding does not block publication. This is still worth doing
+because `aiskillstore/marketplace` is one of only two repos in Hermes' `KNOWN_MARKETPLACES`, so it is
+the cheapest route into Hermes' `claude-marketplace` source. Note `npx skillstore` is install-only —
+there is no CLI submit path.
+
+**skills.sh / `npx skills` — pass `-s treg`, always:**
+
+```bash
+npx skills add superdesigndev/treg -s treg     # ✅ just the treg skill
+npx skills add superdesigndev/treg             # ❌ installs NINE skills
+```
+
+Verified on a scratch machine: the bare form scans the whole repo, finds `.agents/skills/*` as well
+as `skills/treg/`, and installs this repo's **internal development skills** (`dev-local`,
+`tools-registry-context`, `write-provider-skill`, `add-oauth-provider`, `vendor-listing`, the three
+Google-provider skills) into the user's agent alongside treg. That is our layout leaking into a
+product install. `skills.sh.json` does not prevent it — it only supplies category labels.
+
+`-s treg` scopes it to one skill and is what every install line we publish must carry. With it, that
+one command still covers 70+ coding agents beyond Claude Code.
 
 ### 4. anthropics/claude-plugins-official — the queue
 


### PR DESCRIPTION
## Why

treg is now live on ClawHub — [clawhub.ai/superdesigndev](https://clawhub.ai/superdesigndev), `treg@0.11.0`, MIT-0. Getting there turned up several things about the ClawHub CLI that are **not in their published docs**, one of which costs ~40 minutes of thinking the publish failed. This writes all of it down in `docs/CLAUDE-PLUGIN.md`.

No product code changes. Documentation only.

## The finding that matters

**Publishing is two phases.** `clawhub skill publish` only *submits* — it returns `"status": "pending-publication"` and exits, and the version stays invisible on every public surface (org page, search, install, API). What completes publication is:

```bash
clawhub scan --slug treg --version 0.11.0 --update
```

`--update` reads like a convenience ("write published scan results back to the selected version"). It is not — it is the step that publishes. It took **~37 minutes** to return, with no progress output. `package publish` has a `--wait` flag for exactly this; **`skill publish` does not**, and `/api/v1/publish/attempts/<attemptId>` 404s for skill attempts, so there is no indicator available at all.

The moderation record is how you watch it flip:

| | before `scan --update` | after |
|---|---|---|
| `legacyReason` | `pending.publication` | `scanner.llm.review` |
| `reasonCodes` | `[]` | `["review.llm_review"]` |
| public `GET /api/v1/skills/treg` | 403, hidden | returns the skill |

## Two verdicts, and only one gates visibility

I conflated these for a while, so the doc now separates them explicitly:

- **Moderation** is what hides or shows a skill. Ours came back `verdict: "clean"`, `isSuspicious: false`, `isMalwareBlocked: false`, empty `reasonCodes`. Reading the CLI source: `isSuspicious` only prints an install-time warning that `--force` bypasses; only `isMalwareBlocked` hard-blocks.
- **`clawscan`** is an LLM review published as an advisory on the listing. It rated treg `suspicious` — and that gated nothing.

## One finding worth a real decision

Of clawscan's four findings against `SKILL.md`, three restate trade-offs treg made knowingly (broad `description`, `curl … | sh`, the "ask once" approval guidance). **`PE3` (HIGH) does not:**

> `cli_auth` consumes material from a CLI's keychain and relays it — "expands the agent's credential-access surface … without a strong, explicit consent boundary."

That is a real description of a real feature, not a misread. It is recorded in the doc so it gets weighed on its own merits rather than dismissed as scanner noise. **No change made here** — flagging, not fixing.

Static analysis and VirusTotal both clean.

## Other CLI corrections

- **Absolute paths only.** `./skills/treg` fails with `Path must be a folder`, because paths resolve against `--workdir` + `--dir` (default `skills`) — so it looks for `skills/skills/treg`.
- **`--source-repo/--source-commit/--source-ref/--source-path` exist** and are filled in. That provenance link is the one trust signal available on a registry whose vetting history is why Hermes pins every ClawHub skill to `community`.
- **`--categories` wants slugs nothing public enumerates** (`/api/v1/categories` 404s; live listings return empty `categories`). Use free-form `--topics` rather than invent one.
- **Topics are capped at 5.** Passing more fails the publish.
- Publishing is reversible: `delete` / `hide` / `undelete`, and `--migrate-owner` moves a skill to an org later.

## Verification

- Installed the skill **back out of the registry** into a scratch dir: delivered `SKILL.md` is byte-identical to `skills/treg/SKILL.md` in this repo. Uninstalled afterward.
- `clawhub inspect treg` → `@superdesigndev · v0.11.0 · latest=0.11.0`, and it now appears in `clawhub search`.
- `tests/test_plugin.py` + `tests/test_skill_md.py`: 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x16Skh3DNWoqv7LgNxUYF
