### PR TITLE
fix(db): a contended migration fails cleanly instead of stopping the world

### DIFF
--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -195,3 +195,19 @@ a conversation rather than an env-var edit that lifts the rail for every team at
 It is a **blast-radius limit**, not a billing control: it exists because auto-top-up refills the
 balance, so the balance alone is not a ceiling against a runaway agent or a mispriced catalog entry.
 Enforced fail-closed.
+
+## A db.py change needs a Postgres-shaped deploy plan
+
+SQLite cannot catch this class: it has no connection pool and no lock queue. Two rules, both from the
+2026-08-15 outage (an ALTER on `callrecord` queued behind live traffic, every new query queued behind
+the ALTER, both instances starved, and the shared Postgres stayed wedged until a database restart):
+
+- Startup migrations run with `lock_timeout = 5s` (set in `init_db`, postgres only). A contended
+  deploy therefore FAILS CLEANLY — prod keeps serving the old code — and the right response is to
+  redeploy at a quieter moment, not to raise the timeout.
+- The pool is per instance and a rolling deploy runs two: keep `pool_size + max_overflow` such that
+  DOUBLE it stays under the database plan's connection ceiling. A guard test pins this.
+
+If a deploy fails with a lock timeout in the logs, that is the mechanism working. If the database
+itself stops accepting connections, restart the POSTGRES resource, not the web service — an app
+restart cannot release server-side slots (learned the hard way).

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -24,7 +24,12 @@ from .config import get_settings
 _db_url = get_settings().database_url
 _engine_kwargs: dict = {"future": True}
 if "sqlite" not in _db_url:
-    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300, pool_size=20, max_overflow=40)
+    # 5+10, not the 20+40 this shipped with. The pool is PER INSTANCE, and a rolling deploy runs two
+    # instances against one Postgres — 60 each meant 120 potential connections against a basic-plan
+    # ceiling of ~100, so a deploy could starve the database with no bug anywhere. 15 is generous for
+    # an async app on this plan; saturation now surfaces as our own pool queueing (visible, bounded)
+    # rather than Postgres refusing connections for everyone (the 2026-08-15 outage).
+    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300, pool_size=5, max_overflow=10)
 _engine = create_async_engine(_db_url, **_engine_kwargs)
 # Public: the audit writer opens its own session here (off the request path — rule #2).
 session_maker = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)
@@ -54,6 +59,16 @@ async def init_db() -> None:
 
     async with _engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
+        # Fail FAST if a migration cannot get its lock, instead of stopping the world. An ALTER on a
+        # hot table (callrecord is written by every call) needs an ACCESS EXCLUSIVE lock; without a
+        # lock_timeout it queues behind live traffic, and every NEW query then queues behind the
+        # waiting ALTER — both instances starve, the health check fails, and the shared database is
+        # left wedged for the instance that was healthy (the 2026-08-15 outage, root cause).
+        # With the timeout, a contended deploy FAILS CLEANLY in seconds: prod keeps serving on the
+        # old code, nothing is wedged, and the deploy is simply retried at a quieter moment.
+        if _engine.dialect.name == "postgresql":
+            await conn.execute(text("SET lock_timeout = '5s'"))
+            await conn.execute(text("SET statement_timeout = '120s'"))
         await conn.run_sync(_migrate_to_orgs)
 
 

--- a/tests/test_walking_skeleton.py
+++ b/tests/test_walking_skeleton.py
@@ -110,3 +110,37 @@ async def test_meta_reports_the_released_version(clients: AsyncClient):
     assert body["treg_version"], "a release check must be able to read the version from outside"
     assert body["treg_version"] != body["app_version"], "these are different questions"
     assert body["treg_version"][0].isdigit(), f"expected a version, got {body['treg_version']!r}"
+
+
+def test_the_pool_cannot_outnumber_postgres_during_a_deploy():
+    """A rolling deploy runs TWO instances against one database. At 20+40 each, that was 120
+    potential connections against a basic-plan ceiling of ~100 — a deploy could starve Postgres with
+    no bug anywhere, which is exactly what happened on 2026-08-15. Two instances of the current
+    numbers must stay comfortably under a 97-connection ceiling."""
+    import re
+    from pathlib import Path
+
+    import treg.db as db
+
+    src = Path(db.__file__).read_text()
+    m = re.search(r"pool_size=(\d+), max_overflow=(\d+)", src)
+    assert m, "expected explicit pool bounds for the postgres path"
+    per_instance = int(m.group(1)) + int(m.group(2))
+    assert per_instance * 2 <= 90, (
+        f"two deploy-time instances could hold {per_instance * 2} connections — "
+        "that is how the 2026-08-15 outage started")
+
+
+def test_migrations_fail_fast_rather_than_queueing_the_world():
+    """An ALTER on a hot table needs an exclusive lock. Without a lock_timeout it QUEUES behind live
+    traffic, and every new query then queues behind IT — both instances starve and the shared
+    database wedges (2026-08-15, root cause). The startup path must set the timeout before running
+    migrations so a contended deploy fails cleanly instead."""
+    import inspect as _inspect
+
+    import treg.db as db
+
+    src = _inspect.getsource(db.init_db)
+    assert "lock_timeout" in src, "init_db must set lock_timeout before _migrate_to_orgs"
+    assert src.index("lock_timeout") < src.index("_migrate_to_orgs"), (
+        "the timeout must be set BEFORE the migrations run")


### PR DESCRIPTION
Root-cause fix for today's outage. #122's startup migration ran `ALTER TABLE callrecord` — an
exclusive lock on the table **every live call writes**. No `lock_timeout`, so the ALTER queued behind
live traffic, every new query queued behind the ALTER, both instances starved, and the shared
Postgres stayed wedged until the **database** was restarted (an app restart could not release
server-side slots).

## Two changes, each pinned by a test

- **`init_db` sets `lock_timeout=5s` / `statement_timeout=120s` before migrations** (postgres only).
  A contended deploy now fails cleanly in seconds; prod keeps serving; retry at a quieter moment.
- **Pool: 20+40 → 5+10 per instance.** A rolling deploy runs two instances: 60 each was 120
  potential connections against a ~100 ceiling — a deploy could starve Postgres with no bug
  anywhere. The guard test requires double the configured bounds to stay under 90.

`ops/deploy.md` records the operational half: a lock-timeout failure is the mechanism **working**;
a wedged database needs the postgres resource restarted, not the web service.

SQLite has no pool and no lock queue, which is why no local test ever saw this class.

**2 new tests, 1512 pass.**