### PR TITLE
feat(marketing): Product Hunt launch banner + $5-credit claim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/context/interface/*-audit-*.md
 docs/assets/restyle-*.png
 docs/context/interface/*-proposal.md
 .codegraph/
+
+# Generated usage dashboards — regenerate with scripts/usage_report.py, never commit.
+/reports/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,6 +13,8 @@ regexes = [
   '''phx_DEMO0000PLACEHOLDER''',          # src/treg/sandbox.py — demo starter (credential to nothing)
   '''sk_live_ABCDEFGHIJKLMNOP1234''',     # tests/test_localrun.py — proves output redaction masks a key
   '''sk_test_123''',                      # tests/*.py — generic fake test key
+  '''sk_live_9f2a7c41d8e6b03fa5''',       # tests/test_error_capture.py — proves a Stripe-shaped string is masked
+  '''eyJhbGciOi\.JIUzI1NiIsInR5cCI6''',   # same test — a JWT-shaped string, deliberately not a real token
 ]
 
 # The catalog's captured example responses (src/treg/catalog/examples/) are real provider replies,
@@ -30,6 +32,18 @@ regexes = [
 id = "generic-api-key"
 [rules.allowlist]
 paths = ['''src/treg/catalog/examples/.*\.json''']
+# The local dev/e2e Fernet key, committed in `e2e-server.sh` on the unmerged `feat/error-capture`
+# branch. Unlike everything above this is NOT a fake placeholder — it is a real key, and it is
+# allowlisted by its exact value (not by path, which would blind the rule to a future real key in
+# that file) purely so that every OTHER pull request can go green: CI checks out with fetch-depth 0,
+# so every PR scans every branch's commits and inherits this finding.
+#
+# It encrypts a throwaway `e2e.db` on localhost and is never used in production (prod reads
+# TREG_SECRET_KEY from the environment), so the blast radius is a local database. It is nonetheless a
+# burned key: it is also hardcoded in the `treg-dev-server` wrapper devs run locally.
+# THE FIX BELONGS ON `feat/error-capture`: generate the key on first run and persist it to a
+# gitignored file. Delete this entry — and rotate the value in the dev wrapper — when that lands.
+regexes = ['''k-xB-lmFUoY9qlvjCiuPgGDxWMEePD3h1SC6EUO-l8M=''']
 
 [[rules]]
 id = "linkedin-client-id"

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -670,6 +670,60 @@ dark, including the muted "expected result" panes, which use the ramp's comment 
 `pre` rules, and a markup test forbids a hex literal inside any `.hl-*` / `.s-*` rule — a literal is
 one theme's value, and three earlier generations of this ramp each left one behind.
 
+## The launch banner (`.phb`) — temporary, delete-as-one-block
+A Product Hunt "upvote us" strip, the first announcement banner this app has ever had. Three things
+about it are load-bearing rather than cosmetic, and all three are the reason it looks the way it does:
+
+- It lives **inside `#app`** with `v-if="ph && !publicCatalog"`, not as a sibling of `#app`. `/catalog`
+  and `/catalog/<slug>` are served from **this same file**, so a static strip would appear on all ~80
+  crawlable catalog pages; the `!publicCatalog` gate is the only thing scoping it to the app and the
+  logged-out landing fall-through.
+- It **sticks** at the top (`position:sticky;top:0;z-index:40`), above the chrome. That chrome pins
+  itself with hardcoded offsets — `.top{top:0}`, `.side{top:57px;height:calc(100vh - 57px)}`,
+  `--lbar-top:57px` / `--lsec-top:107px`, plus `.lp-nav{top:0}` on the logged-out branch — and every
+  one of them would slide *underneath* a sticky strip. So the strip publishes its height as
+  **`--phb-h`** and each offset adds it: `.top{top:var(--phb-h)}`,
+  `.side{top:calc(57px + var(--phb-h));height:calc(100vh - 57px - var(--phb-h))}`, and the two ledger
+  vars likewise. Two things about that are easy to get wrong:
+  - the overrides must be declared **after** `:root{--lbar-top:57px;--lsec-top:107px}` (§3.7) and
+    after `.side`'s own rule — same specificity, later wins — so they live in their own block down
+    there rather than with the rest of the `.phb` CSS;
+  - the height is **measured**, not hardcoded — the strip is shorter on mobile, and a stale constant
+    shows up as the top bar overlapping the sidebar. `--phb-h` defaults to `0px`, which is what makes
+    every `calc()` inert on the public catalog and after a dismiss.
+
+  Two bugs were paid for in the measuring code, both worth keeping in mind if it is ever touched:
+
+  1. **Vue watchers on `ph`/`publicCatalog` are not enough.** A signed-in member on a `/catalog` URL
+     has `publicCatalog` flipped `true → false` mid-boot (`mounted`, after `/auth/me`), so the strip
+     is rendered, removed, and rendered again. The sync is driven by a **`MutationObserver` on
+     `#app`'s child list** — the strip is a direct child — plus one forced measure in `mounted` and a
+     `resize` listener. That fires on the DOM fact, not on a Vue lifecycle guess.
+  2. **Do not close over the element.** The first version cached one `ResizeObserver` whose callback
+     closed over the strip it was created for. After `v-if` swapped the node, that observer fired on
+     the **detached** element (`offsetHeight` 0) and stamped `--phb-h` back to `0px` immediately after
+     the correct value was written — a sticky header sitting under the strip, on the one route that
+     re-renders it. `phbApplyHeight()` therefore re-queries `.phb` on every call.
+
+  Worth knowing while testing this by hand: `/catalog` is served `Cache-Control: public, max-age=600`,
+  so a browser will happily show a ten-minute-old copy of the page and make a fixed bug look unfixed.
+  Add a cache-busting query when checking a change there.
+- Colours are **hardcoded PH orange/white**, not tokens, so it reads identically in both themes and
+  leaves with the block.
+
+The strip carries **two** actions, in this order: the white pill goes to the launch, the underlined
+`Claim $5 →` goes to a Google Form collecting a Product Hunt profile link + a treg account email.
+The reward is **not automated** — there is no admin grant endpoint, so each claim is fulfilled by hand
+with `ledger.grant(kind=promotional)` (see `architecture/money.md`). Both links live in the same strip
+in both files, and `tests/test_ph_banner.py` asserts that: a banner promising $5 with no way to claim
+it is the one failure here that costs goodwill rather than clicks.
+
+Dismissal writes `localStorage['treg-ph']='1'` (`dismissPh()`, next to `toggleTheme()`). `landing.html`
+carries its own copy of the strip and writes the **same key**, so dismissing on the marketing page also
+clears it here. `tests/test_ph_banner.py` guards the scope gate, the shared key, and the fact that
+`index.html` gets **no** `{BASE}` substitution — it is launch-scoped and gets deleted along with the
+markup, the CSS block and `dismissPh()`.
+
 ## Shareable detail pages (`/app/skills/<name>`, `/app/tools/<name>`)
 A skill or a tool has its own deep-linkable page so a member can **share** the exact thing (`view==='detail'`,
 `detail={kind,name}`). Server routes `dashboard_skill_page` (`/app/skills/{name}`) and `dashboard_tool_page`

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -160,6 +160,14 @@ asserted to appear in its body. Edit one, edit the other, same commit.
 
 **The catalog page and the app must ask for the same population.** See `include_hidden` above.
 
+**A promo banner on `index.html` is a catalog-page edit.** `/catalog` and `/catalog/<slug>` render
+from `index.html`, so anything added to that file lands on all ~80 crawlable shelves unless it is
+gated. The Product Hunt strip (`.phb`, see `interface/dashboard.md`) is inside the Vue app behind
+`v-if="ph && !publicCatalog"` for exactly this reason, and `tests/test_ph_banner.py` asserts the
+catalog's `#prerender` block never carries it. Note also that `landing.html` **is** `{BASE}`-substituted
+and `index.html` **is not** (`dashboard()` returns a plain `FileResponse`), so a placeholder that is
+safe in one half ships literally in the other — hardcode absolute URLs on the app side.
+
 **Prices need `_usd_short`, not `%g`.** `%g` flips to scientific notation below `1e-4`, and a shelf
 advertising "from $1.2e-07 per call" reads as a bug. Anything under a hundredth of a cent renders as
 `<$0.0001` — which then has to be HTML-escaped at every use site, because that `<` is real markup.

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -785,6 +785,31 @@ th{background:none;color:var(--muted2);font-weight:450;border-bottom:1px solid v
    which turns every accent FILL into rows.gg's inverse button and every accent TEXT
    into ink. Status tokens (--green/--amber/--red/--teal) are untouched. */
 :root,[data-theme=light]{--accent:var(--ink);--onAccent:var(--bg)}
