### PR TITLE
feat(providers): the Market data shelf — eight providers, every one verified live

### DIFF
--- a/docs/CATALOG-HUNTER-PLAN.md
+++ b/docs/CATALOG-HUNTER-PLAN.md
@@ -1,0 +1,104 @@
+# The catalog hunter — a weekly agent loop that finds, triages and drafts new providers
+
+**Status:** planned, awaiting review. Nothing built.
+
+## What it is
+
+A scheduled agent run, weekly, that keeps the catalog growing without a human doing the hunting:
+
+1. **Collect** candidates from three sources
+2. **Triage** them against the selection rules we already wrote down
+3. **Draft** a full dossier per surviving candidate
+4. **Report** to Unclecode for approval
+5. On approval, **implement** everything up to the one step that needs a human
+
+The playbook already exists: `docs/context/guides/expanding-a-category.md` was written as a
+repeatable process with selection heuristics and recorded rejection reasons. The loop is that guide,
+executed on a schedule, with a human gate where the guide itself demands one.
+
+## The three inputs
+
+- **The hunt.** Web research per category, including the new market-data one
+  (`docs/MARKET-DATA-CATEGORY-RESEARCH.md` is the standing shortlist to draw from). Also: gaps the
+  usage data shows — a capability teams keep searching for and not finding is a stronger signal than
+  any listicle.
+- **Community issues** on the repo asking for providers or categories (the market-data request came
+  in exactly this way).
+- **Provider PRs.** Right now there are SEVEN open external submissions (#92 risk-data, #94
+  Parallel, #95 Linkup, #96 LemMeBuyIt, #97 Goldsky, #119 Virlo). These are the highest-value input
+  and the least served today: a contributor did the drafting, and nobody has systematically checked
+  their work against our rules.
+
+## Triage: the rules are already written
+
+From the guide, applied mechanically before any human sees the list:
+
+- self-serve API key, no sales call (this is the entire fast path)
+- distinct value against what the category already has, not a near-duplicate
+- reject with a recorded reason: legal risk, deprecated, UI-only, enterprise-gated
+- when N clean picks do not exist, say so rather than pad with a bad fit
+
+Plus the new rung the pricing ladder added: a flat-fee provider is no longer auto-rejected — the
+dossier states which rung it prices on and, for shared-plan candidates, the proposed rate with fee
+and break-even.
+
+## The dossier (one per candidate, the approval artifact)
+
+Exactly the facts the guide says matter, with "unconfirmed" allowed and guessing forbidden:
+
+    provider, category, what gap it fills
+    pricing rung: credits / cap / rate-limit / unlimited — with the numbers and source URL
+    base_url, auth location + format
+    a cheap or FREE probe endpoint, and the documented bad-key behaviour
+    ToS flags: redistribution, non-commercial free tier, data-licensing (market data especially)
+    for provider PRs: does the submitted YAML match reality, and what the diff review found
+    verdict: recommend / reject (with the recorded reason)
+
+## The human seam, stated plainly
+
+**The live bogus-key test cannot be automated away.** It needs a real signup and a real key, and the
+guide is explicit: never ship a key provider you have not watched reject a bogus key. The loop
+therefore ends its automated run at "dossier ready, tested except keys", and the approval email
+lists exactly which signups are needed. After Unclecode (or Jason) supplies keys, the
+implementation half runs: registry entry, logo placeholder, tests, the live bogus-key check, docs.
+
+The second human gate is approval itself: nothing is added, and no PR is opened, without Unclecode
+seeing the dossier list. The loop drafts; it does not ship.
+
+## Mechanics
+
+- **Schedule:** weekly, as a scheduled agent session in this repo. The run's output is one markdown
+  report (dossiers + rejections + the keys-needed list) committed to a branch and linked in the
+  notification, so review happens in VS Code like everything else.
+- **State:** a small `docs/hunter/seen.yaml` of already-evaluated candidates with their verdicts, so
+  a rejected provider is not re-litigated weekly and a "not yet, thin value" can be revisited when
+  something changes. The recorded-rejection habit the guide started becomes the loop's memory.
+- **Provider PRs:** the loop comments its dossier findings on the PR itself (facts, not decisions),
+  which is also the polite thing for the contributor waiting on #92–#119.
+- **Cost:** the hunt is web research plus catalog reads; the only spend is probe calls where a free
+  tier exists. No platform-key spending without approval, ever.
+
+## Order
+
+1. The dossier format + `seen.yaml`, and one manual run END TO END on the seven open PRs — the
+   highest-value pile, and the run that proves the format before any scheduling exists. Reviewed
+   like any work.
+2. The hunt half (web research per category), second manual run.
+3. Only then the schedule, once two manual runs have shown the report is worth waking up to.
+4. The implementation half (post-approval automation) last — it is the guide's steps 3–7, and they
+   are already well-specified.
+
+Deliberately: scheduling is step 3, not step 1. An unattended loop earns its cron slot by being
+useful twice while watched.
+
+## What could go wrong
+
+- **Dossier rot.** A provider verified in week 1 and added in week 6 may have changed pricing. The
+  dossier carries its `checked` dates; the implementation half re-verifies pricing before writing
+  fx entries rather than trusting a stale dossier.
+- **PR flattery.** A contributor's YAML can look complete and be wrong (the b2b-ads-search stamp
+  this week came from OUR OWN verified work, and it was still incomplete). The dossier for a PR is
+  built from the provider's docs independently, then diffed against the submission — never the
+  submission taken as the source.
+- **Category padding.** The guide's rule stands: when clean picks run out, the report says so. A
+  weekly loop with a quota would invent providers to meet it; this one has no quota.

