### PR TITLE
feat(ads): Google Ads conversion tracking — signup, first call, first top-up

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -24,6 +24,7 @@ Regenerate via `scripts/build-map.py`.
 | `render.yaml` | ops/deploy.md |
 | `scripts/build_plugin.py` | interface/skill.md |
 | `src/treg/__main__.py` | ops/deploy.md |
+| `src/treg/adsconv.py` | architecture/ads-conversions.md |
 | `src/treg/agents.py` | interface/cli.md |
 | `src/treg/analytics.py` | architecture/data-model.md |
 | `src/treg/api.py` | architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, guides/expanding-a-category.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
@@ -61,6 +62,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/session.py` | interface/dashboard.md |
 | `src/treg/shell.py` | interface/shell.md |
 | `src/treg/skills.py` | interface/env-import.md |
+| `src/treg/web/adtrack.js` | architecture/ads-conversions.md |
 | `src/treg/web/catalog.css` | interface/seo.md |
 | `src/treg/web/connect-demo.html` | architecture/mcp-oauth.md |
 | `src/treg/web/index.html` | interface/dashboard.md, interface/landing-sandbox.md, interface/onboarding.md, interface/seo.md |
@@ -79,6 +81,7 @@ Regenerate via `scripts/build-map.py`.
 
 | Fragment | Sources |
 |---|---|
+| `architecture/ads-conversions.md` | `adsconv.py`, `adtrack.js` |
 | `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
 | `architecture/catalog.md` | `catalog_store.py`, `endpoint_stats.py` |
 | `architecture/data-model.md` | `models.py`, `db.py`, `audit.py`, `analytics.py`, `ratestore.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -16,6 +16,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
+| [Google Ads conversion tracking — capture, outbox, upload](architecture/ads-conversions.md) | shipped | adsconv.py, adtrack.js |
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog_store.py, endpoint_stats.py |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, analytics.py, … |

--- a/docs/context/architecture/ads-conversions.md
+++ b/docs/context/architecture/ads-conversions.md
@@ -1,0 +1,150 @@
+---
+title: Google Ads conversion tracking — capture, outbox, upload
+status: shipped
+sources:
+  - src/treg/adsconv.py
+  - src/treg/web/adtrack.js
+related:
+  - architecture/money.md
+  - architecture/multi-tenancy.md
+  - architecture/data-model.md
+  - architecture/proxy-model.md
+  - ops/deploy.md
+---
+
+# Google Ads conversion tracking
+
+Off unless both `google_ads_customer_id` and `ads_conv_org_slug` are set (`adsconv.enabled()`) —
+keeps the test suite and self-hosted instances from starting a task that only ever no-ops. When off,
+nothing is captured, queued or uploaded; the whole feature is additive.
+
+## The chain: capture → store → fire → upload
+
+1. **Capture** (`web/adtrack.js`, a first-party script, no Google tag). It reads `gclid`/`gbraid`/
+   `wbraid` off the URL — `gbraid`/`wbraid` are what Google substitutes on iOS traffic, and omitting
+   them silently drops a large share of mobile conversions — and writes them into a `treg_ad` cookie
+   (90 days, the length of Google's click-through attribution window; `SameSite=Lax` so it survives
+   the cross-site top-level navigation an ad click is). No third-party request is made from the
+   browser at any point.
+2. **Store** (`api._ad_attribution_from`, read at BOTH signup doors — `register_user` (`POST /users`)
+   and `create_org` (`POST /orgs`), since a browser visitor who clicked an ad can land on either).
+   The cookie is decoded and persisted onto the new `Org`: `ad_gclid`, `ad_landing` (the use-case page
+   slug or `ref`/`utm_content`), `ad_click_at`. Once set, never overwritten — attribution is "first
+   click that led to a signup," not "most recent."
+3. **Fire** — three chokepoints call `adsconv.queue(db, org, action, ...)`, which writes an
+   `AdConversion` outbox row inside a `SAVEPOINT` (a nested transaction, not a bare flush or a
+   `db.rollback()` — this runs inside the CALLER's transaction, and a plain rollback on a duplicate
+   would roll back their work too, e.g. undoing a Stripe credit on a redelivered webhook):
+   - `api._grant_signup_promo` → `ACTION_SIGNUP`, queued BEFORE `ledger.grant()`.
+   - `api._record_first_call` → `ACTION_FIRST_CALL`, on the org's first successful `/call/`.
+   - `billing._credit` → `ACTION_PAID`, on the org's first credited top-up, carrying `value_usd_micro`.
+   `queue()` no-ops (returns `False`) for an org with no `ad_gclid` — most orgs — so the conversion
+   side stays ad-attributed-only while the product metric it rides alongside (`first_call_at`) is set
+   for every org.
+4. **Upload** (`adsconv.worker`, started from `lifespan` when `adsconv.enabled()`, drains every 300s).
+   `drain_once` selects due rows — not yet uploaded, older than a 6-hour delay, under 8 attempts — and
+   POSTs one batch to the Google Ads API `uploadClickConversions` with `partialFailure` (one bad row
+   can't reject the batch). The delay exists because a `gclid` is not valid for upload until hours
+   after the click; uploading too early is rejected. A failed row is left for the next pass, never
+   dropped silently, until `_MAX_ATTEMPTS` is hit.
+
+## Idempotency: the outbox's unique constraint, not a check-then-insert
+
+`AdConversion` has one row per `(org_id, action)` (`uq_adconversion_org_action`) — this, not an
+application-level check, is what makes every fire site safe under a retried signup or a redelivered
+Stripe webhook: `queue()` tries the insert and treats the resulting `IntegrityError` as "already
+recorded," rather than racing a SELECT against a concurrent insert.
+
+## Durable outbox, deliberately NOT audit.py or analytics.py
+
+`audit.py` and `analytics.py` are both deliberately **droppable** — `audit.py` sheds rows past its
+queue bound, `analytics.py` is lossy by design — because losing a `CallRecord` or a PostHog event
+costs nothing but a metric. A lost `AdConversion` is different: it is a conversion Google never learns
+about, which trains the campaign's bidding on undercounted data, silently, in the direction that makes
+the campaign look worse than it is. So the write is durable (a row, in the firing code's transaction)
+and only the upload is best-effort/retried. Nothing in `adsconv.py` routes through `audit.py`.
+
+## `first_call_at` is NOT derived from `CallRecord`
+
+`Org.first_call_at` is set by a conditional `UPDATE` in `api._record_first_call`, not read off the
+audit table. `audit.py` sheds rows under exactly the load that makes "first call" data most valuable —
+a busy launch — so deriving the flag from `CallRecord` would undercount precisely when traffic is
+highest. `_record_first_call` runs on its **own session**, opened fresh via `session_maker()`, and
+never raises into the caller's response. This is deliberate: an earlier version committed on the
+request's own `db` session mid-settlement (the proxy call was still being billed) and broke 8 billing
+tests, because that reaches into the money transaction from outside `ledger.py` — the same rule
+`money.md` states for ledger writes applies here by extension, even though `adsconv.py` itself never
+touches balance.
+
+## Atomicity: two of three fire sites are atomic with their event, one is not
+
+- **`signup`** — atomic. `adsconv.queue()` runs before `ledger.grant()` in `_grant_signup_promo`, and
+  `grant()`'s own commit lands both rows together.
+- **`first_call`** — atomic. `_record_first_call` queues the conversion and commits once, on its own
+  session.
+- **`paid`** — **not atomic**. `billing._credit` calls `ledger.topup()`, which commits internally
+  (`ledger.py`'s money-write rule), before it queues the `paid` conversion and commits that
+  separately. A crash between the two commits loses the conversion permanently: a Stripe webhook
+  redelivery finds the payment already credited (`fresh` is `False`), and the fire site that would
+  have queued the conversion never runs again.
+
+  This gap was found in review and the decision (2026-08-17) was to **accept it and document it
+  honestly** rather than restructure `ledger.py` to make the credit and the conversion one
+  transaction. The cheap fix, if the gap ever matters in practice: a reconciliation sweep over orgs
+  that have a credited payment (a `CreditBlock`) and a `gclid` but no `paid` `AdConversion` row, in
+  the shape of `reconcile.py`'s other read-only reports. Not built.
+
+## Fixed FX: 1 AUD = 0.70 USD, set 2026-08-17
+
+`usd_micro_to_aud_micro` converts at a **constant** rate (`AUD_PER_USD_NUM=10, AUD_PER_USD_DEN=7`),
+deliberately not a live rate, so a change in reported ROAS means the business moved, not that the
+currency market did. Integer arithmetic throughout (`usd_micro * 10 // 7`) — the one permitted float
+is at the JSON boundary in `build_payload`, because the Ads API's `conversionValue` field is a wire
+double; the value that reaches it is computed from the already-integral micro amount, never the other
+way around. The outbox stores the original USD amount, never AUD, so a future FX correction doesn't
+need to rewrite history — conversion happens once, at upload time.
+
+## The three conversion actions
+
+Created live on Google Ads account `5149790776` (type `UPLOAD_CLICKS`):
+
+| Action | id | Marked |
+|---|---|---|
+| `signup` | `7723667014` | SECONDARY |
+| `first_call` | `7723667017` | PRIMARY |
+| `paid` (first top-up) | `7723667020` | PRIMARY |
+
+`signup` is deliberately **secondary**, not primary: `marketing/landing/_measurement.md` argues a
+signup measures curiosity, not commercial intent, so it should inform Google's targeting without
+being a bidding goal. `first_call` and `paid` are the two events the campaign should actually bid
+toward — an agent successfully calling a tool, and a team paying for more balance.
+
+## API version
+
+The uploader pins Google Ads API **v25** (`adsconv.API_VERSION`). v21 was sunset 2026-08-05; the pin
+moved to v25 on 2026-08-17 across every place a version is hard-coded (`oauth_providers.GOOGLE_ADS`,
+`.agents/skills/google-ads/SKILL.md`, this repo's catalog yaml) — see `architecture/auth-secrets.md`
+for the full four-places-at-once list and the two-failure-modes note (a dead version returns a typed
+`UNSUPPORTED_VERSION`, not the HTML 404 a never-existent version returns).
+
+## Testing hazard: the shared test database
+
+The suite's default SQLite file is `./treg-test.db`, and `reset_db()` (test-only) drops and recreates
+every table. Two pytest runs against the same file concurrently corrupt each other — one run's
+`reset_db()` mid-flight drops a table the other run is about to query — and the failure surfaces as a
+misleading `no such table` error that looks like a flake, not a concurrency bug. This cost this
+feature's development several hours and one conversation-round wrongly dismissing a real bug as a
+flake before the cause was found. Isolate a run with:
+
+```bash
+TREG_TEST_DB_URL="sqlite+aiosqlite:///./some-other.db" uv run --frozen python -m pytest -q
+```
+
+## Not built
+
+- **No router / auto-failover** — not applicable here (there is one destination, Google Ads), but
+  stated for consistency with the rest of the catalog: treg does not model automatic choosing.
+- **The reconciliation sweep for the `paid` atomicity gap** (above) — named as the cheap fix, not
+  implemented.
+- **The live-click verification** — needs a real ad click, cannot be automated, and runs after this
+  documentation lands, before any real spend.

--- a/docs/context/architecture/ads-conversions.md
+++ b/docs/context/architecture/ads-conversions.md
@@ -14,9 +14,10 @@ related:
 
 # Google Ads conversion tracking
 
-Off unless both `google_ads_customer_id` and `ads_conv_org_slug` are set (`adsconv.enabled()`) —
-keeps the test suite and self-hosted instances from starting a task that only ever no-ops. When off,
-nothing is captured, queued or uploaded; the whole feature is additive.
+Off unless `google_ads_customer_id`, `google_ads_developer_token` and `ads_conv_org_slug` are all set
+(`adsconv.enabled()`) — keeps the test suite and self-hosted instances from starting machinery that
+cannot upload. When off, `/adtrack.js` is an empty no-cache response and attribution cookies are
+ignored, so nothing is captured, queued or uploaded; the whole feature is additive.
 
 ## The chain: capture → store → fire → upload
 
@@ -25,12 +26,15 @@ nothing is captured, queued or uploaded; the whole feature is additive.
    them silently drops a large share of mobile conversions — and writes them into a `treg_ad` cookie
    (90 days, the length of Google's click-through attribution window; `SameSite=Lax` so it survives
    the cross-site top-level navigation an ad click is). No third-party request is made from the
-   browser at any point.
+   browser at any point. The cookie records the mutually-exclusive field name as well as its value
+   (`gclid|…`, `gbraid|…`, or `wbraid|…`); the old `CLICK_ID|landing` shape remains readable as a
+   legacy GCLID.
 2. **Store** (`api._ad_attribution_from`, read at BOTH signup doors — `register_user` (`POST /users`)
    and `create_org` (`POST /orgs`), since a browser visitor who clicked an ad can land on either).
-   The cookie is decoded and persisted onto the new `Org`: `ad_gclid`, `ad_landing` (the use-case page
-   slug or `ref`/`utm_content`), `ad_click_at`. Once set, never overwritten — attribution is "first
-   click that led to a signup," not "most recent."
+   The cookie is decoded and persisted onto the new `Org`: `ad_gclid` (the historical column name,
+   now holding any supported click id), `ad_click_id_type`, `ad_landing` (the use-case page slug or
+   `ref`/`utm_content`), `ad_click_at`. Once set, never overwritten — attribution is "first click that
+   led to a signup," not "most recent."
 3. **Fire** — three chokepoints call `adsconv.queue(db, org, action, ...)`, which writes an
    `AdConversion` outbox row inside a `SAVEPOINT` (a nested transaction, not a bare flush or a
    `db.rollback()` — this runs inside the CALLER's transaction, and a plain rollback on a duplicate
@@ -38,15 +42,30 @@ nothing is captured, queued or uploaded; the whole feature is additive.
    - `api._grant_signup_promo` → `ACTION_SIGNUP`, queued BEFORE `ledger.grant()`.
    - `api._record_first_call` → `ACTION_FIRST_CALL`, on the org's first successful `/call/`.
    - `billing._credit` → `ACTION_PAID`, on the org's first credited top-up, carrying `value_usd_micro`.
-   `queue()` no-ops (returns `False`) for an org with no `ad_gclid` — most orgs — so the conversion
-   side stays ad-attributed-only while the product metric it rides alongside (`first_call_at`) is set
-   for every org.
+   `queue()` no-ops (returns `False`) when tracking is disabled or the org has no `ad_gclid` — most
+   orgs — so the conversion side stays ad-attributed-only while the product metric it rides alongside
+   (`first_call_at`) is set for every org.
 4. **Upload** (`adsconv.worker`, started from `lifespan` when `adsconv.enabled()`, drains every 300s).
-   `drain_once` selects due rows — not yet uploaded, older than a 6-hour delay, under 8 attempts — and
-   POSTs one batch to the Google Ads API `uploadClickConversions` with `partialFailure` (one bad row
-   can't reject the batch). The delay exists because a `gclid` is not valid for upload until hours
-   after the click; uploading too early is rejected. A failed row is left for the next pass, never
-   dropped silently, until `_MAX_ATTEMPTS` is hit.
+   `drain_once` selects due rows — neither uploaded nor terminal, older than a 6-hour delay, and past
+   `next_attempt_at` — and POSTs one batch to the Google Ads API `uploadClickConversions` with
+   `partialFailure`. The payload uses the stored click-id field; a braid is never mislabeled as a
+   GCLID. Results are acknowledged per operation index: a successful sibling is marked uploaded, a
+   failed sibling is not. `CLICK_CONVERSION_ALREADY_EXISTS` is also acknowledged because Google has
+   already stored it. HTTP failures, batch/unparseable responses and explicitly transient row errors
+   retry indefinitely with exponential backoff capped at 24 hours. Other indexed per-row errors retry
+   through eight attempts, then retain the row as a visible dead letter (`failed_at` + `error`). The
+   six-hour delay exists because a click id may not be accepted immediately after the click; uploading
+   too early can be rejected.
+
+## Authentication and manager accounts
+
+The uploader decrypts the `google-ads` OAuth `Secret` belonging to `ads_conv_org_slug`, then sends that
+bearer token with the platform `google_ads_developer_token`. `google_ads_customer_id` is the target Ads
+account. When the OAuth identity reaches it through a manager account, configure that manager explicitly
+as `google_ads_login_customer_id`; hyphens are stripped for the request header. Never infer
+`login-customer-id` from `Secret.resource_ref`: discovery stores the selected **target client** there,
+while Google requires the **manager** account in this header. Direct client-account auth leaves the
+header unset.
 
 ## Idempotency: the outbox's unique constraint, not a check-then-insert
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -10,6 +10,7 @@ sources:
 related:
   - architecture/proxy-model.md
   - architecture/auth-secrets.md
+  - architecture/ads-conversions.md
 ---
 
 # Data model
@@ -22,7 +23,11 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   `demo` (a sandbox team seeded by [onboarding](../interface/onboarding.md) — labeled + removable),
   `public_demo` (a team whose member token is PUBLISHED, e.g. on the landing page — non-admin members
   are locked to `/call` + reads and may never act as a user; gated in `api.require_member` /
-  `require_identity`), `created_at`.
+  `require_identity`), `created_at`. **`ad_gclid`/`ad_click_at`/`ad_landing`** (migration A35, all
+  nullable) — set once, at signup, from the first-party `treg_ad` cookie; never overwritten. **
+  `first_call_at`** (same migration) — set once by a guarded UPDATE in the `/call/` handler,
+  deliberately NOT derived from `CallRecord` (which `audit.py` sheds under load, undercounting exactly
+  when traffic is highest). Both feed [ads-conversions](ads-conversions.md).
 - **`User`** — a **global identity** only: `email` (unique), `is_superadmin` + `suspended` (platform
   flags, see [super-admin](super-admin.md)), `token_version` (bump to revoke every session cookie +
   identity token this user holds — the signed token carries the `tv` it was minted at; see `sess.make`
@@ -98,6 +103,12 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   secrets are injected via env, not the command line), `exit_code`, `duration_ms`, `created_at`. Written
   off the request path like `CallRecord`. **Usage metering** (`GET /orgs/{id}/usage`, per-user daily caps)
   counts `CallRecord` + `RunRecord` together — see [the API fragment](../interface/api.md).
+- **`AdConversion`** — the Google Ads conversion outbox: `org_id`, `action` (`signup`|`first_call`|
+  `paid`), `dedupe_key`, `value_usd_micro`, `created_at`, `uploaded_at` (NULL = not yet uploaded),
+  `attempts`, `error`. Unique on `(org_id, action)` — the sole idempotency mechanism, not a
+  check-then-insert. Durable by design (written synchronously in the firing code's transaction,
+  unlike `audit.py`/`analytics.py`, which are droppable); a background worker uploads it later. Full
+  chain and the one non-atomic fire site: [ads-conversions](ads-conversions.md).
 - **`Ephemeral`** — short-lived key/value state that must **survive a restart and stay correct across
   instances**: the emailed OTP code + its brute-force counter, and the auth rate-limit sliding windows.
   Keyed by `(ns, k)` — a namespace (`otp` | `otp_start` | `sandbox_hit`) plus the key within it — with an

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -23,9 +23,11 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   `demo` (a sandbox team seeded by [onboarding](../interface/onboarding.md) — labeled + removable),
   `public_demo` (a team whose member token is PUBLISHED, e.g. on the landing page — non-admin members
   are locked to `/call` + reads and may never act as a user; gated in `api.require_member` /
-  `require_identity`), `created_at`. **`ad_gclid`/`ad_click_at`/`ad_landing`** (migration A35, all
-  nullable) — set once, at signup, from the first-party `treg_ad` cookie; never overwritten. **
-  `first_call_at`** (same migration) — set once by a guarded UPDATE in the `/call/` handler,
+  `require_identity`), `created_at`. **`ad_gclid`/`ad_click_id_type`/`ad_click_at`/`ad_landing`**
+  (migration A35, all nullable) — set once, at signup, from the first-party `treg_ad` cookie; never
+  overwritten. The historically named `ad_gclid` holds the click value; `ad_click_id_type` says
+  `gclid`/`gbraid`/`wbraid`, with NULL meaning a legacy GCLID. **`first_call_at`** (same migration) —
+  set once by a guarded UPDATE in the `/call/` handler,
   deliberately NOT derived from `CallRecord` (which `audit.py` sheds under load, undercounting exactly
   when traffic is highest). Both feed [ads-conversions](ads-conversions.md).
 - **`User`** — a **global identity** only: `email` (unique), `is_superadmin` + `suspended` (platform
@@ -105,10 +107,13 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   counts `CallRecord` + `RunRecord` together — see [the API fragment](../interface/api.md).
 - **`AdConversion`** — the Google Ads conversion outbox: `org_id`, `action` (`signup`|`first_call`|
   `paid`), `dedupe_key`, `value_usd_micro`, `created_at`, `uploaded_at` (NULL = not yet uploaded),
-  `attempts`, `error`. Unique on `(org_id, action)` — the sole idempotency mechanism, not a
-  check-then-insert. Durable by design (written synchronously in the firing code's transaction,
-  unlike `audit.py`/`analytics.py`, which are droppable); a background worker uploads it later. Full
-  chain and the one non-atomic fire site: [ads-conversions](ads-conversions.md).
+  `next_attempt_at` (backoff), `failed_at` (terminal/dead-letter state), `attempts`, `error`. The
+  latter two timestamp columns are migration A36. A pending row has all three state timestamps NULL;
+  uploaded and failed are explicit, mutually exclusive terminal states. Unique on `(org_id, action)`
+  — the sole idempotency mechanism, not a check-then-insert. Durable by design (written synchronously
+  in the firing code's transaction, unlike `audit.py`/`analytics.py`, which are droppable); a
+  background worker uploads it later. Full chain and the one non-atomic fire site:
+  [ads-conversions](ads-conversions.md).
 - **`Ephemeral`** — short-lived key/value state that must **survive a restart and stay correct across
   instances**: the emailed OTP code + its brute-force counter, and the auth rate-limit sliding windows.
   Keyed by `(ns, k)` — a namespace (`otp` | `otp_start` | `sandbox_hit`) plus the key within it — with an

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -11,6 +11,7 @@ related:
   - architecture/catalog.md
   - architecture/proxy-model.md
   - architecture/data-model.md
+  - architecture/ads-conversions.md
 ---
 
 # Money
@@ -119,6 +120,14 @@ synchronous and swallowing by construction — analytics is the one side effect 
 allowed to fail, and it must fail silently, because a raise here would 500 the handler and make Stripe
 retry a payment that already credited. Amounts travel as canonical integer `amount_micro`; the
 `amount_usd` on the event is display-only.
+
+On the same `fresh` branch, `_credit` also queues a `paid` Google Ads conversion (`adsconv.queue`) when
+the org has a click to attribute to — but this one is **not** atomic with the credit: `ledger.topup()`
+already committed by the time `_credit` gets here, so the conversion is a second, separate commit. A
+crash between the two loses the conversion permanently (the money is still correctly credited). Found
+in review and accepted deliberately (2026-08-17) rather than restructuring `ledger.py`'s commit-inside
+convention; full reasoning and the cheap future fix in
+[ads-conversions](ads-conversions.md).
 
 **Invoices exist on the manual path only.** The top-up Checkout sets `invoice_creation`, so a
 one-off purchase produces a real Stripe Invoice — number, PDF, billing address, tax ID — which is the

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -145,7 +145,8 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   test fixture) still creates the user + an org + owner membership via `_make_org_membership` (mints the
   token) — NOT reached by the dashboard/CLI login doors, which no longer auto-make an org. Both this door
   and `create_org` below now also read the first-party ad-click cookie (`api._ad_attribution_from`) and,
-  when present, stamp `Org.ad_gclid`/`ad_landing`/`ad_click_at` on the new org — see
+  when enabled and present, stamp `Org.ad_gclid`/`ad_click_id_type`/`ad_landing`/`ad_click_at` on the
+  new org — preserving whether the click was a GCLID, GBRAID or WBRAID — see
   [ads-conversions](ads-conversions.md). `create_org`
   (`POST /orgs`, `require_identity`),
   `list_orgs` (`GET /orgs`), `create_invite` (`POST /orgs/{id}/invites`, admin+), `accept_invite`

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -143,7 +143,10 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
   with no code (403 if `invite.email != user.email`, 409 if already a member). The code path stays.
 - **Org management endpoints:** `register_user` (`POST /users`, legacy open-registration, used by the
   test fixture) still creates the user + an org + owner membership via `_make_org_membership` (mints the
-  token) — NOT reached by the dashboard/CLI login doors, which no longer auto-make an org. `create_org`
+  token) — NOT reached by the dashboard/CLI login doors, which no longer auto-make an org. Both this door
+  and `create_org` below now also read the first-party ad-click cookie (`api._ad_attribution_from`) and,
+  when present, stamp `Org.ad_gclid`/`ad_landing`/`ad_click_at` on the new org — see
+  [ads-conversions](ads-conversions.md). `create_org`
   (`POST /orgs`, `require_identity`),
   `list_orgs` (`GET /orgs`), `create_invite` (`POST /orgs/{id}/invites`, admin+), `accept_invite`
   (`POST /invites/accept`, open + code-protected → registers the user if new, joins them to the invited
@@ -162,7 +165,9 @@ pair, so every list/create/mutation and the proxy are scoped to the caller's org
 - **Org administration:** `set_member_role` (`PATCH /orgs/{id}/members/{user}`, **owner-only** via
   `_require_owner_of`; a `_count_owners` last-owner guard blocks demoting the sole owner — ownership
   transfer = promote another to owner, then step down), `leave_org` (`POST /orgs/{id}/leave`, self-removal,
-  same last-owner guard), `delete_org` (`DELETE /orgs/{id}`, owner-only, cascades every org-scoped row).
+  same last-owner guard), `delete_org` (`DELETE /orgs/{id}`, owner-only, cascades every org-scoped row —
+  including any pending `AdConversion`, which `_ORG_SCOPED_MODELS` now lists: a queued conversion belongs
+  to the team it would be attributed to).
 - **Invites lifecycle:** one-time **and** time-bounded — `Invite.expires_at` (default `INVITE_TTL_DAYS`),
   `accept_invite` returns `410` past expiry. `list_invites` (`GET /orgs/{id}/invites`, admin+) and
   `revoke_invite` (`DELETE /orgs/{id}/invites/{invite}`, admin+); expired codes are garbage-collected by

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -7,6 +7,7 @@ sources:
 related:
   - architecture/data-model.md
   - architecture/auth-secrets.md
+  - architecture/ads-conversions.md
   - foundation/charter.md
 ---
 
@@ -53,6 +54,11 @@ developer token is the case that exists. The value never lives in the org's secr
 can't read it or extract it through a local run; a missing setting is a clean `502`
 (`this server has no <setting> configured`). Used by the OAuth-marketplace auto-provisioner for a provider
 that needs a second credential treg holds centrally (see [api](../interface/api.md)).
+
+A separate case that looks similar but is NOT a platform binding: the Google Ads **conversion**
+uploader (`adsconv.py`) also spends treg's own platform connection, but it is not a caller-issued
+`/call/` request at all, so it never reaches `relay()` or `injectors.py` — it reads the platform org's
+stored OAuth secret directly and builds its own headers. See [ads-conversions](ads-conversions.md).
 
 **Accept-Encoding is normalized to `identity`** when the caller sent none. `relay()` streams the upstream
 body raw (`aiter_raw`), so if the caller doesn't ask for compression httpx would otherwise add its own

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -54,8 +54,9 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
 - **Users / orgs:** `register_user` (`POST /users`, open, legacy — used by the test fixture) creates the
   user + an org + owner membership and returns a token **once**; the dashboard/CLI login doors do NOT go
   through it (they create the user only, no auto org). Both this door and `create_org` read the
-  first-party `treg_ad` cookie (`_ad_attribution_from`) and stamp `Org.ad_gclid`/`ad_landing`/
-  `ad_click_at` on the new org when present — see [ads-conversions](../architecture/ads-conversions.md).
+  first-party `treg_ad` cookie (`_ad_attribution_from`) and, when conversion tracking is enabled,
+  stamp `Org.ad_gclid`/`ad_click_id_type`/`ad_landing`/`ad_click_at` on the new org when present — see
+  [ads-conversions](../architecture/ads-conversions.md).
   `create_org` (`POST /orgs`, `require_identity` so a
   zero-org user can make their first team) + `list_orgs` (`GET /orgs`,
   each org carries a `tool_count` — one grouped query — so the dashboard can land on the org with tools;
@@ -313,7 +314,9 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   agent-onboarding file (call protocol + discovery + auth + CLI + skills + doc links). See [dashboard](dashboard.md).
   `install_sh` (`GET /install.sh`, `{BASE}`-templated) serves the CLI installer (`web/install.sh`).
   `adtrack_js` (`GET /adtrack.js`, no-cache) serves the first-party ad-click capture script loaded by
-  `index.html`'s `<script src="/adtrack.js">`; see [ads-conversions](../architecture/ads-conversions.md).
+  `index.html`'s `<script src="/adtrack.js">`; it returns an empty script when conversion tracking is
+  disabled, so unconfigured deployments do not collect advertising cookies. See
+  [ads-conversions](../architecture/ads-conversions.md).
   `well_known_skills_index` (`GET /.well-known/skills/index.json`) + `well_known_skill_md`
   (`GET /.well-known/skills/treg/SKILL.md`) advertise treg's own skill under the agentskills.io
   convention, making **this host** a skill source with no registry in between (Hermes reads it

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -11,13 +11,16 @@ related:
   - interface/cli.md
   - architecture/proxy-model.md
   - architecture/auth-secrets.md
+  - architecture/ads-conversions.md
 ---
 
 # The API
 
 FastAPI `app` in `src/treg/api.py`. Everything the CLI + skill do is one HTTP call over this. `lifespan`
 runs `init_db()` and creates the shared keepalive `httpx.AsyncClient` at `app.state.http` (and
-`audit.drain()`s on shutdown).
+`audit.drain()`s on shutdown). It also starts the Google Ads conversion uploader (`adsconv.worker`) as
+a background task, but only when `adsconv.enabled()` — see
+[ads-conversions](../architecture/ads-conversions.md).
 
 ## WAF escape hatch — `X-Treg-Body-Encoding`
 Some hosting edges (Cloudflare, including Render's) 403 any request whose **body** matches an
@@ -50,7 +53,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
 ## Endpoints
 - **Users / orgs:** `register_user` (`POST /users`, open, legacy — used by the test fixture) creates the
   user + an org + owner membership and returns a token **once**; the dashboard/CLI login doors do NOT go
-  through it (they create the user only, no auto org). `create_org` (`POST /orgs`, `require_identity` so a
+  through it (they create the user only, no auto org). Both this door and `create_org` read the
+  first-party `treg_ad` cookie (`_ad_attribution_from`) and stamp `Org.ad_gclid`/`ad_landing`/
+  `ad_click_at` on the new org when present — see [ads-conversions](../architecture/ads-conversions.md).
+  `create_org` (`POST /orgs`, `require_identity` so a
   zero-org user can make their first team) + `list_orgs` (`GET /orgs`,
   each org carries a `tool_count` — one grouped query — so the dashboard can land on the org with tools;
   its `active` flag follows `require_member`'s precedence — per-org membership token, else `X-Treg-Org`,
@@ -306,6 +312,8 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `web/llms.txt` as `text/plain` with `{BASE}` templated from `public_url` — the [llms.txt](https://llmstxt.org)
   agent-onboarding file (call protocol + discovery + auth + CLI + skills + doc links). See [dashboard](dashboard.md).
   `install_sh` (`GET /install.sh`, `{BASE}`-templated) serves the CLI installer (`web/install.sh`).
+  `adtrack_js` (`GET /adtrack.js`, no-cache) serves the first-party ad-click capture script loaded by
+  `index.html`'s `<script src="/adtrack.js">`; see [ads-conversions](../architecture/ads-conversions.md).
   `well_known_skills_index` (`GET /.well-known/skills/index.json`) + `well_known_skill_md`
   (`GET /.well-known/skills/treg/SKILL.md`) advertise treg's own skill under the agentskills.io
   convention, making **this host** a skill source with no registry in between (Hermes reads it

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -15,6 +15,7 @@ related:
   - architecture/catalog.md
   - architecture/super-admin.md
   - architecture/multi-tenancy.md
+  - architecture/ads-conversions.md
 ---
 
 # Web dashboard (Phase 1)
@@ -23,6 +24,10 @@ A single-file Vue 3 (CDN) dashboard in `src/treg/web/index.html`, served **same-
 (`GET /` → `FileResponse`, `dashboard()` in `api.py`, via `_WEB_DIR`). Same origin = no CORS and it
 ships with the server (Render/Fly). Design language: **Ledger** (warm charcoal + clay accent,
 mono-forward, dark default + light toggle) — see `docs/style-board.html` / `docs/DASHBOARD-PLAN.md`.
+
+`index.html`'s closing `<script src="/adtrack.js">` loads the first-party ad-click capture script on
+every page render (dashboard included, since a visitor can arrive on `/app` from an ad) — no Google
+tag, first-party cookie only; see [ads-conversions](../architecture/ads-conversions.md).
 
 ## Shell & design system (2026 rework)
 The design tokens are now **shared across every served page** (`index.html`, `tutorial.html`,

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -59,12 +59,15 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   Advertising OAuth platforms `microsoft_ads_*`, `snapchat_ads_*`, `tiktok_ads_*`, `pinterest_*` (all
   unset by default, so those providers ship **unconfigured** until a deployment registers a dev app).
   Empty for a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
-- **Ad conversion tracking** — `google_ads_customer_id` (which Ads account the uploader reports into)
-  and `ads_conv_org_slug` (which team's `google-ads` OAuth connection the uploader authenticates as —
-  a platform setting, not a per-tenant one, since treg uploads to its OWN ad account). **Both** must be
-  set or the whole feature is off (`adsconv.enabled()`): no capture-side behavior changes either way,
-  but with either empty the background uploader task is never started, so self-hosters and the test
-  suite carry zero ad-conversion machinery by default. See
+- **Ad conversion tracking** — `google_ads_customer_id` (the target Ads account),
+  `google_ads_developer_token`, and `ads_conv_org_slug` (which team's `google-ads` OAuth connection the
+  uploader authenticates as — a platform setting, not a per-tenant one, since treg uploads to its OWN
+  ad account). **All three** must be set or the whole feature is off (`adsconv.enabled()`): the capture
+  script is empty, attribution cookies are ignored, conversions are not queued, and the background
+  uploader is not started. For manager-account auth, set optional `google_ads_login_customer_id` to the
+  manager MCC id; direct client auth leaves it empty. Do not use the selected connection
+  `resource_ref` as the manager id—it names the target account. Self-hosters and the test suite carry
+  zero ad-conversion machinery by default. See
   [ads-conversions](../architecture/ads-conversions.md).
 - **Landing live-wire (optional):** `demo_stripe_key` (`TREG_DEMO_STRIPE_KEY`, a Stripe **sandbox
   restricted** key) powers the landing sandbox's ONE real upstream call — a sandbox call to the exact

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -11,6 +11,7 @@ sources:
   - render.yaml
 related:
   - architecture/data-model.md
+  - architecture/ads-conversions.md
   - foundation/charter.md
 ---
 
@@ -58,6 +59,13 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   Advertising OAuth platforms `microsoft_ads_*`, `snapchat_ads_*`, `tiktok_ads_*`, `pinterest_*` (all
   unset by default, so those providers ship **unconfigured** until a deployment registers a dev app).
   Empty for a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
+- **Ad conversion tracking** — `google_ads_customer_id` (which Ads account the uploader reports into)
+  and `ads_conv_org_slug` (which team's `google-ads` OAuth connection the uploader authenticates as —
+  a platform setting, not a per-tenant one, since treg uploads to its OWN ad account). **Both** must be
+  set or the whole feature is off (`adsconv.enabled()`): no capture-side behavior changes either way,
+  but with either empty the background uploader task is never started, so self-hosters and the test
+  suite carry zero ad-conversion machinery by default. See
+  [ads-conversions](../architecture/ads-conversions.md).
 - **Landing live-wire (optional):** `demo_stripe_key` (`TREG_DEMO_STRIPE_KEY`, a Stripe **sandbox
   restricted** key) powers the landing sandbox's ONE real upstream call — a sandbox call to the exact
   seeded `stripe` tool relays for real with this key injected; the key exists in no sandbox org. Empty ⇒

--- a/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
+++ b/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
@@ -1,0 +1,1104 @@
+# Google Ads Conversion Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record signup, first successful call, and first top-up as Google Ads conversions attributed to the ad click that produced them.
+
+**Architecture:** A `gclid` captured in a first-party cookie on landing is persisted onto the `Org` at signup. Three server-side chokepoints write rows into a durable `AdConversion` outbox table inside the same transaction as the event they describe. A background worker drains unsent rows and uploads them to the Google Ads API. Nothing routes through `audit.py` or `analytics.py` — both shed rows under load, which is correct for charts and wrong for conversions.
+
+**Tech Stack:** FastAPI, SQLModel, httpx, Google Ads API v22. Design doc: `docs/superpowers/specs/2026-08-17-ads-conversion-tracking-design.md`.
+
+## Global Constraints
+
+- Branch is `feat/ads-conversion-tracking`. **Commit with `git commit -- <paths>` (path-scoped)** — there is unrelated staged work in `src/treg/api.py`, `docs/context/interface/api.md` and `src/treg/web/landing.html` that must never enter a commit.
+- **Always `uv run --frozen`.** Never run `uv lock` or `uv sync` — on an older uv it rewrites `uv.lock` into an older format, a ~650-line diff changing no versions. Hand-add dependencies to the lock instead.
+- **No new dependencies.** `httpx` and SQLModel are already present.
+- **Never import a heavy dependency at the top of a CLI-path module** (`cli.py`, `convert.py`, `skills.py`, `providers.py`, `localrun.py`, `shell.py`, `agents.py`, `egress.py`, `fsjail.py`). Nothing in this plan touches those.
+- **Money is integer micro-USD.** Never floats, never cents. The FX conversion is integer arithmetic only.
+- **`ledger.py` is the only path that moves money**; this feature never writes money, it only reads amounts already credited.
+- Migrations use `create_all` + a guarded `ALTER` in `db.py`. The project does **not** use Alembic.
+- Test suite: `uv run --frozen python -m pytest -q`.
+- Fixed FX rate: **1 AUD = 0.70 USD, set 2026-08-17**. `aud_micro = usd_micro * 10 // 7`.
+- Live conversion action IDs on account `5149790776`: signup `7723667014`, first call `7723667017`, first top-up `7723667020`.
+- Google Ads API version is **v22**. v21 returns `UNSUPPORTED_VERSION`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/treg/adsconv.py` | **new** — FX helper, action constants, `queue()` outbox writer, uploader worker. All Ads-conversion logic lives here. |
+| `src/treg/models.py` | **modify** — four new `Org` columns, new `AdConversion` table. |
+| `src/treg/db.py` | **modify** — guarded `ALTER`s for the new `Org` columns. |
+| `src/treg/config.py` | **modify** — three settings that gate the feature off by default. |
+| `src/treg/api.py` | **modify** — gclid read at signup, two fire chokepoints, worker start in `lifespan`. |
+| `src/treg/billing.py` | **modify** — first top-up chokepoint inside `_credit()`. |
+| `src/treg/web/adtrack.js` | **new** — the ~10-line first-party capture snippet. |
+| `tests/test_adsconv.py` | **new** — FX, outbox, dedupe, uploader payload and drain. |
+| `docs/context/architecture/ads-conversions.md` | **new** — the subsystem fragment CLAUDE.md requires. |
+
+---
+
+### Task 1: FX conversion and action constants
+
+Pure functions with no I/O — the easiest thing to get exactly right, and everything else depends on the numbers.
+
+**Files:**
+- Create: `src/treg/adsconv.py`
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `usd_micro_to_aud_micro(usd_micro: int) -> int`; string constants `ACTION_SIGNUP = "signup"`, `ACTION_FIRST_CALL = "first_call"`, `ACTION_PAID = "paid"`; `CONVERSION_ACTION_IDS: dict[str, str]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_adsconv.py
+from treg import adsconv
+
+
+def test_usd_to_aud_uses_fixed_rate():
+    # 1 AUD = 0.70 USD, so USD converts UP into AUD: US$20.00 -> A$28.57
+    assert adsconv.usd_micro_to_aud_micro(20_000_000) == 28_571_428
+
+
+def test_usd_to_aud_is_integer_only():
+    # No float ever appears: 1 micro-USD must not become 1.4285... micro-AUD
+    result = adsconv.usd_micro_to_aud_micro(1)
+    assert isinstance(result, int)
+    assert result == 1
+
+
+def test_usd_to_aud_zero_and_negative():
+    assert adsconv.usd_micro_to_aud_micro(0) == 0
+    # A refund/negative should not silently flip sign under floor division
+    assert adsconv.usd_micro_to_aud_micro(-7_000_000) == -10_000_000
+
+
+def test_action_ids_cover_every_action():
+    assert set(adsconv.CONVERSION_ACTION_IDS) == {
+        adsconv.ACTION_SIGNUP, adsconv.ACTION_FIRST_CALL, adsconv.ACTION_PAID
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'treg.adsconv'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/treg/adsconv.py
+"""Google Ads conversion tracking — the outbox and its uploader.
+
+Unlike audit.py and analytics.py, which are deliberately droppable, a conversion that is
+lost is a conversion Google never learns about, and the bidding is then trained on
+undercounted data. So the write is DURABLE (a row, in the caller's transaction) and only
+the UPLOAD is asynchronous. Nothing here may route through audit.py.
+"""
+
+from __future__ import annotations
+
+# Fixed FX, set 2026-08-17: 1 AUD = 0.70 USD. Deliberately a constant rather than a live
+# rate so reported conversion value stays stable — a change in ROAS should mean the
+# business moved, not that the currency market did. Revisit if the rate drifts far.
+AUD_PER_USD_NUM = 10
+AUD_PER_USD_DEN = 7
+
+ACTION_SIGNUP = "signup"
+ACTION_FIRST_CALL = "first_call"
+ACTION_PAID = "paid"
+
+# Created live on account 5149790776 on 2026-08-17 (type UPLOAD_CLICKS).
+CONVERSION_ACTION_IDS: dict[str, str] = {
+    ACTION_SIGNUP: "7723667014",
+    ACTION_FIRST_CALL: "7723667017",
+    ACTION_PAID: "7723667020",
+}
+
+
+def usd_micro_to_aud_micro(usd_micro: int) -> int:
+    """Convert integer micro-USD to integer micro-AUD at the fixed rate.
+
+    Integer-only, per the money-code rule: a float here would round differently on
+    different platforms and the value is uploaded as a monetary amount.
+    """
+    return usd_micro * AUD_PER_USD_NUM // AUD_PER_USD_DEN
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS, 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(ads): fixed-rate USD->AUD conversion and conversion action ids" -- src/treg/adsconv.py tests/test_adsconv.py
+```
+
+---
+
+### Task 2: Schema — Org columns and the AdConversion outbox
+
+**Files:**
+- Modify: `src/treg/models.py` (add to `class Org`, add new table after `class Secret`)
+- Modify: `src/treg/db.py` (guarded ALTERs alongside the existing `(A33)`/`(A34)` block)
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Org.ad_gclid: str | None`, `Org.ad_click_at: datetime | None`, `Org.ad_landing: str | None`, `Org.first_call_at: datetime | None`; `AdConversion(id, org_id, action, dedupe_key, value_usd_micro, created_at, uploaded_at, attempts, error)` with a unique constraint on `(org_id, action)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_adsconv.py
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
+from treg.db import session_maker
+from treg.models import AdConversion, Org
+
+
+async def test_ad_conversion_is_unique_per_org_and_action(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-adsconv")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+
+        db.add(AdConversion(org_id=org.id, action="signup", dedupe_key="signup"))
+        await db.commit()
+
+        db.add(AdConversion(org_id=org.id, action="signup", dedupe_key="signup"))
+        with pytest.raises(IntegrityError):
+            await db.commit()
+
+
+async def test_org_has_ad_attribution_columns(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-adcols", ad_gclid="ABC123", ad_landing="p2")
+        db.add(org)
+        await db.commit()
+        got = (await db.execute(select(Org).where(Org.slug == "t-adcols"))).scalar_one()
+        assert got.ad_gclid == "ABC123"
+        assert got.ad_landing == "p2"
+        assert got.first_call_at is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL with `ImportError: cannot import name 'AdConversion'`
+
+> Fixture note: `clients` (`tests/conftest.py:144`) yields **one** `AsyncClient`, already authed as a registered user — it is not a tuple. Direct DB access goes through `session_maker` imported from `treg.db`, which is the pattern `tests/test_billing.py` uses. Taking `clients` as a parameter is still required even when a test only touches the DB: the fixture is what calls `reset_db()`.
+
+- [ ] **Step 3: Add the columns and the table**
+
+In `src/treg/models.py`, inside `class Org`, after the `balance_micro` field:
+
+```python
+    # ---- Google Ads attribution (see adsconv.py) --------------------------------------------------
+    # The click that produced this team, captured as a first-party cookie on landing and persisted
+    # here at signup. Kept for the life of the team: a top-up weeks later still attributes to it.
+    ad_gclid: str | None = Field(default=None)
+    ad_click_at: datetime | None = Field(default=None)
+    ad_landing: str | None = Field(default=None)  # utm_content — the landing page id (p1…p5)
+    # Set ONCE, by a guarded UPDATE in the /call/ handler. Deliberately not derived from CallRecord:
+    # audit.py sheds rows past its queue bound, so a derived value undercounts exactly under load.
+    first_call_at: datetime | None = Field(default=None)
+```
+
+Then add the table (place it after `class Secret`):
+
+```python
+class AdConversion(SQLModel, table=True):
+    """One conversion owed to Google Ads — an OUTBOX row, not a log line.
+
+    Written synchronously inside the transaction of the event it describes, so the event and its
+    pending conversion commit or fail together. A background worker uploads it later; until then
+    `uploaded_at` is NULL. The unique constraint on (org_id, action) is what makes every fire site
+    idempotent — a webhook redelivery or a retried signup bounces off it instead of double-counting.
+    """
+
+    __table_args__ = (UniqueConstraint("org_id", "action", name="uq_adconversion_org_action"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    org_id: int = Field(index=True, foreign_key="org.id")
+    action: str  # adsconv.ACTION_* — "signup" | "first_call" | "paid"
+    dedupe_key: str = Field(default="")  # provenance (e.g. the Stripe PaymentIntent id); not the key
+    value_usd_micro: int = Field(default=0)  # converted to AUD at upload time, never stored as AUD
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    uploaded_at: datetime | None = Field(default=None, index=True)
+    attempts: int = Field(default=0)
+    error: str = Field(default="")  # last upload error; a permanent failure stops the retries
+```
+
+Ensure `UniqueConstraint` is imported at the top of `models.py` (`from sqlalchemy import UniqueConstraint`) — check whether it is already there before adding, since other tables may use it.
+
+- [ ] **Step 4: Add the guarded migration**
+
+In `src/treg/db.py`, immediately after the `(A34)` block:
+
+```python
+    # (A35) additive: org ad-attribution columns + first_call_at. `create_all` builds them on a
+    # fresh database; this is for one created before this feature shipped. All nullable, so no
+    # backfill is meaningful — a team that predates the ads work has no click to attribute to.
+    if "org" in tables:
+        org_cols = {c["name"] for c in insp.get_columns("org")}
+        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_landing", "VARCHAR"),
+                         ("ad_click_at", "TIMESTAMP"), ("first_call_at", "TIMESTAMP")):
+            if col not in org_cols:
+                conn.execute(text(f"ALTER TABLE org ADD COLUMN {col} {ddl}"))
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Run the whole suite to prove no schema regression**
+
+Run: `uv run --frozen python -m pytest -q`
+Expected: no new failures versus the pre-task baseline. Record the baseline first if you have not.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(ads): Org attribution columns and the AdConversion outbox table" -- src/treg/models.py src/treg/db.py tests/test_adsconv.py
+```
+
+---
+
+### Task 3: The outbox writer
+
+**Files:**
+- Modify: `src/treg/adsconv.py`
+- Modify: `src/treg/config.py`
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: `AdConversion`, `Org` from Task 2; `ACTION_*` from Task 1.
+- Produces: `async def queue(db: AsyncSession, org: Org, action: str, *, value_usd_micro: int = 0, dedupe_key: str = "") -> bool` — returns `True` if a row was written. Adds settings `google_ads_customer_id: str`, `ads_conv_org_slug: str`, `ads_conv_enabled` via `enabled()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_adsconv.py
+async def test_queue_writes_one_row_and_is_idempotent(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-queue", ad_gclid="CLICK1")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is True
+        await db.commit()
+        # Second call for the same (org, action) must be a silent no-op, not an error
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AdConversion).where(AdConversion.org_id == org.id))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].uploaded_at is None
+
+
+async def test_queue_is_a_noop_without_a_gclid(clients):
+    # Organic signups are the majority; they must not fill the outbox with unattributable rows.
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-noclick")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL with `AttributeError: module 'treg.adsconv' has no attribute 'queue'`
+
+- [ ] **Step 3: Add the settings**
+
+In `src/treg/config.py`, next to the existing `google_ads_*` settings (around line 233):
+
+```python
+    # Google Ads conversion upload. Empty customer id = the whole feature is OFF (tests stay inert,
+    # self-hosters send nothing) — the same gate shape analytics.py uses for posthog_key.
+    google_ads_customer_id: str = ""
+    # Which team's google-ads OAuth connection the uploader authenticates as. treg uploads to its
+    # OWN ad account, so this is a platform setting, never a per-tenant one.
+    ads_conv_org_slug: str = ""
+```
+
+- [ ] **Step 4: Implement `queue()` and `enabled()`**
+
+Append to `src/treg/adsconv.py`:
+
+```python
+from datetime import datetime, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from .config import get_settings
+from .models import AdConversion, Org
+
+
+def enabled() -> bool:
+    """Empty customer id = OFF. Keeps the test suite and self-hosted instances inert."""
+    s = get_settings()
+    return bool(s.google_ads_customer_id and s.ads_conv_org_slug)
+
+
+async def queue(db: AsyncSession, org: Org, action: str, *,
+                value_usd_micro: int = 0, dedupe_key: str = "") -> bool:
+    """Record that `org` owes Google a conversion. Returns True if a row was written.
+
+    Call this INSIDE the caller's transaction: the event and its pending conversion must commit
+    together, or a crash between them loses a conversion with no trace.
+
+    A no-op when the team has no click to attribute to, which is most teams. Duplicate fires are
+    absorbed by the unique constraint rather than checked for first — the check-then-insert race
+    is real under concurrent webhook redelivery.
+    """
+    if not org.ad_gclid:
+        return False
+    db.add(AdConversion(org_id=org.id, action=action, dedupe_key=dedupe_key,
+                        value_usd_micro=value_usd_micro))
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        return False
+    return True
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(ads): durable outbox writer, gated off by default" -- src/treg/adsconv.py src/treg/config.py tests/test_adsconv.py
+```
+
+---
+
+### Task 4: Capture the gclid — client snippet and signup persistence
+
+**Files:**
+- Create: `src/treg/web/adtrack.js`
+- Modify: `src/treg/api.py` (serve the file; read the cookie in `register_user()` at ~3814 and `create_org()` at ~3877)
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: `Org` columns from Task 2.
+- Produces: `_ad_attribution_from(request) -> tuple[str, str]` in `api.py`, returning `(gclid, landing)`; a `/adtrack.js` route.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_adsconv.py
+async def test_signup_persists_the_gclid_cookie(clients):
+    r = await clients.post(
+        "/users",
+        json={"email": "click@example.com"},
+        cookies={"treg_ad": "CLICK_XYZ|p3"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid == "CLICK_XYZ"
+        assert org.ad_landing == "p3"
+        assert org.ad_click_at is not None
+
+
+async def test_signup_without_the_cookie_leaves_attribution_null(clients):
+    r = await clients.post("/users", json={"email": "organic@example.com"})
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid is None
+```
+
+> Confirm the registration route and payload shape against `register_user()` in `api.py` before running — if the path is not `/users` or the body needs more fields, match what the endpoint actually accepts.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL — `org.ad_gclid` is `None`, assertion error on `CLICK_XYZ`
+
+- [ ] **Step 3: Write the capture snippet**
+
+```javascript
+// src/treg/web/adtrack.js
+// First-party ad-click capture. No Google script, no third-party request: this reads the click id
+// off our own URL and stores it in our own cookie, which the signup POST then carries to the server.
+// gbraid/wbraid are what Google substitutes for gclid on iOS traffic — omitting them silently drops
+// a large share of mobile conversions.
+(function () {
+  try {
+    var q = new URLSearchParams(window.location.search);
+    var id = q.get('gclid') || q.get('gbraid') || q.get('wbraid');
+    if (!id) return;
+    var landing = q.get('utm_content') || '';
+    // 90 days: Google's click-through conversion window. Lax so it survives the top-level
+    // navigation from the ad, which is a cross-site GET.
+    var v = encodeURIComponent(id + '|' + landing);
+    document.cookie = 'treg_ad=' + v + ';path=/;max-age=7776000;samesite=lax' +
+      (window.location.protocol === 'https:' ? ';secure' : '');
+  } catch (e) { /* never break the page for a marketing cookie */ }
+})();
+```
+
+- [ ] **Step 4: Serve it and read it at signup**
+
+In `src/treg/api.py`, add a route next to the other static file routes (e.g. near the `/usecase.css` route at ~2323):
+
+```python
+@app.get("/adtrack.js", include_in_schema=False)
+async def adtrack_js():
+    f = _WEB_DIR / "adtrack.js"
+    if not f.exists():
+        raise HTTPException(status_code=404, detail="adtrack.js not bundled")
+    return FileResponse(f, media_type="application/javascript")
+```
+
+Add the helper above `register_user()`:
+
+```python
+def _ad_attribution_from(request: Request) -> tuple[str, str]:
+    """Read the first-party ad cookie set by /adtrack.js. Returns ("", "") when absent."""
+    raw = request.cookies.get("treg_ad") or ""
+    if not raw:
+        return "", ""
+    gclid, _, landing = unquote(raw).partition("|")
+    return gclid.strip()[:255], landing.strip()[:64]
+```
+
+Ensure `from urllib.parse import unquote` is imported in `api.py`; check first, it may already be.
+
+In **both** `register_user()` and `create_org()`, after the org exists and before `await db.commit()`:
+
+```python
+    gclid, landing = _ad_attribution_from(request)
+    if gclid:
+        org.ad_gclid = gclid
+        org.ad_landing = landing or None
+        org.ad_click_at = datetime.now(timezone.utc)
+        db.add(org)
+```
+
+Both endpoints must take `request: Request` — `create_org` may not currently. Add the parameter if missing.
+
+- [ ] **Step 5: Add the snippet to the homepage**
+
+In `src/treg/web/index.html`, immediately before `</body>`:
+
+```html
+<script src="/adtrack.js"></script>
+```
+
+Do **not** add it to `usecase-*.html` yet — those files are untracked and out of scope.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(ads): first-party gclid capture, persisted to the org at signup" -- src/treg/web/adtrack.js src/treg/web/index.html src/treg/api.py tests/test_adsconv.py
+```
+
+---
+
+### Task 5: Fire on signup
+
+**Files:**
+- Modify: `src/treg/api.py` (`_grant_signup_promo()` at ~3748)
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: `adsconv.queue()` from Task 3; attribution columns from Task 4.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_adsconv.py
+async def test_signup_queues_a_conversion_when_attributed(clients):
+    r = await clients.post("/users", json={"email": "conv@example.com"},
+                              cookies={"treg_ad": "CLICK_SIGNUP|p1"})
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == r.json()["org_id"]))).scalars().all()
+        assert [x.action for x in rows] == [adsconv.ACTION_SIGNUP]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py::test_signup_queues_a_conversion_when_attributed -q`
+Expected: FAIL — the row list is empty
+
+- [ ] **Step 3: Fire it**
+
+In `_grant_signup_promo()` in `src/treg/api.py`, inside the existing `try:` block after `await ledger.grant(db, org.id)`:
+
+```python
+        # Same door, same once-only guarantee: this function is already the single place a brand-new
+        # real team comes into existence. A queue failure must not fail the signup, so it rides the
+        # existing except below rather than getting its own.
+        await adsconv.queue(db, org, adsconv.ACTION_SIGNUP)
+        await db.commit()
+```
+
+Add `from . import adsconv` to the imports at the top of `api.py`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(ads): queue a signup conversion from the promo-grant chokepoint" -- src/treg/api.py tests/test_adsconv.py
+```
+
+---
+
+### Task 6: Fire on first successful call
+
+**Files:**
+- Modify: `src/treg/api.py` (the `/call/{rest:path}` handler at ~9098)
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: `adsconv.queue()`; `Org.first_call_at`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+First add a self-contained fixture near the top of `tests/test_adsconv.py`. The shape is copied from
+the `env` fixture in `tests/test_access.py`, trimmed to just one callable HTTP tool:
+
+```python
+# tests/test_adsconv.py — add near the imports
+from types import SimpleNamespace
+
+from httpx import ASGITransport, AsyncClient
+
+from conftest import make_upstream
+from treg.api import app
+from treg.db import reset_db, session_maker
+
+
+def _h(token: str) -> dict:
+    return {"X-Treg-Token": token}
+
+
+@pytest.fixture
+async def callenv():
+    """An ad-attributed org with one callable HTTP tool pointed at the fake upstream."""
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()),
+                                 base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.post("/users", json={"email": "caller@example.com"})
+        assert r.status_code == 200, r.text
+        token, org_id = r.json()["token"], r.json()["org_id"]
+        sid = (await c.post("/secrets", headers=_h(token),
+                            json={"name": "a-key", "value": "v"})).json()["id"]
+        await c.post("/tools", headers=_h(token),
+                     json={"name": "alpha", "base_url": "http://upstream", "secret_id": sid})
+        async with session_maker() as db:            # attribute the org to an ad click
+            org = await db.get(Org, org_id)
+            org.ad_gclid = "CLICK_CALL"
+            db.add(org)
+            await db.commit()
+        yield SimpleNamespace(c=c, token=token, org_id=org_id)
+    await app.state.http.aclose()
+```
+
+Then the tests:
+
+```python
+# append to tests/test_adsconv.py
+async def test_first_successful_call_fires_once(callenv):
+    """Two successful calls: one timestamp, one conversion. The second must be a no-op."""
+    r1 = await callenv.c.get("/call/alpha", headers=_h(callenv.token))
+    assert 200 <= r1.status_code < 400, r1.text
+    r2 = await callenv.c.get("/call/alpha", headers=_h(callenv.token))
+    assert 200 <= r2.status_code < 400, r2.text
+
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        assert org.first_call_at is not None
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == callenv.org_id,
+            AdConversion.action == adsconv.ACTION_FIRST_CALL))).scalars().all()
+        assert len(rows) == 1
+
+
+async def test_unattributed_org_records_timestamp_but_no_conversion(callenv):
+    """first_call_at is a product metric and must be set for every team; only ad-clicked ones queue."""
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        org.ad_gclid = None
+        db.add(org)
+        await db.commit()
+
+    assert (await callenv.c.get("/call/alpha", headers=_h(callenv.token))).status_code < 400
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        assert org.first_call_at is not None
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == callenv.org_id))).scalars().all()
+        assert rows == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the guarded update**
+
+In the `/call/{rest:path}` handler, after the upstream response is known to be successful and before returning:
+
+```python
+    # First successful call — the metric that decides whether a vertical is real (see
+    # marketing/landing/_measurement.md). A CONDITIONAL UPDATE, not a read-then-write: concurrent
+    # first calls would both see NULL and both fire. Deliberately NOT derived from CallRecord —
+    # audit.py sheds rows past its queue bound and would undercount exactly under load.
+    if 200 <= response.status_code < 400 and caller.org_id:
+        updated = (await db.execute(
+            update(Org)
+            .where(Org.id == caller.org_id, Org.first_call_at.is_(None))
+            .values(first_call_at=datetime.now(timezone.utc))
+        )).rowcount
+        if updated:
+            org_row = await db.get(Org, caller.org_id)
+            if org_row is not None:
+                await adsconv.queue(db, org_row, adsconv.ACTION_FIRST_CALL)
+            await db.commit()
+```
+
+Ensure `update` is imported from `sqlalchemy` in `api.py`. Match the handler's real variable names for the response and the caller — the names above are indicative, read the surrounding code and use what is actually in scope.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole suite — this touches the hot path**
+
+Run: `uv run --frozen python -m pytest -q`
+Expected: no new failures. `/call/` is the busiest route in the system; a regression here is serious.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(ads): set first_call_at and queue its conversion on the call path" -- src/treg/api.py tests/test_adsconv.py
+```
+
+---
+
+### Task 7: Fire on first top-up
+
+**Files:**
+- Modify: `src/treg/billing.py` (`_credit()`)
+- Test: `tests/test_billing.py` — the webhook machinery (`_org`, `_deliver`, `_pi_event`, `_no_sdk`) already lives there; duplicating it into `test_adsconv.py` would be a second way to stand up the same thing.
+
+**Interfaces:**
+- Consumes: `adsconv.queue()`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Add these imports to `tests/test_billing.py` (`Org`, `session_maker` are already imported):
+
+```python
+from sqlmodel import select
+
+from treg import adsconv
+from treg.models import AdConversion
+```
+
+```python
+# append to tests/test_billing.py
+async def test_first_topup_queues_exactly_one_ad_conversion(c, monkeypatch):
+    """Stripe delivers at least once; a redelivery must not double-count the conversion."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    async with session_maker() as db:
+        org = await db.get(Org, org_id)
+        org.ad_gclid = "CLICK_PAID"
+        db.add(org)
+        await db.commit()
+
+    event = _pi_event(org_id, pi="pi_ads_once", cents=2000)   # US$20.00
+    assert (await _deliver(c, event)).status_code == 200
+    assert (await _deliver(c, event)).status_code == 200      # the redelivery
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == org_id,
+            AdConversion.action == adsconv.ACTION_PAID))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].value_usd_micro == 20_000_000
+        assert rows[0].dedupe_key == "pi_ads_once"
+
+
+async def test_a_second_topup_queues_nothing_further(c, monkeypatch):
+    """We measure becoming a payer, not revenue — a second, different payment adds no conversion."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    async with session_maker() as db:
+        org = await db.get(Org, org_id)
+        org.ad_gclid = "CLICK_PAID"
+        db.add(org)
+        await db.commit()
+
+    assert (await _deliver(c, _pi_event(org_id, pi="pi_first", cents=2000))).status_code == 200
+    assert (await _deliver(c, _pi_event(org_id, pi="pi_second", cents=5000))).status_code == 200
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == org_id,
+            AdConversion.action == adsconv.ACTION_PAID))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].dedupe_key == "pi_first"   # the FIRST payment is the one recorded
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL
+
+- [ ] **Step 3: Fire it**
+
+In `_credit()` in `src/treg/billing.py`, inside the existing `if fresh:` block:
+
+```python
+        # First top-up only: `fresh` is already the "this delivery moved money" branch, and the
+        # outbox's unique (org_id, action) makes a second top-up a silent no-op. We measure becoming
+        # a payer, not revenue — value-based bidding needs volume treg does not have yet.
+        if org is not None:
+            await adsconv.queue(db, org, adsconv.ACTION_PAID,
+                                value_usd_micro=amount_micro, dedupe_key=pi_id)
+            await db.commit()
+```
+
+Add `from . import adsconv` to `billing.py`. Note `org` is already loaded in that branch, but only inside the `autotopup_failures` conditional — hoist the `org = await db.get(Org, org_id)` above that conditional so it is always available.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py tests/test_billing.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "feat(ads): queue the first-top-up conversion from the credit branch" -- src/treg/billing.py tests/test_billing.py
+```
+
+---
+
+### Task 8: The uploader
+
+**Files:**
+- Modify: `src/treg/adsconv.py`
+- Modify: `src/treg/api.py` (`lifespan` at ~140)
+- Test: `tests/test_adsconv.py`
+
+**Interfaces:**
+- Consumes: everything above; `oauth.ensure_fresh(secret, db, client)`.
+- Produces: `def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict`; `async def drain_once(db, client) -> dict`; `async def worker(session_factory, client) -> None`.
+
+- [ ] **Step 1: Write the failing test for the payload**
+
+```python
+# append to tests/test_adsconv.py
+from datetime import datetime, timedelta, timezone
+
+
+def test_build_payload_converts_currency_and_formats_time():
+    click = datetime(2026, 8, 17, 3, 0, tzinfo=timezone.utc)
+    org = Org(id=1, name="t", slug="t", ad_gclid="CLICK1", ad_click_at=click)
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_PAID,
+                       value_usd_micro=20_000_000,
+                       created_at=click + timedelta(hours=6))
+    payload = adsconv.build_payload([row], {1: org})
+    conv = payload["conversions"][0]
+    assert conv["gclid"] == "CLICK1"
+    assert conv["conversionAction"].endswith("/conversionActions/7723667020")
+    # US$20.00 at the fixed rate -> A$28.571428
+    assert conv["conversionValue"] == pytest.approx(28.571428, rel=1e-6)
+    assert conv["currencyCode"] == "AUD"
+    assert payload["partialFailure"] is True
+
+
+def test_build_payload_omits_value_for_non_revenue_actions():
+    org = Org(id=1, name="t", slug="t", ad_gclid="C", ad_click_at=datetime.now(timezone.utc))
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP, value_usd_micro=0)
+    conv = adsconv.build_payload([row], {1: org})["conversions"][0]
+    assert "conversionValue" not in conv
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: FAIL with `AttributeError: module 'treg.adsconv' has no attribute 'build_payload'`
+
+- [ ] **Step 3: Implement `build_payload`**
+
+```python
+API_VERSION = "v22"  # v21 is blocked: "Version v21 is deprecated" (verified 2026-08-17)
+_UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
+_MAX_ATTEMPTS = 8
+
+
+def _conversion_time(dt: datetime) -> str:
+    """Ads wants 'yyyy-mm-dd hh:mm:ss+hh:mm'. ISO with a 'Z' is rejected."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
+
+
+def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
+    """Turn outbox rows into an uploadClickConversions body.
+
+    `partialFailure` so one bad row cannot reject the batch — results are read per row.
+    Value is converted to the ACCOUNT's currency here, at upload time; the outbox stores USD so a
+    rate change never rewrites history.
+    """
+    cid = get_settings().google_ads_customer_id
+    conversions = []
+    for row in rows:
+        org = orgs.get(row.org_id)
+        if org is None or not org.ad_gclid:
+            continue
+        conv = {
+            "gclid": org.ad_gclid,
+            "conversionAction": f"customers/{cid}/conversionActions/{CONVERSION_ACTION_IDS[row.action]}",
+            "conversionDateTime": _conversion_time(row.created_at),
+        }
+        if row.value_usd_micro:
+            conv["conversionValue"] = usd_micro_to_aud_micro(row.value_usd_micro) / 1_000_000
+            conv["currencyCode"] = "AUD"
+        conversions.append(conv)
+    return {"conversions": conversions, "partialFailure": True}
+```
+
+The division by `1_000_000` is the one permitted float: the Ads API's `conversionValue` field is a
+double, so a decimal amount is what the wire format requires. The *arithmetic* stayed integral.
+
+- [ ] **Step 4: Run the payload tests**
+
+Run: `uv run --frozen python -m pytest tests/test_adsconv.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Write the failing test for the drain**
+
+```python
+# append to tests/test_adsconv.py
+async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch):
+    """A row younger than the upload delay is left alone; an old one is sent and marked."""
+    monkeypatch.setattr(adsconv, "enabled", lambda: True)
+    sent = []
+
+    class FakeResp:
+        status_code = 200
+        def json(self): return {"results": [{}]}
+        text = "{}"
+
+    class FakeClient:
+        async def post(self, url, **kw):
+            sent.append((url, kw.get("json")))
+            return FakeResp()
+
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-drain", ad_gclid="C",
+                  ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        old = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
+                           created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+        young = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
+                             created_at=datetime.now(timezone.utc))
+        db.add(old); db.add(young)
+        await db.commit()
+
+        await adsconv.drain_once(db, FakeClient())
+
+        await db.refresh(old); await db.refresh(young)
+        assert old.uploaded_at is not None
+        assert young.uploaded_at is None
+        assert len(sent) == 1
+```
+
+- [ ] **Step 6: Implement `drain_once` and `worker`**
+
+```python
+async def drain_once(db: AsyncSession, client) -> dict:
+    """Upload one batch of due rows. Returns a small dict for logging.
+
+    Due = not yet uploaded, older than the click-availability delay, under the attempt ceiling.
+    Every failure marks the row and leaves it for the next pass; nothing is dropped silently.
+    """
+    if not enabled():
+        return {"sent": 0, "reason": "disabled"}
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_UPLOAD_DELAY_S)
+    rows = (await db.execute(
+        select(AdConversion)
+        .where(AdConversion.uploaded_at.is_(None),
+               AdConversion.created_at <= cutoff,
+               AdConversion.attempts < _MAX_ATTEMPTS)
+        .limit(100)
+    )).scalars().all()
+    if not rows:
+        return {"sent": 0}
+    orgs = {o.id: o for o in (await db.execute(
+        select(Org).where(Org.id.in_({r.org_id for r in rows})))).scalars().all()}
+    payload = build_payload(rows, orgs)
+    if not payload["conversions"]:
+        return {"sent": 0}
+    cid = get_settings().google_ads_customer_id
+    url = f"https://googleads.googleapis.com/{API_VERSION}/customers/{cid}:uploadClickConversions"
+    headers = await _auth_headers(db, client)
+    resp = await client.post(url, json=payload, headers=headers)
+    now = datetime.now(timezone.utc)
+    for row in rows:
+        row.attempts += 1
+        if resp.status_code == 200:
+            row.uploaded_at = now
+            row.error = ""
+        else:
+            row.error = f"{resp.status_code}: {resp.text[:300]}"
+        db.add(row)
+    await db.commit()
+    return {"sent": len(rows), "status": resp.status_code}
+
+
+async def worker(session_factory, client) -> None:
+    """Drain forever. Runs from `lifespan`; a failure here must never take the server down."""
+    import logging
+    while True:
+        try:
+            async with session_maker() as db:
+                await drain_once(db, client)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — a bad batch must not kill the loop
+            logging.getLogger("treg").warning("ads conversion drain failed: %s", exc)
+        await asyncio.sleep(300)
+```
+
+`_auth_headers` reads the platform org's `google-ads` OAuth `Secret`, calls
+`oauth.ensure_fresh(secret, db, client)` and returns the bearer plus `developer-token` and
+`login-customer-id`. Follow the pattern at `src/treg/health.py:205`, which already refreshes a
+stored OAuth secret from a background task. The developer token comes from
+`settings.google_ads_developer_token` — the same platform binding the proxy injects.
+
+- [ ] **Step 7: Start it in `lifespan`**
+
+In `src/treg/api.py`, inside `lifespan` after `app.state.http` is created:
+
+```python
+    ads_task = asyncio.create_task(adsconv.worker(async_session, app.state.http)) \
+        if adsconv.enabled() else None
+```
+
+and in the `finally:` block, before `await app.state.http.aclose()`:
+
+```python
+        if ads_task is not None:
+            ads_task.cancel()
+```
+
+Use whatever the session factory is actually named in `api.py`'s imports from `db.py`.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `uv run --frozen python -m pytest -q`
+Expected: no new failures.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git commit -m "feat(ads): background uploader draining the conversion outbox to Ads v22" -- src/treg/adsconv.py src/treg/api.py tests/test_adsconv.py
+```
+
+---
+
+### Task 9: Docs — the fragment, the stale skill, and the privacy line
+
+CLAUDE.md requires docs updated **in the same commit as the code**; this is the catch-up commit for a feature built across several.
+
+**Files:**
+- Create: `docs/context/architecture/ads-conversions.md`
+- Modify: `.agents/skills/google-ads/SKILL.md`
+- Modify: `src/treg/web/privacy.html`
+
+- [ ] **Step 1: Run the drift check**
+
+Run: `bash .agents/skills/tools-registry-context/scripts/drift.sh`
+Read its output and map every changed source to the fragment that names it. `src/treg/api.py`, `billing.py`, `models.py`, `db.py` and `config.py` all changed and are all named in existing fragments — those fragments need a line each about the new columns, the outbox and the worker.
+
+- [ ] **Step 2: Write the new fragment**
+
+Create `docs/context/architecture/ads-conversions.md` with frontmatter naming its sources, matching the shape of the other files in `docs/context/architecture/`:
+
+```markdown
+---
+sources:
+  - src/treg/adsconv.py
+  - src/treg/web/adtrack.js
+---
+```
+
+Body: the capture → store → fire → upload chain; why the outbox is durable while audit.py and
+analytics.py are droppable; why first-call is not derived from `CallRecord`; the fixed FX constant
+and its date; the three live conversion action ids.
+
+- [ ] **Step 3: Fix the stale API version in the Google Ads skill**
+
+`.agents/skills/google-ads/SKILL.md` §1 pins **v21** and instructs "do not guess downward". v21 now
+returns `UNSUPPORTED_VERSION`. Change the pin to **v22** (verified 2026-08-17), update the paths in
+its examples, and record that the failure mode changed: a dead version now returns a typed
+`UNSUPPORTED_VERSION` error, not the HTML 404 the file describes.
+
+- [ ] **Step 4: Add the privacy line**
+
+`src/treg/web/privacy.html` needs a sentence covering advertising measurement: a first-party cookie
+recording which ad click led to a signup, retained 90 days, not shared with third parties beyond the
+conversion upload to Google Ads.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -m "docs(ads): conversion-tracking fragment, v22 pin fix, privacy line" -- docs/context/architecture/ads-conversions.md .agents/skills/google-ads/SKILL.md src/treg/web/privacy.html
+```
+
+---
+
+## Not in this plan
+
+- **The five usecase landing pages.** Untracked and undeployed; the capture snippet is a shared
+  include, so adding them later is one `<script>` line per page.
+- **Campaign structure, keywords, budgets.** No code depends on them.
+- **The paused PMax campaign `24150011650`** (A$44.81/day) — an account decision, not a code change.
+- **The live-click verification** in the spec's Verification section. It needs a real ad click and
+  cannot be automated; run it after this plan lands and before any real spend.

--- a/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
+++ b/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
@@ -234,7 +234,11 @@ class AdConversion(SQLModel, table=True):
     action: str  # adsconv.ACTION_* — "signup" | "first_call" | "paid"
     dedupe_key: str = Field(default="")  # provenance (e.g. the Stripe PaymentIntent id); not the key
     value_usd_micro: int = Field(default=0)  # converted to AUD at upload time, never stored as AUD
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # `_now`, NOT `datetime.now(timezone.utc)`: these columns are TIMESTAMP WITHOUT TIME ZONE and
+    # asyncpg rejects a tz-aware value into a naive column. SQLite is lax, so a tz-aware default
+    # passes every test here and fails on the Postgres deploy target. See `_now` at the top of this
+    # file — 24 other tables already follow it.
+    created_at: datetime = Field(default_factory=_now)
     uploaded_at: datetime | None = Field(default=None, index=True)
     attempts: int = Field(default=0)
     error: str = Field(default="")  # last upload error; a permanent failure stops the retries
@@ -454,7 +458,10 @@ Expected: FAIL — `org.ad_gclid` is `None`, assertion error on `CLICK_XYZ`
     var q = new URLSearchParams(window.location.search);
     var id = q.get('gclid') || q.get('gbraid') || q.get('wbraid');
     if (!id) return;
-    var landing = q.get('utm_content') || '';
+    // utm_content is what _measurement.md specifies, but the use-case pages' own CTAs carry the
+    // page id as ?ref=p1 (see the logged-out redirect in index.html). Read either, so attribution
+    // does not come back empty on whichever convention a given page happens to use.
+    var landing = q.get('utm_content') || q.get('ref') || '';
     // 90 days: Google's click-through conversion window. Lax so it survives the top-level
     // navigation from the ad, which is a cross-site GET.
     var v = encodeURIComponent(id + '|' + landing);
@@ -691,7 +698,7 @@ In the `/call/{rest:path}` handler, after the upstream response is known to be s
         updated = (await db.execute(
             update(Org)
             .where(Org.id == caller.org_id, Org.first_call_at.is_(None))
-            .values(first_call_at=datetime.now(timezone.utc))
+            .values(first_call_at=_utcnow_naive())   # naive UTC — see models._now; asyncpg rejects tz-aware
         )).rowcount
         if updated:
             org_row = await db.get(Org, caller.org_id)
@@ -700,7 +707,9 @@ In the `/call/{rest:path}` handler, after the upstream response is known to be s
             await db.commit()
 ```
 
-Ensure `update` is imported from `sqlalchemy` in `api.py`. Match the handler's real variable names for the response and the caller — the names above are indicative, read the surrounding code and use what is actually in scope.
+Ensure `update` is imported from `sqlalchemy` in `api.py`. Use the `_utcnow_naive()` helper that
+already exists in `api.py` (defined around line 3832) — do NOT add a second copy, and do NOT use
+`datetime.now(timezone.utc)`: `first_call_at` is a naive column and asyncpg rejects tz-aware values. Match the handler's real variable names for the response and the caller — the names above are indicative, read the surrounding code and use what is actually in scope.
 
 - [ ] **Step 4: Run the tests**
 
@@ -870,13 +879,28 @@ Expected: FAIL with `AttributeError: module 'treg.adsconv' has no attribute 'bui
 - [ ] **Step 3: Implement `build_payload`**
 
 ```python
+def _utcnow_naive() -> datetime:
+    """Naive UTC. Our datetime columns are TIMESTAMP WITHOUT TIME ZONE and asyncpg rejects a
+    tz-aware value into one; see `_now` in models.py, which 24 other tables already follow.
+    `api.py` has its own copy of this for the same reason — it is private to that module."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 API_VERSION = "v22"  # v21 is blocked: "Version v21 is deprecated" (verified 2026-08-17)
 _UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
 _MAX_ATTEMPTS = 8
 
 
 def _conversion_time(dt: datetime) -> str:
-    """Ads wants 'yyyy-mm-dd hh:mm:ss+hh:mm'. ISO with a 'Z' is rejected."""
+    """Ads wants 'yyyy-mm-dd hh:mm:ss+hh:mm'. ISO with a 'Z' is rejected.
+
+    `dt` comes out of the database as NAIVE UTC (see models._now), so it is stamped with UTC, not
+    converted. `.astimezone()` on a naive value would read it as LOCAL time — on the Sydney deploy
+    target that shifts every conversion by 10-11 hours, which Google would either reject as
+    pre-dating the click or attribute to the wrong day.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
 
 
@@ -964,7 +988,9 @@ async def drain_once(db: AsyncSession, client) -> dict:
     """
     if not enabled():
         return {"sent": 0, "reason": "disabled"}
-    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_UPLOAD_DELAY_S)
+    # Naive UTC on BOTH sides: created_at is a naive column, and comparing it against a tz-aware
+    # value is an asyncpg error on Postgres (and a silently wrong comparison elsewhere).
+    cutoff = _utcnow_naive() - timedelta(seconds=_UPLOAD_DELAY_S)
     rows = (await db.execute(
         select(AdConversion)
         .where(AdConversion.uploaded_at.is_(None),
@@ -983,7 +1009,7 @@ async def drain_once(db: AsyncSession, client) -> dict:
     url = f"https://googleads.googleapis.com/{API_VERSION}/customers/{cid}:uploadClickConversions"
     headers = await _auth_headers(db, client)
     resp = await client.post(url, json=payload, headers=headers)
-    now = datetime.now(timezone.utc)
+    now = _utcnow_naive()
     for row in rows:
         row.attempts += 1
         if resp.status_code == 200:

--- a/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
+++ b/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
@@ -505,7 +505,9 @@ In **both** `register_user()` and `create_org()`, after the org exists and befor
     if gclid:
         org.ad_gclid = gclid
         org.ad_landing = landing or None
-        org.ad_click_at = datetime.now(timezone.utc)
+        org.ad_click_at = _utcnow_naive()   # naive UTC: asyncpg rejects tz-aware into a
+                                           # TIMESTAMP WITHOUT TIME ZONE column (see models._now).
+                                           # api.py already defines _utcnow_naive (~line 3832).
         db.add(org)
 ```
 
@@ -519,7 +521,8 @@ In `src/treg/web/index.html`, immediately before `</body>`:
 <script src="/adtrack.js"></script>
 ```
 
-Do **not** add it to `usecase-*.html` yet — those files are untracked and out of scope.
+For the five `usecase-*.html` pages and `resources.html`, see the CONTROLLER ADDENDUM at the end of
+this brief — they are now in scope, but are GENERATED and must not be hand-edited.
 
 - [ ] **Step 6: Run the tests**
 

--- a/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
+++ b/docs/superpowers/plans/2026-08-17-ads-conversion-tracking.md
@@ -10,7 +10,8 @@
 
 ## Global Constraints
 
-- Branch is `feat/ads-conversion-tracking`. **Commit with `git commit -- <paths>` (path-scoped)** — there is unrelated staged work in `src/treg/api.py`, `docs/context/interface/api.md` and `src/treg/web/landing.html` that must never enter a commit.
+- Branch is `feat/ads-conversion-tracking`. **Commit with `git commit -- <paths>` (path-scoped)** — there is unrelated staged work in `src/treg/api.py`, `docs/context/interface/api.md` and `src/treg/web/landing.html` that must never enter a commit. A plain `git commit` takes the whole index and would sweep that work in.
+- **A path-scoped commit cannot see an untracked file.** For any file this plan *creates*, run `git add <path>` first, then `git commit -- <path>`. The `add` stages only that path; the path-scoped commit still ignores everything else in the index. Skipping the `add` fails with `pathspec … did not match any file(s) known to git`.
 - **Always `uv run --frozen`.** Never run `uv lock` or `uv sync` — on an older uv it rewrites `uv.lock` into an older format, a ~650-line diff changing no versions. Hand-add dependencies to the lock instead.
 - **No new dependencies.** `httpx` and SQLModel are already present.
 - **Never import a heavy dependency at the top of a CLI-path module** (`cli.py`, `convert.py`, `skills.py`, `providers.py`, `localrun.py`, `shell.py`, `agents.py`, `egress.py`, `fsjail.py`). Nothing in this plan touches those.
@@ -370,12 +371,15 @@ async def queue(db: AsyncSession, org: Org, action: str, *,
     """
     if not org.ad_gclid:
         return False
-    db.add(AdConversion(org_id=org.id, action=action, dedupe_key=dedupe_key,
-                        value_usd_micro=value_usd_micro))
     try:
-        await db.flush()
+        # A SAVEPOINT, not a bare flush: this runs inside the CALLER's transaction (the signup
+        # grant, the Stripe credit), and a plain `db.rollback()` on the duplicate would roll back
+        # THEIR work too — a redelivered webhook would undo a credit. The nested block confines the
+        # rollback to this insert.
+        async with db.begin_nested():
+            db.add(AdConversion(org_id=org.id, action=action, dedupe_key=dedupe_key,
+                                value_usd_micro=value_usd_micro))
     except IntegrityError:
-        await db.rollback()
         return False
     return True
 ```

--- a/docs/superpowers/specs/2026-08-17-ads-conversion-tracking-design.md
+++ b/docs/superpowers/specs/2026-08-17-ads-conversion-tracking-design.md
@@ -1,0 +1,151 @@
+# Google Ads conversion tracking for treg — design
+
+**Date:** 2026-08-17
+**Branch:** `feat/ads-conversion-tracking`
+**Ads account:** `5149790776` ("Treg"), AUD, `Australia/Sydney`, client of the Shirley Lou MCC (`3519125194`)
+
+## The problem
+
+treg has no analytics instrumentation of any kind — no `gtag`, GTM, GA, PostHog or Plausible, in the
+repo or on the live site. The Ads account's only conversion action (`Purchase`, `7722657530`) is a
+`WEBPAGE` action created by the signup wizard; with no tag on the site it has never fired and never
+could.
+
+`marketing/landing/_measurement.md` states the consequence: *"A vertical whose visitors sign up and
+never call looks identical to a vertical whose visitors sign up and call daily."* Spending against
+this returns a verdict on the wrong metric.
+
+## Goal
+
+Record three conversions against the ad click that produced them: **signup**, **first successful
+call**, and **first top-up**.
+
+## Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Conversion set | signup + first call + first top-up | `_measurement.md` names first call as the metric that decides whether a vertical is real |
+| Mechanism | server-side upload (`uploadClickConversions`) | a first call happens in a CLI/MCP client with no browser; a tag physically cannot see it |
+| Top-up counting | once per org, not per payment | optimises for acquiring payers; value-based bidding needs volume treg does not have yet |
+| Currency | fixed rate, 1 AUD = 0.70 USD | stable reported value; `aud_micro = usd_micro * 10 // 7`, integer only |
+| Ad landing | five usecase pages for those verticals, homepage otherwise | landing-page relevance feeds Quality Score, which sets CPC |
+
+### Decisions recorded against a documented position
+
+- **`_measurement.md` treats signup as a weak metric** ("signups measure curiosity"). Signup is
+  therefore created as a **secondary** action — tracked, but not something Google bids toward.
+- **`wiki/topics/treg.to SEO.md` §9 (2026-08-17) states "No ads for treg"**, on the grounds that the
+  preconditions — a working funnel, ~50 tracked conversions, call instrumentation — are unmet. This
+  work *builds* the missing precondition; it does not authorise spend. The wiki's inherited
+  thresholds (~50 conversions to learn, 2–3 weeks to read, 3 months to judge) still apply before any
+  campaign verdict is trusted.
+- **Competitor-alternative keywords**: §3 finds that family declining across the board
+  (`semrush alternative` −73%, `ahrefs alternative` −52%, `clearbit alternative` −48%,
+  `bright data alternative` −64%) and "the highest-competition, lowest-CTR shape". Deliberately left
+  open — nothing in this design depends on keyword choice.
+
+## Architecture
+
+```
+ad click ──► landing page ──► first-party cookie ──► signup ──► Org row
+                                                                  │
+        signup ─┐                                                 │ ad_gclid
+     first call ─┼──► AdConversion outbox (uploaded_at NULL) ◄─────┘
+       first top-up ─┘            │
+                                  ▼
+                    background drain ──► Ads API uploadClickConversions
+```
+
+### 1. Capture (client)
+
+Ten lines of first-party JS on the homepage and, when they ship, the five usecase pages. Reads
+`gclid`, `gbraid`, `wbraid` (Google substitutes the latter two on iOS traffic; omitting them silently
+drops mobile conversions) and `utm_content` (carries the page id `p1`…`p5` per `_measurement.md`).
+Writes a `SameSite=Lax` cookie with a 90-day life, matching Google's click-conversion window. No
+Google script, no third-party request.
+
+### 2. Store — new columns on `Org`
+
+| column | purpose |
+|---|---|
+| `ad_gclid` | the click id, kept for the life of the team |
+| `ad_click_at` | uploads must postdate the click and fall inside 90 days |
+| `ad_landing` | which page, for the per-page hypotheses |
+| `first_call_at` | the decisive metric; also the guard that makes first-call fire once |
+
+New table `AdConversion(org_id, action, dedupe_key, uploaded_at, error, attempts)`, unique on
+`(org_id, action)`. Migrations follow the existing `create_all` + guarded `ALTER` pattern in `db.py`;
+the project does not use Alembic.
+
+### 3. Fire — three existing chokepoints
+
+- **Signup** → `_grant_signup_promo()` (`api.py:3748`), called from exactly two doors,
+  `register_user()` (3814) and `create_org()` (3877), already idempotent per `(org, kind)`.
+- **First call** → guarded `UPDATE ... WHERE first_call_at IS NULL` in the `/call/{rest:path}`
+  handler (`api.py:9098`) on a successful upstream response. **Not** `ledger.reserve` — a team using
+  its own key is never metered and never touches the ledger, so a ledger hook would miss exactly
+  those teams.
+- **First top-up** → `_credit()` in `billing.py`, on the existing branch that distinguishes "this
+  delivery moved money" from a webhook redelivery.
+
+Each writes its outbox row **in the same transaction as the event**, so the event and its pending
+conversion commit or fail together.
+
+### 4. Upload — a durable outbox, never fire-and-forget
+
+A background worker drains rows with `uploaded_at IS NULL` and POSTs to
+`v22/customers/5149790776/conversionUploads:uploadClickConversions` with `partialFailure: true`,
+recording each row's result individually. The request path never waits on Google.
+
+This also solves a timing problem that otherwise reads as random data loss: **a `gclid` is not valid
+for upload immediately.** Google needs several hours after the click before it will accept a
+conversion against it, so anything uploaded at signup time is rejected. Retry-with-backoff turns
+"rejected, gone" into "sent a few hours later". Rows failing permanently (expired click, malformed
+id) are marked with the error code rather than retried forever.
+
+**Nothing routes through `audit.py`.** It sheds rows past `_MAX_PENDING = 5000` — correct for
+analytics, and it would undercount conversions exactly when traffic peaks (`CLAUDE.md`, money-code
+rule).
+
+## Done already (2026-08-17)
+
+Created on the live account via the Ads API, `validateOnly` first:
+
+| ID | Name | Type | Category | Primary |
+|---|---|---|---|---|
+| `7723667014` | treg Signup | `UPLOAD_CLICKS` | `SIGNUP` | no |
+| `7723667017` | treg First successful call | `UPLOAD_CLICKS` | `QUALIFIED_LEAD` | **yes** |
+| `7723667020` | treg First top-up | `UPLOAD_CLICKS` | `PURCHASE` | **yes** |
+
+`Purchase` (`7722657530`) demoted from primary — a `WEBPAGE` action cannot receive uploads, and
+leaving it primary meant Google bidding toward a goal that would always read zero.
+
+**API version is `v22`.** `v21` — the version pinned in `.agents/skills/google-ads/SKILL.md` — now
+returns `UNSUPPORTED_VERSION`. That file needs updating.
+
+## Deferred
+
+The five usecase landing pages (`usecase-*.html`, `usecase.css`, `resources.html`) are untracked and
+therefore undeployed, so their routes (`api.py:2315`) 404. The capture snippet is written as one
+shared include so adding them later is a one-line change per page.
+
+## Verification
+
+No test `gclid` exists, so the chain cannot be proven without a real click:
+
+1. One Search campaign, minimum budget, tight geo.
+2. A genuine click on your own ad.
+3. Confirm `gclid` → cookie → `Org.ad_gclid`.
+4. Walk the funnel: sign up, install agent, one call, minimum top-up.
+5. Wait — uploads cannot succeed for several hours after the click, and conversions take up to 24h
+   to surface in the UI. Do not conclude failure before then.
+6. Assert three conversions, and that a US$20 top-up reads **A$28.57**. A$20.00 or A$14.00 means the
+   currency math is wrong.
+
+## Risks
+
+- **Fixed FX drifts.** Named constant with the date it was set, not a magic number.
+- **Privacy policy.** `privacy.html` needs a line on advertising measurement; a first-party cookie is
+  still advertising data.
+- **PMax campaign `24150011650`** sits paused at A$44.81/day on a signup-wizard default. It should be
+  restructured or deleted, not unpaused as-is.

--- a/docs/superpowers/specs/2026-08-17-ads-conversion-tracking-design.md
+++ b/docs/superpowers/specs/2026-08-17-ads-conversion-tracking-design.md
@@ -88,8 +88,20 @@ the project does not use Alembic.
 - **First top-up** → `_credit()` in `billing.py`, on the existing branch that distinguishes "this
   delivery moved money" from a webhook redelivery.
 
-Each writes its outbox row **in the same transaction as the event**, so the event and its pending
-conversion commit or fail together.
+Signup and first-call write their outbox row **in the same transaction as the event**, so the event
+and its pending conversion commit or fail together.
+
+**The paid path is the exception, and it is not atomic.** `ledger.topup()` commits internally
+(`ledger.py:36`) before `_credit()` reaches the conversion code, so the credit and the conversion are
+two separate commits. If the process dies between them the conversion is lost permanently — a Stripe
+redelivery finds the payment already credited, `fresh` is False, and the fire site never runs again.
+No error is raised and nothing detects it.
+
+This is accepted, deliberately (2026-08-17). The window is sub-millisecond, the blast radius is one
+missing conversion rather than lost money or a failed webhook, and closing it properly would mean
+restructuring `ledger.py` — the only code path that moves money — to serve a marketing feature. A
+reconciliation sweep (find orgs with a credited payment and a `gclid` but no `paid` row, backfill it)
+is the cheap fix if this ever proves to matter in practice.
 
 ### 4. Upload — a durable outbox, never fire-and-forget
 

--- a/marketing/landing/build_html.py
+++ b/marketing/landing/build_html.py
@@ -507,6 +507,7 @@ TEMPLATE = """<!doctype html>
   }}
 }})();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>
 """
@@ -643,6 +644,7 @@ HUB = """<!doctype html>
   </div>
 </footer>
 
+<script src="/adtrack.js"></script>
 </body>
 </html>
 """

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -1,0 +1,35 @@
+"""Google Ads conversion tracking — the outbox and its uploader.
+
+Unlike audit.py and analytics.py, which are deliberately droppable, a conversion that is
+lost is a conversion Google never learns about, and the bidding is then trained on
+undercounted data. So the write is DURABLE (a row, in the caller's transaction) and only
+the UPLOAD is asynchronous. Nothing here may route through audit.py.
+"""
+
+from __future__ import annotations
+
+# Fixed FX, set 2026-08-17: 1 AUD = 0.70 USD. Deliberately a constant rather than a live
+# rate so reported conversion value stays stable — a change in ROAS should mean the
+# business moved, not that the currency market did. Revisit if the rate drifts far.
+AUD_PER_USD_NUM = 10
+AUD_PER_USD_DEN = 7
+
+ACTION_SIGNUP = "signup"
+ACTION_FIRST_CALL = "first_call"
+ACTION_PAID = "paid"
+
+# Created live on account 5149790776 on 2026-08-17 (type UPLOAD_CLICKS).
+CONVERSION_ACTION_IDS: dict[str, str] = {
+    ACTION_SIGNUP: "7723667014",
+    ACTION_FIRST_CALL: "7723667017",
+    ACTION_PAID: "7723667020",
+}
+
+
+def usd_micro_to_aud_micro(usd_micro: int) -> int:
+    """Convert integer micro-USD to integer micro-AUD at the fixed rate.
+
+    Integer-only, per the money-code rule: a float here would round differently on
+    different platforms and the value is uploaded as a monetary amount.
+    """
+    return usd_micro * AUD_PER_USD_NUM // AUD_PER_USD_DEN

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -64,7 +64,10 @@ async def queue(db: AsyncSession, org: Org, action: str, *,
     """Record that `org` owes Google a conversion. Returns True if a row was written.
 
     Call this INSIDE the caller's transaction: the event and its pending conversion must commit
-    together, or a crash between them loses a conversion with no trace.
+    together, or a crash between them loses a conversion with no trace. The `paid` caller
+    (`billing._credit`) cannot honour this — `ledger.topup()` has already committed by the time
+    `_credit` gets here, so that one path is a known, accepted two-commit gap rather than a bug (see
+    `docs/context/architecture/ads-conversions.md`).
 
     A no-op when the team has no click to attribute to, which is most teams. Duplicate fires are
     absorbed by the unique constraint rather than checked for first — the check-then-insert race

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -37,3 +37,42 @@ def usd_micro_to_aud_micro(usd_micro: int) -> int:
     (top-ups); the negative case is defensive only.
     """
     return usd_micro * AUD_PER_USD_NUM // AUD_PER_USD_DEN
+
+
+from sqlalchemy.exc import IntegrityError
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from .config import get_settings
+from .models import AdConversion, Org
+
+
+def enabled() -> bool:
+    """Empty customer id = OFF. Keeps the test suite and self-hosted instances inert."""
+    s = get_settings()
+    return bool(s.google_ads_customer_id and s.ads_conv_org_slug)
+
+
+async def queue(db: AsyncSession, org: Org, action: str, *,
+                value_usd_micro: int = 0, dedupe_key: str = "") -> bool:
+    """Record that `org` owes Google a conversion. Returns True if a row was written.
+
+    Call this INSIDE the caller's transaction: the event and its pending conversion must commit
+    together, or a crash between them loses a conversion with no trace.
+
+    A no-op when the team has no click to attribute to, which is most teams. Duplicate fires are
+    absorbed by the unique constraint rather than checked for first — the check-then-insert race
+    is real under concurrent webhook redelivery.
+    """
+    if not org.ad_gclid:
+        return False
+    try:
+        # A SAVEPOINT, not a bare flush: this runs inside the CALLER's transaction (the signup
+        # grant, the Stripe credit), and a plain `db.rollback()` on the duplicate would roll back
+        # THEIR work too — a redelivered webhook would undo a credit. The nested block confines the
+        # rollback to this insert.
+        async with db.begin_nested():
+            db.add(AdConversion(org_id=org.id, action=action, dedupe_key=dedupe_key,
+                                value_usd_micro=value_usd_micro))
+    except IntegrityError:
+        return False
+    return True

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -39,11 +39,18 @@ def usd_micro_to_aud_micro(usd_micro: int) -> int:
     return usd_micro * AUD_PER_USD_NUM // AUD_PER_USD_DEN
 
 
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
 from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
+from . import crypto, oauth
 from .config import get_settings
-from .models import AdConversion, Org
+from .models import AdConversion, Org, Secret
 
 
 def enabled() -> bool:
@@ -76,3 +83,168 @@ async def queue(db: AsyncSession, org: Org, action: str, *,
     except IntegrityError:
         return False
     return True
+
+
+# ---- the uploader ---------------------------------------------------------------------------
+
+
+def _utcnow_naive() -> datetime:
+    """Naive UTC. Our datetime columns are TIMESTAMP WITHOUT TIME ZONE and asyncpg rejects a
+    tz-aware value into one; see `_now` in models.py, which every other table already follows.
+    `api.py` has its own copy of this for the same reason — it is private to that module."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+# v21 was sunset 2026-08-05 (JSON 400 UNSUPPORTED_VERSION); every other path that names a Google
+# Ads API version in this repo (oauth_providers.GOOGLE_ADS, .agents/skills/google-ads/SKILL.md,
+# docs/context/architecture/auth-secrets.md) was repointed at v25 on 2026-08-17 — see commit
+# 6541167. The original task brief for this file still said v22 (written before that fix landed);
+# v25 is what is actually live, so that is what's pinned here. Bump all four places together next
+# time Google sunsets a version — see auth-secrets.md's note on this.
+API_VERSION = "v25"
+_UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
+_MAX_ATTEMPTS = 8
+
+
+def _conversion_time(dt: datetime) -> str:
+    """Ads wants 'yyyy-mm-dd hh:mm:ss+hh:mm'. ISO with a 'Z' is rejected.
+
+    `dt` comes out of the database as NAIVE UTC (see models._now), so it is stamped with UTC, not
+    converted. `.astimezone()` on a naive value would read it as LOCAL time — on the Sydney deploy
+    target that shifts every conversion by 10-11 hours, which Google would either reject as
+    pre-dating the click or attribute to the wrong day.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
+
+
+def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
+    """Turn outbox rows into an uploadClickConversions body.
+
+    `partialFailure` so one bad row cannot reject the batch — results are read per row.
+    Value is converted to the ACCOUNT's currency here, at upload time; the outbox stores USD so a
+    rate change never rewrites history.
+    """
+    cid = get_settings().google_ads_customer_id
+    conversions = []
+    for row in rows:
+        org = orgs.get(row.org_id)
+        if org is None or not org.ad_gclid:
+            continue
+        conv = {
+            "gclid": org.ad_gclid,
+            "conversionAction": f"customers/{cid}/conversionActions/{CONVERSION_ACTION_IDS[row.action]}",
+            "conversionDateTime": _conversion_time(row.created_at),
+        }
+        if row.value_usd_micro:
+            # The one permitted float: the Ads API's conversionValue field is a wire double, so a
+            # decimal amount is what the JSON boundary requires. The arithmetic that produced the
+            # micro amount stayed integral (usd_micro_to_aud_micro).
+            conv["conversionValue"] = usd_micro_to_aud_micro(row.value_usd_micro) / 1_000_000
+            conv["currencyCode"] = "AUD"
+        conversions.append(conv)
+    return {"conversions": conversions, "partialFailure": True}
+
+
+async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
+    """Bearer + developer-token (+ login-customer-id if the connection is scoped to a client
+    account under a manager), for a direct call to the Ads REST API.
+
+    This does NOT go through proxy.relay/injectors.py — the uploader is not a caller-issued
+    `/call/` request, it's treg spending its OWN platform connection, so there is no Tool/bindings
+    row to resolve credentials from. Instead it reads the `google-ads` OAuth `Secret` stored on
+    the platform org named by `ads_conv_org_slug`, the same shape a normal registry connect
+    produces (see api.py's `/oauth/callback`, which stores `kind="oauth"` + a JSON blob).
+
+    Raises if the platform org, its google-ads connection, or a usable token is missing — the
+    caller (`drain_once`, called from `worker`'s try/except) logs that and retries next pass
+    rather than crashing the loop.
+    """
+    settings = get_settings()
+    org = (await db.execute(
+        select(Org).where(Org.slug == settings.ads_conv_org_slug)
+    )).scalar_one_or_none()
+    if org is None:
+        raise RuntimeError(f"ads_conv_org_slug {settings.ads_conv_org_slug!r} matches no org")
+    secret = (await db.execute(
+        select(Secret).where(Secret.org_id == org.id, Secret.provider == "google-ads",
+                              Secret.kind == "oauth")
+    )).scalars().first()
+    if secret is None:
+        raise RuntimeError(f"org {settings.ads_conv_org_slug!r} has no google-ads oauth connection")
+    # Same call health.py:205 makes from its own background task — refreshes in place if stale,
+    # no-ops for a still-valid or MANUAL-mode (non-refreshable) token.
+    await oauth.ensure_fresh(secret, db, client)
+    blob = json.loads(crypto.decrypt(secret.value))
+    token = blob.get("access_token") or blob.get("token")
+    if not token:
+        raise RuntimeError("google-ads secret decrypted with no access token")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "developer-token": settings.google_ads_developer_token,
+        "Content-Type": "application/json",
+    }
+    # resource_ref is the account this connection was pointed at during connect/discovery — stored
+    # as the full resource name ("customers/1234567890"); login-customer-id wants the bare digits.
+    # Only needed when acting on a client account under a manager (SKILL.md #7) — omit rather than
+    # send an empty/wrong header, which Ads reports as 401 UNAUTHENTICATED, not a targeting error.
+    if secret.resource_ref:
+        headers["login-customer-id"] = secret.resource_ref.rsplit("/", 1)[-1]
+    return headers
+
+
+async def drain_once(db: AsyncSession, client) -> dict:
+    """Upload one batch of due rows. Returns a small dict for logging.
+
+    Due = not yet uploaded, older than the click-availability delay, under the attempt ceiling.
+    Every failure marks the row and leaves it for the next pass; nothing is dropped silently.
+    """
+    if not enabled():
+        return {"sent": 0, "reason": "disabled"}
+    # Naive UTC on BOTH sides: created_at is a naive column, and comparing it against a tz-aware
+    # value is an asyncpg error on Postgres (and a silently wrong comparison elsewhere).
+    cutoff = _utcnow_naive() - timedelta(seconds=_UPLOAD_DELAY_S)
+    rows = (await db.execute(
+        select(AdConversion)
+        .where(AdConversion.uploaded_at.is_(None),
+               AdConversion.created_at <= cutoff,
+               AdConversion.attempts < _MAX_ATTEMPTS)
+        .limit(100)
+    )).scalars().all()
+    if not rows:
+        return {"sent": 0}
+    orgs = {o.id: o for o in (await db.execute(
+        select(Org).where(Org.id.in_({r.org_id for r in rows})))).scalars().all()}
+    payload = build_payload(rows, orgs)
+    if not payload["conversions"]:
+        return {"sent": 0}
+    cid = get_settings().google_ads_customer_id
+    url = f"https://googleads.googleapis.com/{API_VERSION}/customers/{cid}:uploadClickConversions"
+    headers = await _auth_headers(db, client)
+    resp = await client.post(url, json=payload, headers=headers)
+    now = _utcnow_naive()
+    for row in rows:
+        row.attempts += 1
+        if resp.status_code == 200:
+            row.uploaded_at = now
+            row.error = ""
+        else:
+            row.error = f"{resp.status_code}: {resp.text[:300]}"
+        db.add(row)
+    await db.commit()
+    return {"sent": len(rows), "status": resp.status_code}
+
+
+async def worker(session_factory, client) -> None:
+    """Drain forever. Runs from `lifespan`; a failure here must never take the server down."""
+    log = logging.getLogger("treg")
+    while True:
+        try:
+            async with session_factory() as db:
+                await drain_once(db, client)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — a bad batch must not kill the loop
+            log.warning("ads conversion drain failed: %s", exc)
+        await asyncio.sleep(300)

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -44,6 +44,7 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -54,9 +55,9 @@ from .models import AdConversion, Org, Secret
 
 
 def enabled() -> bool:
-    """Empty customer id = OFF. Keeps the test suite and self-hosted instances inert."""
+    """Missing upload configuration = OFF. Keeps tests and self-hosted instances inert."""
     s = get_settings()
-    return bool(s.google_ads_customer_id and s.ads_conv_org_slug)
+    return bool(s.google_ads_customer_id and s.google_ads_developer_token and s.ads_conv_org_slug)
 
 
 async def queue(db: AsyncSession, org: Org, action: str, *,
@@ -73,7 +74,7 @@ async def queue(db: AsyncSession, org: Org, action: str, *,
     absorbed by the unique constraint rather than checked for first — the check-then-insert race
     is real under concurrent webhook redelivery.
     """
-    if not org.ad_gclid:
+    if not enabled() or not org.ad_gclid:
         return False
     try:
         # A SAVEPOINT, not a bare flush: this runs inside the CALLER's transaction (the signup
@@ -107,6 +108,17 @@ def _utcnow_naive() -> datetime:
 API_VERSION = "v25"
 _UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
 _MAX_ATTEMPTS = 8
+_RETRY_BASE_S = 5 * 60
+_RETRY_CAP_S = 24 * 3600
+_CLICK_ID_FIELDS = frozenset({"gclid", "gbraid", "wbraid"})
+_ACKNOWLEDGED_ROW_ERRORS = frozenset({"CLICK_CONVERSION_ALREADY_EXISTS"})
+_RETRYABLE_ROW_ERRORS = frozenset({
+    "INTERNAL_ERROR",
+    "RESOURCE_EXHAUSTED",
+    "TEMPORARILY_UNAVAILABLE",
+    "TOO_RECENT_CONVERSION_ACTION",
+    "TOO_RECENT_EVENT",
+})
 
 
 def _conversion_time(dt: datetime) -> str:
@@ -122,21 +134,22 @@ def _conversion_time(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
 
 
-def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
-    """Turn outbox rows into an uploadClickConversions body.
-
-    `partialFailure` so one bad row cannot reject the batch — results are read per row.
-    Value is converted to the ACCOUNT's currency here, at upload time; the outbox stores USD so a
-    rate change never rewrites history.
-    """
+def _payload_and_rows(
+    rows: list[AdConversion], orgs: dict[int, Org]
+) -> tuple[dict, list[AdConversion]]:
+    """Build the request and preserve its operation-index -> outbox-row mapping."""
     cid = get_settings().google_ads_customer_id
     conversions = []
+    payload_rows = []
     for row in rows:
         org = orgs.get(row.org_id)
         if org is None or not org.ad_gclid:
             continue
+        click_field = org.ad_click_id_type or "gclid"  # NULL means a pre-type-migration GCLID.
+        if click_field not in _CLICK_ID_FIELDS:
+            click_field = "gclid"  # defensive for a manually edited legacy row
         conv = {
-            "gclid": org.ad_gclid,
+            click_field: org.ad_gclid,
             "conversionAction": f"customers/{cid}/conversionActions/{CONVERSION_ACTION_IDS[row.action]}",
             "conversionDateTime": _conversion_time(row.created_at),
         }
@@ -147,7 +160,19 @@ def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
             conv["conversionValue"] = usd_micro_to_aud_micro(row.value_usd_micro) / 1_000_000
             conv["currencyCode"] = "AUD"
         conversions.append(conv)
-    return {"conversions": conversions, "partialFailure": True}
+        payload_rows.append(row)
+    return {"conversions": conversions, "partialFailure": True}, payload_rows
+
+
+def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
+    """Turn outbox rows into an uploadClickConversions body.
+
+    `partialFailure` keeps a bad row from rejecting its siblings. `drain_once` retains the row
+    mapping from `_payload_and_rows` and reads every result before acknowledging anything.
+    Value is converted to the ACCOUNT's currency here, at upload time; the outbox stores USD so a
+    rate change never rewrites history.
+    """
+    return _payload_and_rows(rows, orgs)[0]
 
 
 async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
@@ -188,55 +213,155 @@ async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
         "developer-token": settings.google_ads_developer_token,
         "Content-Type": "application/json",
     }
-    # resource_ref is the account this connection was pointed at during connect/discovery — stored
-    # as the full resource name ("customers/1234567890"); login-customer-id wants the bare digits.
-    # Only needed when acting on a client account under a manager (SKILL.md #7) — omit rather than
-    # send an empty/wrong header, which Ads reports as 401 UNAUTHENTICATED, not a targeting error.
-    if secret.resource_ref:
-        headers["login-customer-id"] = secret.resource_ref.rsplit("/", 1)[-1]
+    # `resource_ref` is the TARGET account chosen in discovery. It is not the manager account that
+    # Google requires in login-customer-id, so never infer this header from the Secret. Direct client
+    # auth omits it; manager auth configures the MCC explicitly.
+    if settings.google_ads_login_customer_id:
+        headers["login-customer-id"] = settings.google_ads_login_customer_id.replace("-", "").strip()
     return headers
+
+
+def _retry_delay(attempts: int) -> timedelta:
+    """Exponential retry delay, bounded so a repaired integration eventually drains."""
+    exponent = min(max(attempts - 1, 0), 9)  # 2^9 already exceeds the 24-hour cap.
+    seconds = min(_RETRY_BASE_S * (2 ** exponent), _RETRY_CAP_S)
+    return timedelta(seconds=seconds)
+
+
+def _partial_failure_errors(body: dict) -> tuple[dict[int, list[tuple[str, str]]], list[tuple[str, str]]]:
+    """Return Google Ads partial errors keyed by conversions[index], plus batch-level details."""
+    by_index: dict[int, list[tuple[str, str]]] = {}
+    general: list[tuple[str, str]] = []
+    status = body.get("partialFailureError") or {}
+    for detail in status.get("details") or []:
+        if not isinstance(detail, dict):
+            continue
+        for error in detail.get("errors") or []:
+            if not isinstance(error, dict):
+                continue
+            error_code = error.get("errorCode") or {}
+            code = next((str(v) for v in error_code.values() if v), "UNKNOWN") \
+                if isinstance(error_code, dict) else "UNKNOWN"
+            message = str(error.get("message") or status.get("message") or "partial failure")
+            index = None
+            location = error.get("location") or {}
+            for part in location.get("fieldPathElements") or []:
+                if isinstance(part, dict) and part.get("fieldName") == "conversions":
+                    candidate = part.get("index")
+                    if isinstance(candidate, int):
+                        index = candidate
+                        break
+            target = by_index.setdefault(index, []) if index is not None else general
+            target.append((code, message))
+    if not by_index and not general and status:
+        general.append(("UNKNOWN", str(status.get("message") or "partial failure")))
+    return by_index, general
+
+
+def _schedule_retry(row: AdConversion, now: datetime, error: str) -> None:
+    row.error = error[:300]
+    row.next_attempt_at = now + _retry_delay(row.attempts)
+    row.failed_at = None
+
+
+def _acknowledge(row: AdConversion, now: datetime) -> None:
+    row.uploaded_at = now
+    row.next_attempt_at = None
+    row.failed_at = None
+    row.error = ""
 
 
 async def drain_once(db: AsyncSession, client) -> dict:
     """Upload one batch of due rows. Returns a small dict for logging.
 
-    Due = not yet uploaded, older than the click-availability delay, under the attempt ceiling.
-    Every failure marks the row and leaves it for the next pass; nothing is dropped silently.
+    Due = not uploaded/terminal, older than the click-availability delay, and past its retry time.
+    HTTP failures retry indefinitely with backoff. Per-row permanent failures are dead-lettered
+    after `_MAX_ATTEMPTS`; they remain queryable with `failed_at` + the last Google error.
     """
     if not enabled():
         return {"sent": 0, "reason": "disabled"}
     # Naive UTC on BOTH sides: created_at is a naive column, and comparing it against a tz-aware
     # value is an asyncpg error on Postgres (and a silently wrong comparison elsewhere).
-    cutoff = _utcnow_naive() - timedelta(seconds=_UPLOAD_DELAY_S)
+    now = _utcnow_naive()
+    cutoff = now - timedelta(seconds=_UPLOAD_DELAY_S)
     rows = (await db.execute(
         select(AdConversion)
         .where(AdConversion.uploaded_at.is_(None),
+               AdConversion.failed_at.is_(None),
                AdConversion.created_at <= cutoff,
-               AdConversion.attempts < _MAX_ATTEMPTS)
+               or_(AdConversion.next_attempt_at.is_(None), AdConversion.next_attempt_at <= now))
+        .order_by(AdConversion.created_at, AdConversion.id)
         .limit(100)
     )).scalars().all()
     if not rows:
         return {"sent": 0}
     orgs = {o.id: o for o in (await db.execute(
         select(Org).where(Org.id.in_({r.org_id for r in rows})))).scalars().all()}
-    payload = build_payload(rows, orgs)
+    payload, payload_rows = _payload_and_rows(rows, orgs)
+    payload_ids = {row.id for row in payload_rows}
+    skipped = [row for row in rows if row.id not in payload_ids]
+    for row in skipped:
+        row.attempts += 1
+        row.failed_at = now
+        row.error = "outbox row has no attributable org/click id"
+        db.add(row)
     if not payload["conversions"]:
-        return {"sent": 0}
+        await db.commit()
+        return {"sent": 0, "failed": len(skipped)}
     cid = get_settings().google_ads_customer_id
     url = f"https://googleads.googleapis.com/{API_VERSION}/customers/{cid}:uploadClickConversions"
     headers = await _auth_headers(db, client)
     resp = await client.post(url, json=payload, headers=headers)
-    now = _utcnow_naive()
-    for row in rows:
+    if resp.status_code != 200:
+        for row in payload_rows:
+            row.attempts += 1
+            _schedule_retry(row, now, f"{resp.status_code}: {resp.text[:260]}")
+            db.add(row)
+        await db.commit()
+        return {"sent": 0, "retried": len(payload_rows), "failed": len(skipped),
+                "status": resp.status_code}
+
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 — an unexpected 200 body must not acknowledge durable rows
+        body = {}
+    results = body.get("results") if isinstance(body, dict) else None
+    indexed_errors, general_errors = _partial_failure_errors(body if isinstance(body, dict) else {})
+    sent = retried = failed = 0
+    for index, row in enumerate(payload_rows):
         row.attempts += 1
-        if resp.status_code == 200:
-            row.uploaded_at = now
-            row.error = ""
+        result = results[index] if isinstance(results, list) and index < len(results) else None
+        if isinstance(result, dict) and result:
+            _acknowledge(row, now)
+            sent += 1
         else:
-            row.error = f"{resp.status_code}: {resp.text[:300]}"
+            row_errors = indexed_errors.get(index)
+            errors = row_errors or general_errors
+            codes = {code for code, _ in errors}
+            detail = "; ".join(f"{code}: {message}" for code, message in errors) \
+                or "200: missing conversion result"
+            if codes and codes <= _ACKNOWLEDGED_ROW_ERRORS:
+                # A retry may race the prior worker's commit; Google has already stored this event.
+                _acknowledge(row, now)
+                sent += 1
+            elif (
+                row_errors is None
+                or codes & _RETRYABLE_ROW_ERRORS
+                or row.attempts < _MAX_ATTEMPTS
+            ):
+                # A missing/unparseable result or batch-level failure is not evidence that this row
+                # is permanently bad. Only an indexed row error may reach the dead-letter ceiling.
+                _schedule_retry(row, now, detail)
+                retried += 1
+            else:
+                row.error = detail[:300]
+                row.next_attempt_at = None
+                row.failed_at = now
+                failed += 1
         db.add(row)
     await db.commit()
-    return {"sent": len(rows), "status": resp.status_code}
+    return {"sent": sent, "retried": retried, "failed": failed + len(skipped),
+            "status": resp.status_code}
 
 
 async def worker(session_factory, client) -> None:
@@ -245,7 +370,9 @@ async def worker(session_factory, client) -> None:
     while True:
         try:
             async with session_factory() as db:
-                await drain_once(db, client)
+                result = await drain_once(db, client)
+                if result.get("retried") or result.get("failed") or result.get("status", 200) >= 400:
+                    log.warning("ads conversion drain incomplete: %s", result)
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 — a bad batch must not kill the loop

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -31,5 +31,9 @@ def usd_micro_to_aud_micro(usd_micro: int) -> int:
 
     Integer-only, per the money-code rule: a float here would round differently on
     different platforms and the value is uploaded as a monetary amount.
+
+    Note: // floors toward negative infinity, so negative amounts round away from zero
+    while positive amounts round toward zero. Real inputs are always positive
+    (top-ups); the negative case is defensive only.
     """
     return usd_micro * AUD_PER_USD_NUM // AUD_PER_USD_DEN

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -144,6 +144,10 @@ async def lifespan(app: FastAPI):
     # TCP+TLS connections across requests — the single biggest latency win for a relay.
     limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
     app.state.http = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(float(get_settings().call_timeout_s)))
+    # Off unless configured (adsconv.enabled() gates on google_ads_customer_id + ads_conv_org_slug)
+    # — keeps the test suite and self-hosted instances from starting a task that only ever no-ops.
+    ads_task = asyncio.create_task(adsconv.worker(session_maker, app.state.http)) \
+        if adsconv.enabled() else None
     try:
         if _mcp is None:
             yield
@@ -154,6 +158,8 @@ async def lifespan(app: FastAPI):
             async with _mcp.mcp_lifespan():
                 yield
     finally:
+        if ads_task is not None:
+            ads_task.cancel()
         await audit.drain()  # flush pending audit writes before tearing down
         await analytics.drain()  # best-effort flush of queued analytics events
         await app.state.http.aclose()

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -144,8 +144,8 @@ async def lifespan(app: FastAPI):
     # TCP+TLS connections across requests — the single biggest latency win for a relay.
     limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
     app.state.http = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(float(get_settings().call_timeout_s)))
-    # Off unless configured (adsconv.enabled() gates on google_ads_customer_id + ads_conv_org_slug)
-    # — keeps the test suite and self-hosted instances from starting a task that only ever no-ops.
+    # Off unless configured (adsconv.enabled() requires the customer id, developer token and OAuth
+    # org slug) — keeps the test suite and self-hosted instances completely inert by default.
     ads_task = asyncio.create_task(adsconv.worker(session_maker, app.state.http)) \
         if adsconv.enabled() else None
     try:
@@ -2339,12 +2339,17 @@ async def privacy_page():
 async def adtrack_js():
     """First-party ad-click capture (see the file itself): sets the `treg_ad` cookie that
     `_ad_attribution_from` reads at signup. No Google script, no third-party request."""
+    headers = {"Cache-Control": "no-cache"}
+    if not adsconv.enabled():
+        # The page keeps one static script include, but an unconfigured/self-hosted deployment must
+        # not collect an advertising cookie at all. A stale cookie is also ignored at signup below.
+        return Response(content="", media_type="application/javascript", headers=headers)
     f = _WEB_DIR / "adtrack.js"
     if not f.exists():
         raise HTTPException(status_code=404, detail="adtrack.js not bundled")
     # no-cache, same reasoning as tutorial.js: served as a bare `<script src="/adtrack.js">` with no
     # version query, so without this header a browser would keep an ad-window-stale copy after a fix.
-    return FileResponse(f, media_type="application/javascript", headers={"Cache-Control": "no-cache"})
+    return FileResponse(f, media_type="application/javascript", headers=headers)
 
 
 @app.get("/resources", include_in_schema=False)
@@ -3822,13 +3827,21 @@ async def _find_or_create_user(db: AsyncSession, email: str) -> User:
     return user
 
 
-def _ad_attribution_from(request: Request) -> tuple[str, str]:
-    """Read the first-party ad cookie set by /adtrack.js. Returns ("", "") when absent."""
+def _ad_attribution_from(request: Request) -> tuple[str, str, str]:
+    """Return (click-id field, click-id, landing), with legacy GCLID-cookie compatibility."""
+    if not adsconv.enabled():
+        return "", "", ""
     raw = request.cookies.get("treg_ad") or ""
     if not raw:
-        return "", ""
-    gclid, _, landing = unquote(raw).partition("|")
-    return gclid.strip()[:255], landing.strip()[:64]
+        return "", "", ""
+    first, separator, rest = unquote(raw).partition("|")
+    if separator and first in ("gclid", "gbraid", "wbraid"):
+        click_id, _, landing = rest.partition("|")
+        click_field = first
+    else:
+        # Old cookies were `CLICK_ID|landing` and always held a GCLID.
+        click_field, click_id, landing = "gclid", first, rest
+    return click_field, click_id.strip()[:255], landing.strip()[:64]
 
 
 # ---- users (open registration; personal org + owner membership; token shown once) ---------
@@ -3849,9 +3862,10 @@ async def register_user(body: UserIn, request: Request, db: AsyncSession = Depen
     org, token = await _make_org_membership(
         db, user, name=email, slug_base=_slugify(email), role="owner", webhook_url=body.webhook_url
     )
-    gclid, landing = _ad_attribution_from(request)
+    click_field, gclid, landing = _ad_attribution_from(request)
     if gclid:
         org.ad_gclid = gclid
+        org.ad_click_id_type = click_field
         org.ad_landing = landing or None
         org.ad_click_at = _utcnow_naive()  # naive UTC: asyncpg rejects tz-aware into a
                                             # TIMESTAMP WITHOUT TIME ZONE column (see models._now).
@@ -3911,7 +3925,7 @@ async def create_org(
             "the demo sandbox can't create a real team — sign in with GitHub, Google, or email to make one"))
     user_id = user.id  # snapshot BEFORE the loop: db.rollback() expires ORM instances, so
     name = body.name   # touching `user` afterwards could trigger a lazy load → MissingGreenlet.
-    gclid, landing = _ad_attribution_from(request)  # this is create_org — the OTHER signup door
+    click_field, gclid, landing = _ad_attribution_from(request)  # the OTHER signup door
     # (browser sign-in → mandatory first-team creation), separate from register_user's /users. A
     # browser visitor who clicked an ad lands here, not there, so attribution must be read in both.
     for _ in range(3):  # a concurrent create can take the slug between _unique_slug and commit — retry
@@ -3922,6 +3936,7 @@ async def create_org(
         db.add(Membership(user_id=user_id, org_id=org.id, role="owner", token_hash=crypto.hash_token(token)))
         if gclid:
             org.ad_gclid = gclid
+            org.ad_click_id_type = click_field
             org.ad_landing = landing or None
             org.ad_click_at = _utcnow_naive()  # naive UTC: asyncpg rejects tz-aware into a
                                                 # TIMESTAMP WITHOUT TIME ZONE column (see models._now).

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -55,10 +55,10 @@ from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import LEGACY_PUBLIC_HOSTS, PUBLIC_HOST_ALIASES, get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
-from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold,
-                     IdempotentCall, Invite, LedgerEntry, Membership, OAuthClient, OAuthCode,
-                     OAuthRefresh, Org, PendingOAuth, Project, RunRecord, Secret, TagBudget, TagSpend, Tool,
-                     ToolRequest, User)
+from .models import (ROLE_RANK, AdConversion, Bundle, CallRecord, CapabilityPin, CreditBlock,
+                     DenyRule, Hold, IdempotentCall, Invite, LedgerEntry, Membership, OAuthClient,
+                     OAuthCode, OAuthRefresh, Org, PendingOAuth, Project, RunRecord, Secret,
+                     TagBudget, TagSpend, Tool, ToolRequest, User)
 from .proxy import relay
 
 
@@ -3361,6 +3361,7 @@ _ORG_SCOPED_MODELS = (
     OAuthCode, OAuthRefresh,   # grants naming a team that no longer exists
     IdempotentCall,            # a remembered answer belongs to the team that paid for it
     ToolRequest,  # attribution rows go with the team; anonymous filings carry no org_id and stay
+    AdConversion,  # pending Google Ads conversions belong to the team they'd be attributed to
     Membership,   # last: it is what makes the caller a member of the org being deleted
 )
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3771,12 +3771,15 @@ async def _grant_signup_promo(db: AsyncSession, org: Org) -> None:
     if org is None or org.id is None or org.demo or org.public_demo:
         return
     try:
-        await ledger.grant(db, org.id)
+        # Queue BEFORE granting: adsconv.queue() only adds a row inside a SAVEPOINT, it never commits.
+        # ledger.grant() commits internally, so calling it second is what makes its commit durable for
+        # BOTH rows in one transaction — the event and its conversion must land together (see
+        # adsconv.queue's docstring). Reordering this silently reintroduces a two-transaction gap.
         # Same door, same once-only guarantee: this function is already the single place a brand-new
         # real team comes into existence. A queue failure must not fail the signup, so it rides the
         # existing except below rather than getting its own.
         await adsconv.queue(db, org, adsconv.ACTION_SIGNUP)
-        await db.commit()
+        await ledger.grant(db, org.id)  # commits — absorbs the queued conversion row too
     except Exception as exc:  # noqa: BLE001 — the team is already created; don't 500 the signup over credit
         logging.getLogger("treg").warning("promo grant failed for org %s: %s", org.id, exc)
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -30,7 +30,7 @@ import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from urllib.parse import parse_qsl, quote, urlsplit, urlunsplit
+from urllib.parse import parse_qsl, quote, unquote, urlsplit, urlunsplit
 
 from sqlalchemy import case, delete, func, or_
 
@@ -2329,6 +2329,18 @@ async def privacy_page():
     return _legal_page("privacy.html")
 
 
+@app.get("/adtrack.js", include_in_schema=False)
+async def adtrack_js():
+    """First-party ad-click capture (see the file itself): sets the `treg_ad` cookie that
+    `_ad_attribution_from` reads at signup. No Google script, no third-party request."""
+    f = _WEB_DIR / "adtrack.js"
+    if not f.exists():
+        raise HTTPException(status_code=404, detail="adtrack.js not bundled")
+    # no-cache, same reasoning as tutorial.js: served as a bare `<script src="/adtrack.js">` with no
+    # version query, so without this header a browser would keep an ad-window-stale copy after a fix.
+    return FileResponse(f, media_type="application/javascript", headers={"Cache-Control": "no-cache"})
+
+
 @app.get("/resources", include_in_schema=False)
 async def resources_page():
     """The hub for the outcome pages. It exists for two reasons beyond navigation: without it the
@@ -3790,9 +3802,18 @@ async def _find_or_create_user(db: AsyncSession, email: str) -> User:
     return user
 
 
+def _ad_attribution_from(request: Request) -> tuple[str, str]:
+    """Read the first-party ad cookie set by /adtrack.js. Returns ("", "") when absent."""
+    raw = request.cookies.get("treg_ad") or ""
+    if not raw:
+        return "", ""
+    gclid, _, landing = unquote(raw).partition("|")
+    return gclid.strip()[:255], landing.strip()[:64]
+
+
 # ---- users (open registration; personal org + owner membership; token shown once) ---------
 @app.post("/users")
-async def register_user(body: UserIn, db: AsyncSession = Depends(get_session)) -> dict:
+async def register_user(body: UserIn, request: Request, db: AsyncSession = Depends(get_session)) -> dict:
     email = _norm_email(body.email)
     # This door creates a User directly (it predates `_find_or_create_user`), so it needs the same
     # machine-domain block — otherwise open registration could squat an agent address.
@@ -3808,6 +3829,13 @@ async def register_user(body: UserIn, db: AsyncSession = Depends(get_session)) -
     org, token = await _make_org_membership(
         db, user, name=email, slug_base=_slugify(email), role="owner", webhook_url=body.webhook_url
     )
+    gclid, landing = _ad_attribution_from(request)
+    if gclid:
+        org.ad_gclid = gclid
+        org.ad_landing = landing or None
+        org.ad_click_at = _utcnow_naive()  # naive UTC: asyncpg rejects tz-aware into a
+                                            # TIMESTAMP WITHOUT TIME ZONE column (see models._now).
+        db.add(org)
     try:
         await db.commit()
     except IntegrityError:
@@ -3852,7 +3880,8 @@ async def _count_owners(org_id: int, db: AsyncSession) -> int:
 
 @app.post("/orgs")
 async def create_org(
-    body: OrgIn, user: User = Depends(require_identity), db: AsyncSession = Depends(get_session)
+    body: OrgIn, request: Request,
+    user: User = Depends(require_identity), db: AsyncSession = Depends(get_session),
 ) -> dict:
     # Any authenticated user spins up a new org and becomes its owner, minting a fresh org-scoped
     # token for it. **require_identity, NOT require_member** — a brand-new user has zero orgs (no auto
@@ -3862,12 +3891,21 @@ async def create_org(
             "the demo sandbox can't create a real team — sign in with GitHub, Google, or email to make one"))
     user_id = user.id  # snapshot BEFORE the loop: db.rollback() expires ORM instances, so
     name = body.name   # touching `user` afterwards could trigger a lazy load → MissingGreenlet.
+    gclid, landing = _ad_attribution_from(request)  # this is create_org — the OTHER signup door
+    # (browser sign-in → mandatory first-team creation), separate from register_user's /users. A
+    # browser visitor who clicked an ad lands here, not there, so attribution must be read in both.
     for _ in range(3):  # a concurrent create can take the slug between _unique_slug and commit — retry
         org = Org(name=name, slug=await _unique_slug(_slugify(name), db))
         db.add(org)
         await db.flush()
         token = crypto.new_token()
         db.add(Membership(user_id=user_id, org_id=org.id, role="owner", token_hash=crypto.hash_token(token)))
+        if gclid:
+            org.ad_gclid = gclid
+            org.ad_landing = landing or None
+            org.ad_click_at = _utcnow_naive()  # naive UTC: asyncpg rejects tz-aware into a
+                                                # TIMESTAMP WITHOUT TIME ZONE column (see models._now).
+            db.add(org)
         try:
             await db.commit()
             break

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -50,7 +50,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
-from . import analytics, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
+from . import adsconv, analytics, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
 from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
 from .config import LEGACY_PUBLIC_HOSTS, PUBLIC_HOST_ALIASES, get_settings, platform_setting_name
@@ -3772,6 +3772,11 @@ async def _grant_signup_promo(db: AsyncSession, org: Org) -> None:
         return
     try:
         await ledger.grant(db, org.id)
+        # Same door, same once-only guarantee: this function is already the single place a brand-new
+        # real team comes into existence. A queue failure must not fail the signup, so it rides the
+        # existing except below rather than getting its own.
+        await adsconv.queue(db, org, adsconv.ACTION_SIGNUP)
+        await db.commit()
     except Exception as exc:  # noqa: BLE001 — the team is already created; don't 500 the signup over credit
         logging.getLogger("treg").warning("promo grant failed for org %s: %s", org.id, exc)
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3776,9 +3776,15 @@ async def _grant_signup_promo(db: AsyncSession, org: Org) -> None:
         # BOTH rows in one transaction — the event and its conversion must land together (see
         # adsconv.queue's docstring). Reordering this silently reintroduces a two-transaction gap.
         # Same door, same once-only guarantee: this function is already the single place a brand-new
-        # real team comes into existence. A queue failure must not fail the signup, so it rides the
-        # existing except below rather than getting its own.
-        await adsconv.queue(db, org, adsconv.ACTION_SIGNUP)
+        # real team comes into existence.
+        try:
+            await adsconv.queue(db, org, adsconv.ACTION_SIGNUP)
+        except Exception as exc:  # noqa: BLE001 — its OWN guard, deliberately, not the outer one
+            # Because the queue now runs FIRST, sharing the outer except would mean an unexpected
+            # failure here (anything but the IntegrityError queue() already absorbs) skips the grant
+            # entirely and costs the team its $1 promotional credit. A marketing metric must not be
+            # able to take away a product benefit: swallow it here so the grant still runs.
+            logging.getLogger("treg").warning("ad conversion queue failed for org %s: %s", org.id, exc)
         await ledger.grant(db, org.id)  # commits — absorbs the queued conversion row too
     except Exception as exc:  # noqa: BLE001 — the team is already created; don't 500 the signup over credit
         logging.getLogger("treg").warning("promo grant failed for org %s: %s", org.id, exc)

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qsl, quote, unquote, urlsplit, urlunsplit
 
-from sqlalchemy import case, delete, func, or_
+from sqlalchemy import case, delete, func, or_, update
 
 INVITE_TTL_DAYS = 7  # invite codes are one-time AND expire after this many days
 
@@ -9120,6 +9120,34 @@ async def _platform_settle(
     return charged, observed
 
 
+async def _record_first_call(org_id: int) -> None:
+    """Set Org.first_call_at once — the metric that decides whether a marketing channel is real (see
+    marketing/landing/_measurement.md). A CONDITIONAL UPDATE, not read-then-write: concurrent first
+    calls would both see NULL and both fire. Set for EVERY org (it is a product metric in its own
+    right); adsconv.queue() itself no-ops for orgs with no ad_gclid, so the conversion side stays
+    ad-attributed-only.
+
+    Runs on its OWN session, same reason as _platform_settle: this fires after the response is built,
+    while the request's `db` may still be mid-settlement (or mid-rollback from one), and a commit or
+    rollback issued here would land on THAT transaction instead of this one. Never raises — a metric
+    write must not turn a working proxied call into a 500."""
+    try:
+        async with session_maker() as db:
+            result = await db.execute(
+                update(Org)
+                .where(Org.id == org_id, Org.first_call_at.is_(None))
+                .values(first_call_at=_utcnow_naive())  # naive UTC — asyncpg rejects tz-aware here
+            )
+            if result.rowcount:
+                org_row = await db.get(Org, org_id)
+                if org_row is not None:
+                    await adsconv.queue(db, org_row, adsconv.ACTION_FIRST_CALL)
+                await db.commit()
+    except Exception:  # noqa: BLE001 — loudly, but never into the caller's response
+        logging.getLogger("treg.adsconv").error(
+            "first_call_at update/queue failed for org %s", org_id, exc_info=True)
+
+
 async def _relay_live_demo(request: Request, upstream_url: str, key: str, visitor: str):
     """The sandbox's ONE real upstream call (the landing live wire). Deliberately narrower than
     relay(): form-encoded only, auth header built here from the env key (never from a sandbox
@@ -9366,6 +9394,13 @@ async def call_tool(
             await _platform_settle(mk, None, reason="call_crashed")
         raise
     duration_ms = _now_ms() - started
+    # First successful call. The common case — an org that already has one — is an in-memory check
+    # against `caller.org` (freshly loaded this request by require_member): zero DB cost on a path
+    # that runs on every proxied call. Only an org's actual first call touches the database, and it
+    # does so via _record_first_call's own session, never the request's `db` (which _platform_settle,
+    # right below, is about to settle/release — see its docstring for why that session is off-limits).
+    if 200 <= response.status_code < 400 and caller.org_id and caller.org.first_call_at is None:
+        await _record_first_call(caller.org_id)
     if mk is not None and mk.metered:
         charged, observed = await _platform_settle(mk, response.status_code, body)
         _audit(response.status_code, observed_micro=observed, charged_micro=charged,

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -779,6 +779,9 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
     )).first() is not None
     block = await ledger.topup(db, org_id, amount_micro, pi_id,
                               meta={"auto": auto, "source": "stripe"})
+    block_id = block.id  # captured now: a later rollback (the ad-conversion except below) expires
+                        # every object this session is tracking, `block` included, and reading an
+                        # expired attribute outside an awaited call raises MissingGreenlet.
     after = await ledger.balance_of(db, org_id)
     fresh = not already
     if fresh:
@@ -814,8 +817,16 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                                     value_usd_micro=amount_micro, dedupe_key=pi_id)
                 await db.commit()
             except Exception as e:  # noqa: BLE001 — see comment above
+                # A failure here (not just adsconv.queue's own IntegrityError, which it already
+                # absorbs via savepoint, but e.g. the commit above failing on a serialization
+                # error or connection blip) can leave the session in SQLAlchemy's "pending
+                # rollback" state. The callers below reuse this same `db` for more work
+                # (_set_default_pm's db.get(Org, ...)); without rolling back here, that next use
+                # raises PendingRollbackError, which 500s the webhook and makes Stripe retry a
+                # payment ledger.topup() already credited. Do not remove this as redundant.
+                await db.rollback()
                 log.warning("billing: could not queue ad conversion for org %s: %s", org_id, e)
-    return {"handled": True, "credited": fresh, "block_id": block.id,
+    return {"handled": True, "credited": fresh, "block_id": block_id,
             "amount_micro": amount_micro, "balance_micro": after}
 
 

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -42,6 +42,7 @@ import stripe
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from . import adsconv
 from . import analytics
 from . import email as email_mod
 from . import ledger
@@ -802,6 +803,18 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                            "auto": auto, "balance_after_micro": after,
                            "org": org.slug if org else ""},
                           groups={"team": org.slug if org else ""})
+        # First top-up only: `fresh` is already the "this delivery moved money" branch, and the
+        # outbox's unique (org_id, action) makes a second top-up a silent no-op. We measure becoming
+        # a payer, not revenue — value-based bidding needs volume treg does not have yet. Guarded like
+        # analytics.capture above: an exception here must not 500 the webhook and make Stripe retry an
+        # already-credited payment.
+        if org is not None:
+            try:
+                await adsconv.queue(db, org, adsconv.ACTION_PAID,
+                                    value_usd_micro=amount_micro, dedupe_key=pi_id)
+                await db.commit()
+            except Exception as e:  # noqa: BLE001 — see comment above
+                log.warning("billing: could not queue ad conversion for org %s: %s", org_id, e)
     return {"handled": True, "credited": fresh, "block_id": block.id,
             "amount_micro": amount_micro, "balance_micro": after}
 

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -238,6 +238,12 @@ class Settings(BaseSettings):
     # can't work without this) rather than silently reusing the wrong client.
     google_ads_client_id: str = ""
     google_ads_client_secret: str = ""
+    # Google Ads conversion upload. Empty customer id = the whole feature is OFF (tests stay inert,
+    # self-hosters send nothing) — the same gate shape analytics.py uses for posthog_key.
+    google_ads_customer_id: str = ""
+    # Which team's google-ads OAuth connection the uploader authenticates as. treg uploads to its
+    # OWN ad account, so this is a platform setting, never a per-tenant one.
+    ads_conv_org_slug: str = ""
 
     linkedin_client_id: str = ""
     linkedin_client_secret: str = ""

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -238,9 +238,14 @@ class Settings(BaseSettings):
     # can't work without this) rather than silently reusing the wrong client.
     google_ads_client_id: str = ""
     google_ads_client_secret: str = ""
-    # Google Ads conversion upload. Empty customer id = the whole feature is OFF (tests stay inert,
+    # Google Ads conversion upload. This customer id, the developer token above, and the OAuth org
+    # slug below are all required; if any is empty the whole feature is OFF (tests stay inert and
     # self-hosters send nothing) — the same gate shape analytics.py uses for posthog_key.
     google_ads_customer_id: str = ""
+    # Manager (MCC) account used to access google_ads_customer_id. Optional for direct client auth;
+    # when present this is sent as login-customer-id. It cannot be inferred from Secret.resource_ref,
+    # which is the TARGET client account selected in discovery, not its manager.
+    google_ads_login_customer_id: str = ""
     # Which team's google-ads OAuth connection the uploader authenticates as. treg uploads to its
     # OWN ad account, so this is a platform setting, never a per-tenant one.
     ads_conv_org_slug: str = ""

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -359,10 +359,19 @@ def _migrate_to_orgs(conn) -> None:
     # backfill is meaningful — a team that predates the ads work has no click to attribute to.
     if "org" in tables:
         org_cols = {c["name"] for c in insp.get_columns("org")}
-        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_click_at", "TIMESTAMP"),
+        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_click_id_type", "VARCHAR"),
+                         ("ad_click_at", "TIMESTAMP"),
                          ("ad_landing", "VARCHAR"), ("first_call_at", "TIMESTAMP")):
             if col not in org_cols:
                 conn.execute(text(f"ALTER TABLE org ADD COLUMN {col} {ddl}"))
+
+    # (A36) additive: durable retry/dead-letter state for the Ads conversion outbox. The table may
+    # already exist from the first conversion-tracking deploy; create_all does not add new columns.
+    if "adconversion" in tables:
+        conv_cols = {c["name"] for c in insp.get_columns("adconversion")}
+        for col in ("next_attempt_at", "failed_at"):
+            if col not in conv_cols:
+                conn.execute(text(f"ALTER TABLE adconversion ADD COLUMN {col} TIMESTAMP"))
 
     # (A28) corrective: creditblock.stripe_payment_intent must be UNIQUE (the top-up idempotency
     # key). It sits HERE, above the (B) block, because (B) returns early on a fresh/new-schema DB —

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -359,8 +359,8 @@ def _migrate_to_orgs(conn) -> None:
     # backfill is meaningful — a team that predates the ads work has no click to attribute to.
     if "org" in tables:
         org_cols = {c["name"] for c in insp.get_columns("org")}
-        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_landing", "VARCHAR"),
-                         ("ad_click_at", "TIMESTAMP"), ("first_call_at", "TIMESTAMP")):
+        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_click_at", "TIMESTAMP"),
+                         ("ad_landing", "VARCHAR"), ("first_call_at", "TIMESTAMP")):
             if col not in org_cols:
                 conn.execute(text(f"ALTER TABLE org ADD COLUMN {col} {ddl}"))
 

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -354,6 +354,16 @@ def _migrate_to_orgs(conn) -> None:
             "AND monthly_cap_micro IS NULL AND calls_per_day < 0 AND status = 'active' "
             "AND (note IS NULL OR note = '')"))
 
+    # (A35) additive: org ad-attribution columns + first_call_at. `create_all` builds them on a
+    # fresh database; this is for one created before this feature shipped. All nullable, so no
+    # backfill is meaningful — a team that predates the ads work has no click to attribute to.
+    if "org" in tables:
+        org_cols = {c["name"] for c in insp.get_columns("org")}
+        for col, ddl in (("ad_gclid", "VARCHAR"), ("ad_landing", "VARCHAR"),
+                         ("ad_click_at", "TIMESTAMP"), ("first_call_at", "TIMESTAMP")):
+            if col not in org_cols:
+                conn.execute(text(f"ALTER TABLE org ADD COLUMN {col} {ddl}"))
+
     # (A28) corrective: creditblock.stripe_payment_intent must be UNIQUE (the top-up idempotency
     # key). It sits HERE, above the (B) block, because (B) returns early on a fresh/new-schema DB —
     # and a fresh DB created between the ledger landing and this fix is precisely the one that has

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -93,6 +93,8 @@ class Org(SQLModel, table=True):
     # The click that produced this team, captured as a first-party cookie on landing and persisted
     # here at signup. Kept for the life of the team: a top-up weeks later still attributes to it.
     ad_gclid: str | None = Field(default=None)
+    # Which mutually-exclusive Google click-id field ad_gclid contains. NULL means a legacy GCLID.
+    ad_click_id_type: str | None = Field(default=None)  # gclid | gbraid | wbraid
     ad_click_at: datetime | None = Field(default=None)
     ad_landing: str | None = Field(default=None)  # utm_content — the landing page id (p1…p5)
     # Set ONCE, by a guarded UPDATE in the /call/ handler. Deliberately not derived from CallRecord:
@@ -417,8 +419,12 @@ class AdConversion(SQLModel, table=True):
     # values into naive columns. Use _now (defined above) to stay consistent with other tables.
     created_at: datetime = Field(default_factory=_now)
     uploaded_at: datetime | None = Field(default=None, index=True)
+    # Retryable failures wait here with exponential backoff. Terminal per-row failures keep the
+    # outbox row and error for inspection rather than being mislabeled as uploaded or disappearing.
+    next_attempt_at: datetime | None = Field(default=None, index=True)
+    failed_at: datetime | None = Field(default=None, index=True)
     attempts: int = Field(default=0)
-    error: str = Field(default="")  # last upload error; a permanent failure stops the retries
+    error: str = Field(default="")
 
 
 class Tool(SQLModel, table=True):

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -395,9 +395,15 @@ class AdConversion(SQLModel, table=True):
     """One conversion owed to Google Ads — an OUTBOX row, not a log line.
 
     Written synchronously inside the transaction of the event it describes, so the event and its
-    pending conversion commit or fail together. A background worker uploads it later; until then
-    `uploaded_at` is NULL. The unique constraint on (org_id, action) is what makes every fire site
-    idempotent — a webhook redelivery or a retried signup bounces off it instead of double-counting.
+    pending conversion commit or fail together — true for `signup` (queued before `ledger.grant`,
+    whose own commit lands both) and `first_call` (queued and committed on its own dedicated
+    session). It is NOT true for `paid`: `ledger.topup()` commits internally before `billing._credit`
+    queues the conversion, so a crash between the two commits loses that conversion permanently. This
+    gap is a known, accepted trade-off (2026-08-17) rather than a reason to restructure `ledger.py` —
+    see `docs/context/architecture/ads-conversions.md`. A background worker uploads every row later;
+    until then `uploaded_at` is NULL. The unique constraint on (org_id, action) is what makes every
+    fire site idempotent — a webhook redelivery or a retried signup bounces off it instead of
+    double-counting.
     """
 
     __table_args__ = (UniqueConstraint("org_id", "action", name="uq_adconversion_org_action"),)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -89,6 +89,16 @@ class Org(SQLModel, table=True):
     # env-var edit that lifts the blast-radius rail for every team at once.
     daily_cap_micro: int = Field(default=0)
 
+    # ---- Google Ads attribution (see adsconv.py) --------------------------------------------------
+    # The click that produced this team, captured as a first-party cookie on landing and persisted
+    # here at signup. Kept for the life of the team: a top-up weeks later still attributes to it.
+    ad_gclid: str | None = Field(default=None)
+    ad_click_at: datetime | None = Field(default=None)
+    ad_landing: str | None = Field(default=None)  # utm_content — the landing page id (p1…p5)
+    # Set ONCE, by a guarded UPDATE in the /call/ handler. Deliberately not derived from CallRecord:
+    # audit.py sheds rows past its queue bound, so a derived value undercounts exactly under load.
+    first_call_at: datetime | None = Field(default=None)
+
     created_at: datetime = Field(default_factory=_now)
 
 
@@ -379,6 +389,28 @@ class Secret(SQLModel, table=True):
     last_error: str = Field(default="")
 
     created_at: datetime = Field(default_factory=_now)
+
+
+class AdConversion(SQLModel, table=True):
+    """One conversion owed to Google Ads — an OUTBOX row, not a log line.
+
+    Written synchronously inside the transaction of the event it describes, so the event and its
+    pending conversion commit or fail together. A background worker uploads it later; until then
+    `uploaded_at` is NULL. The unique constraint on (org_id, action) is what makes every fire site
+    idempotent — a webhook redelivery or a retried signup bounces off it instead of double-counting.
+    """
+
+    __table_args__ = (UniqueConstraint("org_id", "action", name="uq_adconversion_org_action"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    org_id: int = Field(index=True, foreign_key="org.id")
+    action: str  # adsconv.ACTION_* — "signup" | "first_call" | "paid"
+    dedupe_key: str = Field(default="")  # provenance (e.g. the Stripe PaymentIntent id); not the key
+    value_usd_micro: int = Field(default=0)  # converted to AUD at upload time, never stored as AUD
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    uploaded_at: datetime | None = Field(default=None, index=True)
+    attempts: int = Field(default=0)
+    error: str = Field(default="")  # last upload error; a permanent failure stops the retries
 
 
 class Tool(SQLModel, table=True):

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -407,7 +407,9 @@ class AdConversion(SQLModel, table=True):
     action: str  # adsconv.ACTION_* — "signup" | "first_call" | "paid"
     dedupe_key: str = Field(default="")  # provenance (e.g. the Stripe PaymentIntent id); not the key
     value_usd_micro: int = Field(default=0)  # converted to AUD at upload time, never stored as AUD
-    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    # Naive UTC (no tzinfo): columns are TIMESTAMP WITHOUT TIME ZONE, and Postgres rejects tz-aware
+    # values into naive columns. Use _now (defined above) to stay consistent with other tables.
+    created_at: datetime = Field(default_factory=_now)
     uploaded_at: datetime | None = Field(default=None, index=True)
     attempts: int = Field(default=0)
     error: str = Field(default="")  # last upload error; a permanent failure stops the retries

--- a/src/treg/web/adtrack.js
+++ b/src/treg/web/adtrack.js
@@ -1,0 +1,24 @@
+// First-party ad-click capture. No Google script, no third-party request: this reads the click id
+// off our own URL and stores it in our own cookie, which the signup POST then carries to the server.
+// gbraid/wbraid are what Google substitutes for gclid on iOS traffic — omitting them silently drops
+// a large share of mobile conversions.
+(function () {
+  try {
+    var q = new URLSearchParams(window.location.search);
+    var id = q.get('gclid') || q.get('gbraid') || q.get('wbraid');
+    if (!id) return;
+    // The use-case pages set data-page on <body> (their own ev() already reads it) — more reliable
+    // than any query parameter, since a visitor can navigate on-site before the query string is
+    // available. utm_content is what _measurement.md specifies; ref is the use-case pages' own CTA
+    // convention (?ref=p1, see index.html's logged-out redirect). Fall back through both so
+    // attribution does not come back empty on whichever convention a given page happens to use —
+    // the homepage has no data-page.
+    var landing = (document.body && document.body.dataset && document.body.dataset.page)
+               || q.get('utm_content') || q.get('ref') || '';
+    // 90 days: Google's click-through conversion window. Lax so it survives the top-level
+    // navigation from the ad, which is a cross-site GET.
+    var v = encodeURIComponent(id + '|' + landing);
+    document.cookie = 'treg_ad=' + v + ';path=/;max-age=7776000;samesite=lax' +
+      (window.location.protocol === 'https:' ? ';secure' : '');
+  } catch (e) { /* never break the page for a marketing cookie */ }
+})();

--- a/src/treg/web/adtrack.js
+++ b/src/treg/web/adtrack.js
@@ -5,7 +5,10 @@
 (function () {
   try {
     var q = new URLSearchParams(window.location.search);
-    var id = q.get('gclid') || q.get('gbraid') || q.get('wbraid');
+    var kind = q.get('gclid') ? 'gclid'
+             : q.get('gbraid') ? 'gbraid'
+             : q.get('wbraid') ? 'wbraid' : '';
+    var id = kind && q.get(kind);
     if (!id) return;
     // The use-case pages set data-page on <body> (their own ev() already reads it) — more reliable
     // than any query parameter, since a visitor can navigate on-site before the query string is
@@ -17,7 +20,9 @@
                || q.get('utm_content') || q.get('ref') || '';
     // 90 days: Google's click-through conversion window. Lax so it survives the top-level
     // navigation from the ad, which is a cross-site GET.
-    var v = encodeURIComponent(id + '|' + landing);
+    // Keep the mutually-exclusive Ads API field name. Treating a braid value as a GCLID makes the
+    // eventual upload fail even though capture itself appeared to work.
+    var v = encodeURIComponent(kind + '|' + id + '|' + landing);
     document.cookie = 'treg_ad=' + v + ';path=/;max-age=7776000;samesite=lax' +
       (window.location.protocol === 'https:' ? ';secure' : '');
   } catch (e) { /* never break the page for a marketing cookie */ }

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -5987,5 +5987,6 @@ createApp({
   },
 }).mount('#app');
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/privacy.html
+++ b/src/treg/web/privacy.html
@@ -39,7 +39,7 @@
       <li><b>We collect almost nothing about you.</b> An email address to sign in, the teams you're in, and a log of which tools were called. That's the account.</li>
       <li><b>Your credentials are encrypted and never returned.</b> No stored secret value is ever sent back to a client, shown in the dashboard, or read by us.</li>
       <li><b>We don't store what flows through the proxy.</b> A call's request and response bodies pass through and are gone. We keep the method, path, status code, and timestamp — not the content.</li>
-      <li><b>No trackers.</b> No analytics scripts, no advertising pixels, no third-party cookies. One session cookie, and that's it.</li>
+      <li><b>No trackers.</b> No analytics scripts, no advertising pixels, no third-party cookies. Two first-party cookies, both ours: one keeps you signed in, one (only if you arrived from a Google Ads click) tells us the ad worked.</li>
       <li><b>No training, no selling.</b> Your credentials, skills, and connected-account data are never sold and never used to train models.</li>
     </ul>
   </div>
@@ -178,6 +178,7 @@
     <tr><td>Resend</td><td>Your email address and the message body</td><td>Sends sign-in codes and invitations</td><td>USA</td></tr>
     <tr><td>Google Fonts</td><td>Your IP address, when you load a treg web page</td><td>Serves the site's typefaces</td><td>USA</td></tr>
     <tr><td>Upstream APIs you connect</td><td>Whatever your call sends them</td><td>The call you asked us to make</td><td>Varies by provider</td></tr>
+    <tr><td>Google Ads</td><td>A click id and a conversion event (signup, first call, or first payment) — only if you arrived via a Google Ads click</td><td>Measures whether the ad that brought you converted</td><td>USA</td></tr>
   </table></div>
   <p>We'll also disclose data where legally required, or where necessary to protect the Service or
   its users from a live security threat. If we're ever compelled to hand over data about you, we'll
@@ -187,10 +188,18 @@
   protective.</p>
 
   <h2 class="sec" id="s7"><span class="n">07</span>Cookies</h2>
-  <p>One cookie: <code>treg_session</code>. It's HTTP-only, SameSite=Lax, and secure over HTTPS. It
-  holds a signed session reference and nothing else. It's strictly necessary to keep you signed in,
-  so there's no consent banner and nothing to opt out of short of signing out.</p>
-  <p>There are no analytics, advertising, or third-party tracking cookies anywhere on the Service.</p>
+  <p><code>treg_session</code>: HTTP-only, SameSite=Lax, secure over HTTPS. It holds a signed session
+  reference and nothing else. It's strictly necessary to keep you signed in, so there's no consent
+  banner and nothing to opt out of short of signing out.</p>
+  <p><code>treg_ad</code>: set by our own <code>/adtrack.js</code>, not a Google script — if you arrive
+  from a Google Ads click, it records which ad click led to your visit (the click id and the landing
+  page), retained for <b>90 days</b>. It exists to tell us whether an ad turned into a signup, an active
+  agent, or a paying team, so we can tell which ads to keep running. It is <b>first-party</b> (set by
+  <code>treg.to</code>, readable only by us, never by Google or any other third party) and it is
+  <b>not shared with third parties</b> beyond the conversion event itself — a signup, a first call, or
+  a first payment, each tagged with only the click id — uploaded to Google Ads so it can measure the
+  campaign. There is no advertising pixel, no third-party cookie, and no cross-site tracking script
+  anywhere on the Service.</p>
 
   <h2 class="sec" id="s8"><span class="n">08</span>How we protect it</h2>
   <ul>

--- a/src/treg/web/resources.html
+++ b/src/treg/web/resources.html
@@ -63,5 +63,6 @@
   </div>
 </footer>
 
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-ads.html
+++ b/src/treg/web/usecase-ads.html
@@ -272,5 +272,6 @@ Codex included — can use the <code>treg</code> CLI or plain HTTP.</p>
   }
 })();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-company.html
+++ b/src/treg/web/usecase-company.html
@@ -281,5 +281,6 @@ Codex included — can use the <code>treg</code> CLI or plain HTTP.</p>
   }
 })();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-enrichment.html
+++ b/src/treg/web/usecase-enrichment.html
@@ -253,5 +253,6 @@ Codex included — can use the <code>treg</code> CLI or plain HTTP.</p>
   }
 })();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-seo.html
+++ b/src/treg/web/usecase-seo.html
@@ -295,5 +295,6 @@ Codex included — can use the <code>treg</code> CLI or plain HTTP.</p>
   }
 })();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-social.html
+++ b/src/treg/web/usecase-social.html
@@ -265,5 +265,6 @@ Codex included — can use the <code>treg</code> CLI or plain HTTP.</p>
   }
 })();
 </script>
+<script src="/adtrack.js"></script>
 </body>
 </html>

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -1,10 +1,42 @@
+from types import SimpleNamespace
+
 import pytest
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
+from conftest import make_upstream
 from treg import adsconv
-from treg.db import session_maker
+from treg.api import app
+from treg.db import reset_db, session_maker
 from treg.models import AdConversion, Org
+
+
+def _h(token: str) -> dict:
+    return {"X-Treg-Token": token}
+
+
+@pytest.fixture
+async def callenv():
+    """An ad-attributed org with one callable HTTP tool pointed at the fake upstream."""
+    await reset_db()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()),
+                                 base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+        r = await c.post("/users", json={"email": "caller@example.com"})
+        assert r.status_code == 200, r.text
+        token, org_id = r.json()["token"], r.json()["org_id"]
+        sid = (await c.post("/secrets", headers=_h(token),
+                            json={"name": "a-key", "value": "v"})).json()["id"]
+        await c.post("/tools", headers=_h(token),
+                     json={"name": "alpha", "base_url": "http://upstream", "secret_id": sid})
+        async with session_maker() as db:            # attribute the org to an ad click
+            org = await db.get(Org, org_id)
+            org.ad_gclid = "CLICK_CALL"
+            db.add(org)
+            await db.commit()
+        yield SimpleNamespace(c=c, token=token, org_id=org_id)
+    await app.state.http.aclose()
 
 
 def test_usd_to_aud_uses_fixed_rate():
@@ -144,3 +176,36 @@ async def test_org_creation_without_the_cookie_leaves_attribution_null(clients):
     async with session_maker() as db:
         org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
         assert org.ad_gclid is None
+
+
+async def test_first_successful_call_fires_once(callenv):
+    """Two successful calls: one timestamp, one conversion. The second must be a no-op."""
+    r1 = await callenv.c.get("/call/alpha", headers=_h(callenv.token))
+    assert 200 <= r1.status_code < 400, r1.text
+    r2 = await callenv.c.get("/call/alpha", headers=_h(callenv.token))
+    assert 200 <= r2.status_code < 400, r2.text
+
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        assert org.first_call_at is not None
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == callenv.org_id,
+            AdConversion.action == adsconv.ACTION_FIRST_CALL))).scalars().all()
+        assert len(rows) == 1
+
+
+async def test_unattributed_org_records_timestamp_but_no_conversion(callenv):
+    """first_call_at is a product metric and must be set for every team; only ad-clicked ones queue."""
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        org.ad_gclid = None
+        db.add(org)
+        await db.commit()
+
+    assert (await callenv.c.get("/call/alpha", headers=_h(callenv.token))).status_code < 400
+    async with session_maker() as db:
+        org = await db.get(Org, callenv.org_id)
+        assert org.first_call_at is not None
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == callenv.org_id))).scalars().all()
+        assert rows == []

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -1,0 +1,25 @@
+from treg import adsconv
+
+
+def test_usd_to_aud_uses_fixed_rate():
+    # 1 AUD = 0.70 USD, so USD converts UP into AUD: US$20.00 -> A$28.57
+    assert adsconv.usd_micro_to_aud_micro(20_000_000) == 28_571_428
+
+
+def test_usd_to_aud_is_integer_only():
+    # No float ever appears: 1 micro-USD must not become 1.4285... micro-AUD
+    result = adsconv.usd_micro_to_aud_micro(1)
+    assert isinstance(result, int)
+    assert result == 1
+
+
+def test_usd_to_aud_zero_and_negative():
+    assert adsconv.usd_micro_to_aud_micro(0) == 0
+    # A refund/negative should not silently flip sign under floor division
+    assert adsconv.usd_micro_to_aud_micro(-7_000_000) == -10_000_000
+
+
+def test_action_ids_cover_every_action():
+    assert set(adsconv.CONVERSION_ACTION_IDS) == {
+        adsconv.ACTION_SIGNUP, adsconv.ACTION_FIRST_CALL, adsconv.ACTION_PAID
+    }

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -87,3 +87,25 @@ async def test_queue_is_a_noop_without_a_gclid(clients):
         await db.commit()
         await db.refresh(org)
         assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
+
+
+async def test_signup_persists_the_gclid_cookie(clients):
+    r = await clients.post(
+        "/users",
+        json={"email": "click@example.com"},
+        cookies={"treg_ad": "CLICK_XYZ|p3"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid == "CLICK_XYZ"
+        assert org.ad_landing == "p3"
+        assert org.ad_click_at is not None
+
+
+async def test_signup_without_the_cookie_leaves_attribution_null(clients):
+    r = await clients.post("/users", json={"email": "organic@example.com"})
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid is None

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -15,8 +15,11 @@ def test_usd_to_aud_is_integer_only():
 
 def test_usd_to_aud_zero_and_negative():
     assert adsconv.usd_micro_to_aud_micro(0) == 0
-    # A refund/negative should not silently flip sign under floor division
+    # Even-divisible negative: -7,000,000 * 10 / 7 = -10,000,000 exactly
     assert adsconv.usd_micro_to_aud_micro(-7_000_000) == -10_000_000
+    # Non-exact negative: floor division toward -∞ rounds away from zero
+    # -1,000,000 * 10 = -10,000,000; -10,000,000 // 7 = -1,428,572 (not -1,428,571)
+    assert adsconv.usd_micro_to_aud_micro(-1_000_000) == -1_428_572
 
 
 def test_action_ids_cover_every_action():

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -1,3 +1,5 @@
+import json
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -6,10 +8,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
 from conftest import make_upstream
-from treg import adsconv
+from treg import adsconv, crypto
 from treg.api import app
+from treg.config import get_settings
 from treg.db import reset_db, session_maker
-from treg.models import AdConversion, Org
+from treg.models import AdConversion, Org, Secret
 
 
 def _h(token: str) -> dict:
@@ -209,3 +212,74 @@ async def test_unattributed_org_records_timestamp_but_no_conversion(callenv):
         rows = (await db.execute(select(AdConversion).where(
             AdConversion.org_id == callenv.org_id))).scalars().all()
         assert rows == []
+
+
+def test_build_payload_converts_currency_and_formats_time():
+    click = datetime(2026, 8, 17, 3, 0, tzinfo=timezone.utc)
+    org = Org(id=1, name="t", slug="t", ad_gclid="CLICK1", ad_click_at=click)
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_PAID,
+                       value_usd_micro=20_000_000,
+                       created_at=click + timedelta(hours=6))
+    payload = adsconv.build_payload([row], {1: org})
+    conv = payload["conversions"][0]
+    assert conv["gclid"] == "CLICK1"
+    assert conv["conversionAction"].endswith("/conversionActions/7723667020")
+    # US$20.00 at the fixed rate -> A$28.571428
+    assert conv["conversionValue"] == pytest.approx(28.571428, rel=1e-6)
+    assert conv["currencyCode"] == "AUD"
+    assert payload["partialFailure"] is True
+
+
+def test_build_payload_omits_value_for_non_revenue_actions():
+    org = Org(id=1, name="t", slug="t", ad_gclid="C", ad_click_at=datetime.now(timezone.utc))
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP, value_usd_micro=0)
+    conv = adsconv.build_payload([row], {1: org})["conversions"][0]
+    assert "conversionValue" not in conv
+
+
+async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch):
+    """A row younger than the upload delay is left alone; an old one is sent and marked.
+
+    _auth_headers reads a real `google-ads` oauth Secret off the platform org named by
+    `ads_conv_org_slug` (see adsconv.py) — it is not mocked away, so this sets that org up for
+    real: a slug settings can point at, and a MANUAL-mode oauth blob (no refresh_token) so
+    oauth.ensure_fresh no-ops rather than trying to hit a real token endpoint through FakeClient.
+    """
+    monkeypatch.setattr(adsconv, "enabled", lambda: True)
+    monkeypatch.setattr(get_settings(), "google_ads_developer_token", "dev-tok-test", raising=False)
+    sent = []
+
+    class FakeResp:
+        status_code = 200
+        def json(self): return {"results": [{}]}
+        text = "{}"
+
+    class FakeClient:
+        async def post(self, url, **kw):
+            sent.append((url, kw.get("json")))
+            return FakeResp()
+
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-drain", ad_gclid="C",
+                  ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        monkeypatch.setattr(get_settings(), "ads_conv_org_slug", org.slug, raising=False)
+        # No refresh_token/client_id/client_secret -> oauth.is_refreshable() is False -> ensure_fresh
+        # no-ops instead of calling FakeClient.post against a real token endpoint.
+        db.add(Secret(org_id=org.id, name="google-ads", kind="oauth", provider="google-ads",
+                      value=crypto.encrypt(json.dumps({"access_token": "tok-test"}))))
+        old = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
+                           created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+        young = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
+                             created_at=datetime.now(timezone.utc))
+        db.add(old); db.add(young)
+        await db.commit()
+
+        await adsconv.drain_once(db, FakeClient())
+
+        await db.refresh(old); await db.refresh(young)
+        assert old.uploaded_at is not None
+        assert young.uploaded_at is None
+        assert len(sent) == 1

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -119,3 +119,28 @@ async def test_signup_queues_a_conversion_when_attributed(clients):
         rows = (await db.execute(select(AdConversion).where(
             AdConversion.org_id == r.json()["org_id"]))).scalars().all()
         assert [x.action for x in rows] == [adsconv.ACTION_SIGNUP]
+
+
+async def test_org_creation_persists_the_gclid_cookie(clients):
+    # The OTHER signup door: a signed-in user creating their first team via /orgs (the browser
+    # sign-in path). `clients` is already authenticated (X-Treg-Token from /users registration
+    # in the fixture) — this only adds the ad-click cookie on top, same shape as the /users test.
+    r = await clients.post(
+        "/orgs",
+        json={"name": "ad team"},
+        cookies={"treg_ad": "CLICK_XYZ|p3"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid == "CLICK_XYZ"
+        assert org.ad_landing == "p3"
+        assert org.ad_click_at is not None
+
+
+async def test_org_creation_without_the_cookie_leaves_attribution_null(clients):
+    r = await clients.post("/orgs", json={"name": "organic team"})
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
+        assert org.ad_gclid is None

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -58,3 +58,32 @@ async def test_org_has_ad_attribution_columns(clients):
         assert got.ad_gclid == "ABC123"
         assert got.ad_landing == "p2"
         assert got.first_call_at is None
+
+
+async def test_queue_writes_one_row_and_is_idempotent(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-queue", ad_gclid="CLICK1")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is True
+        await db.commit()
+        # Second call for the same (org, action) must be a silent no-op, not an error
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AdConversion).where(AdConversion.org_id == org.id))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].uploaded_at is None
+
+
+async def test_queue_is_a_noop_without_a_gclid(clients):
+    # Organic signups are the majority; they must not fill the outbox with unattributable rows.
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-noclick")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -109,3 +109,13 @@ async def test_signup_without_the_cookie_leaves_attribution_null(clients):
     async with session_maker() as db:
         org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
         assert org.ad_gclid is None
+
+
+async def test_signup_queues_a_conversion_when_attributed(clients):
+    r = await clients.post("/users", json={"email": "conv@example.com"},
+                              cookies={"treg_ad": "CLICK_SIGNUP|p1"})
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == r.json()["org_id"]))).scalars().all()
+        assert [x.action for x in rows] == [adsconv.ACTION_SIGNUP]

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -1,4 +1,10 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+
 from treg import adsconv
+from treg.db import session_maker
+from treg.models import AdConversion, Org
 
 
 def test_usd_to_aud_uses_fixed_rate():
@@ -26,3 +32,29 @@ def test_action_ids_cover_every_action():
     assert set(adsconv.CONVERSION_ACTION_IDS) == {
         adsconv.ACTION_SIGNUP, adsconv.ACTION_FIRST_CALL, adsconv.ACTION_PAID
     }
+
+
+async def test_ad_conversion_is_unique_per_org_and_action(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-adsconv")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+
+        db.add(AdConversion(org_id=org.id, action="signup", dedupe_key="signup"))
+        await db.commit()
+
+        db.add(AdConversion(org_id=org.id, action="signup", dedupe_key="signup"))
+        with pytest.raises(IntegrityError):
+            await db.commit()
+
+
+async def test_org_has_ad_attribution_columns(clients):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-adcols", ad_gclid="ABC123", ad_landing="p2")
+        db.add(org)
+        await db.commit()
+        got = (await db.execute(select(Org).where(Org.slug == "t-adcols"))).scalar_one()
+        assert got.ad_gclid == "ABC123"
+        assert got.ad_landing == "p2"
+        assert got.first_call_at is None

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
@@ -11,7 +12,7 @@ from conftest import make_upstream
 from treg import adsconv, crypto
 from treg.api import app
 from treg.config import get_settings
-from treg.db import reset_db, session_maker
+from treg.db import _migrate_to_orgs, reset_db, session_maker
 from treg.models import AdConversion, Org, Secret
 
 
@@ -19,8 +20,49 @@ def _h(token: str) -> dict:
     return {"X-Treg-Token": token}
 
 
+class FakeAdsResponse:
+    def __init__(self, body: dict, status_code: int = 200):
+        self._body = body
+        self.status_code = status_code
+        self.text = json.dumps(body)
+
+    def json(self) -> dict:
+        return self._body
+
+
+class FakeAdsClient:
+    def __init__(self, response: FakeAdsResponse):
+        self.response = response
+        self.calls = []
+
+    async def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return self.response
+
+
 @pytest.fixture
-async def callenv():
+def ads_enabled(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "google_ads_customer_id", "5149790776", raising=False)
+    monkeypatch.setattr(settings, "google_ads_developer_token", "dev-tok-test", raising=False)
+    monkeypatch.setattr(settings, "google_ads_login_customer_id", "", raising=False)
+    monkeypatch.setattr(settings, "ads_conv_org_slug", "platform-ads", raising=False)
+    assert adsconv.enabled() is True
+    return settings
+
+
+@pytest.fixture
+def ads_disabled(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "google_ads_customer_id", "", raising=False)
+    monkeypatch.setattr(settings, "google_ads_developer_token", "", raising=False)
+    monkeypatch.setattr(settings, "ads_conv_org_slug", "", raising=False)
+    assert adsconv.enabled() is False
+    return settings
+
+
+@pytest.fixture
+async def callenv(ads_enabled):
     """An ad-attributed org with one callable HTTP tool pointed at the fake upstream."""
     await reset_db()
     app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()),
@@ -69,6 +111,31 @@ def test_action_ids_cover_every_action():
     }
 
 
+@pytest.mark.parametrize(
+    "setting_name",
+    ["google_ads_customer_id", "google_ads_developer_token", "ads_conv_org_slug"],
+)
+def test_tracking_is_disabled_when_any_required_setting_is_missing(
+    monkeypatch, ads_enabled, setting_name
+):
+    monkeypatch.setattr(ads_enabled, setting_name, "", raising=False)
+    assert adsconv.enabled() is False
+
+
+def test_existing_ads_tables_receive_additive_state_columns():
+    engine = create_engine("sqlite://")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE org (id INTEGER PRIMARY KEY)"))
+        conn.execute(text("INSERT INTO org (id) VALUES (1)"))
+        conn.execute(text("CREATE TABLE adconversion (id INTEGER PRIMARY KEY)"))
+
+        _migrate_to_orgs(conn)
+
+        assert "ad_click_id_type" in {c["name"] for c in inspect(conn).get_columns("org")}
+        conversion_columns = {c["name"] for c in inspect(conn).get_columns("adconversion")}
+        assert {"next_attempt_at", "failed_at"} <= conversion_columns
+
+
 async def test_ad_conversion_is_unique_per_org_and_action(clients):
     async with session_maker() as db:
         org = Org(name="t", slug="t-adsconv")
@@ -86,16 +153,18 @@ async def test_ad_conversion_is_unique_per_org_and_action(clients):
 
 async def test_org_has_ad_attribution_columns(clients):
     async with session_maker() as db:
-        org = Org(name="t", slug="t-adcols", ad_gclid="ABC123", ad_landing="p2")
+        org = Org(name="t", slug="t-adcols", ad_gclid="ABC123",
+                  ad_click_id_type="wbraid", ad_landing="p2")
         db.add(org)
         await db.commit()
         got = (await db.execute(select(Org).where(Org.slug == "t-adcols"))).scalar_one()
         assert got.ad_gclid == "ABC123"
+        assert got.ad_click_id_type == "wbraid"
         assert got.ad_landing == "p2"
         assert got.first_call_at is None
 
 
-async def test_queue_writes_one_row_and_is_idempotent(clients):
+async def test_queue_writes_one_row_and_is_idempotent(clients, ads_enabled):
     async with session_maker() as db:
         org = Org(name="t", slug="t-queue", ad_gclid="CLICK1")
         db.add(org)
@@ -114,7 +183,7 @@ async def test_queue_writes_one_row_and_is_idempotent(clients):
         assert rows[0].uploaded_at is None
 
 
-async def test_queue_is_a_noop_without_a_gclid(clients):
+async def test_queue_is_a_noop_without_a_gclid(clients, ads_enabled):
     # Organic signups are the majority; they must not fill the outbox with unattributable rows.
     async with session_maker() as db:
         org = Org(name="t", slug="t-noclick")
@@ -124,7 +193,17 @@ async def test_queue_is_a_noop_without_a_gclid(clients):
         assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
 
 
-async def test_signup_persists_the_gclid_cookie(clients):
+async def test_queue_is_a_noop_when_disabled(clients, ads_disabled):
+    async with session_maker() as db:
+        org = Org(name="t", slug="t-disabled", ad_gclid="CLICK_DISABLED")
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+        assert await adsconv.queue(db, org, adsconv.ACTION_SIGNUP) is False
+        assert (await db.execute(select(AdConversion))).scalars().all() == []
+
+
+async def test_signup_persists_the_gclid_cookie(clients, ads_enabled):
     r = await clients.post(
         "/users",
         json={"email": "click@example.com"},
@@ -134,6 +213,7 @@ async def test_signup_persists_the_gclid_cookie(clients):
     async with session_maker() as db:
         org = (await db.execute(select(Org).where(Org.id == r.json()["org_id"]))).scalar_one()
         assert org.ad_gclid == "CLICK_XYZ"
+        assert org.ad_click_id_type == "gclid"  # legacy cookie format remains readable
         assert org.ad_landing == "p3"
         assert org.ad_click_at is not None
 
@@ -146,7 +226,40 @@ async def test_signup_without_the_cookie_leaves_attribution_null(clients):
         assert org.ad_gclid is None
 
 
-async def test_signup_queues_a_conversion_when_attributed(clients):
+async def test_signup_persists_the_braid_field(clients, ads_enabled):
+    r = await clients.post(
+        "/users",
+        json={"email": "braid@example.com"},
+        cookies={"treg_ad": "wbraid|BRAID_XYZ|p4"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = await db.get(Org, r.json()["org_id"])
+        assert org.ad_gclid == "BRAID_XYZ"
+        assert org.ad_click_id_type == "wbraid"
+        assert org.ad_landing == "p4"
+
+
+async def test_disabled_signup_ignores_ad_cookie(clients, ads_disabled):
+    r = await clients.post(
+        "/users",
+        json={"email": "disabled-click@example.com"},
+        cookies={"treg_ad": "gclid|CLICK_DISABLED|p1"},
+    )
+    assert r.status_code == 200, r.text
+    async with session_maker() as db:
+        org = await db.get(Org, r.json()["org_id"])
+        assert org.ad_gclid is None
+        assert (await db.execute(select(AdConversion))).scalars().all() == []
+
+
+async def test_adtrack_script_is_empty_when_disabled(clients, ads_disabled):
+    r = await clients.get("/adtrack.js")
+    assert r.status_code == 200
+    assert r.text == ""
+
+
+async def test_signup_queues_a_conversion_when_attributed(clients, ads_enabled):
     r = await clients.post("/users", json={"email": "conv@example.com"},
                               cookies={"treg_ad": "CLICK_SIGNUP|p1"})
     assert r.status_code == 200, r.text
@@ -156,7 +269,7 @@ async def test_signup_queues_a_conversion_when_attributed(clients):
         assert [x.action for x in rows] == [adsconv.ACTION_SIGNUP]
 
 
-async def test_org_creation_persists_the_gclid_cookie(clients):
+async def test_org_creation_persists_the_gclid_cookie(clients, ads_enabled):
     # The OTHER signup door: a signed-in user creating their first team via /orgs (the browser
     # sign-in path). `clients` is already authenticated (X-Treg-Token from /users registration
     # in the fixture) — this only adds the ad-click cookie on top, same shape as the /users test.
@@ -230,6 +343,15 @@ def test_build_payload_converts_currency_and_formats_time():
     assert payload["partialFailure"] is True
 
 
+@pytest.mark.parametrize("click_field", ["gclid", "gbraid", "wbraid"])
+def test_build_payload_preserves_click_id_field(click_field):
+    org = Org(id=1, name="t", slug="t", ad_gclid="CLICK1", ad_click_id_type=click_field)
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP)
+    conversion = adsconv.build_payload([row], {1: org})["conversions"][0]
+    assert conversion[click_field] == "CLICK1"
+    assert set(conversion) & {"gclid", "gbraid", "wbraid"} == {click_field}
+
+
 def test_build_payload_omits_value_for_non_revenue_actions():
     org = Org(id=1, name="t", slug="t", ad_gclid="C", ad_click_at=datetime.now(timezone.utc))
     row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP, value_usd_micro=0)
@@ -237,7 +359,7 @@ def test_build_payload_omits_value_for_non_revenue_actions():
     assert "conversionValue" not in conv
 
 
-async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch):
+async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch, ads_enabled):
     """A row younger than the upload delay is left alone; an old one is sent and marked.
 
     _auth_headers reads a real `google-ads` oauth Secret off the platform org named by
@@ -245,19 +367,7 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
     real: a slug settings can point at, and a MANUAL-mode oauth blob (no refresh_token) so
     oauth.ensure_fresh no-ops rather than trying to hit a real token endpoint through FakeClient.
     """
-    monkeypatch.setattr(adsconv, "enabled", lambda: True)
-    monkeypatch.setattr(get_settings(), "google_ads_developer_token", "dev-tok-test", raising=False)
-    sent = []
-
-    class FakeResp:
-        status_code = 200
-        def json(self): return {"results": [{}]}
-        text = "{}"
-
-    class FakeClient:
-        async def post(self, url, **kw):
-            sent.append((url, kw.get("json")))
-            return FakeResp()
+    client = FakeAdsClient(FakeAdsResponse({"results": [{"gclid": "C"}]}))
 
     async with session_maker() as db:
         org = Org(name="t", slug="t-drain", ad_gclid="C",
@@ -277,9 +387,184 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
         db.add(old); db.add(young)
         await db.commit()
 
-        await adsconv.drain_once(db, FakeClient())
+        await adsconv.drain_once(db, client)
 
         await db.refresh(old); await db.refresh(young)
         assert old.uploaded_at is not None
+        assert old.next_attempt_at is None
+        assert old.failed_at is None
         assert young.uploaded_at is None
-        assert len(sent) == 1
+        assert len(client.calls) == 1
+
+
+async def _seed_upload_rows(db, monkeypatch, *, actions, attempts=0):
+    """Create the platform OAuth connection and old, upload-due outbox rows."""
+    org = Org(name="t", slug="t-upload-batch", ad_gclid="CLICK_BATCH",
+              ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+    db.add(org)
+    await db.commit()
+    await db.refresh(org)
+    monkeypatch.setattr(get_settings(), "ads_conv_org_slug", org.slug, raising=False)
+    db.add(Secret(org_id=org.id, name="google-ads", kind="oauth", provider="google-ads",
+                  resource_ref="customers/5149790776",
+                  value=crypto.encrypt(json.dumps({"access_token": "tok-test"}))))
+    rows = [
+        AdConversion(org_id=org.id, action=action, attempts=attempts,
+                     created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+        for action in actions
+    ]
+    db.add_all(rows)
+    await db.commit()
+    return org, rows
+
+
+def _partial_error(index: int, code: str, message: str = "conversion rejected") -> dict:
+    return {
+        "errorCode": {"conversionUploadError": code},
+        "message": message,
+        "location": {"fieldPathElements": [{"fieldName": "conversions", "index": index}]},
+    }
+
+
+async def test_drain_acknowledges_only_successful_rows_in_partial_response(
+    clients, monkeypatch, ads_enabled
+):
+    body = {
+        "results": [{"gclid": "CLICK_BATCH"}, {}],
+        "partialFailureError": {
+            "code": 3,
+            "message": "partial failure",
+            "details": [{"errors": [_partial_error(1, "UNPARSEABLE_GCLID")]}],
+        },
+    }
+    client = FakeAdsClient(FakeAdsResponse(body))
+    async with session_maker() as db:
+        _org, rows = await _seed_upload_rows(
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP, adsconv.ACTION_PAID)
+        )
+        result = await adsconv.drain_once(db, client)
+        for row in rows:
+            await db.refresh(row)
+
+        assert result == {"sent": 1, "retried": 1, "failed": 0, "status": 200}
+        assert rows[0].uploaded_at is not None
+        assert rows[0].error == ""
+        assert rows[1].uploaded_at is None
+        assert rows[1].failed_at is None
+        assert rows[1].next_attempt_at is not None
+        assert "UNPARSEABLE_GCLID" in rows[1].error
+
+
+async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
+    clients, monkeypatch, ads_enabled
+):
+    client = FakeAdsClient(FakeAdsResponse({"error": "unavailable"}, status_code=503))
+    async with session_maker() as db:
+        _org, (row,) = await _seed_upload_rows(
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
+        )
+
+        first = await adsconv.drain_once(db, client)
+        await db.refresh(row)
+        assert first["retried"] == 1
+        assert row.attempts == 8
+        assert row.failed_at is None
+        assert row.next_attempt_at is not None
+
+        # Make the scheduled retry due without sleeping. A second transport failure still must not
+        # dead-letter the conversion merely because its historical attempt count is now above 8.
+        row.next_attempt_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=1)
+        db.add(row)
+        await db.commit()
+        second = await adsconv.drain_once(db, client)
+        await db.refresh(row)
+        assert second["retried"] == 1
+        assert row.attempts == 9
+        assert row.failed_at is None
+        assert row.next_attempt_at is not None
+
+
+async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(
+    clients, monkeypatch, ads_enabled
+):
+    body = {
+        "results": [{}],
+        "partialFailureError": {
+            "code": 3,
+            "details": [{"errors": [_partial_error(0, "UNPARSEABLE_GCLID")]}],
+        },
+    }
+    client = FakeAdsClient(FakeAdsResponse(body))
+    async with session_maker() as db:
+        _org, (row,) = await _seed_upload_rows(
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
+        )
+        result = await adsconv.drain_once(db, client)
+        await db.refresh(row)
+
+        assert result["failed"] == 1
+        assert row.attempts == 8
+        assert row.uploaded_at is None
+        assert row.next_attempt_at is None
+        assert row.failed_at is not None
+        assert "UNPARSEABLE_GCLID" in row.error
+
+
+async def test_unstructured_success_response_does_not_dead_letter_rows(
+    clients, monkeypatch, ads_enabled
+):
+    client = FakeAdsClient(FakeAdsResponse({}))
+    async with session_maker() as db:
+        _org, (row,) = await _seed_upload_rows(
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
+        )
+        result = await adsconv.drain_once(db, client)
+        await db.refresh(row)
+
+        assert result["retried"] == 1
+        assert row.attempts == 8
+        assert row.uploaded_at is None
+        assert row.failed_at is None
+        assert row.next_attempt_at is not None
+        assert row.error == "200: missing conversion result"
+
+
+async def test_duplicate_row_response_is_acknowledged(clients, monkeypatch, ads_enabled):
+    body = {
+        "results": [{}],
+        "partialFailureError": {
+            "code": 3,
+            "details": [{"errors": [_partial_error(0, "CLICK_CONVERSION_ALREADY_EXISTS")]}],
+        },
+    }
+    client = FakeAdsClient(FakeAdsResponse(body))
+    async with session_maker() as db:
+        _org, (row,) = await _seed_upload_rows(
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,)
+        )
+        result = await adsconv.drain_once(db, client)
+        await db.refresh(row)
+
+        assert result["sent"] == 1
+        assert row.uploaded_at is not None
+        assert row.error == ""
+
+
+async def test_auth_uses_explicit_manager_account_not_target_resource_ref(
+    clients, monkeypatch, ads_enabled
+):
+    async with session_maker() as db:
+        await _seed_upload_rows(db, monkeypatch, actions=())
+        monkeypatch.setattr(
+            get_settings(), "google_ads_login_customer_id", "351-912-5194", raising=False
+        )
+        headers = await adsconv._auth_headers(
+            db, FakeAdsClient(FakeAdsResponse({"results": []}))
+        )
+        assert headers["login-customer-id"] == "3519125194"
+
+        monkeypatch.setattr(get_settings(), "google_ads_login_customer_id", "", raising=False)
+        headers = await adsconv._auth_headers(
+            db, FakeAdsClient(FakeAdsResponse({"results": []}))
+        )
+        assert "login-customer-id" not in headers

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -23,14 +23,15 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import stripe
 from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
 
 from conftest import make_upstream
 
-from treg import billing, ledger
+from treg import adsconv, billing, ledger
 from treg.api import app
 from treg.config import get_settings
 from treg.db import reset_db, session_maker
-from treg.models import Org
+from treg.models import AdConversion, Org
 
 WHSEC = "whsec_test_secret_for_the_suite"
 
@@ -872,3 +873,48 @@ async def test_no_posthog_key_means_no_events(c: AsyncClient, monkeypatch):
     analytics._queue.clear()  # default settings: no key
     assert (await _deliver(c, _pi_event(org_id, pi="pi_no_key", cents=500))).status_code == 200
     assert analytics._queue == []
+
+
+# ---- Google Ads conversion tracking: first top-up ------------------------------------------------
+async def test_first_topup_queues_exactly_one_ad_conversion(c, monkeypatch):
+    """Stripe delivers at least once; a redelivery must not double-count the conversion."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    async with session_maker() as db:
+        org = await db.get(Org, org_id)
+        org.ad_gclid = "CLICK_PAID"
+        db.add(org)
+        await db.commit()
+
+    event = _pi_event(org_id, pi="pi_ads_once", cents=2000)   # US$20.00
+    assert (await _deliver(c, event)).status_code == 200
+    assert (await _deliver(c, event)).status_code == 200      # the redelivery
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == org_id,
+            AdConversion.action == adsconv.ACTION_PAID))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].value_usd_micro == 20_000_000
+        assert rows[0].dedupe_key == "pi_ads_once"
+
+
+async def test_a_second_topup_queues_nothing_further(c, monkeypatch):
+    """We measure becoming a payer, not revenue — a second, different payment adds no conversion."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    async with session_maker() as db:
+        org = await db.get(Org, org_id)
+        org.ad_gclid = "CLICK_PAID"
+        db.add(org)
+        await db.commit()
+
+    assert (await _deliver(c, _pi_event(org_id, pi="pi_first", cents=2000))).status_code == 200
+    assert (await _deliver(c, _pi_event(org_id, pi="pi_second", cents=5000))).status_code == 200
+
+    async with session_maker() as db:
+        rows = (await db.execute(select(AdConversion).where(
+            AdConversion.org_id == org_id,
+            AdConversion.action == adsconv.ACTION_PAID))).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].dedupe_key == "pi_first"   # the FIRST payment is the one recorded

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -878,6 +878,7 @@ async def test_no_posthog_key_means_no_events(c: AsyncClient, monkeypatch):
 # ---- Google Ads conversion tracking: first top-up ------------------------------------------------
 async def test_first_topup_queues_exactly_one_ad_conversion(c, monkeypatch):
     """Stripe delivers at least once; a redelivery must not double-count the conversion."""
+    monkeypatch.setattr(adsconv, "enabled", lambda: True)
     org_id, owner = await _org(c)
     monkeypatch.setattr(billing, "_sdk", _no_sdk)
     async with session_maker() as db:
@@ -901,6 +902,7 @@ async def test_first_topup_queues_exactly_one_ad_conversion(c, monkeypatch):
 
 async def test_a_second_topup_queues_nothing_further(c, monkeypatch):
     """We measure becoming a payer, not revenue — a second, different payment adds no conversion."""
+    monkeypatch.setattr(adsconv, "enabled", lambda: True)
     org_id, owner = await _org(c)
     monkeypatch.setattr(billing, "_sdk", _no_sdk)
     async with session_maker() as db:
@@ -932,6 +934,7 @@ async def test_adsconv_commit_failure_cannot_500_or_break_the_webhook(c, monkeyp
     complete."""
     from sqlalchemy.ext.asyncio import AsyncSession as SAAsyncSession
 
+    monkeypatch.setattr(adsconv, "enabled", lambda: True)
     org_id, owner = await _org(c)
     monkeypatch.setattr(billing, "_sdk", _no_sdk)
     async with session_maker() as db:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -918,3 +918,51 @@ async def test_a_second_topup_queues_nothing_further(c, monkeypatch):
             AdConversion.action == adsconv.ACTION_PAID))).scalars().all()
         assert len(rows) == 1
         assert rows[0].dedupe_key == "pi_first"   # the FIRST payment is the one recorded
+
+
+async def test_adsconv_commit_failure_cannot_500_or_break_the_webhook(c, monkeypatch):
+    """A CRITICAL regression: if the ad-conversion `db.commit()` inside `_credit`'s try block fails
+    for a reason unrelated to `adsconv.queue`'s own IntegrityError savepoint (a serialization
+    failure, a connection blip — plausible under concurrent webhook redelivery), the session is left
+    by SQLAlchemy in "pending rollback" state. `_on_payment_succeeded` immediately reuses the same
+    `db` for `_set_default_pm`'s `db.get(Org, ...)`; without a rollback in the except block, that
+    raises PendingRollbackError, which 500s the webhook and makes Stripe retry a payment
+    `ledger.topup()` had ALREADY durably credited. The webhook must still return 200, the credit
+    must still stand, and the rest of the request (saving the default payment method) must still
+    complete."""
+    from sqlalchemy.ext.asyncio import AsyncSession as SAAsyncSession
+
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    async with session_maker() as db:
+        org = await db.get(Org, org_id)
+        org.ad_gclid = "CLICK_PAID"  # gives adsconv.queue something to write, so its commit matters
+        db.add(org)
+        await db.commit()
+
+    real_commit = SAAsyncSession.commit
+    calls = {"n": 0}
+
+    async def flaky_commit(self):
+        calls["n"] += 1
+        if calls["n"] == 2:  # the ad-conversion commit inside _credit's try block, not the topup one
+            raise RuntimeError("simulated serialization failure")
+        return await real_commit(self)
+
+    monkeypatch.setattr(SAAsyncSession, "commit", flaky_commit)
+
+    event = _pi_event(org_id, pi="pi_adsconv_commit_blip", cents=1000)
+    r = await _deliver(c, event)
+    assert r.status_code == 200, r.text  # NOT a 500 — Stripe must not be told to retry this
+    assert r.json()["credited"] is True
+    assert calls["n"] >= 3, "the flaky commit was never reached, or the request stopped early"
+
+    body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
+    # The payment is credited regardless of the ad-conversion commit's fate.
+    assert body["balance_micro"] == get_settings().promo_grant_micro + 10_000_000
+
+    async with session_maker() as db:
+        # The default payment method save runs AFTER the failed ads-conversion commit; it only
+        # succeeds if the session was rolled back and made usable again.
+        fresh_org = await db.get(Org, org_id)
+        assert fresh_org.stripe_default_pm == "pm_card_visa"


### PR DESCRIPTION
Records **signup**, **first successful call**, and **first top-up** as Google Ads conversions,
attributed to the ad click that produced the team.

## The chain

```text
ad click → first-party cookie → Org attribution
                                  │
       signup ─┐                  │
    first call ─┼─→ durable AdConversion outbox ─→ Google Ads API v25
   first top-up ┘
```

Uploads are server-side because first calls happen through CLI/MCP and top-ups may happen later on
another device. The browser only captures the first-party click identifier; no Google tag or
third-party browser request is added.

## Reliability and correctness

- Preserves the mutually exclusive `gclid`, `gbraid`, or `wbraid` field from capture through upload.
- Reads partial-failure responses per conversion index; successful siblings are acknowledged while
  failed rows remain pending.
- Treats `CLICK_CONVERSION_ALREADY_EXISTS` as delivered, making overlapping worker retries safe.
- Retries HTTP, batch-level, unparseable, and explicitly transient failures indefinitely with bounded
  exponential backoff.
- Retains permanent row failures as visible dead letters after eight attempts.
- Does not capture, persist, queue, or upload unless conversion tracking is fully configured.
- Uses an explicit `google_ads_login_customer_id` for manager-account authentication rather than
  incorrectly inferring the manager from the target account's `Secret.resource_ref`.
- Keeps the outbox durable and separate from droppable audit/analytics queues.

## Switching it on

Off by default. All three settings are required:

- `google_ads_customer_id` — target Ads account
- `google_ads_developer_token` — platform developer token
- `ads_conv_org_slug` — team holding the `google-ads` OAuth connection

For manager-account access, also set optional `google_ads_login_customer_id` to the MCC account id.
Direct client-account authentication leaves it empty.

## Validation

- Full integrated suite: **1,701 passing** after merging current `main`
- Focused Ads/billing/migration/error-capture suite: **138 passing**
- GitHub CI test, gitleaks, CodeQL Python/actions, aggregate CodeQL, and PR labeling: **green** on
  pushed head `a64608e`
- Context drift checked and generated indexes refreshed
- Independent second-agent review: **no actionable findings**

## Known gaps

- The paid conversion retains the documented two-commit crash window: `ledger.topup()` commits before
  the conversion row is queued. This is an accepted limitation; a reconciliation sweep is the named
  future mitigation.
- A real Google-issued ad click is required for the final end-to-end production smoke test. Before
  meaningful spend, verify a US$20 top-up appears as approximately A$28.57.

The three `UPLOAD_CLICKS` actions already exist on the configured Ads account. Signup is secondary;
first-call and first-top-up are the primary bidding signals.
