### PR TITLE
feat(billing): collect a billing address and accept promotion codes at top-up

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -127,6 +127,18 @@ PaymentIntent and therefore has **no** invoice, only a receipt: attaching one wo
 the automatic charge as InvoiceItem + Invoice paid off-session, rewriting the money path and its
 idempotency guarantees for the minority of payments. Say "invoice" only about the manual path.
 
+The address on that invoice comes from `billing_address_collection="required"` **plus**
+`customer_update={"address": "auto", "name": "auto"}` on the same session. Both are needed: the first
+asks, the second persists the answer onto the Customer so the next top-up and the portal's invoice
+archive already have it. Collecting without `customer_update` looks like it works and stores nothing.
+
+**A promotion code discounts the price, it does not bonus the balance.** `allow_promotion_codes=True`
+puts the code field on the top-up Checkout (codes are created in the Stripe dashboard, so a campaign
+needs no deploy). Because the webhook credits `amount_total` — what Stripe actually collected — 20%
+off means $40 paid and $40 credited. "Pay $40, get $50" would be a `ledger.grant` on top and is not
+built. A 100%-off code collects nothing, so the session credits nothing: `_on_checkout_completed`
+drops it as `zero amount`. Grant free balance through `ledger.grant`, never through a Stripe coupon.
+
 Turning `invoice_creation` on makes Stripe emit `invoice.created` / `invoice.paid` for every top-up.
 `handle_webhook_event` drops them, deliberately: crediting on an invoice event as well as on the
 PaymentIntent would be a second door onto the same money. The invoice is a document; the

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -266,6 +266,17 @@ async def create_topup_checkout(
     which is what a finance team actually accepts. It is post-purchase — the invoice appears once the
     payment succeeds, not when the session opens — so nothing here changes what the payer sees.
 
+    `billing_address_collection` + `customer_update` are what put a real address on that invoice. The
+    address is asked for on the Checkout page and written back to the Customer, so the NEXT top-up —
+    and every portal-rendered invoice — already has it. Without `customer_update` Stripe collects the
+    address for the payment and then throws it away, which is the failure mode that looks like it
+    works.
+
+    `allow_promotion_codes` shows the "Add promotion code" field. Note what a discount does downstream:
+    the webhook credits `amount_total`, i.e. what Stripe actually collected, so 20% off means the payer
+    pays $40 and is credited $40 of balance — a discount on the price, NOT a bonus on the balance. A
+    "pay $40, get $50" promotion is a different mechanism (`ledger.grant`) and is not built.
+
     Currency is pinned to USD explicitly — the Stripe account's own default is AUD, and inheriting it
     would charge a number the ledger would then credit as dollars.
     """
@@ -307,6 +318,14 @@ async def create_topup_checkout(
                 "metadata": {"treg_org_id": str(org.id), "treg_kind": "topup"},
             },
         },
+        # Billing identity for that invoice (see docstring). "required" asks every payer, not only the
+        # ones whose payment method forces it; `customer_update` is what persists the answer onto the
+        # Customer instead of onto this one payment.
+        billing_address_collection="required",
+        customer_update={"address": "auto", "name": "auto"},
+        # The promotion-code field. Codes themselves are created in the Stripe dashboard, so a campaign
+        # needs no deploy here.
+        allow_promotion_codes=True,
         # Idempotent per (org, amount, minute): a double-clicked "Add funds" reuses the same session
         # instead of opening a second one the payer might also complete.
         metadata={"treg_org_id": str(org.id), "treg_kind": "topup"},


### PR DESCRIPTION
Two additions to the one-off top-up Checkout (`create_topup_checkout`, `src/treg/billing.py`). VAT is deliberately **not** in here.

## Billing address

The session already sets `invoice_creation`, so every manual top-up produces a real Stripe Invoice — but the address line was blank, because nothing ever asked for one. Now:

- `billing_address_collection="required"` — asks every payer, not just the ones whose payment method forces it.
- `customer_update={"address": "auto", "name": "auto"}` — persists the answer onto the Customer.

Both are needed. Collecting without `customer_update` attaches the address to the single payment and then discards it, so the next top-up asks again and the portal's invoice archive stays blank. That is the failure mode that looks like it works.

## Promotion codes

`allow_promotion_codes=True` shows the "Add promotion code" field. Codes are created in the Stripe dashboard, so running a campaign needs no deploy.

**Semantics worth knowing before you make a code** — the webhook credits `amount_total`, i.e. what Stripe actually collected:

- 20% off a $50 top-up → payer pays $40, is credited **$40** of balance. A discount on the price, not a bonus on the balance.
- "Pay $40, get $50" is a different mechanism (`ledger.grant` on top) and is not built.
- A 100%-off code collects nothing, so `_on_checkout_completed` drops the session as `zero amount` and no balance appears. Free balance goes through `ledger.grant`, never through a Stripe coupon.

## Not included: VAT

`automatic_tax` needs Stripe Tax enabled with an origin address and a registration per jurisdiction; without registrations it computes $0 everywhere and just adds latency. `tax_id_collection` is likewise left off — the Customer Portal already lets a payer add their tax ID, and it lands on the invoices. Both are a one-line follow-up once the registrations exist.

## Verification

- `uv run --frozen python -m pytest tests/test_billing.py -q` → 65 passed.
- `drift.sh` maps `billing.py` → `architecture/money.md`; that fragment is updated in the same commit.
- Not exercised against live Stripe — the Checkout page itself should be eyeballed once in test mode after deploy (address fields present, promo field present, a test coupon applies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BpB749ufgKDUAzibW88pJ