### PR TITLE
docs: the Market data shelf on the agent surfaces, and its traps in the guide

### DIFF
--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -70,6 +70,9 @@ this fragment is the *process*, not the mechanics reference.
 | 200 on a bad key; an error object present = invalid | `token_reject_field` | Serpstat `error` |
 | 200 on a bad key; an `ERROR …` text body | handled automatically (text-error guard) | Semrush |
 | No free probe; valid key 400s on empty body, invalid 401s | `probe_reject_statuses=(401,403)` | Coresignal |
+| The provider's OWN "test my auth" endpoint answers 200 with prose for a bad key | probe a DATA endpoint instead | Tiingo `/api/test` (2026-08-14; `/tiingo/daily/aapl` 403s cleanly) |
+| A second host that answers 200 to anything (demo/free tier) | pin the host that rejects | CoinGecko demo host (2026-08-14) |
+| Accepts ANY key on every endpoint, even premium ones | DROP — cannot ship | Alpha Vantage (2026-08-14: `apikey=bogus123` returned real quote data) |
 | Ongoing tool health check | `probe_path` (a cheap GET on `base_url`) | most |
 
 The connect verify already parses JSON only when the response *is* JSON (so a CSV/text body doesn't error), and

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -152,6 +152,11 @@ provenance says whose price it is.
 An endpoint treg has no published price for is **refused**, not served free — you are told to
 connect your own key instead.
 
+**New shelf: Market data** (crypto + stocks) — coingecko, polygon, finnhub, twelvedata, fmp, eodhd,
+marketstack, tiingo. Connect-your-own-key today; catalogued endpoints and treg-key serving are being
+added. (Alpha Vantage is deliberately absent: its API accepts any key, so a pasted key can never be
+verified.)
+
 **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists
 every provider serving the same job with `COST`, `WORKS` (the success rate treg has actually
 observed, with its sample size), `SPEED` (median) and `LAST OK`. Work down this order:


### PR DESCRIPTION
llms.txt announces the new shelf in the connect section (catalog counts deliberately NOT bumped: no catalogued endpoints yet). The guide gains three dated trap rows from the market-data batch, for the hunter loop to inherit. Docs only; goes live with the next deploy.