--- a/docs/CUSTOMER-BILLING-PLAN.md
+++ b/docs/CUSTOMER-BILLING-PLAN.md
@@ -1,0 +1,173 @@
+# Customer-level billing — builders reselling treg to their own customers
+
+**Status:** planned, awaiting review. Nothing built. Written to be handed to a maintainer cold; no
+context from the design conversation is assumed.
+
+## Who is asking, and for what
+
+Builders are integrating treg into their own agent products. Their end-customers use the product;
+the product calls treg underneath. The builder needs to know and limit what each of THEIR customers
+consumed, and to bill those customers themselves.
+
+## The boundary decision everything follows from
+
+**treg meters and enforces; the builder monetizes.** treg never bills a builder's end-customer, never
+holds their card, never sets their price. What treg owes the builder is exactly three things:
+
+1. **Attribution** — what did customer X consume this month
+2. **Enforcement** — refuse customer X at the limit the builder set
+3. **Export** — numbers clean enough to invoice from
+
+Everything below is those three things and nothing else. Margin, pricing to the end-customer, and
+invoicing are the builder's own Stripe and their own business.
+
+## Two models, one already shipped
+
+| Model | Who pays treg | Status |
+|---|---|---|
+| **Customer-pays** | each end-customer, their own team + balance | **Shipped.** The builder's product connects through treg's OAuth server (consent screen, team picker). Built for ChatGPT, deliberately client-agnostic |
+| **Builder-pays** | the builder, one org, one balance | **This plan** |
+
+Customer-pays suits developer-tool products whose users would want their own treg anyway. Builder-pays
+is what most builders mean, and is the gap.
+
+## Builder-pays: the design
+
+### The metadata bag, and the reserved `customer` key
+
+ONE mechanism, deliberately — not a dedicated header per special concept. Every call may carry a
+small tag bag, and `customer` is a reserved key inside it:
+
+    POST /call/hunter.people.email.find
+    X-Treg-Token: <builder org token>
+    X-Treg-Meta: customer=cust_8123, feature=email-finder, env=prod
+
+Over MCP, the same thing as an optional `meta` dict argument on the `call` tool.
+
+The split of powers:
+
+- **Any key** is recorded and can be grouped in the usage report (`group_by=feature` works the same
+  as `group_by=customer`). This is the AWS cost-allocation-tags model; Anthropic's API does the same
+  (free metadata, one blessed `user_id`).
+- **Only `customer`** carries enforcement: budgets, `blocked`, idempotency scoping, and the
+  token-per-customer upgrade path. Two reasons this must not generalize: a budget check against
+  arbitrary tag combinations is N lookups on the hot path instead of one, and retry scoping needs
+  exactly ONE partitioning dimension (a call tagged `customer=a, feature=b` has no right answer for
+  which one partitions its idempotency keys).
+
+Future special keys get semantics by reserving another key in the bag, never by adding a header.
+
+Bag rules: max 5 keys per call; key and value are opaque strings, max 32/128 chars, stored as given.
+Docs must say "use your internal ids, not emails" — tags land in audit rows and usage exports, so
+PII does not belong in them. No bag means today's behaviour exactly.
+
+Spoofing is a non-issue by construction: the only party who could mis-tag is the builder, and the
+only budgets and reports a tag touches are the builder's own.
+
+### Piece 1 — record the bag (attribution)
+
+Audit rows already carry a `telemetry` dict and ledger settles already carry a `meta` dict. The
+bag's keys merge into each. No schema change; attribution becomes a query.
+
+### Piece 2 — `CustomerBudget` (enforcement)
+
+New table, org-scoped (goes into `_ORG_SCOPED_MODELS` — the delete-cascade test will catch it if
+forgotten, it has before):
+
+    CustomerBudget: org_id, customer (string), monthly_cap_micro | daily_cap_micro (nullable),
+                    calls_per_day (nullable), status (active|blocked), created/updated
+
+CRUD under `/orgs/{id}/customers`. Enforcement sits at the same insertion point as
+`_enforce_daily_cap` in the `/call/` path and reads the trailing spend for (org, customer) the same
+way the daily cap reads per-user spend.
+
+The refusal must be its own error, `customer_budget_exceeded`, with the cap and the period in the
+body. The builder's product needs to show THEIR user a clean "you have reached your plan limit"
+message, not a treg error about someone else's balance. Never include the org's overall balance in
+this response: that is the builder's private number, and the response may be shown to their customer.
+
+A `status: blocked` customer is refused outright — the soft version of revocation, no token
+management needed.
+
+### Piece 3 — the usage endpoint (export)
+
+    GET /orgs/{id}/usage?group_by=customer&from=...&to=...
+    -> [{customer, calls, charged_micro, by_provider: {...}}, ...]
+
+The aggregation pattern already exists in `reconcile.provider_spend` (audit rows, 30-day window);
+this is the same query with a different group-by and a date range. JSON now; CSV later if builders
+ask. This output is what the builder invoices from.
+
+### Isolation mode: a token per customer (already exists)
+
+The tag counts; a token controls. For customers needing real control, the builder mints them a
+dedicated agent token: `POST /orgs/{id}/agents` — which already exists end to end.
+
+| Need | Tag enough? | Token needed? |
+|---|---|---|
+| usage counting, budgets, invoicing | yes | no |
+| cut off ONE customer instantly | `status: blocked` works | revocation also works |
+| different tool access per customer (premium vs free tier) | no | yes — per-member `tool_access` exists |
+| token runs on the CUSTOMER's device (leak containment) | no | yes |
+
+Rule for the docs: **tag for counting, token for control.** Start everyone on tags; upgrade the few.
+
+One glue task: a call made with a per-customer token should attribute to that customer WITHOUT the
+bag — set `meta.customer` from a `customer` field on the membership (nullable column on Membership, set
+when the agent is minted with `--customer cust_8123`). Then both modes produce one consistent usage
+report.
+
+## Three traps, found at design time — do not skip these
+
+1. **The per-member daily cap throttles the whole customer base.** All tagged traffic rides one
+   membership, so one member's $5/day cap becomes the product-wide ceiling. Builder orgs need that
+   cap raisable (per-member override already exists in spirit via unmetered members; the clean fix is
+   a per-membership `daily_cap_micro` override column). Without this, builder-pays does not survive
+   contact with its tenth customer.
+2. **Idempotency must scope by tag.** Two of the builder's customers WILL both send `retry-1` under
+   the shared token. `IdempotentCall` is unique on `(membership_id, key)` today; it must become
+   `(membership_id, customer, key)` with `customer` defaulting to "". NOTE: this is an ALTER of an
+   existing unique constraint — `create_all` will not do it; prod is Postgres and needs a real
+   migration step in the deploy.
+3. **Why not one org per customer** (the tempting shortcut): the builder's balance fragments into N
+   pots topped up separately, their secrets would need copying into every org, and the $1 promo grant
+   multiplies by N — a free-credit printing machine. Rejected; do not revisit without solving all
+   three.
+
+## Order, with a stop after each step
+
+1. The bag: accept the `X-Treg-Meta` header + the MCP `meta` arg, record into audit telemetry +
+   ledger meta. Attribution only, nothing enforced. Tests: tagged call lands in both records with all
+   keys; untagged call byte-identical to today; a 6th key refused with a clear error.
+2. The usage endpoint. Tests: grouping, date range, tags with zero spend absent, and org isolation
+   (org A cannot read org B's usage — the multi-tenancy test pattern).
+3. `CustomerBudget` + enforcement + `blocked`. Tests: cap refusal shape, the error never leaks org
+   balance, blocked refused, capless customer unaffected.
+4. Idempotency scoping + the Postgres migration for the constraint.
+5. The membership `customer` field + `--customer` on agent-new (isolation glue).
+6. The per-membership cap override.
+7. Docs: llms.txt (a "for builders" section), `docs/context/architecture/multi-tenancy.md` and
+   `money.md` fragments, MAP.md entries, skill regeneration if skill.md changes.
+
+Steps 1–3 are the product; 4–6 are correctness and scale; each is shippable alone.
+
+## Reuse scoreboard
+
+Reused: orgs, ledger reserve/settle, audit, the daily-cap insertion point, the OAuth server
+(customer-pays model), the public-demo precedent (it already meters many anonymous users on one
+shared token, by IP — this is the same mechanism with the grain changed to a customer id), agent
+tokens, per-member ACLs.
+
+Genuinely new: one table, one header (the meta bag), one endpoint, two columns, one migration.
+
+## What could go wrong, where to look first
+
+- **The budget check racing itself** — two concurrent calls both under the cap, together over it.
+  Same class as every reserve race; acceptable for v1 (caps are soft business limits, not ledger
+  invariants), but say so in the code comment rather than let it be discovered as a bug.
+- **Usage endpoint performance** — audit rows per org can be large; the query needs the existing
+  org+created index plus a telemetry-tag strategy (worst case, a small denormalised
+  `customer_spend` daily rollup later; do not build it until it hurts).
+- **Tag cardinality abuse** — a runaway integration sending a fresh UUID per call (as any key's
+  value) bloats reports. Cap distinct values per key per org (say 10k) with a clear error, counted
+  cheaply at budget-create and report time.

--- a/docs/MARKET-DATA-CATEGORY-RESEARCH.md
+++ b/docs/MARKET-DATA-CATEGORY-RESEARCH.md
@@ -103,7 +103,23 @@ to have picked one.
 
 ---
 
+## Status update (2026-08-14): eight added, one dropped
+
+All of tier 1 and 2 went through the fast path with LIVE bogus-key verification: coingecko, polygon,
+finnhub, twelvedata, fmp, eodhd, marketstack, tiingo are registered under the new "Market data"
+shelf, each entry recording its verified bad-key behaviour. Two traps found and dodged on the way:
+CoinGecko's demo host and Tiingo's /api/test both answer 200 to garbage, so both entries pin the
+path that genuinely rejects.
+
+**Alpha Vantage moved to the rejects below.** The connect entry cannot exist: the API served real
+quote data to a garbage key, and even premium endpoints answer 200 with an upsell note, so a pasted
+key can never be validated (the ScrapeCreators rule). Its shared-plan pilot rate in fx.yaml stands —
+platform-tier serving uses our own subscribed key, which needs no connect verify.
+
 ## Rejected, with reasons
+
+- **Alpha Vantage** — accepts ANY key (verified live 2026-08-14: `apikey=bogus123` returned the IBM
+  quote). A key provider whose key cannot be checked cannot be shipped.
 
 - **Yahoo Finance** — no official API. Every wrapper is unofficial and has been broken or
   legally pressured before. Same class of risk as Proxycurl, which the guide says to reject on sight.

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1300,6 +1300,42 @@ LEADMAGIC = OAuthProvider(
 
 # ---- Advertising API-key providers (ad intelligence) -----------------------------------------
 
+# ---- Market data API-key providers -------------------------------------------------------------
+# The first category added under the shared-plan pricing ladder (docs/SHARED-PLAN-PRICING-PLAN.md);
+# provider selection: docs/MARKET-DATA-CATEGORY-RESEARCH.md. CoinGecko leads because it is the one
+# true credit-priced provider in the sector — its fx.yaml entry divides like Hunter's.
+
+COINGECKO = OAuthProvider(
+    service="coingecko",
+    display_name="CoinGecko",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your CoinGecko Pro API key",
+    token_header="x-cg-pro-api-key",
+    token_format="{secret}",  # raw key, no Bearer prefix
+    setup_url="https://www.coingecko.com/en/developers/dashboard",
+    setup_action_label="Get your CoinGecko API key",
+    setup_steps=(
+        "Sign up for a CoinGecko API plan (Basic and up) and open the developer dashboard.",
+        "Create an API key and copy it.",
+    ),
+    # The distinction that will bite users: free "demo" keys ride a DIFFERENT host
+    # (api.coingecko.com) with a different header, and that host answers 200 to anything — so a demo
+    # key can never be verified here. Saying so up front beats a confusing rejection.
+    setup_note="Needs a paid (Pro) key. Free demo keys use a different host and will not verify.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Crypto prices, market caps, volume and history across 17,000+ coins and 1,000+ exchanges.",
+    base_url="https://pro-api.coingecko.com/api/v3",
+    docs_url="https://docs.coingecko.com/reference/authentication",
+    # Free probe; validity is the HTTP status. Verified live 2026-08-14: a bogus key answers 401
+    # {"status":{"error_code":10002,...}} on the pro host, so the default reject-on-status works.
+    probe_path="/ping",
+)
+
+
 SPYFU = OAuthProvider(
     service="spyfu",
     display_name="SpyFu",
@@ -1497,6 +1533,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
         # more Enrichment API-key providers
         LUSHA, CORESIGNAL, DIFFBOT, THECOMPANIESAPI, LEADMAGIC,
+        # Market data API-key providers
+        COINGECKO,
         # Advertising: API-key ad intelligence + unconfigured OAuth ad platforms
         SPYFU, APIFY, META_AD_LIBRARY, SERPAPI,
         MICROSOFT_ADS, SNAPCHAT_ADS, TIKTOK_ADS, PINTEREST_ADS,
@@ -1507,7 +1545,7 @@ DEFAULT_CAPABILITY = "read"
 
 # Shelf order in the marketplace. Anything carrying a category not named here sorts last, so a
 # provider added without one is visible rather than lost between the shelves.
-CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Community", "Other")
+CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Market data", "Community", "Other")
 
 
 def get(service: str) -> OAuthProvider | None:

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1336,6 +1336,199 @@ COINGECKO = OAuthProvider(
 )
 
 
+POLYGON = OAuthProvider(
+    service="polygon",
+    display_name="Polygon.io",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Polygon API key",
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://polygon.io/dashboard/keys",
+    setup_action_label="Get your Polygon API key",
+    setup_steps=(
+        "Sign up at polygon.io (rebranding to Massive) and open Dashboard → API Keys.",
+        "Copy the default key, or create one per environment.",
+    ),
+    setup_note="The free tier is 5 requests/min with 15-minute delayed data — fine for verifying.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="US stocks, options, indices, forex and crypto — real-time and deep history, tick-level.",
+    base_url="https://api.polygon.io",
+    docs_url="https://polygon.io/docs",
+    # Free-tier listable reference call; a bogus key answers 401 "Unknown API Key" (verified live
+    # 2026-08-14), so the default reject-on-status works.
+    probe_path="/v3/reference/tickers?limit=1",
+)
+
+FINNHUB = OAuthProvider(
+    service="finnhub",
+    display_name="Finnhub",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Finnhub API key",
+    token_header="X-Finnhub-Token",
+    token_format="{secret}",
+    setup_url="https://finnhub.io/dashboard",
+    setup_action_label="Get your Finnhub API key",
+    setup_steps=(
+        "Register at finnhub.io (no card needed) and open the dashboard.",
+        "Copy the API key shown at the top.",
+    ),
+    # Their free tier's terms, said before it bites: personal use only.
+    setup_note="Free-tier keys are licensed for personal, non-commercial use — a product needs a paid plan.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Real-time quotes, company fundamentals, earnings, and news sentiment.",
+    base_url="https://finnhub.io/api/v1",
+    docs_url="https://finnhub.io/docs/api",
+    # One free-tier quote; a bogus key answers 401 {"error":"Invalid API key."} (verified live 2026-08-14).
+    probe_path="/quote?symbol=AAPL",
+)
+
+TWELVEDATA = OAuthProvider(
+    service="twelvedata",
+    display_name="Twelve Data",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Twelve Data API key",
+    token_location="query",
+    token_param="apikey",
+    token_format="{secret}",
+    setup_url="https://twelvedata.com/account/api-keys",
+    setup_action_label="Get your Twelve Data API key",
+    setup_steps=(
+        "Create a Twelve Data account (free Basic plan: 800 requests/day).",
+        "Open Account → API keys and copy the key.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Equities, forex and crypto quotes and time series across global exchanges.",
+    base_url="https://api.twelvedata.com",
+    docs_url="https://twelvedata.com/docs",
+    # One-credit quote; a bogus key answers 401 {"code":401,...} (verified live 2026-08-14).
+    probe_path="/quote?symbol=AAPL",
+)
+
+FMP = OAuthProvider(
+    service="fmp",
+    display_name="Financial Modeling Prep",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your FMP API key",
+    token_location="query",
+    token_param="apikey",
+    token_format="{secret}",
+    setup_url="https://site.financialmodelingprep.com/developer/docs/dashboard",
+    setup_action_label="Get your FMP API key",
+    setup_steps=(
+        "Create an FMP account (free tier: 250 requests/day).",
+        "Open the developer dashboard and copy the API key.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Company fundamentals: statements, ratios, profiles, earnings and institutional data.",
+    base_url="https://financialmodelingprep.com/api/v3",
+    docs_url="https://site.financialmodelingprep.com/developer/docs",
+    # Free-tier profile call; a bogus key answers 401 {"Error Message": ...} (verified live 2026-08-14).
+    probe_path="/profile/AAPL",
+)
+
+EODHD = OAuthProvider(
+    service="eodhd",
+    display_name="EODHD",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your EODHD API token",
+    token_location="query",
+    token_param="api_token",
+    token_format="{secret}",
+    setup_url="https://eodhd.com/cp/settings",
+    setup_action_label="Get your EODHD API token",
+    setup_steps=(
+        "Register at eodhd.com and open Settings.",
+        "Copy the API token.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="End-of-day and historical prices across 70+ global exchanges, plus fundamentals.",
+    base_url="https://eodhd.com/api",
+    docs_url="https://eodhd.com/financial-apis/",
+    # A bogus key answers 401 with a PLAIN-TEXT body ("Unauthenticated") — fine, the connect verify
+    # only JSON-parses JSON responses and rejects on status (verified live 2026-08-14).
+    probe_path="/eod/AAPL.US?fmt=json",
+)
+
+MARKETSTACK = OAuthProvider(
+    service="marketstack",
+    display_name="Marketstack",
+    auth_kind="key",
+    token_label="API access key",
+    token_placeholder="your Marketstack access key",
+    token_location="query",
+    token_param="access_key",
+    token_format="{secret}",
+    setup_url="https://marketstack.com/dashboard",
+    setup_action_label="Get your Marketstack access key",
+    setup_steps=(
+        "Sign up at marketstack.com (free plan available).",
+        "Copy the API access key from the dashboard.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Global end-of-day and intraday stock prices — simple, cheap, 70+ exchanges.",
+    base_url="https://api.marketstack.com/v1",
+    docs_url="https://marketstack.com/documentation",
+    # A bogus key answers 401 {"error":{"code":"invalid_access_key",...}} (verified live 2026-08-14).
+    probe_path="/eod?symbols=AAPL",
+)
+
+TIINGO = OAuthProvider(
+    service="tiingo",
+    display_name="Tiingo",
+    auth_kind="key",
+    token_label="API token",
+    token_placeholder="your Tiingo API token",
+    token_header="Authorization",
+    token_format="Token {secret}",
+    setup_url="https://www.tiingo.com/account/api/token",
+    setup_action_label="Get your Tiingo API token",
+    setup_steps=(
+        "Create a Tiingo account and open Account → API.",
+        "Copy the API token.",
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Equities with 30+ years of history, plus curated news and fundamentals.",
+    base_url="https://api.tiingo.com",
+    docs_url="https://www.tiingo.com/documentation/general/overview",
+    # NOT /api/test — that endpoint answers 200 with prose for a BAD key ("Auth Token was not
+    # correct"), the Apollo trap. The daily-metadata endpoint 403s cleanly {"detail":"Invalid
+    # token."} (verified live 2026-08-14), so reject-on-status works with this probe instead.
+    probe_path="/tiingo/daily/aapl",
+)
+
+
+# Alpha Vantage is DELIBERATELY absent. Its API served real quote data to a garbage key (verified
+# live 2026-08-14: bogus key -> HTTP 200 with the IBM quote; even premium endpoints answer 200 with
+# an upsell note), so a pasted key can never be validated at connect — the ScrapeCreators rule:
+# never ship a key provider whose key cannot be checked. Its fx.yaml shared-plan pilot rate is
+# unaffected (platform-tier serving uses OUR OWN subscribed key, which needs no connect verify).
+
 SPYFU = OAuthProvider(
     service="spyfu",
     display_name="SpyFu",
@@ -1534,7 +1727,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         # more Enrichment API-key providers
         LUSHA, CORESIGNAL, DIFFBOT, THECOMPANIESAPI, LEADMAGIC,
         # Market data API-key providers
-        COINGECKO,
+        COINGECKO, POLYGON, FINNHUB, TWELVEDATA, FMP, EODHD, MARKETSTACK, TIINGO,
         # Advertising: API-key ad intelligence + unconfigured OAuth ad platforms
         SPYFU, APIFY, META_AD_LIBRARY, SERPAPI,
         MICROSOFT_ADS, SNAPCHAT_ADS, TIKTOK_ADS, PINTEREST_ADS,

--- a/src/treg/web/logos/coingecko.svg
+++ b/src/treg/web/logos/coingecko.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="coingecko">
+  <!-- Placeholder lettermark. Replace with the official CoinGecko brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#4A7B3F"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">C</text>
+</svg>

--- a/src/treg/web/logos/eodhd.svg
+++ b/src/treg/web/logos/eodhd.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="eodhd">
+  <!-- Placeholder lettermark. Replace with the official eodhd brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#374151"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">E</text>
+</svg>

--- a/src/treg/web/logos/finnhub.svg
+++ b/src/treg/web/logos/finnhub.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="finnhub">
+  <!-- Placeholder lettermark. Replace with the official finnhub brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#1D4ED8"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">F</text>
+</svg>

--- a/src/treg/web/logos/fmp.svg
+++ b/src/treg/web/logos/fmp.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="fmp">
+  <!-- Placeholder lettermark. Replace with the official fmp brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#B45309"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">F</text>
+</svg>

--- a/src/treg/web/logos/marketstack.svg
+++ b/src/treg/web/logos/marketstack.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="marketstack">
+  <!-- Placeholder lettermark. Replace with the official marketstack brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#9D174D"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">M</text>
+</svg>

--- a/src/treg/web/logos/polygon.svg
+++ b/src/treg/web/logos/polygon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="polygon">
+  <!-- Placeholder lettermark. Replace with the official polygon brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#5B21B6"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">P</text>
+</svg>

--- a/src/treg/web/logos/tiingo.svg
+++ b/src/treg/web/logos/tiingo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tiingo">
+  <!-- Placeholder lettermark. Replace with the official tiingo brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#7C2D12"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">T</text>
+</svg>

--- a/src/treg/web/logos/twelvedata.svg
+++ b/src/treg/web/logos/twelvedata.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="twelvedata">
+  <!-- Placeholder lettermark. Replace with the official twelvedata brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#0E7490"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">T</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -21,7 +21,9 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
-                "spyfu", "apify", "meta-ad-library", "serpapi", "coingecko"):
+                "spyfu", "apify", "meta-ad-library", "serpapi",
+                "coingecko", "polygon", "finnhub", "twelvedata", "fmp", "eodhd", "marketstack",
+                "tiingo"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -21,7 +21,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
-                "spyfu", "apify", "meta-ad-library", "serpapi"):
+                "spyfu", "apify", "meta-ad-library", "serpapi", "coingecko"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc
@@ -36,7 +36,9 @@ def test_key_providers_appear_in_the_marketplace_listing():
     assert listing["apollo"]["auth_kind"] == "key"
     assert listing["semrush"]["category"] == "SEO"
     assert listing["tikhub"]["category"] == "Social media"
+    assert listing["coingecko"]["category"] == "Market data"
     assert "Enrichment" in P.CATEGORY_ORDER
+    assert "Market data" in P.CATEGORY_ORDER
 
 
 # ---- connect-by-key ----------------------------------------------------------------------

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -48,7 +48,7 @@ def test_every_provider_is_registered():
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",
-        "coingecko",
+        "coingecko", "polygon", "finnhub", "twelvedata", "fmp", "eodhd", "marketstack", "tiingo",
         "microsoft-ads", "snapchat-ads", "tiktok-ads", "pinterest-ads",
     }
 

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -48,6 +48,7 @@ def test_every_provider_is_registered():
         "dataforseo", "seranking", "moz", "majestic", "serpstat",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic",
         "spyfu", "apify", "meta-ad-library", "serpapi",
+        "coingecko",
         "microsoft-ads", "snapchat-ads", "tiktok-ads", "pinterest-ads",
     }
 


### PR DESCRIPTION
The first category admitted by the shared-plan pricing ladder. Eight providers: **CoinGecko** (the
sector's one true credit-priced API), then **Polygon, Finnhub, Twelve Data, FMP, EODHD, Marketstack,
Tiingo** — every entry written from LIVE probes rather than documentation, and every one verified
through the guide's load-bearing step: a garbage key through `POST /connections/token` answered
`422 rejected` against the real API.

Traps found by probing and dodged in the entries:

- **CoinGecko's demo host answers 200 to anything** — entry pins the pro host, setup note warns demo
  keys will not verify
- **Tiingo's `/api/test` answers 200 with prose for a bad key** (the Apollo trap) — the entry probes
  `/tiingo/daily/aapl`, which 403s cleanly

One drop, recorded: **Alpha Vantage served the real IBM quote to `apikey=bogus123`** — a pasted key
can never be validated (the ScrapeCreators rule). Its fx.yaml shared-plan pilot stands, since
platform serving uses our own subscribed key.

Also: the catalog-hunter plan doc, and the customer-billing plan that #122 implemented.

Rebased onto #122's merge; suite green on the rebase.