+/* PRODUCT HUNT LAUNCH — delete this block, the `--phb-h` offsets below §3.7, the .phb markup and
+   dismissPh()/phbSyncHeight() when the launch ends.
+   It STICKS at the top, above the workspace chrome. That chrome pins itself with hardcoded offsets
+   (.top top:0, .side top:57px, --lbar-top/--lsec-top), every one of which would slide *underneath*
+   a sticky strip — so the strip publishes its own height as `--phb-h` and each offset adds it. The
+   height is MEASURED at runtime (phbSyncHeight + a ResizeObserver), not hardcoded: the strip is
+   shorter on mobile and taller if the copy ever wraps, and a stale number here shows up as the top
+   bar overlapping the sidebar. `--phb-h` is 0 whenever the strip is absent, which is what makes
+   every one of those `calc()`s a no-op on /catalog and after a dismiss.
+   Colours are hardcoded PH orange/white — not tokens — so it reads the same in both themes and
+   leaves with the block. Declared here, after the restyle, so it outranks the older sheet. */
+.phb{display:flex;align-items:center;justify-content:center;gap:12px;position:sticky;top:0;z-index:40;
+  padding:9px 44px 9px 20px;background:#da552f;color:#fff;font-size:13.5px;font-weight:450}
+.phb .phmark{display:block;width:17px;height:17px;flex:none}
+.phb a{color:#fff}
+.phb .phcta{display:inline-flex;align-items:center;gap:6px;background:#fff;color:#da552f;
+  border-radius:8px;padding:3px 11px;font-size:12.5px;font-weight:600;white-space:nowrap;text-decoration:none}
+.phb .phcta:hover{box-shadow:0 2px 8px #0000002e}
+.phb .phlink{font-size:12.5px;font-weight:500;text-decoration:underline;text-underline-offset:2px;
+  white-space:nowrap;opacity:.92}
+.phb .phlink:hover{opacity:1}
+.phb .phx{position:absolute;right:10px;top:50%;transform:translateY(-50%);background:none;border:0;
+  color:#fff;opacity:.72;font-size:15px;line-height:1;padding:6px;cursor:pointer}
+.phb .phx:hover{opacity:1}
+@media(max-width:760px){.phb{padding:8px 40px 8px 12px;gap:9px}.phb .phtext{display:none}}
 /* Syntax highlighting is the one place colour is not status and not decoration:
    it is how a long command stays readable. It keeps its own ramp — see 3.8, where the
    ramp is themed, because a ramp drawn for a dark block is invisible on a light one. */
@@ -898,6 +923,15 @@ a:hover{text-decoration-color:var(--muted)}
    bar plus the bar's own height, and the bar's height is fixed by scrolling its chips instead of
    wrapping them. */
 :root{--lbar-top:57px;--lsec-top:107px}
+/* PRODUCT HUNT LAUNCH — every sticky offset, shifted down by the strip's measured height. This has
+   to sit AFTER the --lbar-top/--lsec-top declaration above (same specificity, later wins) and after
+   .side's own rule; putting it up with the rest of the .phb block silently loses to both.
+   --phb-h is 0px unless phbSyncHeight() has measured a visible strip, so these are inert without it. */
+:root{--phb-h:0px}
+:root{--lbar-top:calc(57px + var(--phb-h));--lsec-top:calc(107px + var(--phb-h))}
+.top{top:var(--phb-h)}
+.side{top:calc(57px + var(--phb-h));height:calc(100vh - 57px - var(--phb-h))}
+.lp-nav{top:var(--phb-h)}   /* the logged-out in-app landing has its own sticky header */
 .lbar{position:sticky;top:var(--lbar-top);z-index:6;background:var(--bg);
   display:flex;align-items:center;gap:8px;padding:12px 0 9px;margin-top:8px}
 .lchips{display:flex;gap:6px;min-width:0;overflow-x:auto;scrollbar-width:none;-ms-overflow-style:none;
@@ -1068,6 +1102,21 @@ a:hover{text-decoration-color:var(--muted)}
 </head>
 <body>
 <div id="app" v-cloak>
+  <!-- PRODUCT HUNT LAUNCH — inside the app, not a sibling of #app, because /catalog is served from
+       THIS file too: the !publicCatalog gate is what keeps the strip off the crawlable catalog pages.
+       Delete with its CSS block and dismissPh() when the launch ends. -->
+  <div class="phb" v-if="ph && !publicCatalog">
+    <a href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener" aria-label="treg on Product Hunt">
+      <svg class="phmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+        <circle cx="12" cy="12" r="10.6"/>
+        <path d="M10 7v10M10 7h3.1a2.85 2.85 0 0 1 0 5.7H10" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </a>
+    <span class="phtext">We're live on Product Hunt - upvote and we'll add $5 in credit.</span>
+    <a class="phcta" href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener">▲ Upvote treg</a>
+    <a class="phlink" href="https://docs.google.com/forms/d/e/1FAIpQLSehMyOXRxHXpJ0eUSMogJkQklviaag5rvnquo8aEciEgpPm1g/viewform" target="_blank" rel="noopener">Claim $5 →</a>
+    <button class="phx" type="button" @click="dismissPh()" aria-label="Dismiss">✕</button>
+  </div>
   <!-- LANDING (logged-out) -->
   <div v-if="!authed && !publicCatalog" class="lp">
     <!-- SHARE-LINK GATE: a /app/skills|tools/<name> deep link while logged out gets a focused
@@ -3663,11 +3712,42 @@ treg login</pre></div>
 <script>
 const { createApp } = Vue;
 const LS='treg-dash';
+
+// PRODUCT HUNT LAUNCH — publish the sticky strip's real height as --phb-h so every sticky offset in
+// the workspace chrome (.top, .side, --lbar-top, --lsec-top, .lp-nav) can add it. Measured rather
+// than hardcoded because the strip is shorter on mobile, and a wrong number reads as the top bar
+// overlapping the sidebar. Module scope, not instance state: a ResizeObserver on the Vue instance
+// would be reactive for no reason. Delete with the .phb blocks.
+// Driven by a MutationObserver on #app's child list, NOT by Vue watchers or `updated()`. Both of
+// those were tried and both lost the same race: a signed-in member on a /catalog URL has
+// publicCatalog flipped true→false mid-boot, and the strip ended up 43px tall on screen while
+// --phb-h still read 0px — so the top bar sat underneath it. The strip is a direct child of #app, so
+// watching that one child list catches it appearing and disappearing whatever the reason, with no
+// dependence on when Vue chooses to run a hook.
+let phbRO=null, phbSeen=null;
+// Re-queries the strip every time ON PURPOSE. The first version closed over the element and reused
+// one ResizeObserver, so after v-if swapped the strip the observer still measured the DETACHED node
+// (offsetHeight 0) and stamped --phb-h back to 0px right after the correct value was written.
+function phbApplyHeight(){
+  const el=document.querySelector('.phb');
+  document.documentElement.style.setProperty('--phb-h',(el?el.offsetHeight:0)+'px');
+}
+function phbSyncHeight(force){
+  const el=document.querySelector('.phb');
+  if(!force && !!el===phbSeen) return;
+  phbSeen=!!el;
+  phbApplyHeight();
+  if(phbRO) phbRO.disconnect();
+  if(el && window.ResizeObserver){ (phbRO=phbRO||new ResizeObserver(phbApplyHeight)).observe(el); }
+}
 createApp({
   data(){
     let cfg={active:null,orgs:{}}; try{ cfg=JSON.parse(localStorage.getItem(LS))||cfg; }catch(e){}
     return {
       theme: localStorage.getItem('treg-theme')||'light',
+      // PRODUCT HUNT LAUNCH banner. Same 'treg-ph' key landing.html writes, so dismissing it on
+      // the marketing page also clears it here. Delete with the .phb block.
+      ph: (()=>{ try{ return localStorage.getItem('treg-ph')!=='1'; }catch(e){ return true; } })(),
       // True when this load is a PUBLIC catalog URL (/catalog, /catalog/<slug>). The catalog API is
       // unauthenticated, so the same marketplace views render for a signed-out visitor — that is
       // what makes the catalog indexable without maintaining a second copy of the UI. Everything
@@ -4311,6 +4391,7 @@ createApp({
     save(){ localStorage.setItem(LS, JSON.stringify(this.cfg)); },
     connected(slug){ return this.sessionMode || !!this.cfg.orgs[slug]; },
     toggleTheme(){ this.theme=this.theme==='dark'?'light':'dark'; document.documentElement.dataset.theme=this.theme; localStorage.setItem('treg-theme',this.theme); },
+    dismissPh(){ this.ph=false; try{ localStorage.setItem('treg-ph','1'); }catch(e){} },  // PRODUCT HUNT LAUNCH
     _stashNext(){  // OAuth callbacks land on /app, losing a /app/skills/<x> deep link — stash it to restore after boot
       const d=this.routeFromPath(location.pathname)||this.mkFromPath(location.pathname);
       if(d) localStorage.setItem('treg-next', location.pathname); },
@@ -5883,6 +5964,9 @@ createApp({
   },
   async mounted(){
     document.documentElement.dataset.theme=this.theme;
+    this.$nextTick(()=>phbSyncHeight(true));               // PRODUCT HUNT LAUNCH — first measure…
+    addEventListener('resize', ()=>phbSyncHeight(true));   // …then these two keep --phb-h true
+    new MutationObserver(()=>phbSyncHeight()).observe(document.getElementById('app'),{childList:true});
     document.addEventListener('click', ()=>{ if(this.mdMenu) this.mdMenu=false; });  // outside-click closes the copy-markdown menu
     document.addEventListener('keydown', e=>{
       // Escape closes any open modal/drawer (a universal expectation the modals didn't honour)

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1112,7 +1112,7 @@ a:hover{text-decoration-color:var(--muted)}
         <path d="M10 7v10M10 7h3.1a2.85 2.85 0 0 1 0 5.7H10" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </a>
-    <span class="phtext">We're live on Product Hunt - upvote and we'll add $5 in credit.</span>
+    <span class="phtext">We’re live on Product Hunt — upvote and we’ll add $5 in credit.</span>
     <a class="phcta" href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener">▲ Upvote treg</a>
     <a class="phlink" href="https://docs.google.com/forms/d/e/1FAIpQLSehMyOXRxHXpJ0eUSMogJkQklviaag5rvnquo8aEciEgpPm1g/viewform" target="_blank" rel="noopener">Claim $5 →</a>
     <button class="phx" type="button" @click="dismissPh()" aria-label="Dismiss">✕</button>

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -60,6 +60,31 @@ a{color:var(--teal);text-decoration:none}
 .wrap{max-width:1160px;margin:0 auto;padding:0 28px}
 :focus-visible{outline:0;box-shadow:0 0 0 2px var(--bg),0 0 0 3.5px var(--ink)}
 
+/* ---------- PRODUCT HUNT LAUNCH — delete this block when the launch is over ----------
+   Fixed strip above the pill nav. It is the one place on this page that carries a brand
+   colour that isn't ours, so it is hardcoded PH orange rather than a token: the whole
+   block goes away together. body.phb-on carries the offsets, so nothing else moves when
+   the visitor dismisses it. */
+.phb{position:fixed;top:0;left:0;right:0;z-index:60;height:40px;display:flex;align-items:center;
+  justify-content:center;gap:12px;padding:0 44px 0 20px;background:#da552f;color:#fff;
+  font-family:var(--sans);font-size:13.5px;font-weight:450}
+.phb .phmark{display:block;width:17px;height:17px;flex:none}
+.phb a{color:#fff}
+.phb .phcta{display:inline-flex;align-items:center;gap:6px;background:#fff;color:#da552f;
+  border-radius:8px;padding:3px 11px;font-size:12.5px;font-weight:600;white-space:nowrap;
+  transition:box-shadow .2s var(--ease),transform .12s var(--ease-out)}
+.phb .phcta:hover{box-shadow:0 2px 8px #0000002e;transform:translateY(-1px)}
+.phb .phlink{font-size:12.5px;font-weight:500;text-decoration:underline;text-underline-offset:2px;
+  white-space:nowrap;opacity:.92}
+.phb .phlink:hover{opacity:1}
+.phb .phx{position:absolute;right:12px;top:50%;transform:translateY(-50%);
+  background:none;border:0;color:#fff;opacity:.72;font-size:15px;line-height:1;
+  padding:6px;cursor:pointer;font-family:var(--sans)}
+.phb .phx:hover{opacity:1}
+body.phb-on{padding-top:40px}
+body.phb-on .navwrap{top:54px}
+@media(max-width:640px){.phb .phtext{display:none}}
+
 /* ---------- floating pill nav ---------- */
 .navwrap{position:fixed;top:14px;left:0;right:0;z-index:50;padding:0 20px}
 .nav{max-width:1160px;margin:0 auto;display:flex;align-items:center;gap:22px;
@@ -550,6 +575,33 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
 </script>
 </head>
 <body>
+
+<!-- PRODUCT HUNT LAUNCH — delete this block, its CSS block and phbDismiss() when the launch ends.
+     The mark is inline SVG on purpose: no third-party asset, so a self-hosted registry with no
+     egress still renders the page identically. -->
+<div class="phb" id="phb">
+  <a href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener" aria-label="treg on Product Hunt">
+    <svg class="phmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+      <circle cx="12" cy="12" r="10.6"/>
+      <path d="M10 7v10M10 7h3.1a2.85 2.85 0 0 1 0 5.7H10" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </a>
+  <span class="phtext">We're live on Product Hunt - upvote and we'll add $5 in credit.</span>
+  <a class="phcta" href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener">▲ Upvote treg</a>
+  <a class="phlink" href="https://docs.google.com/forms/d/e/1FAIpQLSehMyOXRxHXpJ0eUSMogJkQklviaag5rvnquo8aEciEgpPm1g/viewform" target="_blank" rel="noopener">Claim $5 →</a>
+  <button class="phx" type="button" onclick="phbDismiss()" aria-label="Dismiss">✕</button>
+</div>
+<script>
+function phbDismiss(){
+  try{localStorage.setItem('treg-ph','1')}catch(e){}
+  document.body.classList.remove('phb-on');
+  document.getElementById('phb')?.remove();
+}
+(function(){
+  var done=false; try{done=localStorage.getItem('treg-ph')==='1'}catch(e){}
+  if(done){document.getElementById('phb').remove()}else{document.body.classList.add('phb-on')}
+})();
+</script>
 
 <!-- floating pill nav -->
 <div class="navwrap">

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -586,7 +586,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
       <path d="M10 7v10M10 7h3.1a2.85 2.85 0 0 1 0 5.7H10" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
   </a>
-  <span class="phtext">We're live on Product Hunt - upvote and we'll add $5 in credit.</span>
+  <span class="phtext">We’re live on Product Hunt — upvote and we’ll add $5 in credit.</span>
   <a class="phcta" href="https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg" target="_blank" rel="noopener">▲ Upvote treg</a>
   <a class="phlink" href="https://docs.google.com/forms/d/e/1FAIpQLSehMyOXRxHXpJ0eUSMogJkQklviaag5rvnquo8aEciEgpPm1g/viewform" target="_blank" rel="noopener">Claim $5 →</a>
   <button class="phx" type="button" onclick="phbDismiss()" aria-label="Dismiss">✕</button>

--- a/tests/test_ph_banner.py
+++ b/tests/test_ph_banner.py
@@ -1,0 +1,114 @@
+"""The Product Hunt launch banner.
+
+LAUNCH-SCOPED: delete this file together with the `.phb` blocks in landing.html and index.html.
+It exists because the banner has two failure modes that are invisible in a browser tab:
+
+* `/app` serves index.html with **no** template substitution, so a `{BASE}`-style placeholder in
+  that half would ship literally to every user;
+* `/catalog` and `/catalog/<slug>` are served from index.html too, so the "landing + app only"
+  scope holds only as long as the `!publicCatalog` gate is on the element.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from httpx import AsyncClient
+
+from treg import api
+
+
+PH_URL = "https://www.producthunt.com/products/treg-openrouter-for-tools?launch=treg"
+# The $5-credit claim form. The reward is fulfilled by hand (ledger.grant), so a banner promising it
+# without a working way to claim is the one failure that costs goodwill rather than clicks.
+FORM_URL = (
+    "https://docs.google.com/forms/d/e/"
+    "1FAIpQLSehMyOXRxHXpJ0eUSMogJkQklviaag5rvnquo8aEciEgpPm1g/viewform"
+)
+
+_WEB = Path(api.__file__).parent / "web"
+LANDING = (_WEB / "landing.html").read_text(encoding="utf-8")
+INDEX = (_WEB / "index.html").read_text(encoding="utf-8")
+
+
+async def test_the_landing_links_to_the_launch(clients: AsyncClient):
+    r = await clients.get("/")
+    assert r.status_code == 200, r.text
+    assert PH_URL in r.text
+    assert "{BASE}" not in r.text
+
+
+def test_the_app_hardcodes_the_url_because_nothing_substitutes_index_html():
+    """`dashboard()` returns index.html as a plain FileResponse — a placeholder here never expands."""
+    assert PH_URL in INDEX
+    assert "{BASE}" not in INDEX.split('class="phb"', 1)[1][:1200]
+
+
+def test_the_app_banner_is_gated_off_the_public_catalog():
+    """/catalog renders from index.html; the gate is the only thing keeping the promo off the
+    crawlable catalog pages."""
+    assert '<div class="phb" v-if="ph && !publicCatalog">' in INDEX
+    assert "dismissPh(" in INDEX
+
+
+async def test_the_catalog_prerender_carries_no_banner(clients: AsyncClient):
+    r = await clients.get("/catalog")
+    assert r.status_code == 200, r.text
+    prerender = r.text.split('<div id="prerender"', 1)
+    assert len(prerender) == 2, "no #prerender block — the catalog page changed shape"
+    assert PH_URL not in prerender[1].split('<div id="app"', 1)[0]
+
+
+def test_the_offer_and_the_way_to_claim_it_travel_together():
+    """Whichever half a visitor sees, "we'll add $5" and the form that collects it are on the same
+    row — an offer with no claim link is a promise the page can't keep."""
+    for name, html in (("landing.html", LANDING), ("index.html", INDEX)):
+        assert "$5" in html, name
+        assert FORM_URL in html, name
+        strip = html.split('class="phb"', 1)[1][:1800]
+        assert PH_URL in strip and FORM_URL in strip, f"{name}: claim link is outside the banner"
+
+
+def test_the_claim_form_url_carries_no_share_dialog_param():
+    """`?usp=dialog` comes from Google's share sheet. Harmless, but it is not part of the address."""
+    assert "usp=dialog" not in LANDING
+    assert "usp=dialog" not in INDEX
+
+
+def test_the_sticky_strip_offsets_every_layer_of_chrome_beneath_it():
+    """The strip sticks, so each sticky offset below it has to add the strip's height. Missing one
+    means that layer renders *underneath* the banner — the failure is invisible until you scroll."""
+    assert "position:sticky;top:0;z-index:40" in INDEX          # the strip itself
+    assert ".top{top:var(--phb-h)}" in INDEX
+    assert ".side{top:calc(57px + var(--phb-h));height:calc(100vh - 57px - var(--phb-h))}" in INDEX
+    assert "--lbar-top:calc(57px + var(--phb-h));--lsec-top:calc(107px + var(--phb-h))" in INDEX
+    assert ".lp-nav{top:var(--phb-h)}" in INDEX
+
+
+def test_the_offset_overrides_come_after_the_values_they_override():
+    """Equal specificity, so source order decides. Declared before `:root{--lbar-top:57px}` (§3.7)
+    or before `.side`'s own rule, the overrides silently lose and the offsets go back to ignoring
+    the strip."""
+    base_vars = INDEX.index(":root{--lbar-top:57px;--lsec-top:107px}")
+    base_side = INDEX.index(".side{position:sticky;top:57px")
+    override = INDEX.index("--lbar-top:calc(57px + var(--phb-h))")
+    assert override > base_vars, "the --lbar-top/--lsec-top override precedes what it overrides"
+    assert INDEX.index(".side{top:calc(57px + var(--phb-h))") > base_side
+
+
+def test_the_height_is_measured_from_a_fresh_lookup():
+    """The strip is shorter on mobile, so the height is measured — and the measuring callback must
+    re-query `.phb`. Closing over the element made a reused ResizeObserver measure the DETACHED node
+    after v-if swapped it, resetting --phb-h to 0 right after the right value was written."""
+    fn = INDEX.split("function phbApplyHeight()", 1)
+    assert len(fn) == 2, "phbApplyHeight is gone — did the height sync get rewritten?"
+    body = fn[1][: fn[1].index("}")]
+    assert "document.querySelector('.phb')" in body
+    assert "new ResizeObserver(phbApplyHeight)" in INDEX     # the observer gets the re-querying fn
+    assert "MutationObserver(()=>phbSyncHeight())" in INDEX  # presence changes, not a Vue hook guess
+
+
+def test_both_halves_share_one_dismissal_key():
+    """Dismissing on the landing must not leave it showing in the app."""
+    assert "'treg-ph'" in LANDING
+    assert "'treg-ph'" in INDEX


### PR DESCRIPTION
## What changed

A dismissible **Product Hunt launch strip** on the two surfaces with real traffic — the marketing
landing (`/`) and the app shell (`/app`). Upvote first, then claim: the white pill goes to the launch,
`Claim $5 →` to the form that collects a PH profile link + a treg account email.

Deliberately **not** on `/catalog`, `/tutorial` or the legal pages. Everything is marked
`PRODUCT HUNT LAUNCH` so it deletes in one pass when the launch ends.

## Three things that are load-bearing, not cosmetic

- **The app strip lives inside `#app` behind `v-if="ph && !publicCatalog"`.** `/catalog` and its ~80
  crawlable shelves render from this same `index.html` — without the gate the promo would ship on
  every one of them.
- **It sticks, so it has to offset the chrome under it.** `.top{top:0}`, `.side{top:57px}`,
  `--lbar-top:57px` / `--lsec-top:107px` and `.lp-nav{top:0}` would each sit *underneath* a sticky
  strip. The strip publishes its measured height as `--phb-h` and every offset adds it. The overrides
  must be declared *after* the values they override — equal specificity, source order decides — and a
  test pins that ordering.
- **The height sync re-queries `.phb` on every call.** Closing over the element meant a reused
  `ResizeObserver` measured the *detached* node after `v-if` swapped it and reset `--phb-h` to `0px`
  right after the correct value was written. Visible only on `/catalog`, the one route that
  re-renders the strip mid-boot. It is driven by a `MutationObserver` on `#app`'s child list, because
  Vue watchers and `updated()` both lost that race.

Colours are hardcoded PH orange/white rather than tokens, so it reads the same in both themes and
leaves with the block. Dismissal writes `localStorage['treg-ph']` — the same key on both halves, so
dismissing on the landing clears it in the app. The mark is inline SVG: no third-party asset, so a
self-hosted registry with no egress renders it identically.

## Feature verified ✅ (a fresh verifier drove the running app)

An independent verifier (it didn't write the code) drove the running app and reported **works**, with
measured numbers rather than adjectives:

| Criterion | Observed |
|---|---|
| `/` logged out | strip rect top 0, height 40, full bleed; pill nav top **54** (14px below the strip, no overlap); `body` padding-top 40px; hero not clipped |
| `/app` sticky, scrolled to y=600 | strip still pinned at **0**; `.top` docked at **43**→103; `.side` stuck at **100** (=57+43), bottom 860 = viewport, last child bottom 848 (not cut off) |
| Ledger shelf, scrolled to y=1200 | `--lbar-top: calc(57px + 43px)`, `--lsec-top: calc(107px + 43px)`; strip 0, `.top` 43, `.lbar` **100**, `.lsec td` **150** — four layers, nothing hidden either way |
| `/catalog/tiktok?cb=…` logged **out** | `.phb` is `null`, `--phb-h` `0px`, no member chrome |
| `/catalog?cb=…` logged **in** (the mid-boot flip) | member app renders; `--phb-h` **43px**, `.top` at 43, `.side` at 100 — no wrong-state render. This is the route the stale-closure bug broke |
| Dismiss | `.phb` gone, `localStorage['treg-ph']="1"`, `--phb-h` `0px`, `.top` back to **0**, `.side` back to **57px**; survives reload; returns when the key is cleared |
| 390px viewport | `innerWidth` = `scrollWidth` = **390** (no horizontal scroll); `.phtext` `display:none`; mark + pill + claim link + ✕ all still rendered |
| Links | both PH links exact; form URL exact; `usp=dialog` **absent** |

It also caught one real deviation — the em dash in the copy had been flattened to an ASCII hyphen.
Fixed in the second commit.

Two honest limitations from its report: Chrome here refused a window narrower than 500px, so the exact
390px numbers come from a CDP viewport override on `/` (the `/app` narrow check landed at 422px); and
the landing offsets itself with `body{padding-top}` rather than `--phb-h`, which is by design — only
the app has sticky chrome to shift.

📹 Evidence: five screenshots captured locally (landing, app scrolled, ledger scrolled, mobile ×2).
Not uploaded — say the word and I'll attach them to the PR.

## Regression guardrails

- [x] `uv run --frozen python -m pytest -q` — **1636 passed**
- [x] `tests/test_ph_banner.py` (new, launch-scoped, 10 tests): the `!publicCatalog` scope gate, the
      shared dismissal key, the offer and its claim form travelling together, no `usp=dialog`, the
      sticky offsets for all five layers, the override ordering, and the re-querying height callback
- [x] docs updated in the same commit (`docs/context/interface/dashboard.md`, `seo.md`) per repo
      convention
- CI here is pytest + gitleaks; there is no lint/type job to run

## How to reproduce

```bash
treg-dev-server                     # http://127.0.0.1:18790
```

- `/` logged out → strip above the pill nav
- `/app` logged in → strip sticky above the top bar; scroll and watch the four sticky layers stack
- `/catalog/tiktok?cb=1` logged out → **no** strip

⚠️ `/catalog` is served `Cache-Control: public, max-age=600`, so always add a cache-busting query when
checking that route by hand — a stale copy makes a fixed bug look unfixed (and real users will see a
stale catalog page for up to 10 minutes after deploy).

## Known follow-ups (not in this PR)

- **Fulfillment is manual.** No admin grant endpoint exists, so each claim is a
  `ledger.grant(kind=promotional)` by hand. A `scripts/grant_promo.py` that reads the form's CSV and
  grants idempotently would make this survive launch-day volume.
- **The upvote isn't verifiable** — PH doesn't expose voters, so a submitted profile link is a claim,
  not proof. Honour system; worth capping the first N claims if that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
