### PR TITLE
Referral program: dual-sided $5 credit

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -56,6 +56,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/pubfeed.py` | interface/landing-sandbox.md |
 | `src/treg/ratestore.py` | architecture/data-model.md, interface/api.md |
 | `src/treg/reconcile.py` | architecture/money.md |
+| `src/treg/referrals.py` | architecture/data-model.md, architecture/money.md |
 | `src/treg/runner.py` | interface/api.md |
 | `src/treg/sandbox.py` | interface/landing-sandbox.md |
 | `src/treg/session.py` | interface/dashboard.md |
@@ -81,11 +82,11 @@ Regenerate via `scripts/build-map.py`.
 |---|---|
 | `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
 | `architecture/catalog.md` | `catalog_store.py`, `endpoint_stats.py` |
-| `architecture/data-model.md` | `models.py`, `db.py`, `audit.py`, `analytics.py`, `ratestore.py` |
+| `architecture/data-model.md` | `models.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
 | `architecture/mcp-oauth.md` | `mcp.py`, `mcp_oauth.py`, `connect-demo.html` |
-| `architecture/money.md` | `ledger.py`, `models.py`, `billing.py`, `reconcile.py`, `api.py` |
+| `architecture/money.md` | `ledger.py`, `models.py`, `billing.py`, `reconcile.py`, `referrals.py`, `api.py` |
 | `architecture/multi-tenancy.md` | `models.py`, `api.py`, `db.py` |
 | `architecture/proxy-model.md` | `proxy.py`, `api.py` |
 | `architecture/super-admin.md` | `api.py`, `config.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -18,7 +18,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 |---|---|---|
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog_store.py, endpoint_stats.py |
-| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, audit.py, analytics.py, … |
+| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, referrals.py, audit.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |
 | [MCP — the front door for assistants, and treg as an OAuth authorization server](architecture/mcp-oauth.md) | shipped | mcp.py, mcp_oauth.py, connect-demo.html |

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -4,6 +4,7 @@ status: shipped
 sources:
   - src/treg/models.py
   - src/treg/db.py
+  - src/treg/referrals.py
   - src/treg/audit.py
   - src/treg/analytics.py
   - src/treg/ratestore.py
@@ -266,3 +267,28 @@ Migrations `A30`-`A32` in `db.py` add the columns, guarded as usual; `TagSpend` 
 tables and need no DDL. Note `A31` also required adding the two new NOT NULL `org` columns to the raw
 `INSERT INTO org` in the legacy `(B)` backfill: a column `create_all` builds from a SQLModel default is
 NOT NULL with **no server default**, so raw SQL must supply it (ops/deploy.md §migration portability).
+
+## `Referral` — one invitation, and what it owes
+
+Written by `referrals.py`; the money it results in is granted through `ledger.grant`. See
+[money](money.md) for the policy and the gates. Two things about the SHAPE belong here:
+
+**Two UNIQUE columns do the arbitration, not application code.** `referred_org_id` (an org can be
+referred exactly once, ever) and `qualifying_payment_intent` (one payment funds one qualification).
+`ledger.grant(once=True)` was not enough: its check is a SELECT with no backing unique index, which
+survives a retry but not two concurrent redemptions — and this is money owed to a third party, not a
+signup promo. NULL is exempt from a unique index, so any number of `pending` rows coexist.
+
+**`status` is a ladder and every terminal state is kept**, never deleted:
+`pending` (signed up, owes nothing) → `qualified` (friend paid, owes both bonuses after the hold) →
+`paid`; or `capped` (referrer out of self-serve allowance) / `rejected` (a gate said no, or the
+funding payment was reversed inside the hold — `reject_reason` says which). A deleted row cannot
+answer "why did I not get paid", which is the first question this feature generates.
+
+`User.referral_code` is on the USER, not the Org: a person refers a friend, and anyone may create
+unlimited orgs, so a per-org code would hand the same human unlimited codes to farm with. It is
+minted lazily on first visit to the Referrals page — NULL is the normal state.
+
+`Referral.card_fingerprint` holds Stripe's stable per-card id. It is **not card data** (opaque
+outside our own Stripe account) and lives here alone, never on `Org`, which keeps
+`Org.stripe_default_pm`'s no-card-data posture intact.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -498,8 +498,24 @@ cost is the mirror failure — a crash between claim and grant pays nobody and s
 is the right way round for money, is visible in `/admin/referrals` as a paid row with a null block
 id, and errs toward paying once rather than twice.
 
-**The hold is the only clawback window there is.** Rewards land `referral_hold_days` (7) after
-qualifying. `charge.dispute.created` / `charge.refunded` — the first reversal events treg has ever
+**The two sides are paid at different times, on purpose.** The REFEREE is credited the instant they
+qualify; only the REFERRER waits out `referral_hold_days` (7).
+
+They are not in the same position. The referrer has a Referrals page listing every invitation and
+what it is worth, so a pending reward there is legible. The referee has no such page — for them the
+**balance is the only feedback that exists**, and a bonus that is merely "coming" is
+indistinguishable from one that never happened. That is not hypothetical: it was reported exactly
+that way (topped up, saw the plain total, assumed it had failed), and an "earned, lands on <date>"
+banner was built and then discarded in favour of just paying them, because explaining a delay is
+worse than not having one.
+
+The price is half the clawback window, and it is worth paying: exposure is one bounty per card (the
+fingerprint gate still binds), the referee has just handed us the qualifying payment, and a
+chargeback already costs us that payment plus the dispute fee — against which $5 is marginal.
+`_grant_referee` is guarded on `referred_block_id`, which is both the once-only guard and the
+record, so `sweep`'s referee branch survives only as a fallback for a failed instant grant.
+
+**The hold is the only clawback window there is**, and it now covers the referrer's half alone. `charge.dispute.created` / `charge.refunded` — the first reversal events treg has ever
 handled — cancel a bonus still inside that window. Anything already granted is **logged for a human,
 never auto-reversed**: referral credit burns first and is usually spent by then, and reversing it
 would mean a second code path able to drive a balance negative. The clawback touches the *bonus*

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -522,6 +522,17 @@ queue) and from `GET /referrals` (someone checking on their reward is the one wh
 the same lazy, caller-pays bargain as `reap_stale_holds`. It never raises: its callers are a Stripe
 webhook and a page load, and neither may fail over a bonus.
 
+**The referee is told, on the screen where it changes their behaviour.** `offer_for_org` is the
+mirror of `summary`: a team that arrived through a link has a `pending` row and no idea a bonus
+exists. `GET /billing` carries a `referral_offer` (merged in the api route, not in `billing.py` —
+that module keeps its one job) and the dashboard names the MINIMUM there, because the first top-up
+preset is $5 and the minimum is $10, so the most-clicked button silently forfeits the reward
+otherwise. The qualifying presets say `+$5 bonus` on themselves; a note alone sits above the place
+the decision is actually made. The offer is returned only while `pending` — after qualifying the
+money is already on its way through `sweep`, and still advertising it would read as a second bonus —
+and it names no one: the referee came through a friend's link so they already know who, and naming
+the referrer is a disclosure the privacy policy makes in one direction only.
+
 **Cash payouts are not built.** The self-serve program pays in credit only, and the cap refusal is
 the commercial conversation that replaces an uncapped percentage. When an influencer tier lands, it
 reads `/admin/referrals` — the same table, filtered — and the payout rail (and its W-9/1099

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -493,11 +493,25 @@ would mean a second code path able to drive a balance negative. The clawback tou
 only; it never refunds the top-up, because that has always been a human decision.
 
 **The gates** (`qualify`): first top-up only, at or above the minimum; not a self-referral; the
-referrer has paid us at least once themselves; the paying card's Stripe fingerprint has not already
-claimed a referral; and the referrer is under their lifetime cap. The fingerprint is the load-bearing
-one — an email address is free and a card is not — and it is read via `expand=["payment_method"]` on
-the `PaymentIntent.retrieve` that `_on_checkout_completed` was already making. It is not card data
-and it lives on the `referral` row alone, never on an `Org`.
+paying card's Stripe fingerprint has not already claimed a referral; and the referrer is under their
+lifetime cap. The fingerprint is the load-bearing one — an email address is free and a card is not —
+and it is read via `expand=["payment_method"]` on the `PaymentIntent.retrieve` that
+`_on_checkout_completed` was already making. It is not card data and it lives on the `referral` row
+alone, never on an `Org`.
+
+**There is deliberately no "the referrer must have topped up first" gate.** It was built and then
+removed, and the reasoning is worth keeping because it will be proposed again. A top-up is not a cost
+to a self-dealer — it converts into credit they keep — so the attack it appears to block survives it
+untouched: requiring one of the *referrer* too just adds a step that returns its own money. The cap
+is per-referrer and referrer accounts are free, so a farm's real constraint is CARDS, and the gate
+added roughly one card per twenty referrals: a ~5% tax. Against that it hid the link from every
+free-tier user, who on a product pitched as "$1.00 free, no card" are most of the userbase and the
+likeliest people to tell a friend — a ~90% tax on legitimate referrers. **Before adding any new
+eligibility rule here, price it against cards, not accounts.**
+
+The remaining ceiling to be aware of: because the cap is per-referrer and accounts are free, global
+exposure is bounded only by how many cards an attacker has. A platform-wide monthly payout budget is
+the fix if that ever matters; it is not built.
 
 A refusal is **recorded, not dropped**, and `capped` is deliberately distinct from `rejected`: one is
 "you ran out of self-serve allowance", the other is "a gate said no". "I referred someone and got

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -530,8 +530,19 @@ preset is $5 and the minimum is $10, so the most-clicked button silently forfeit
 otherwise. The qualifying presets say `+$5 bonus` on themselves; a note alone sits above the place
 the decision is actually made. The offer is returned only while `pending` — after qualifying the
 money is already on its way through `sweep`, and still advertising it would read as a second bonus —
-and it names no one: the referee came through a friend's link so they already know who, and naming
-the referrer is a disclosure the privacy policy makes in one direction only.
+and it names the referrer MASKED (`mask_email`, `j•••@domain`). Not anonymous — "you were invited"
+with nobody attached reads as marketing copy, and someone who clicked a link off a tweet last week
+genuinely may not recall whose it was. Not in full either: **a referral link is public by design**,
+so the full address would publish one influencer's email to every stranger who signs up through it,
+a harvestable list at exactly the volume this program is built to produce. The domain survives the
+mask because it is what makes a real friend recognisable; the local part collapses to one character
+plus a FIXED bullet run, so the mask cannot leak its own length.
+
+Note the asymmetry against `summary`, which returns referee addresses in FULL: there the referrer has
+no other way to tell which of their invitations converted. Here the referee needs no identity at all
+to decide whether to add funds, so the same exposure would buy nothing. It is worth stating plainly
+that this protects the person who opted into the program and exposes the person who merely signed up
+— justified only by that attribution need, and not a precedent to extend.
 
 **Cash payouts are not built.** The self-serve program pays in credit only, and the cap refusal is
 the commercial conversation that replaces an uncapped percentage. When an influencer tier lands, it

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -6,6 +6,7 @@ sources:
   - src/treg/models.py
   - src/treg/billing.py
   - src/treg/reconcile.py
+  - src/treg/referrals.py
   - src/treg/api.py
 related:
   - architecture/catalog.md
@@ -445,3 +446,69 @@ the entire point of giving them a scoped token.
 trips it. Raising past our ceiling is **refused, not clamped**: a builder who thinks they set $500/day
 and silently got the platform default discovers it as an outage mid-launch. That refusal is the commercial conversation,
 and it replaces editing one env var that would lift the blast-radius rail for every team at once.
+
+## Referrals — paying for growth out of the one margin we have
+
+`referrals.py` decides; `ledger.py` moves. The only crossing is `ledger.grant(...)`, exactly as
+`billing.py`'s only crossing is `ledger.topup(...)`.
+
+**Why a flat bounty and not a percentage.** `platform_margin` is 0.0 and "we add no markup" is a
+public promise (terms §08, landing 04), so there is no gross margin on a catalog call to share. The
+only thing treg actually keeps is the gap between what a team tops up and what it consumes. A
+percentage of top-ups would therefore be a permanent share of pass-through GMV — and, worse, it
+scales the reward with effort, which is the definition of a farmable incentive. Flat figures ($10 to
+the referrer, $5 to the friend, `config.referral_*`) are budgetable as CAC, bounded by construction,
+and not worth building a fake-account farm for.
+
+**The qualifying event is the friend's FIRST PAID TOP-UP, never their signup.** `promo_grant_micro`
+is granted per ORG and nothing caps orgs per user, so a signup-triggered bounty is a faucet pointed
+at itself. The minimum top-up sits deliberately above both bounties combined: below it, buying your
+own bonus with your own card turns a profit.
+
+**Referral credit burns first.** `_KIND_ORDER` gives `referral` the same rank as `promotional`,
+because both are marketing spend we can never be asked to return, and spending them first keeps the
+refundable/disputable purchased pool as small as possible. This is not cosmetic: an unrecognised
+kind sorts LAST (`.get(kind, 99)`), so omitting the entry would have made the bonus burn *after*
+money someone actually paid us. Pinned by a test.
+
+**The `Referral` row is the idempotency guard, not `grant(once=True)`.** `grant`'s `once` check is a
+SELECT with no backing unique index — fine for a signup promo that is merely retried, wrong for
+money owed to a third party, where two concurrent redemptions can both miss it. So every referral
+grant passes `once=False`, and two UNIQUE columns arbitrate instead: `referred_org_id` (an org is
+referred once, ever) and `qualifying_payment_intent` (one payment funds one qualification). Same
+reasoning as the conditional UPDATE in `reserve` and the unique `stripe_payment_intent` in `topup` —
+where two paths can read before either writes, the database has to be the one that says no.
+
+`_pay` **claims before it grants**: the row flips to `paid` in its own committed statement, and only
+then does credit move. The opposite order would mean the loser of a race had already granted. The
+cost is the mirror failure — a crash between claim and grant pays nobody and says otherwise — which
+is the right way round for money, is visible in `/admin/referrals` as a paid row with a null block
+id, and errs toward paying once rather than twice.
+
+**The hold is the only clawback window there is.** Rewards land `referral_hold_days` (7) after
+qualifying. `charge.dispute.created` / `charge.refunded` — the first reversal events treg has ever
+handled — cancel a bonus still inside that window. Anything already granted is **logged for a human,
+never auto-reversed**: referral credit burns first and is usually spent by then, and reversing it
+would mean a second code path able to drive a balance negative. The clawback touches the *bonus*
+only; it never refunds the top-up, because that has always been a human decision.
+
+**The gates** (`qualify`): first top-up only, at or above the minimum; not a self-referral; the
+referrer has paid us at least once themselves; the paying card's Stripe fingerprint has not already
+claimed a referral; and the referrer is under their lifetime cap. The fingerprint is the load-bearing
+one — an email address is free and a card is not — and it is read via `expand=["payment_method"]` on
+the `PaymentIntent.retrieve` that `_on_checkout_completed` was already making. It is not card data
+and it lives on the `referral` row alone, never on an `Org`.
+
+A refusal is **recorded, not dropped**, and `capped` is deliberately distinct from `rejected`: one is
+"you ran out of self-serve allowance", the other is "a gate said no". "I referred someone and got
+nothing" is the ticket this program generates, and the answer has to be on the page.
+
+**No scheduler, as everywhere else.** `sweep()` runs from `billing._credit` (any top-up advances the
+queue) and from `GET /referrals` (someone checking on their reward is the one who makes it land) —
+the same lazy, caller-pays bargain as `reap_stale_holds`. It never raises: its callers are a Stripe
+webhook and a page load, and neither may fail over a bonus.
+
+**Cash payouts are not built.** The self-serve program pays in credit only, and the cap refusal is
+the commercial conversation that replaces an uncapped percentage. When an influencer tier lands, it
+reads `/admin/referrals` — the same table, filtered — and the payout rail (and its W-9/1099
+obligations) is what gets bought rather than built.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -456,9 +456,10 @@ and it replaces editing one env var that would lift the blast-radius rail for ev
 public promise (terms §08, landing 04), so there is no gross margin on a catalog call to share. The
 only thing treg actually keeps is the gap between what a team tops up and what it consumes. A
 percentage of top-ups would therefore be a permanent share of pass-through GMV — and, worse, it
-scales the reward with effort, which is the definition of a farmable incentive. Flat figures ($10 to
-the referrer, $5 to the friend, `config.referral_*`) are budgetable as CAC, bounded by construction,
-and not worth building a fake-account farm for.
+scales the reward with effort, which is the definition of a farmable incentive. Flat figures ($5 to
+each side, `config.referral_*`) are budgetable as CAC, bounded by construction, and not worth
+building a fake-account farm for. The two sides are deliberately SYMMETRIC: it makes the offer one
+sentence to explain, and neither party can feel short-changed by the other's share.
 
 **The qualifying event is the friend's FIRST PAID TOP-UP, never their signup.** `promo_grant_micro`
 is granted per ORG and nothing caps orgs per user, so a signup-triggered bounty is a faucet pointed

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -461,10 +461,22 @@ each side, `config.referral_*`) are budgetable as CAC, bounded by construction, 
 building a fake-account farm for. The two sides are deliberately SYMMETRIC: it makes the offer one
 sentence to explain, and neither party can feel short-changed by the other's share.
 
-**The qualifying event is the friend's FIRST PAID TOP-UP, never their signup.** `promo_grant_micro`
-is granted per ORG and nothing caps orgs per user, so a signup-triggered bounty is a faucet pointed
-at itself. The minimum top-up sits deliberately above both bounties combined: below it, buying your
-own bonus with your own card turns a profit.
+**The qualifying event is a PAID TOP-UP, never a signup.** `promo_grant_micro` is granted per ORG
+and nothing caps orgs per user, so a signup-triggered bounty is a faucet pointed at itself.
+
+**The threshold is cumulative, and falling short is not fatal.** This first shipped as "the first
+top-up must clear the minimum, or the referral is rejected", and that was wrong in the one way that
+mattered: **$5 is the first preset on the billing page and the minimum is $10**, so the most obvious
+button silently destroyed the reward, permanently, with no way back even if the team added $100 the
+next day. It punished exactly the person the program exists to convert and removed their reason to
+add the rest. A short payment now leaves the row `pending`, counts toward the total, and the billing
+page keeps the offer up — asking for the REMAINDER, because repeating the full figure reads as
+though the money already paid did not count.
+
+This costs nothing in abuse terms: the money still has to arrive, so $5 + $5 buys a referral on
+exactly the terms $10 does, and the fingerprint and the cap are untouched. It also let the old
+"must be the first purchase" rule go — that existed to stop a second bounty, and `pending` already
+does it, since `qualify` only ever selects a pending row.
 
 **Referral credit burns first.** `_KIND_ORDER` gives `referral` the same rank as `promotional`,
 because both are marketing spend we can never be asked to return, and spending them first keeps the

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -612,3 +612,29 @@ Untagged traffic shows up as `unattributed_micro` rather than being dropped.
 
 **Isolation.** `treg org agent-new <name> --pin customer=cust_A` mints a token pinned to one tag value;
 the pin beats the header and a mismatch is a 403. Rule of thumb: **tag for counting, token for control.**
+
+## Referrals
+
+`GET /referrals` · `POST /referrals/code` · `GET /admin/referrals`. Policy lives in
+[money](../architecture/money.md); three API-shaped decisions live here.
+
+**`require_identity`, not `require_member`.** A referral belongs to a PERSON, not to one of their
+teams (`User.referral_code`). The reward does land in an org, but *which* org is our decision —
+the oldest one they own — so nothing on these routes is scoped by `X-Treg-Org`.
+
+**`GET /referrals` returns the referred person's full email**, which makes it the one route here
+where a scoping mistake leaks another user's data rather than merely miscounting. It is scoped in
+the query itself (`referrer_user_id == caller.id`), never filtered afterwards, and pinned by a test.
+`privacy.html` discloses the visibility.
+
+**`/?ref=CODE` is the one query string the landing route serves.** `GET /` deliberately treats any
+query string as the SPA's and falls through to the dashboard — which for a referral link would send
+a stranger who has never heard of treg to an empty app shell instead of the pitch. So a *lone* `ref`
+counts as parameterless (anything alongside it still belongs to the SPA), and the code is parked in
+`treg_ref` — httponly, lax, 30 days, and revalidated on read exactly like `_take_oauth_return`,
+because a cookie is attacker-supplied and this value reaches a query.
+
+Redemption happens at **first team creation**, in both org-creating doors (`POST /orgs` and the
+legacy `POST /users`), immediately after `_grant_signup_promo` and with the same swallow-and-log
+posture: a referral is a marketing nicety and a signup is not. It must never be why someone cannot
+make a team.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -876,7 +876,10 @@ work rides on a request someone is already making.
 The Billing tab renders `billing.referral_offer` when the team was referred: a green note naming the
 minimum, and `+$X bonus` on each preset that clears it (`refPresetBonus`). Both are measured
 against `remaining_micro`, not the full minimum — the threshold is cumulative, so a team that has
-already added $5 is asked for "$5 more" and sees the bonus marked on the $5 button. Both are needed — the
+already added $5 is asked for "$5 more" and sees the bonus marked on the $5 button. The note says
+the referee is credited **straight away** and the referrer after the hold — that timing is
+load-bearing copy, not decoration: the referee has no Referrals page, so an unstated delay is what
+made a correct payout look like a failure. Both are needed — the
 amount is chosen at the buttons, and the first preset ($5) is below the $10 minimum, so a note on its
 own would let the most-clicked button quietly forfeit the reward. Null offer = the page renders
 exactly as it did before this shipped.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -870,3 +870,11 @@ rather than in an email to us.
 Opening the page **has a side effect**: `GET /referrals` runs the payout sweep, so a user checking
 whether their reward has landed is the one who makes it land. There is no scheduler in treg, so this
 work rides on a request someone is already making.
+
+### The billing page's referral prompt
+
+The Billing tab renders `billing.referral_offer` when the team was referred: a green note naming the
+minimum, and `+$X bonus` on each preset that clears it (`refPresetBonus`). Both are needed — the
+amount is chosen at the buttons, and the first preset ($5) is below the $10 minimum, so a note on its
+own would let the most-clicked button quietly forfeit the reward. Null offer = the page renders
+exactly as it did before this shipped.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -844,3 +844,25 @@ multi-binding + edit, skill bundles, super-admin mutations, OAuth connect, share
 shipped. Packaging: `src/treg/web` lives inside the `treg` package, so the wheel's `packages`
 inclusion ships every asset (incl. `tutorial.js`/`tutorial.html`) — no `force-include` (a redundant
 one double-adds each file and breaks the wheel build).
+
+## The Referrals view
+
+A top-level `<template v-if="view==='referrals'">`, plus a nav button and a second entry point under
+the balance chip (where someone is already thinking about what treg costs them).
+
+**`'referrals'` must appear in BOTH view whitelists** — `viewFromHash()` and the `popstate` handler.
+`go('referrals')` works on click regardless of them; those two lists are what make the view survive
+a RELOAD and a BACK button. Missing either is invisible in review and in clicking around, which is
+precisely the silent failure CLAUDE.md warns about. Pinned by a test that counts both.
+
+**The not-eligible state is a gate made visible.** A referrer who has never topped up earns nothing
+(`referrals.qualify`). Rather than show them a live link that silently pays zero, the link is
+replaced by "Add funds once to unlock your link" and a button into Billing.
+
+**Every status renders a reason** (`refStatus`), including `capped` and `rejected`. "I referred
+someone and got nothing" is the ticket this program generates, and the answer belongs on the page
+rather than in an email to us.
+
+Opening the page **has a side effect**: `GET /referrals` runs the payout sweep, so a user checking
+whether their reward has landed is the one who makes it land. There is no scheduler in treg, so this
+work rides on a request someone is already making.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -874,7 +874,9 @@ work rides on a request someone is already making.
 ### The billing page's referral prompt
 
 The Billing tab renders `billing.referral_offer` when the team was referred: a green note naming the
-minimum, and `+$X bonus` on each preset that clears it (`refPresetBonus`). Both are needed — the
+minimum, and `+$X bonus` on each preset that clears it (`refPresetBonus`). Both are measured
+against `remaining_micro`, not the full minimum — the threshold is cumulative, so a team that has
+already added $5 is asked for "$5 more" and sees the bonus marked on the $5 button. Both are needed — the
 amount is chosen at the buttons, and the first preset ($5) is below the $10 minimum, so a note on its
 own would let the most-clicked button quietly forfeit the reward. Null offer = the page renders
 exactly as it did before this shipped.

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -855,9 +855,13 @@ the balance chip (where someone is already thinking about what treg costs them).
 a RELOAD and a BACK button. Missing either is invisible in review and in clicking around, which is
 precisely the silent failure CLAUDE.md warns about. Pinned by a test that counts both.
 
-**The not-eligible state is a gate made visible.** A referrer who has never topped up earns nothing
-(`referrals.qualify`). Rather than show them a live link that silently pays zero, the link is
-replaced by "Add funds once to unlock your link" and a button into Billing.
+**The link is NOT gated behind paying us.** Every signed-in person gets one, free tier included —
+see [money](../architecture/money.md) for why that gate was removed. The `!eligible` branch survives
+only for the degenerate case of owning no team to pay a reward into, and a test asserts it never
+again asks anyone to add funds.
+
+`GET /referrals` mints the code as well as sweeping, so the page is one call and `link` is never
+empty on a first visit.
 
 **Every status renders a reason** (`refStatus`), including `capped` and `rejected`. "I referred
 someone and got nothing" is the ticket this program generates, and the answer belongs on the page

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -5227,6 +5227,13 @@ async def my_referrals(
     whether their reward has landed is the one who makes it land. That is the same lazy,
     caller-pays-for-their-own-cleanup bargain as `ledger.reap_stale_holds`.
     """
+    # Mint the code here too, not only on POST. Asking for this page IS the lazy trigger the code
+    # was always meant to hang off, and every caller needs a usable `link` — a response carrying an
+    # empty one is a footgun for any client that doesn't know to POST first.
+    try:
+        await referrals.ensure_code(db, user)
+    except Exception as exc:  # noqa: BLE001 — a code we couldn't mint is an empty link, not a 500
+        logging.getLogger("treg").warning("referral code mint failed for user %s: %s", user.id, exc)
     try:
         await referrals.sweep(db, referrer_user_id=user.id)
     except Exception as exc:  # noqa: BLE001 — pragma: no cover

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -54,13 +54,13 @@ from sqlmodel import select
 
 from . import analytics, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, endpoint_stats, health, injectors, ledger, localrun, oauth
 from . import oauth_providers
-from . import pubfeed, ratestore, reconcile, runner, sandbox as demo_sandbox, session as sess
+from . import pubfeed, ratestore, reconcile, referrals, runner, sandbox as demo_sandbox, session as sess
 from .config import LEGACY_PUBLIC_HOSTS, PUBLIC_HOST_ALIASES, get_settings, platform_setting_name
 from .db import get_session, init_db, session_maker
 from .models import (ROLE_RANK, Bundle, CallRecord, CapabilityPin, CreditBlock, DenyRule, Hold,
                      IdempotentCall, Invite, LedgerEntry, Membership, OAuthClient, OAuthCode,
-                     OAuthGrant, OAuthRefresh, Org, PendingOAuth, Project, RunRecord, Secret, TagBudget, TagSpend, Tool,
-                     ToolRequest, User)
+                     OAuthGrant, OAuthRefresh, Org, PendingOAuth, Project, Referral, RunRecord, Secret,
+                     TagBudget, TagSpend, Tool, ToolRequest, User)
 from .proxy import relay
 
 
@@ -1988,9 +1988,19 @@ async def landing(request: Request, treg_session: str = Cookie(default=""),
     """Serve the marketing landing at the root. Any query string (invite links, OAuth returns,
     tour deep-links) belongs to the SPA, so those requests fall through to the dashboard —
     the landing is only the clean, parameterless front door. A signed-in visitor belongs on
-    the dashboard, so a live session redirects to /app instead of re-showing the pitch."""
+    the dashboard, so a live session redirects to /app instead of re-showing the pitch.
+
+    `?ref=<code>` is the ONE exception, and it has to be: a referral link's whole job is to show a
+    stranger the pitch. Falling through to the SPA would send someone who has never heard of treg
+    to an empty dashboard shell — so a lone `ref` counts as parameterless, and the code is parked in
+    a cookie on the way past. It is only redeemed much later, when they create their first team.
+    """
     page = _WEB_DIR / "landing.html"
-    if page.exists() and not request.query_params:
+    ref = referrals.normalize_code(request.query_params.get("ref", ""))
+    # Only `ref` may be present. Anything else alongside it belongs to the SPA, and a referral code
+    # is not a reason to hijack an invite or an OAuth return.
+    ref_only = set(request.query_params.keys()) <= {"ref"}
+    if page.exists() and (not request.query_params or (ref and ref_only)):
         if treg_session and await _user_from_session(treg_session, db):
             return RedirectResponse("/app", status_code=302)
         # Read-and-substitute rather than a bare FileResponse: the canonical, og:url and og:image
@@ -1998,7 +2008,10 @@ async def landing(request: Request, treg_session: str = Cookie(default=""),
         # would tell crawlers its front page really lives on treg.to.
         html = page.read_text(encoding="utf-8").replace(
             "{BASE}", get_settings().public_url.rstrip("/"))
-        return HTMLResponse(html, headers={"Cache-Control": "no-cache"})
+        resp = HTMLResponse(html, headers={"Cache-Control": "no-cache"})
+        if ref:
+            _remember_referral(resp, request, ref)
+        return resp
     return await dashboard(request, treg_session, db)
 
 
@@ -2668,6 +2681,39 @@ def _take_oauth_return(request: Request) -> str | None:
     # would have cost a silently-dropped authorization in production.
     target = (request.cookies.get(OAUTH_RETURN_COOKIE) or "").strip('"')
     return target if target.startswith("/oauth/authorize?") else None
+
+
+REFERRAL_COOKIE = "treg_ref"
+# A month. The gap between clicking a friend's link and actually creating a team is measured in days
+# for the people this program is for — they read the landing, think about it, and come back. Shorter
+# would silently drop the referrals that took the longest to convert, which are exactly the genuine
+# ones; much longer would keep attributing a signup to a link somebody forgot they ever clicked.
+REFERRAL_COOKIE_MAX_AGE = 30 * 24 * 3600
+
+
+def _remember_referral(resp, request: Request, code: str) -> None:
+    """Park a referral code from `/?ref=…` until the visitor creates their first team.
+
+    Same shape as `_remember_oauth_return`: httponly (no script needs it), `samesite=lax` so it
+    survives the click through to a GitHub/Google sign-in and back, and `secure` only when we are
+    actually on HTTPS so local development still works.
+
+    First code wins is NOT enforced here — the cookie is simply overwritten. Someone who clicks two
+    different referral links before signing up gets attributed to the second, which is both the
+    normal advertising convention (last touch) and the one that needs no extra state.
+    """
+    resp.set_cookie(REFERRAL_COOKIE, code, httponly=True, samesite="lax",
+                    secure=_is_https(request), max_age=REFERRAL_COOKIE_MAX_AGE)
+
+
+def _take_referral(request: Request) -> str:
+    """The parked code, revalidated. "" when there is none or it is not a shape we ever mint.
+
+    Validated on READ as well as on write, exactly like `_take_oauth_return`: a cookie is
+    attacker-supplied, and this value reaches a database query. `normalize_code` is a strict
+    allowlist, so anything odd becomes "" and the signup simply proceeds unreferred.
+    """
+    return referrals.normalize_code((request.cookies.get(REFERRAL_COOKIE) or "").strip('"'))
 
 
 def _wrong_resource(resource: str) -> str | None:
@@ -3909,7 +3955,7 @@ async def _find_or_create_user(db: AsyncSession, email: str) -> User:
 
 # ---- users (open registration; personal org + owner membership; token shown once) ---------
 @app.post("/users")
-async def register_user(body: UserIn, db: AsyncSession = Depends(get_session)) -> dict:
+async def register_user(body: UserIn, request: Request, db: AsyncSession = Depends(get_session)) -> dict:
     email = _norm_email(body.email)
     # This door creates a User directly (it predates `_find_or_create_user`), so it needs the same
     # machine-domain block — otherwise open registration could squat an agent address.
@@ -3930,6 +3976,9 @@ async def register_user(body: UserIn, db: AsyncSession = Depends(get_session)) -
     except IntegrityError:
         raise HTTPException(status_code=409, detail="email already registered")
     await _grant_signup_promo(db, org)
+    # Both org-creating doors redeem, for the same reason both grant the signup promo: this one
+    # predates `_find_or_create_user` but still ends with a person owning a fresh team and a balance.
+    await _redeem_referral(db, request, user, org)
     return {"id": user.id, "email": user.email, "org": org.slug, "org_id": org.id, "role": "owner", "token": token}
 
 
@@ -3969,7 +4018,8 @@ async def _count_owners(org_id: int, db: AsyncSession) -> int:
 
 @app.post("/orgs")
 async def create_org(
-    body: OrgIn, user: User = Depends(require_identity), db: AsyncSession = Depends(get_session)
+    body: OrgIn, request: Request, user: User = Depends(require_identity),
+    db: AsyncSession = Depends(get_session),
 ) -> dict:
     # Any authenticated user spins up a new org and becomes its owner, minting a fresh org-scoped
     # token for it. **require_identity, NOT require_member** — a brand-new user has zero orgs (no auto
@@ -3993,7 +4043,28 @@ async def create_org(
     else:
         raise HTTPException(status_code=409, detail="could not allocate a unique org slug — retry")
     await _grant_signup_promo(db, org)
+    await _redeem_referral(db, request, user, org)
     return {"org": org.slug, "org_id": org.id, "name": org.name, "role": "owner", "token": token}
+
+
+async def _redeem_referral(db: AsyncSession, request: Request, user: User, org: Org) -> None:
+    """Attribute a brand-new team to whoever's link brought them here. Owes nothing yet — the bonus
+    is earned at the team's first paid top-up, not at signup (see referrals.py).
+
+    Team creation is the right and only redemption point: `_find_or_create_user` deliberately makes
+    no org, so this is where a person first becomes a tenant with a balance. It fires on EVERY team
+    a user creates, and `referrals.attribute` is what refuses the ones that should not count — a
+    self-referral, a demo team, or an org that already carries a referral.
+
+    Swallow-and-log, matching `_grant_signup_promo` immediately above: a referral is a marketing
+    nicety and a signup is not. Nothing here may ever be the reason someone cannot make a team.
+    """
+    try:
+        code = _take_referral(request)
+        if code:
+            await referrals.attribute(db, user=user, org=org, code=code)
+    except Exception as exc:  # noqa: BLE001
+        logging.getLogger("treg").warning("referral attribution failed for org %s: %s", org.id, exc)
 
 
 class GrantTeamIn(BaseModel):
@@ -5139,6 +5210,42 @@ async def billing_portal(
         raise HTTPException(status_code=503, detail=str(e))
     except billing.TopupRejected as e:
         raise HTTPException(status_code=422, detail=str(e))
+
+
+# ---- referrals ---------------------------------------------------------------------------------
+# Deliberately `require_identity`, not `require_member`: a referral belongs to a PERSON, not to one
+# of their teams (see models.Referral). The reward lands in an org, but which org is our decision,
+# not the caller's — so nothing here is scoped by `X-Treg-Org`.
+@app.get("/referrals")
+async def my_referrals(
+    user: User = Depends(require_identity), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """This person's referral link and everyone who has used it.
+
+    Also runs the payout sweep, scoped to this user. There is no scheduler in treg, so the two
+    trigger points are any top-up (`billing._credit`) and this page — which means someone checking
+    whether their reward has landed is the one who makes it land. That is the same lazy,
+    caller-pays-for-their-own-cleanup bargain as `ledger.reap_stale_holds`.
+    """
+    try:
+        await referrals.sweep(db, referrer_user_id=user.id)
+    except Exception as exc:  # noqa: BLE001 — pragma: no cover
+        logging.getLogger("treg").warning("referral sweep failed for user %s: %s", user.id, exc)
+    return await referrals.summary(db, user)
+
+
+@app.post("/referrals/code")
+async def mint_referral_code(
+    user: User = Depends(require_identity), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Mint this person's referral code, or return the one they already have.
+
+    Idempotent, so the dashboard can call it every time the page opens without checking first. Codes
+    are minted here rather than at signup because most people never open this page, and a code
+    nobody has seen is a unique index entry earning nothing.
+    """
+    code = await referrals.ensure_code(db, user)
+    return {"code": code, "link": f"{get_settings().public_url.rstrip('/')}/?ref={code}"}
 
 
 @app.post("/billing/stripe/webhook", include_in_schema=False)
@@ -8171,6 +8278,56 @@ async def admin_reconcile_repeats(
     since = reconcile.window_start(since_days)
     return {"since": since.isoformat(), "since_days": since_days,
             **await reconcile.repeat_rate(db, since, top=top)}
+
+
+@app.get("/admin/referrals")
+async def admin_referrals(
+    status: str = "", limit: int = Query(200, ge=1, le=1000),
+    _: str = Depends(require_superadmin), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Every referral, across every team — who invited whom, what it cost, and what is still owed.
+
+    Cross-org, so `require_superadmin` and nothing weaker, exactly like the reconcile trio above.
+    Read-only: it pays nothing and refuses nothing. `pending_payout_micro` is what the sweep will
+    grant once holds elapse, and it is the number that says whether this program is affordable
+    before the money leaves — the same job `provider_spend` does for provider bills.
+
+    This is also the report the influencer tier will read when it lands: a cash payout run is this
+    list, filtered to partners on a contract, exported.
+    """
+    s = get_settings()
+    q = select(Referral).order_by(Referral.created_at.desc()).limit(limit)
+    if status:
+        q = q.where(Referral.status == status)
+    rows = (await db.execute(q)).scalars().all()
+
+    emails: dict[int, str] = {}
+    for uid in {r.referrer_user_id for r in rows} | {r.referred_user_id for r in rows}:
+        u = await db.get(User, uid)
+        if u is not None:
+            emails[uid] = u.email
+
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    pending = sum(int(s.referral_referrer_micro) + int(s.referral_referred_micro)
+                  for r in rows if r.status == "qualified")
+    paid = sum(r.referrer_reward_micro + r.referred_reward_micro for r in rows if r.status == "paid")
+    return {
+        "counts": by_status,
+        "paid_micro": paid,
+        "pending_payout_micro": pending,
+        "referrals": [{
+            "id": r.id, "code": r.code, "status": r.status, "reason": r.reject_reason,
+            "referrer": emails.get(r.referrer_user_id, ""),
+            "referred": emails.get(r.referred_user_id, ""),
+            "referred_org_id": r.referred_org_id,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "qualified_at": r.qualified_at.isoformat() if r.qualified_at else None,
+            "paid_at": r.paid_at.isoformat() if r.paid_at else None,
+            "paid_micro": r.referrer_reward_micro + r.referred_reward_micro,
+        } for r in rows],
+    }
 
 
 # ---- the proxy: call a tool without holding its credential --------------------------------

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -10252,6 +10252,13 @@ async def call_tool(
     # network: everything above (ACL, deny rules, caps) can still refuse the call, and a refused
     # call must not leave a hold behind for the reaper to clean up.
     if mk is not None and mk.metered:
+        # Rendered BEFORE the reserve, while `tool` is still live. `ledger.reserve` calls
+        # `db.rollback()` on InsufficientBalance, which EXPIRES every ORM object this session is
+        # tracking — `tool` included — and reading an expired attribute outside an awaited call
+        # raises MissingGreenlet. Doing it inside the handler below turned the one refusal an agent
+        # is most likely to hit into a 500 with no `balance_micro` and no top-up URL. Same reasoning
+        # as `block_id` in billing._credit, and the reason that capture is pinned by a test.
+        refusal_secrets = _platform_secret_renderings(tool)
         try:
             await _platform_reserve(mk, caller, db, meta=meta, call_ref=call_ref)
         except HTTPException as exc:
@@ -10272,8 +10279,7 @@ async def call_tool(
             # already retains, and it is bounded by the same redaction and 14-day retention.
             _audit(exc.status_code, charged_micro=0,
                    refused_by="balance" if exc.status_code == 402 else "cap",
-                   error_response=_redact_snippet(f"treg: {exc.detail}",
-                                                  _platform_secret_renderings(tool),
+                   error_response=_redact_snippet(f"treg: {exc.detail}", refusal_secrets,
                                                   _ERROR_RESPONSE_MAX))
             raise
     started = _now_ms()

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -5114,7 +5114,13 @@ async def billing_get(
     there's a Stripe customer and a saved card, the auto-top-up policy + why it's off if it is, and how
     much of this month's automatic cap has been used."""
     org = _billing_org(caller)
-    return await billing.billing_state(db, org)
+    state = await billing.billing_state(db, org)
+    # Merged HERE rather than inside `billing_state`, so billing.py keeps its one job (Stripe) and
+    # does not grow a second reason to know about referrals. This is the screen where a referred team
+    # is already deciding how much to add, so it is the only place the minimum actually changes a
+    # decision — see referrals.offer_for_org.
+    state["referral_offer"] = await referrals.offer_for_org(db, org.id)
+    return state
 
 
 @app.post("/billing/topup")

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -45,6 +45,7 @@ from sqlmodel import select
 from . import analytics
 from . import email as email_mod
 from . import ledger
+from . import referrals
 from .config import get_settings
 from .models import CreditBlock, LedgerEntry, Membership, Org, User
 
@@ -239,13 +240,34 @@ async def _set_default_pm(db: AsyncSession, org_id: int, payment_method: str | N
 async def _pm_of_payment_intent(pi_id: str) -> str | None:
     """The PaymentMethod a succeeded PaymentIntent used — how a Checkout with
     `setup_future_usage` hands us the card to reuse, without any Stripe.js on our side."""
+    pm_id, _ = await _pm_and_fingerprint(pi_id)
+    return pm_id
+
+
+async def _pm_and_fingerprint(pi_id: str) -> tuple[str | None, str | None]:
+    """`(payment_method_id, card_fingerprint)` for a succeeded PaymentIntent, in ONE retrieve.
+
+    The fingerprint is Stripe's stable per-CARD identifier: the same physical card presented under a
+    different email, name or Customer produces the same string. That makes it the only durable
+    signal the referral program's abuse checks have — an email address is free, a card is not (see
+    referrals.qualify). It is not card data: the value is opaque and meaningless outside our own
+    Stripe account, so nothing here weakens `Org.stripe_default_pm`'s no-card-data-in-our-DB posture.
+    It is stored on the `referral` row alone, never on an org.
+
+    `expand` rather than a second `PaymentMethod.retrieve`: this call already happens on every
+    Checkout completion, and one round trip on the webhook path is enough.
+    """
     try:
-        pi = await _sdk(stripe.PaymentIntent.retrieve, id=pi_id)
+        pi = await _sdk(stripe.PaymentIntent.retrieve, id=pi_id, expand=["payment_method"])
     except Exception as e:  # noqa: BLE001 — a card we can't look up just means no auto-top-up yet
         log.warning("billing: could not retrieve PaymentIntent %s: %s", pi_id, e)
-        return None
+        return None, None
     pm = pi.get("payment_method")
-    return pm if isinstance(pm, str) else (pm or {}).get("id")
+    if isinstance(pm, str):  # not expanded (an older API version, or a fake in tests)
+        return pm, None
+    pm = pm or {}
+    fingerprint = ((pm.get("card") or {}).get("fingerprint")) or None
+    return pm.get("id"), fingerprint
 
 
 # ---- manual top-up (Stripe-hosted Checkout) ----------------------------------------------------
@@ -760,6 +782,8 @@ async def handle_webhook_event(db: AsyncSession, event: dict) -> dict:
         return await _on_payment_failed(db, obj)
     if kind == "setup_intent.succeeded":
         return await _on_setup_succeeded(db, obj)
+    if kind in ("charge.dispute.created", "charge.refunded"):
+        return await _on_payment_reversed(db, obj, kind)
     # Everything else acknowledged and dropped — deliberately, not by omission. `invoice_creation` on
     # the top-up Checkout makes Stripe emit `invoice.created` / `invoice.paid` for every purchase, and
     # crediting on those too would be a second door onto the same money. The invoice is a document; the
@@ -767,9 +791,14 @@ async def handle_webhook_event(db: AsyncSession, event: dict) -> dict:
     return {"handled": False, "type": kind}
 
 
-async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, *, auto: bool) -> dict:
+async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, *, auto: bool,
+                  fingerprint: str | None = None) -> dict:
     """Credit a paid PaymentIntent to the org's balance, once. Emails a receipt only when this
-    delivery is the one that actually moved money — a redelivery must not re-notify."""
+    delivery is the one that actually moved money — a redelivery must not re-notify.
+
+    `fingerprint` is the paying card's Stripe fingerprint, used only by the referral abuse checks;
+    None is always safe (it costs a gate, not a payout).
+    """
     # "Has this PaymentIntent already been credited?" is asked BEFORE the credit rather than inferred
     # from a balance change afterwards — a concurrent reserve moves the balance too, and mistaking that
     # for a fresh credit would email a receipt on every webhook redelivery.
@@ -802,6 +831,23 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                            "auto": auto, "balance_after_micro": after,
                            "org": org.slug if org else ""},
                           groups={"team": org.slug if org else ""})
+        # A first paid top-up is the referral program's qualifying event, so this `fresh` branch is
+        # the only correct place to ask: it is the one point that knows money genuinely moved for
+        # the first time. Swallowed for the same reason `analytics.capture` is — a raise here would
+        # 500 the handler and make Stripe retry a payment that has already credited. A bonus is
+        # never worth double-charging someone's card.
+        try:
+            await referrals.qualify(db, org_id=org_id, payment_intent=pi_id,
+                                    amount_micro=amount_micro, fingerprint=fingerprint)
+        except Exception as e:  # noqa: BLE001
+            log.warning("billing: referral qualification failed for org %s: %s", org_id, e)
+    # Pay out whatever has cleared its hold. Lazy and caller-paid, exactly like ledger's stale-hold
+    # reaper: there is no scheduler in treg, and every top-up anywhere is a fine clock to advance a
+    # queue this small. `sweep` never raises, but the belt stays on — this is a money webhook.
+    try:
+        await referrals.sweep(db)
+    except Exception as e:  # noqa: BLE001 — pragma: no cover
+        log.warning("billing: referral sweep failed: %s", e)
     return {"handled": True, "credited": fresh, "block_id": block.id,
             "amount_micro": amount_micro, "balance_micro": after}
 
@@ -834,10 +880,14 @@ async def _on_checkout_completed(db: AsyncSession, session: dict) -> dict:
     amount_micro = cents_to_micro(session.get("amount_total") or 0)
     if amount_micro <= 0:
         return {"handled": False, "reason": "zero amount"}
-    result = await _credit(db, org_id, amount_micro, pi_id, auto=False)
+    # Read the card BEFORE crediting: `_credit` is where a referral qualifies, and the fingerprint is
+    # the abuse gate that stops one card claiming a bounty under a second email. Same single retrieve
+    # that already ran here for the saved-card id, just moved above the credit.
+    pm_id, fingerprint = await _pm_and_fingerprint(pi_id)
+    result = await _credit(db, org_id, amount_micro, pi_id, auto=False, fingerprint=fingerprint)
     # The Checkout saved the card (setup_future_usage); remember it so auto-top-up can be armed
     # without asking for a second card entry.
-    await _set_default_pm(db, org_id, await _pm_of_payment_intent(pi_id))
+    await _set_default_pm(db, org_id, pm_id)
     return result
 
 
@@ -858,6 +908,35 @@ async def _on_payment_succeeded(db: AsyncSession, pi: dict) -> dict:
     pm = pi.get("payment_method")
     await _set_default_pm(db, org_id, pm if isinstance(pm, str) else (pm or {}).get("id"))
     return result
+
+
+async def _on_payment_reversed(db: AsyncSession, charge_or_dispute: dict, kind: str) -> dict:
+    """A funded payment was disputed or refunded. Cancels any referral bonus it earned that has not
+    landed yet — and does NOTHING to the balance itself.
+
+    That split is deliberate and it is the reason the hold window exists. treg has never reversed a
+    top-up automatically: `ledger.py` has no path that drives a balance negative, blocks burn
+    promotional-first precisely to keep the disputable pool small, and refund policy is a human
+    decision. What IS safe to automate is not paying a third party a bounty funded by money that
+    just went away. A bonus already granted is logged for a human instead (see
+    `referrals.reject_for_payment`); referral credit burns first, so by then it is usually spent.
+
+    Both event shapes carry the PaymentIntent: a Charge has `payment_intent`, and a Dispute has it
+    directly too (as well as `charge`). We key on it because it is what `CreditBlock` and
+    `Referral` already store.
+    """
+    pi = charge_or_dispute.get("payment_intent")
+    pi_id = pi if isinstance(pi, str) else (pi or {}).get("id")
+    if not pi_id:
+        return {"handled": False, "reason": "no payment_intent on event"}
+    try:
+        cancelled = await referrals.reject_for_payment(db, pi_id, kind)
+    except Exception as e:  # noqa: BLE001 — a webhook must not 500 over a bonus
+        log.warning("billing: referral clawback failed for %s: %s", pi_id, e)
+        return {"handled": False, "reason": "clawback failed"}
+    if cancelled:
+        log.warning("billing: %s on %s cancelled %s pending referral bonus(es)", kind, pi_id, cancelled)
+    return {"handled": True, "type": kind, "referrals_cancelled": cancelled}
 
 
 async def _on_payment_failed(db: AsyncSession, pi: dict) -> dict:

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -111,6 +111,26 @@ class Settings(BaseSettings):
     call_timeout_s: int = 180
     hold_grace_s: int = 60
 
+    # ---- referral program (referrals.py) --------------------------------------------------------
+    # Flat bounties, not a percentage of top-ups. At 0% platform margin a percentage would be a
+    # permanent share of pass-through GMV, and — unlike a flat figure — it rewards farming in
+    # proportion to effort. Nobody builds a fake-account farm for $10; plenty would for 15% of an
+    # uncapped balance. All figures are micro-USD (1e-6 USD), like every other amount in the system.
+    referral_referrer_micro: int = 10_000_000   # $10 to the person who shared the link
+    referral_referred_micro: int = 5_000_000    # $5 to the friend who signed up
+    # The friend's first top-up must clear this for anything to be owed. Deliberately well above the
+    # bounties themselves: below it, buying the bonus with your own card is profitable.
+    referral_min_topup_micro: int = 10_000_000  # $10
+    # Days between qualifying and the credit landing. This is the ONLY clawback window that exists:
+    # referral credit is promotional, burns first (ledger._KIND_ORDER) and is typically spent within
+    # days, so once granted it cannot be recovered. Short on purpose — a referral program that pays
+    # in 60 days does not feel like a reward, and the exposure at these amounts is tiny.
+    referral_hold_days: int = 7
+    # Lifetime paid referrals per person. Anyone who wants more is an influencer, and that is a
+    # conversation with a contract and a bank transfer — not a self-serve link. The refusal IS the
+    # commercial conversation, the same posture as raising a daily cap.
+    referral_cap: int = 20
+
     # ---- tier-4 platform keys (api.py credential ladder) ---------------------------------------
     # treg's OWN provider keys, spent on a caller's behalf and metered against their prepaid balance.
     # Read by `proxy.relay` through a `platform_setting` binding (never copied into an org's secrets,

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -116,7 +116,9 @@ class Settings(BaseSettings):
     # permanent share of pass-through GMV, and — unlike a flat figure — it rewards farming in
     # proportion to effort. Nobody builds a fake-account farm for $10; plenty would for 15% of an
     # uncapped balance. All figures are micro-USD (1e-6 USD), like every other amount in the system.
-    referral_referrer_micro: int = 10_000_000   # $10 to the person who shared the link
+    # Symmetric on purpose: both sides get the same, so the offer is one sentence to explain and
+    # neither party can feel like the other got the better end of it.
+    referral_referrer_micro: int = 5_000_000    # $5 to the person who shared the link
     referral_referred_micro: int = 5_000_000    # $5 to the friend who signed up
     # The friend's first top-up must clear this for anything to be owed. Deliberately well above the
     # bounties themselves: below it, buying the bonus with your own card is profitable.

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -380,6 +380,20 @@ def _migrate_to_orgs(conn) -> None:
             if col not in cols:
                 conn.execute(text(f"ALTER TABLE callrecord ADD COLUMN {col} VARCHAR"))
 
+    # (A37) additive: user.referral_code — this person's `?ref=` code (see referrals.py). NULLABLE
+    # with no default: it is minted lazily the first time someone opens the Referrals page, so NULL
+    # ("never asked for one") is the correct and overwhelmingly common state. "user" is QUOTED — a
+    # reserved word in Postgres, and this ALTER runs in place on the live PG database.
+    #
+    # The UNIQUE index is created separately and NOT as a column constraint: `create_all` already
+    # built it on a fresh database, so this branch only runs where the table predates the feature,
+    # and IF NOT EXISTS keeps it idempotent across a restarted deploy. The `referral` table itself
+    # needs nothing here — create_all makes a brand-new table for free.
+    if "user" in tables and "referral_code" not in {c["name"] for c in insp.get_columns("user")}:
+        conn.execute(text('ALTER TABLE "user" ADD COLUMN referral_code VARCHAR'))
+        conn.execute(text(
+            'CREATE UNIQUE INDEX IF NOT EXISTS ix_user_referral_code ON "user" (referral_code)'))
+
     # (A28) corrective: creditblock.stripe_payment_intent must be UNIQUE (the top-up idempotency
     # key). It sits HERE, above the (B) block, because (B) returns early on a fresh/new-schema DB —
     # and a fresh DB created between the ledger landing and this fix is precisely the one that has

--- a/src/treg/ledger.py
+++ b/src/treg/ledger.py
@@ -57,7 +57,13 @@ from .models import CreditBlock, Hold, LedgerEntry, Org, TagSpend
 # Block consumption order: promotional credit burns first, then the oldest purchased block. Promo is
 # a marketing expense and never refundable, so spending it first keeps the refundable (and disputable)
 # purchased pool as small as possible for as long as possible.
-_KIND_ORDER = {"promotional": 0, "purchased": 1}
+#
+# `referral` sits alongside `promotional` at 0 for exactly that reason — a referral bonus is marketing
+# spend we can never be asked to return, so it must burn before the money someone actually paid us.
+# It is a separate kind ONLY so reporting can tell the two apart. Note that an unrecognised kind
+# sorts LAST (`.get(kind, 99)` in `_consume_blocks`), i.e. after purchased: any new non-refundable
+# kind must be added here or it silently gets the most expensive treatment available.
+_KIND_ORDER = {"promotional": 0, "referral": 0, "purchased": 1}
 
 
 class InsufficientBalance(Exception):

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -106,6 +106,11 @@ class User(SQLModel, table=True):
     token_version: int = Field(default=0)
     onboarded: bool = Field(default=False)  # has completed OR skipped first-run onboarding (don't re-offer)
     demo: bool = Field(default=False)  # a fake teammate seeded into a demo team (can't log in; excluded from stats)
+    # This person's referral code (`treg.to/?ref=<code>`). On the USER, not the Org, because a person
+    # refers a friend — and because anyone may create unlimited orgs, so a per-org code would hand the
+    # same human unlimited codes to farm with. NULL until they open the Referrals page; minted lazily
+    # so we never generate codes for the majority who never look. See referrals.py.
+    referral_code: str | None = Field(default=None, index=True, unique=True)
     created_at: datetime = Field(default_factory=_now)
 
 
@@ -653,6 +658,64 @@ class TagBudget(SQLModel, table=True):
     note: str = Field(default="")
     created_at: datetime = Field(default_factory=_now)
     updated_at: datetime = Field(default_factory=_now)
+
+
+class Referral(SQLModel, table=True):
+    """One person invited another, and what we owe for it. See referrals.py and
+    docs/context/architecture/money.md.
+
+    THE ROW IS THE IDEMPOTENCY GUARD, not `ledger.grant`. `grant(once=True)` checks
+    `(org_id, kind)` with a SELECT and no backing unique index, so two concurrent redemptions
+    can both miss it — fine for a signup promo that is retried, wrong for money owed to a third
+    party. So referrals.py calls `grant(..., once=False)` and lets these two UNIQUE columns
+    arbitrate instead, the same way `CreditBlock.stripe_payment_intent` arbitrates a topup and
+    the conditional UPDATE arbitrates a reserve. Where two paths can read before either writes,
+    the database has to be the one that says no.
+
+    Status is a one-way ladder, and every terminal state is kept rather than deleted — a referral
+    we refused is the record of WHY someone was not paid, which is the first thing asked when a
+    user emails about a missing reward:
+
+        pending    attributed at signup; the friend has not topped up yet. Owes nothing.
+        qualified  the friend made their first paid top-up. Owes both bonuses, AFTER the hold.
+        paid       both grants landed. `referrer_block_id` / `referred_block_id` name them.
+        capped     qualified, but the referrer is already at their lifetime cap. Pays nothing.
+        rejected   an abuse gate said no, or the funding payment was disputed/refunded inside
+                   the hold window. `reject_reason` says which.
+    """
+
+    __table_args__ = (
+        # An org can be referred exactly once, ever. This is what stops a second signup door, a
+        # retried request, or two concurrent redemptions from paying the same bounty twice.
+        UniqueConstraint("referred_org_id", name="uq_referral_referred_org"),
+        # And one payment can fund at most one qualification, for the same reason `topup` keys on
+        # the PaymentIntent: Stripe delivers at least once and prod runs more than one instance.
+        UniqueConstraint("qualifying_payment_intent", name="uq_referral_qualifying_pi"),
+        Index("ix_referral_status_qualified", "status", "qualified_at"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    code: str = Field(index=True)  # the code as typed, kept even if the referrer later changes theirs
+    referrer_user_id: int = Field(foreign_key="user.id", index=True)
+    referred_user_id: int = Field(foreign_key="user.id", index=True)
+    referred_org_id: int = Field(foreign_key="org.id")  # unique — see __table_args__
+    status: str = Field(default="pending", index=True)
+    reject_reason: str = Field(default="")
+    # The payment that qualified this referral. NULL while pending — and NULL is exempt from a
+    # unique index, so any number of pending rows coexist happily.
+    qualifying_payment_intent: str | None = Field(default=None)
+    # Stripe's stable per-card id (`pm.card.fingerprint`). NOT card data — an opaque token that only
+    # means anything inside our own Stripe account. It is the one signal that survives a fresh email
+    # address, which is exactly the abuse this program invites. Stored here and nowhere else.
+    card_fingerprint: str | None = Field(default=None, index=True)
+    # The blocks the two grants created, so a payout can be traced back into the ledger by id.
+    referrer_block_id: str | None = Field(default=None)
+    referred_block_id: str | None = Field(default=None)
+    referrer_reward_micro: int = Field(default=0)  # what was actually granted, not what was promised
+    referred_reward_micro: int = Field(default=0)
+    qualified_at: datetime | None = Field(default=None)
+    paid_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_now, index=True)
 
 
 class Project(SQLModel, table=True):

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -7,7 +7,7 @@ under load — right for analytics, fatal for money).
 
 THE SHAPE, and why it is this shape
 -----------------------------------
-A friend gets $5, the referrer gets $10, both flat. The qualifying event is the friend's FIRST
+Both sides get $5, flat and symmetric. The qualifying event is the friend's FIRST
 PAID TOP-UP, never their signup: `promo_grant_micro` is granted per ORG and a user may create
 unlimited orgs, so a signup-triggered bounty is a faucet pointed at itself.
 

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -434,3 +434,34 @@ async def summary(db: AsyncSession, user: User) -> dict:
         },
         "referrals": items,
     }
+
+
+# ---- the referee's side ------------------------------------------------------------------------
+async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
+    """"You were invited — here is what a top-up earns you." None when there is nothing to say.
+
+    The mirror of `summary`, for the OTHER party. A team that arrived through someone's link has a
+    `pending` row and does not know it: the bounty is invisible until it either lands or doesn't, and
+    a reward nobody was told about cannot change what they do. So the billing page — the one screen
+    where they are already deciding how much to add — says the minimum out loud.
+
+    Returns only while `pending`. Once qualified the offer has been taken, and the money is on its way
+    through `sweep`; still advertising it there would read as a second bonus.
+
+    Deliberately says nothing about WHO referred them. They came through a friend's link so they
+    already know, and naming the referrer here would be a disclosure the privacy policy does not make
+    (it covers the other direction only).
+    """
+    if org_id is None:
+        return None
+    row = (await db.execute(
+        select(Referral).where(Referral.referred_org_id == org_id, Referral.status == "pending")
+    )).scalars().first()
+    if row is None:
+        return None
+    s = get_settings()
+    return {
+        "referred_micro": int(s.referral_referred_micro),
+        "referrer_micro": int(s.referral_referrer_micro),
+        "min_topup_micro": int(s.referral_min_topup_micro),
+    }

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -448,9 +448,17 @@ async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
     Returns only while `pending`. Once qualified the offer has been taken, and the money is on its way
     through `sweep`; still advertising it there would read as a second bonus.
 
-    Deliberately says nothing about WHO referred them. They came through a friend's link so they
-    already know, and naming the referrer here would be a disclosure the privacy policy does not make
-    (it covers the other direction only).
+    Names the referrer, MASKED (`j•••@superdesign.dev`). Not anonymous, because "you were invited"
+    with nobody attached reads as marketing copy rather than a fact, and someone who clicked a link
+    off a tweet a week ago genuinely may not remember whose it was. Not the full address either: a
+    referral link is PUBLIC by design, so printing it in full would publish one influencer's email to
+    every stranger who signs up through their link — a harvestable list, at exactly the volume this
+    program is meant to produce. The domain survives masking because that is the part that actually
+    triggers recognition in a real friend.
+
+    Note the asymmetry with `summary`, which returns FULL referee addresses: there, the referrer
+    cannot otherwise tell which of their invitations converted. Here the referee needs no identity to
+    decide whether to add funds, so the same exposure buys nothing.
     """
     if org_id is None:
         return None
@@ -459,9 +467,24 @@ async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
     )).scalars().first()
     if row is None:
         return None
+    referrer = await db.get(User, row.referrer_user_id)
     s = get_settings()
     return {
         "referred_micro": int(s.referral_referred_micro),
         "referrer_micro": int(s.referral_referrer_micro),
         "min_topup_micro": int(s.referral_min_topup_micro),
+        "referrer_masked": mask_email(referrer.email if referrer else ""),
     }
+
+
+def mask_email(email: str) -> str:
+    """`jason@superdesign.dev` -> `j•••@superdesign.dev`. "" for anything that isn't an address.
+
+    The local part collapses to its FIRST character only — a fixed three-bullet run, never one bullet
+    per character, because a length-preserving mask leaks the length. The domain is kept whole: it is
+    what makes a friend recognisable, and it is not personally identifying on its own.
+    """
+    local, _, domain = (email or "").partition("@")
+    if not local or not domain:
+        return ""
+    return f"{local[0]}•••@{domain}"

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -144,11 +144,22 @@ async def qualify(
     db: AsyncSession, *, org_id: int, payment_intent: str, amount_micro: int,
     fingerprint: str | None = None,
 ) -> Referral | None:
-    """The org just paid for the first time — decide whether that earns anybody anything. Commits.
+    """The org just paid — decide whether that earns anybody anything. Commits.
 
-    Returns the row in whatever state it ended in (`qualified`, `capped`, `rejected`) or None if
-    this org was never referred. A refusal is RECORDED, not dropped: "why did I not get paid" is the
-    first support question a referral program generates, and a deleted row cannot answer it.
+    Returns the row in whatever state it ended in (`pending`, `qualified`, `capped`, `rejected`) or
+    None if this org was never referred. A refusal is RECORDED, not dropped: "why did I not get paid"
+    is the first support question a referral program generates, and a deleted row cannot answer it.
+
+    The threshold is CUMULATIVE and a short payment is not fatal. This started out as "the first
+    top-up must clear the minimum, or the referral is rejected", which was wrong in the one way that
+    matters: $5 is the first preset on the billing page, so the most obvious button permanently
+    destroyed the reward — silently, and with no way back even if the team added $100 the next day.
+    That punishes exactly the person we are trying to convert, and removes their reason to add the
+    rest. So a below-threshold payment now leaves the row PENDING and the offer on screen, counting
+    toward the total.
+
+    It costs nothing in abuse terms: the money still has to arrive, so $5 + $5 buys a referral on the
+    same terms $10 does, and the card fingerprint and the cap are untouched.
     """
     row = (await db.execute(
         select(Referral).where(Referral.referred_org_id == org_id, Referral.status == "pending")
@@ -168,18 +179,22 @@ async def qualify(
         log.info("referral %s refused: %s", row.id, reason)
         return row
 
-    # Gate 1 — the top-up has to be big enough that buying your own bonus loses money.
-    if int(amount_micro) < int(s.referral_min_topup_micro):
-        return await _refuse("topup_below_minimum")
-
-    # Gate 2 — this must be the org's FIRST purchase. `_credit` only calls us on a fresh payment,
-    # but a second top-up is still a fresh payment, and the bounty is for arriving, not for paying
-    # twice. Count blocks rather than trusting the caller's framing.
-    purchased = (await db.execute(
-        select(CreditBlock.id).where(CreditBlock.org_id == org_id, CreditBlock.kind == "purchased")
-    )).scalars().all()
-    if len(purchased) > 1:
-        return await _refuse("not_first_topup")
+    # Gate 1 — enough money has to have arrived that buying your own bonus loses money. CUMULATIVE,
+    # and read from the blocks rather than from this one payment: a team that adds $5 twice has paid
+    # the same $10 as a team that added it at once, and telling them otherwise would be a rule whose
+    # only effect is to punish a small first payment.
+    #
+    # Falling short is NOT a refusal — the row stays pending, so the billing page keeps offering the
+    # bonus and can say how much is left to go. `pending` is also what keeps this once-only: a row
+    # that has already qualified is not selected above, so no later payment can earn a second bounty.
+    paid_micro = sum((await db.execute(
+        select(CreditBlock.amount_micro).where(
+            CreditBlock.org_id == org_id, CreditBlock.kind == "purchased")
+    )).scalars().all())
+    if paid_micro < int(s.referral_min_topup_micro):
+        log.info("referral %s: %s of %s micro-USD paid — still pending",
+                 row.id, paid_micro, s.referral_min_topup_micro)
+        return row
 
     referrer = await db.get(User, row.referrer_user_id)
     if referrer is None or referrer.suspended:
@@ -469,10 +484,19 @@ async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
         return None
     referrer = await db.get(User, row.referrer_user_id)
     s = get_settings()
+    # How far along they already are. A team that added $5 has NOT lost the bonus (see `qualify`), so
+    # the page must be able to say "add $5 more" rather than silently repeating the full ask — which
+    # reads as though the $5 they just paid did not count.
+    paid_micro = sum((await db.execute(
+        select(CreditBlock.amount_micro).where(
+            CreditBlock.org_id == org_id, CreditBlock.kind == "purchased")
+    )).scalars().all())
     return {
         "referred_micro": int(s.referral_referred_micro),
         "referrer_micro": int(s.referral_referrer_micro),
         "min_topup_micro": int(s.referral_min_topup_micro),
+        "topped_up_micro": int(paid_micro),
+        "remaining_micro": max(0, int(s.referral_min_topup_micro) - int(paid_micro)),
         "referrer_masked": mask_email(referrer.email if referrer else ""),
     }
 

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -253,7 +253,46 @@ async def qualify(
         # sequential path: it is qualified, and it will be paid exactly once.
         await db.rollback()
         return (await db.execute(select(Referral).where(Referral.id == row.id))).scalars().first()
+
+    # THE REFEREE IS PAID NOW; only the referrer waits out the hold.
+    #
+    # The two sides are not in the same position. The referrer has a Referrals page showing every
+    # invitation and what it is worth, so a pending reward there is legible. The referee has no such
+    # page — for them the only feedback that exists is the balance, and a bonus that is "coming"
+    # is indistinguishable from one that never happened. Reported exactly that way: topped up
+    # expecting the bonus, saw the plain total, assumed it had failed.
+    #
+    # The hold is a chargeback window, and giving up half of it is the price. It is a fair one: the
+    # exposure is one bounty per card (the fingerprint gate still binds), the referee has just handed
+    # us the qualifying payment, and a chargeback already costs us that payment plus the dispute fee,
+    # against which the bonus is marginal. The referrer's half stays held because nothing about their
+    # experience needs it sooner.
+    await _grant_referee(db, row)
     return row
+
+
+async def _grant_referee(db: AsyncSession, row: Referral) -> None:
+    """Put the referee's bonus in their balance immediately. Never raises.
+
+    `referred_block_id` is the guard AND the record: set means paid, so a retry cannot double-grant
+    and `sweep` knows to skip this side. A failure here is not fatal — the row stays qualified with
+    the field unset, and the sweep pays it as a fallback.
+    """
+    if row.referred_block_id:
+        return
+    try:
+        block = await ledger.grant(
+            db, row.referred_org_id, amount_micro=int(get_settings().referral_referred_micro),
+            kind="referral", once=False,
+            meta={"referral_id": row.id, "code": row.code, "side": "referred"})
+        if block is not None:
+            row.referred_block_id = block.id
+            row.referred_reward_micro = block.amount_micro
+            db.add(row)
+            await db.commit()
+    except Exception as exc:  # noqa: BLE001 — the sweep retries; a bonus must not fail a webhook
+        await db.rollback()
+        log.warning("referral %s: instant referee grant failed, sweep will retry: %s", row.id, exc)
 
 
 # ---- clawback ----------------------------------------------------------------------------------
@@ -264,6 +303,10 @@ async def reject_for_payment(db: AsyncSession, payment_intent: str, reason: str)
     Only touches `qualified`. A `paid` row is left alone and merely logged: the credit burns first
     and is typically already spent, and clawing it back would mean a code path that can drive a
     balance negative. That is the boundary the hold window buys us, and it is deliberate.
+
+    Since the referee is paid instantly, the hold now only protects the REFERRER's half. Cancelling
+    a qualified row therefore recovers half a bounty, not all of it — the deliberate price of giving
+    the referee immediate feedback, and the reason the per-card gate matters more than this one.
     """
     rows = (await db.execute(
         select(Referral).where(Referral.qualifying_payment_intent == payment_intent)
@@ -275,6 +318,14 @@ async def reject_for_payment(db: AsyncSession, payment_intent: str, reason: str)
             row.reject_reason = reason
             db.add(row)
             cancelled += 1
+            # Cancelling `qualified` stops the REFERRER's half, which is the one still held. The
+            # referee's was granted the moment they qualified, so by now it is spent or spendable —
+            # same position as an already-paid row, and logged the same way rather than reversed.
+            if row.referred_block_id:
+                log.warning(
+                    "referral %s: referee bonus of %s micro-USD was already granted when payment "
+                    "%s was %s — needs a human", row.id, row.referred_reward_micro,
+                    payment_intent, reason)
         elif row.status == "paid":
             log.warning(
                 "referral %s was already PAID when payment %s was %s — %s micro-USD needs a human",
@@ -335,7 +386,12 @@ async def sweep(db: AsyncSession, *, limit: int = 100, referrer_user_id: int | N
 
 
 async def _pay(db: AsyncSession, row: Referral) -> bool:
-    """Grant both sides and mark the row paid. Returns False if it could not be paid this pass.
+    """Pay whatever this row still owes and mark it paid. Returns False if it could not be paid.
+
+    In practice that is the REFERRER's half: the referee was paid the moment they qualified (see
+    `_grant_referee`). The referee branch here is a fallback for the case where that instant grant
+    failed, which is why it is guarded on `referred_block_id` rather than run unconditionally —
+    granting it again would be a second bonus.
 
     THE CLAIM COMES FIRST. The row is flipped to `paid` and committed BEFORE any credit moves, so
     that the unique row — not the grant — is what stops a double payout when two instances sweep at
@@ -364,18 +420,22 @@ async def _pay(db: AsyncSession, row: Referral) -> bool:
         return False  # another sweep claimed it between our SELECT and here
 
     meta = {"referral_id": row.id, "code": row.code}
-    referred_block = await ledger.grant(
-        db, referred_org.id, amount_micro=int(s.referral_referred_micro), kind="referral",
-        once=False, meta={**meta, "side": "referred"})
+    # Only if the instant grant did not already land it — see the docstring.
+    referred_block = None
+    if not row.referred_block_id:
+        referred_block = await ledger.grant(
+            db, referred_org.id, amount_micro=int(s.referral_referred_micro), kind="referral",
+            once=False, meta={**meta, "side": "referred"})
     referrer_block = await ledger.grant(
         db, referrer_org.id, amount_micro=int(s.referral_referrer_micro), kind="referral",
         once=False, meta={**meta, "side": "referrer"})
 
     fresh = await db.get(Referral, row.id)
     if fresh is not None:
-        fresh.referred_block_id = referred_block.id if referred_block else None
+        if referred_block is not None:
+            fresh.referred_block_id = referred_block.id
+            fresh.referred_reward_micro = referred_block.amount_micro
         fresh.referrer_block_id = referrer_block.id if referrer_block else None
-        fresh.referred_reward_micro = referred_block.amount_micro if referred_block else 0
         fresh.referrer_reward_micro = referrer_block.amount_micro if referrer_block else 0
         db.add(fresh)
         await db.commit()
@@ -460,8 +520,9 @@ async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
     a reward nobody was told about cannot change what they do. So the billing page — the one screen
     where they are already deciding how much to add — says the minimum out loud.
 
-    Returns only while `pending`. Once qualified the offer has been taken, and the money is on its way
-    through `sweep`; still advertising it there would read as a second bonus.
+    Returns only while `pending`. Once qualified the referee's bonus is ALREADY IN THEIR BALANCE
+    (see `qualify`), so the balance is the confirmation and a banner promising money that has
+    already arrived is noise.
 
     Names the referrer, MASKED (`j•••@superdesign.dev`). Not anonymous, because "you were invited"
     with nobody attached reads as marketing copy rather than a fact, and someone who clicked a link
@@ -497,6 +558,9 @@ async def offer_for_org(db: AsyncSession, org_id: int | None) -> dict | None:
         "min_topup_micro": int(s.referral_min_topup_micro),
         "topped_up_micro": int(paid_micro),
         "remaining_micro": max(0, int(s.referral_min_topup_micro) - int(paid_micro)),
+        # The REFERRER's wait, not the referee's — the referee is paid the moment they qualify.
+        # Kept in the payload because the note names what each side gets and when.
+        "hold_days": int(s.referral_hold_days),
         "referrer_masked": mask_email(referrer.email if referrer else ""),
     }
 

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -185,14 +185,18 @@ async def qualify(
     if referrer is None or referrer.suspended:
         return await _refuse("referrer_unavailable")
 
-    # Gate 3 — the referrer must have paid us at least once themselves. This is what a throwaway
-    # account cannot cheaply satisfy, and it costs a genuine referrer nothing: they are, by
-    # construction, already a customer.
-    if not await _has_paid(db, referrer.id):
-        return await _refuse("referrer_never_topped_up")
+    # There is deliberately NO "the referrer must have topped up first" gate. It was built and then
+    # removed, because the attack it appears to stop is unaffected by it: a top-up is not a cost to a
+    # self-dealer, it converts into credit they keep. Requiring one of the REFERRER too just adds a
+    # step that returns its own money — roughly one extra card per twenty referrals, a ~5% tax on a
+    # farm. Against that it hid the link from every free-tier user, who on a product whose pitch is
+    # "$1.00 free, no card" are most users and the likeliest people to tell a friend.
+    #
+    # The gate below is the one with teeth. Keep that asymmetry in mind before adding another
+    # eligibility rule here: the constraint on a farm is CARDS, not accounts.
 
-    # Gate 4 — the same card may fund exactly one referral, ever. An email address is free and a
-    # card is not, so this is the signal that actually survives a determined farm.
+    # The same card may fund exactly one referral, ever. An email address is free and a card is not,
+    # so this is the signal that actually survives a determined farm.
     if fingerprint:
         clash = (await db.execute(
             select(Referral.id).where(
@@ -204,7 +208,7 @@ async def qualify(
         if clash is not None:
             return await _refuse("card_already_used")
 
-    # Gate 5 — the lifetime cap. Kept distinct from `rejected` because it is not an accusation:
+    # Gate 3 — the lifetime cap. Kept distinct from `rejected` because it is not an accusation:
     # this person referred someone real and simply ran out of self-serve allowance.
     paid_count = len((await db.execute(
         select(Referral.id).where(
@@ -235,24 +239,6 @@ async def qualify(
         await db.rollback()
         return (await db.execute(select(Referral).where(Referral.id == row.id))).scalars().first()
     return row
-
-
-async def _has_paid(db: AsyncSession, user_id: int | None) -> bool:
-    """Has this person's money ever reached us — in ANY org they belong to?"""
-    if user_id is None:
-        return False
-    org_ids = (await db.execute(
-        select(Membership.org_id).where(Membership.user_id == user_id)
-    )).scalars().all()
-    if not org_ids:
-        return False
-    found = (await db.execute(
-        select(CreditBlock.id).where(
-            CreditBlock.org_id.in_(org_ids),  # type: ignore[attr-defined]
-            CreditBlock.kind == "purchased",
-        ).limit(1)
-    )).scalars().first()
-    return found is not None
 
 
 # ---- clawback ----------------------------------------------------------------------------------
@@ -429,7 +415,10 @@ async def summary(db: AsyncSession, user: User) -> dict:
         "code": code,
         "link": f"{get_settings().public_url.rstrip('/')}/?ref={code}" if code else "",
         "credit_org": ({"org_id": credit_org.id, "name": credit_org.name} if credit_org else None),
-        "eligible": await _has_paid(db, user.id),
+        # Every signed-in person can refer. Kept in the payload rather than dropped because the
+        # dashboard branches on it, and because a future eligibility rule (a suspension, a fraud
+        # hold) belongs here rather than as a second shape the UI has to learn.
+        "eligible": credit_org is not None,
         "terms": {
             "referrer_micro": int(s.referral_referrer_micro),
             "referred_micro": int(s.referral_referred_micro),

--- a/src/treg/referrals.py
+++ b/src/treg/referrals.py
@@ -1,0 +1,447 @@
+"""The referral program: who invited whom, whether we owe for it, and paying it out.
+
+This module DECIDES; `ledger.py` MOVES. The only money crossing is `ledger.grant(...)`, exactly
+as `billing.py`'s only crossing is `ledger.topup(...)`. Nothing here writes `creditblock`,
+`ledgerentry` or `org.balance_micro`, and nothing here goes through `audit.py` (which sheds rows
+under load — right for analytics, fatal for money).
+
+THE SHAPE, and why it is this shape
+-----------------------------------
+A friend gets $5, the referrer gets $10, both flat. The qualifying event is the friend's FIRST
+PAID TOP-UP, never their signup: `promo_grant_micro` is granted per ORG and a user may create
+unlimited orgs, so a signup-triggered bounty is a faucet pointed at itself.
+
+Payment is held for `referral_hold_days` and then granted lazily. There is no scheduler anywhere
+in treg by design (see ledger.py's reaper), so `sweep()` is called from paths someone is already
+paying for: every top-up, and the Referrals page itself.
+
+WHAT ARBITRATES A DOUBLE PAYOUT
+-------------------------------
+The `Referral` row, via two UNIQUE constraints — NOT `ledger.grant(once=True)`, whose check is a
+SELECT with no backing index and which therefore cannot survive two concurrent redemptions. So
+every grant here passes `once=False` and the database decides. Same reasoning as the conditional
+UPDATE in `ledger.reserve` and the unique `stripe_payment_intent` in `ledger.topup`.
+
+WHAT THIS DELIBERATELY DOES NOT DO
+----------------------------------
+It never reverses a grant that has already landed. Referral credit burns before purchased credit
+(`ledger._KIND_ORDER`), so by the time a dispute arrives the money is usually spent, and inventing
+a negative-balance path would mean a second module that can move money. A dispute inside the hold
+cancels the payout; a dispute after it is logged for a human. That boundary is the whole reason
+the hold exists.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from . import ledger
+from .config import get_settings
+from .models import CreditBlock, Membership, Org, Referral, User
+
+log = logging.getLogger("treg")
+
+# The charset a code may contain. Codes appear in a URL and get retyped off a screenshot, so the
+# generated half avoids look-alikes; the validator stays permissive enough to accept any code we
+# have ever minted plus a hand-set vanity one.
+_CODE_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,31}$")
+_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"  # no i/l/o/0/1
+
+
+def _now() -> datetime:
+    """Naive UTC, matching models._now — our timestamp columns are TIMESTAMP WITHOUT TIME ZONE and
+    asyncpg rejects a tz-aware value into one."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def normalize_code(raw: str) -> str:
+    """A code as it arrived (query string, cookie, form) → the canonical form, or "" if it could
+    never be one of ours. Called on every read, so a junk cookie is dropped rather than queried."""
+    code = (raw or "").strip().lower()
+    return code if _CODE_RE.match(code) else ""
+
+
+def hold_cutoff() -> datetime:
+    """Qualified before this instant → payable now."""
+    return _now() - timedelta(days=int(get_settings().referral_hold_days))
+
+
+# ---- the code ----------------------------------------------------------------------------------
+async def ensure_code(db: AsyncSession, user: User) -> str:
+    """This user's referral code, minting one on first ask. Commits when it mints.
+
+    Lazy because most people never open the Referrals page, and a code nobody has seen is a row
+    nobody needs. The retry loop exists because `User.referral_code` is UNIQUE: a collision is
+    astronomically unlikely at 8 characters but it is the database's answer, not ours, so it is
+    handled rather than assumed away.
+    """
+    if user.referral_code:
+        return user.referral_code
+    base = re.sub(r"[^a-z0-9]+", "", (user.email or "").split("@")[0].lower())[:12] or "treg"
+    if len(base) < 2:
+        base = f"{base}treg"
+    for _ in range(5):
+        candidate = f"{base}-{''.join(secrets.choice(_ALPHABET) for _ in range(5))}"
+        user.referral_code = candidate
+        db.add(user)
+        try:
+            await db.commit()
+        except IntegrityError:
+            await db.rollback()
+            await db.refresh(user)
+            if user.referral_code:  # someone else minted one for this row first
+                return user.referral_code
+            continue
+        return candidate
+    raise RuntimeError("could not mint a unique referral code")
+
+
+async def user_by_code(db: AsyncSession, code: str) -> User | None:
+    code = normalize_code(code)
+    if not code:
+        return None
+    return (await db.execute(select(User).where(User.referral_code == code))).scalars().first()
+
+
+# ---- attribution (at signup) -------------------------------------------------------------------
+async def attribute(db: AsyncSession, *, user: User, org: Org, code: str) -> Referral | None:
+    """Record that `org` arrived through `code`. Owes nothing yet. Commits.
+
+    Called right after the signup promo when a new team is created. Returns None — silently — for
+    every reason a referral is not applicable: no code, unknown code, self-referral, a demo team, or
+    an org that already carries one. None of these are errors the caller should react to; the caller
+    is a signup and a referral must never be able to fail one.
+    """
+    code = normalize_code(code)
+    if not code or org is None or org.id is None or org.demo or org.public_demo:
+        return None
+    referrer = await user_by_code(db, code)
+    if referrer is None or referrer.id is None or user.id is None:
+        return None
+    if referrer.id == user.id:
+        return None  # self-referral: the cheapest possible check, and the most common attempt
+    row = Referral(code=code, referrer_user_id=referrer.id, referred_user_id=user.id,
+                   referred_org_id=org.id, status="pending")
+    db.add(row)
+    try:
+        await db.commit()
+    except IntegrityError:
+        # This org already has a referral. Whoever got there first keeps it.
+        await db.rollback()
+        return None
+    return row
+
+
+# ---- qualification (at the friend's first paid top-up) -----------------------------------------
+async def qualify(
+    db: AsyncSession, *, org_id: int, payment_intent: str, amount_micro: int,
+    fingerprint: str | None = None,
+) -> Referral | None:
+    """The org just paid for the first time — decide whether that earns anybody anything. Commits.
+
+    Returns the row in whatever state it ended in (`qualified`, `capped`, `rejected`) or None if
+    this org was never referred. A refusal is RECORDED, not dropped: "why did I not get paid" is the
+    first support question a referral program generates, and a deleted row cannot answer it.
+    """
+    row = (await db.execute(
+        select(Referral).where(Referral.referred_org_id == org_id, Referral.status == "pending")
+    )).scalars().first()
+    if row is None:
+        return None
+
+    s = get_settings()
+
+    async def _refuse(reason: str) -> Referral:
+        row.status = "rejected"
+        row.reject_reason = reason
+        row.qualifying_payment_intent = payment_intent
+        row.card_fingerprint = fingerprint
+        db.add(row)
+        await db.commit()
+        log.info("referral %s refused: %s", row.id, reason)
+        return row
+
+    # Gate 1 — the top-up has to be big enough that buying your own bonus loses money.
+    if int(amount_micro) < int(s.referral_min_topup_micro):
+        return await _refuse("topup_below_minimum")
+
+    # Gate 2 — this must be the org's FIRST purchase. `_credit` only calls us on a fresh payment,
+    # but a second top-up is still a fresh payment, and the bounty is for arriving, not for paying
+    # twice. Count blocks rather than trusting the caller's framing.
+    purchased = (await db.execute(
+        select(CreditBlock.id).where(CreditBlock.org_id == org_id, CreditBlock.kind == "purchased")
+    )).scalars().all()
+    if len(purchased) > 1:
+        return await _refuse("not_first_topup")
+
+    referrer = await db.get(User, row.referrer_user_id)
+    if referrer is None or referrer.suspended:
+        return await _refuse("referrer_unavailable")
+
+    # Gate 3 — the referrer must have paid us at least once themselves. This is what a throwaway
+    # account cannot cheaply satisfy, and it costs a genuine referrer nothing: they are, by
+    # construction, already a customer.
+    if not await _has_paid(db, referrer.id):
+        return await _refuse("referrer_never_topped_up")
+
+    # Gate 4 — the same card may fund exactly one referral, ever. An email address is free and a
+    # card is not, so this is the signal that actually survives a determined farm.
+    if fingerprint:
+        clash = (await db.execute(
+            select(Referral.id).where(
+                Referral.card_fingerprint == fingerprint,
+                Referral.status.in_(("qualified", "paid")),  # type: ignore[attr-defined]
+                Referral.id != row.id,
+            )
+        )).scalars().first()
+        if clash is not None:
+            return await _refuse("card_already_used")
+
+    # Gate 5 — the lifetime cap. Kept distinct from `rejected` because it is not an accusation:
+    # this person referred someone real and simply ran out of self-serve allowance.
+    paid_count = len((await db.execute(
+        select(Referral.id).where(
+            Referral.referrer_user_id == row.referrer_user_id,
+            Referral.status.in_(("qualified", "paid")),  # type: ignore[attr-defined]
+            Referral.id != row.id,
+        )
+    )).scalars().all())
+    if paid_count >= int(s.referral_cap):
+        row.status = "capped"
+        row.reject_reason = "referrer_at_cap"
+        row.qualifying_payment_intent = payment_intent
+        row.card_fingerprint = fingerprint
+        db.add(row)
+        await db.commit()
+        return row
+
+    row.status = "qualified"
+    row.qualified_at = _now()
+    row.qualifying_payment_intent = payment_intent
+    row.card_fingerprint = fingerprint
+    db.add(row)
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Another delivery of the same PaymentIntent qualified it first. Same answer as the
+        # sequential path: it is qualified, and it will be paid exactly once.
+        await db.rollback()
+        return (await db.execute(select(Referral).where(Referral.id == row.id))).scalars().first()
+    return row
+
+
+async def _has_paid(db: AsyncSession, user_id: int | None) -> bool:
+    """Has this person's money ever reached us — in ANY org they belong to?"""
+    if user_id is None:
+        return False
+    org_ids = (await db.execute(
+        select(Membership.org_id).where(Membership.user_id == user_id)
+    )).scalars().all()
+    if not org_ids:
+        return False
+    found = (await db.execute(
+        select(CreditBlock.id).where(
+            CreditBlock.org_id.in_(org_ids),  # type: ignore[attr-defined]
+            CreditBlock.kind == "purchased",
+        ).limit(1)
+    )).scalars().first()
+    return found is not None
+
+
+# ---- clawback ----------------------------------------------------------------------------------
+async def reject_for_payment(db: AsyncSession, payment_intent: str, reason: str) -> int:
+    """The funding payment was disputed or refunded — cancel anything it earned that has not landed.
+    Returns how many rows were cancelled. Commits.
+
+    Only touches `qualified`. A `paid` row is left alone and merely logged: the credit burns first
+    and is typically already spent, and clawing it back would mean a code path that can drive a
+    balance negative. That is the boundary the hold window buys us, and it is deliberate.
+    """
+    rows = (await db.execute(
+        select(Referral).where(Referral.qualifying_payment_intent == payment_intent)
+    )).scalars().all()
+    cancelled = 0
+    for row in rows:
+        if row.status == "qualified":
+            row.status = "rejected"
+            row.reject_reason = reason
+            db.add(row)
+            cancelled += 1
+        elif row.status == "paid":
+            log.warning(
+                "referral %s was already PAID when payment %s was %s — %s micro-USD needs a human",
+                row.id, payment_intent, reason,
+                row.referrer_reward_micro + row.referred_reward_micro)
+    if cancelled:
+        await db.commit()
+    return cancelled
+
+
+# ---- payout ------------------------------------------------------------------------------------
+async def credit_org_for(db: AsyncSession, user_id: int) -> Org | None:
+    """Where this person's reward lands: the OLDEST org they own.
+
+    Deterministic on purpose. A referrer may belong to many teams, and "whichever one they had
+    selected when the friend happened to top up" would make the destination depend on a race. The
+    oldest owned org is their first team — the one they think of as theirs — and the Referrals page
+    names it so the answer is never a surprise.
+    """
+    memberships = (await db.execute(
+        select(Membership).where(Membership.user_id == user_id, Membership.role == "owner")
+        .order_by(Membership.id)
+    )).scalars().all()
+    for m in memberships:
+        org = await db.get(Org, m.org_id)
+        if org is not None and not org.demo and not org.public_demo and not org.suspended:
+            return org
+    return None
+
+
+async def sweep(db: AsyncSession, *, limit: int = 100, referrer_user_id: int | None = None) -> int:
+    """Pay out every qualified referral whose hold has elapsed. Returns how many were paid. Commits.
+
+    Lazy and caller-paid, exactly like `ledger.reap_stale_holds`: there is no scheduler to hang this
+    on, and a background timer would need leader election on a multi-instance deploy. It runs from
+    `billing._credit` (so any top-up anywhere advances the queue) and from the Referrals page (so a
+    user checking on their reward is the one who makes it land).
+
+    Never raises. A payout that cannot complete is logged and left `qualified` for the next pass —
+    the callers are a Stripe webhook and a page load, and neither may fail over a bonus.
+    """
+    q = (select(Referral)
+         .where(Referral.status == "qualified", Referral.qualified_at < hold_cutoff())
+         .order_by(Referral.qualified_at).limit(limit))
+    if referrer_user_id is not None:
+        q = q.where(Referral.referrer_user_id == referrer_user_id)
+    due = (await db.execute(q)).scalars().all()
+
+    paid = 0
+    for row in due:
+        try:
+            if await _pay(db, row):
+                paid += 1
+        except Exception as exc:  # pragma: no cover — defensive; the next sweep retries
+            await db.rollback()
+            log.warning("referral %s payout failed, will retry: %s", row.id, exc)
+    return paid
+
+
+async def _pay(db: AsyncSession, row: Referral) -> bool:
+    """Grant both sides and mark the row paid. Returns False if it could not be paid this pass.
+
+    THE CLAIM COMES FIRST. The row is flipped to `paid` and committed BEFORE any credit moves, so
+    that the unique row — not the grant — is what stops a double payout when two instances sweep at
+    the same time. Losing the claim means somebody else is paying it; granting first and claiming
+    second would mean the loser had already granted.
+
+    The cost of that ordering is the opposite failure: a crash between the claim and the grant pays
+    nobody and leaves the row saying otherwise. That is the right way round for money — it is
+    visible in `/admin/referrals` as a paid row with a null block id, and it errs toward paying
+    once rather than twice.
+    """
+    s = get_settings()
+    referred_org = await db.get(Org, row.referred_org_id)
+    referrer_org = await credit_org_for(db, row.referrer_user_id)
+    if referred_org is None or referrer_org is None:
+        log.warning("referral %s has nowhere to pay (referrer org missing) — skipping", row.id)
+        return False
+
+    claimed = (await db.execute(
+        Referral.__table__.update()
+        .where(Referral.__table__.c.id == row.id, Referral.__table__.c.status == "qualified")
+        .values(status="paid", paid_at=_now())
+    )).rowcount
+    await db.commit()
+    if claimed != 1:
+        return False  # another sweep claimed it between our SELECT and here
+
+    meta = {"referral_id": row.id, "code": row.code}
+    referred_block = await ledger.grant(
+        db, referred_org.id, amount_micro=int(s.referral_referred_micro), kind="referral",
+        once=False, meta={**meta, "side": "referred"})
+    referrer_block = await ledger.grant(
+        db, referrer_org.id, amount_micro=int(s.referral_referrer_micro), kind="referral",
+        once=False, meta={**meta, "side": "referrer"})
+
+    fresh = await db.get(Referral, row.id)
+    if fresh is not None:
+        fresh.referred_block_id = referred_block.id if referred_block else None
+        fresh.referrer_block_id = referrer_block.id if referrer_block else None
+        fresh.referred_reward_micro = referred_block.amount_micro if referred_block else 0
+        fresh.referrer_reward_micro = referrer_block.amount_micro if referrer_block else 0
+        db.add(fresh)
+        await db.commit()
+    return True
+
+
+# ---- the read model ----------------------------------------------------------------------------
+async def summary(db: AsyncSession, user: User) -> dict:
+    """Everything the Referrals page renders, for ONE user.
+
+    Scoped to `referrer_user_id == user.id` in the query itself rather than filtered afterwards:
+    this response carries the referred person's email address, so a scoping mistake here leaks
+    another user's data rather than merely miscounting — the one failure in this feature that is
+    worse than losing money.
+    """
+    s = get_settings()
+    rows = (await db.execute(
+        select(Referral).where(Referral.referrer_user_id == user.id)
+        .order_by(Referral.created_at.desc())  # type: ignore[attr-defined]
+    )).scalars().all()
+
+    emails: dict[int, str] = {}
+    for uid in {r.referred_user_id for r in rows}:
+        friend = await db.get(User, uid)
+        if friend is not None:
+            emails[uid] = friend.email
+
+    hold = timedelta(days=int(s.referral_hold_days))
+    items, earned, pending = [], 0, 0
+    for r in rows:
+        if r.status == "paid":
+            earned += r.referrer_reward_micro
+        elif r.status == "qualified":
+            pending += int(s.referral_referrer_micro)
+        items.append({
+            "email": emails.get(r.referred_user_id, ""),
+            "status": r.status,
+            "reason": r.reject_reason,
+            "signed_up_at": r.created_at.isoformat() if r.created_at else None,
+            "topped_up_at": r.qualified_at.isoformat() if r.qualified_at else None,
+            "paid_at": r.paid_at.isoformat() if r.paid_at else None,
+            "pays_at": ((r.qualified_at + hold).isoformat()
+                        if r.status == "qualified" and r.qualified_at else None),
+            "reward_micro": (r.referrer_reward_micro if r.status == "paid"
+                             else int(s.referral_referrer_micro) if r.status == "qualified" else 0),
+        })
+
+    credit_org = await credit_org_for(db, user.id) if user.id else None
+    paid_count = sum(1 for r in rows if r.status in ("qualified", "paid"))
+    code = user.referral_code or ""
+    return {
+        "code": code,
+        "link": f"{get_settings().public_url.rstrip('/')}/?ref={code}" if code else "",
+        "credit_org": ({"org_id": credit_org.id, "name": credit_org.name} if credit_org else None),
+        "eligible": await _has_paid(db, user.id),
+        "terms": {
+            "referrer_micro": int(s.referral_referrer_micro),
+            "referred_micro": int(s.referral_referred_micro),
+            "min_topup_micro": int(s.referral_min_topup_micro),
+            "hold_days": int(s.referral_hold_days),
+        },
+        "cap": {"paid": paid_count, "limit": int(s.referral_cap)},
+        "totals": {
+            "signed_up": len(rows),
+            "topped_up": sum(1 for r in rows if r.status in ("qualified", "paid", "capped")),
+            "earned_micro": earned,
+            "pending_micro": pending,
+        },
+        "referrals": items,
+    }

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2430,14 +2430,19 @@ a:hover{text-decoration-color:var(--muted)}
                           <b>{{billing.referral_offer.referrer_masked}}</b></template>
                         <template v-else>to treg</template>
                         — add
-                        <!-- Once they have paid something, ask for the REMAINDER. Repeating the full
-                             amount reads as though the money they already added did not count, and
-                             it does: the threshold is cumulative. -->
+                        <!-- Once they have paid something, ask for the REMAINDER. Repeating the
+                             full amount reads as though the money they already added did not
+                             count, and it does: the threshold is cumulative. -->
                         <b>{{money(billing.referral_offer.remaining_micro)}}</b>
                         <template v-if="billing.referral_offer.topped_up_micro"> more</template>
                         <template v-else> or more</template>
-                        and we'll put <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in
-                        your balance. They get {{money(billing.referral_offer.referrer_micro)}}.
+                        <!-- "straight away" is load-bearing. The referee has no Referrals page, so
+                             the balance is their ONLY feedback; promising a bonus without saying
+                             when is what made a correct payout look like a failure. -->
+                        and we'll add <b>{{money(billing.referral_offer.referred_micro)}}</b> to your
+                        balance <b>straight away</b>. They get
+                        {{money(billing.referral_offer.referrer_micro)}} after
+                        {{billing.referral_offer.hold_days}} days.
                       </div>
                       <div class="fundgrid" style="margin-top:8px">
                         <button v-for="p in billing.topup.presets" :key="p" class="fundcard" :disabled="billingBusy" @click="addFunds(p)">
@@ -4916,9 +4921,14 @@ createApp({
     // How much extra THIS preset earns a referred team, or 0. Guarded on the offer existing, so a
     // team that arrived on its own sees the buttons exactly as before.
     refPresetBonus(usd){ const o=this.billing&&this.billing.referral_offer;
+      // NULL-GUARD FIRST. `referral_offer` is null for every team that was not referred — i.e. most
+      // of them — and reading through it throws inside a render, which in Vue blanks the ENTIRE
+      // dashboard rather than just this row. Cost one blank page during review; keep it on its own
+      // line rather than folded into the expression below, where deleting a clause drops it silently.
+      if(!o) return 0;
       // Against what is REMAINING, not the full minimum: a team that already added $5 unlocks the
       // bonus with another $5, and marking that button "one-time" would be simply wrong.
-      return (o && usd*1000000 >= o.remaining_micro) ? o.referred_micro : 0; },
+      return (usd*1000000 >= o.remaining_micro) ? o.referred_micro : 0; },
     async copyRefLink(){ try{ await navigator.clipboard.writeText(this.ref.link); }catch(e){}
       this.refCopied=true; this.track('referral_link_copied');
       setTimeout(()=>{ this.refCopied=false; }, 1600); },

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1380,10 +1380,10 @@ a:hover{text-decoration-color:var(--muted)}
           <span style="font-family:var(--mono);font-weight:700;color:var(--accent)">{{money(billing.balance_micro)}}</span>
         </div>
         <!-- Second door into Referrals, right under the balance: this is where someone is already
-             thinking about what treg costs them, which is the moment "get $10" actually lands. -->
+             thinking about what treg costs them, which is the moment the offer actually lands. -->
         <div v-if="billing" style="margin:0 10px 6px;text-align:center">
           <a href="#referrals" @click.prevent="go('referrals')" class="sub"
-             style="font-size:11px;text-decoration:none">Refer a friend — get {{money(ref.terms.referrer_micro||10000000)}}</a>
+             style="font-size:11px;text-decoration:none">Refer a friend — get {{money(ref.terms.referrer_micro||5000000)}}</a>
         </div>
         <!-- PUBLIC (bottom): a signed-out catalog visitor gets the way in, where a member's
              account block would be. The catalog is readable without an account; calling is not. -->

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2429,8 +2429,14 @@ a:hover{text-decoration-color:var(--muted)}
                         <template v-if="billing.referral_offer.referrer_masked">by
                           <b>{{billing.referral_offer.referrer_masked}}</b></template>
                         <template v-else>to treg</template>
-                        — add <b>{{money(billing.referral_offer.min_topup_micro)}}</b> or more and
-                        we'll put <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in
+                        — add
+                        <!-- Once they have paid something, ask for the REMAINDER. Repeating the full
+                             amount reads as though the money they already added did not count, and
+                             it does: the threshold is cumulative. -->
+                        <b>{{money(billing.referral_offer.remaining_micro)}}</b>
+                        <template v-if="billing.referral_offer.topped_up_micro"> more</template>
+                        <template v-else> or more</template>
+                        and we'll put <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in
                         your balance. They get {{money(billing.referral_offer.referrer_micro)}}.
                       </div>
                       <div class="fundgrid" style="margin-top:8px">
@@ -4910,7 +4916,9 @@ createApp({
     // How much extra THIS preset earns a referred team, or 0. Guarded on the offer existing, so a
     // team that arrived on its own sees the buttons exactly as before.
     refPresetBonus(usd){ const o=this.billing&&this.billing.referral_offer;
-      return (o && usd*1000000 >= o.min_topup_micro) ? o.referred_micro : 0; },
+      // Against what is REMAINING, not the full minimum: a team that already added $5 unlocks the
+      // bonus with another $5, and marking that button "one-time" would be simply wrong.
+      return (o && usd*1000000 >= o.remaining_micro) ? o.referred_micro : 0; },
     async copyRefLink(){ try{ await navigator.clipboard.writeText(this.ref.link); }catch(e){}
       this.refCopied=true; this.track('referral_link_copied');
       setTimeout(()=>{ this.refCopied=false; }, 1600); },

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1365,6 +1365,7 @@ a:hover{text-decoration-color:var(--muted)}
           <button v-if="authed" class="nav" :class="{active:view==='tools'||view==='secrets'}" @click="go('tools')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>Your vault</button>
           <button v-if="authed" class="nav" :class="{active:view==='activity'}" @click="go('activity')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>Activity</button>
           <button v-if="authed" class="nav" :class="{active:view==='orgs'}" @click="go('orgs')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>Team</button>
+          <button v-if="authed" class="nav" :class="{active:view==='referrals'}" @click="go('referrals')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/></svg>Refer a friend</button>
           <div v-if="isAdmin"><div class="grp">Platform</div><button class="nav" :class="{active:view==='admin'}" @click="go('admin')" style="gap:6px"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>Admin</button></div>
           <div class="grp" style="margin-top:auto">Help</div>
           <a class="nav" href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener" style="gap:6px;text-decoration:none"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.17-.02-2.12-3.2.7-3.88-1.36-3.88-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.75 2.69 1.25 3.34.95.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.18a10.9 10.9 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.59.23 2.76.11 3.05.73.81 1.18 1.83 1.18 3.09 0 4.41-2.69 5.38-5.25 5.67.41.35.77 1.04.77 2.1 0 1.52-.01 2.74-.01 3.11 0 .3.2.66.8.55A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>Open source</a>
@@ -1377,6 +1378,12 @@ a:hover{text-decoration-color:var(--muted)}
              style="margin:8px 10px 6px;padding:7px 12px;display:flex;align-items:center;justify-content:space-between;gap:8px;border:1px solid var(--line);border-radius:999px;background:var(--panel2);cursor:pointer">
           <span style="font-size:11px;color:var(--muted);letter-spacing:.04em;text-transform:uppercase">Balance</span>
           <span style="font-family:var(--mono);font-weight:700;color:var(--accent)">{{money(billing.balance_micro)}}</span>
+        </div>
+        <!-- Second door into Referrals, right under the balance: this is where someone is already
+             thinking about what treg costs them, which is the moment "get $10" actually lands. -->
+        <div v-if="billing" style="margin:0 10px 6px;text-align:center">
+          <a href="#referrals" @click.prevent="go('referrals')" class="sub"
+             style="font-size:11px;text-decoration:none">Refer a friend — get {{money(ref.terms.referrer_micro||10000000)}}</a>
         </div>
         <!-- PUBLIC (bottom): a signed-out catalog visitor gets the way in, where a member's
              account block would be. The catalog is readable without an account; calling is not. -->
@@ -2961,6 +2968,75 @@ product, including per-customer usage tracking and billing.</pre>
           </div>
         </template>
 
+        <!-- REFERRALS — a person's link and everyone who used it. A top-level view (never nested):
+             a view inside a view renders nowhere, and the nav button would look dead. -->
+        <template v-if="view==='referrals'">
+          <h1>Refer a friend</h1>
+          <p class="sub">They get {{money(ref.terms.referred_micro)}} when they add
+            {{money(ref.terms.min_topup_micro)}}. You get {{money(ref.terms.referrer_micro)}},
+            {{ref.terms.hold_days}} days later.</p>
+
+          <p v-if="ref.loading" class="sub">Loading…</p>
+          <template v-else>
+            <!-- Gate 3 (the referrer must have paid us once) made VISIBLE. Unshown, someone shares a
+                 link, converts a friend, and silently earns nothing — the worst possible version. -->
+            <div v-if="!ref.eligible" class="card" style="max-width:620px;margin-top:14px">
+              <div class="lbl">Add funds once to unlock your link</div>
+              <p class="sub" style="margin:6px 0 12px">Referral rewards are for teams who use treg.
+                Add funds to your team and your link turns on.</p>
+              <button class="btn primary sm" @click="orgTab='billing'; go('orgs')">Add funds</button>
+            </div>
+
+            <template v-else>
+              <div class="card" style="max-width:620px;margin-top:14px">
+                <div class="lbl">Your link</div>
+                <div style="display:flex;gap:8px;margin-top:8px">
+                  <input readonly :value="ref.link" @focus="$event.target.select()"
+                         style="flex:1;font-family:var(--mono);font-size:12px">
+                  <button class="btn sm" @click="copyRefLink">{{refCopied?'Copied':'Copy'}}</button>
+                </div>
+                <p class="sub" style="margin:10px 0 0" v-if="ref.credit_org">
+                  Your reward lands in <b>{{ref.credit_org.name}}</b>.</p>
+              </div>
+
+              <div class="statgrid" style="margin-top:14px;max-width:620px">
+                <div class="stat"><div class="k">Signed up</div><div class="v">{{ref.totals.signed_up}}</div></div>
+                <div class="stat"><div class="k">Topped up</div><div class="v">{{ref.totals.topped_up}}</div></div>
+                <div class="stat"><div class="k">Earned</div><div class="v">{{money(ref.totals.earned_micro)}}</div></div>
+              </div>
+              <p v-if="ref.totals.pending_micro" class="sub" style="margin:8px 0 0">
+                {{money(ref.totals.pending_micro)}} on the way — rewards land
+                {{ref.terms.hold_days}} days after your friend adds funds.</p>
+
+              <!-- The cap refusal IS the commercial conversation, same posture as a daily-cap
+                   refusal: it names the limit and points at a human rather than silently paying 0. -->
+              <div v-if="ref.cap.paid >= ref.cap.limit" class="card"
+                   style="max-width:620px;margin-top:14px;border-color:var(--accent)">
+                <div class="lbl">You've hit the {{ref.cap.limit}}-referral limit</div>
+                <p class="sub" style="margin:6px 0 0">That's as far as the self-serve program goes.
+                  If you're sending real volume, email <b>support@treg.to</b> — we pay partners in cash.</p>
+              </div>
+
+              <div style="margin-top:18px;max-width:720px">
+                <div class="lbl">Your referrals</div>
+                <p v-if="!ref.referrals.length" class="sub" style="margin:8px 0 0">
+                  Nobody yet. Share your link above.</p>
+                <table v-else style="width:100%;margin-top:8px;border-collapse:collapse">
+                  <tr v-for="(r,i) in ref.referrals" :key="i" style="border-top:1px solid var(--line)">
+                    <td style="padding:8px 10px 8px 0">{{r.email || '—'}}</td>
+                    <td style="padding:8px 10px 8px 0" class="sub">{{bhistDate(r.signed_up_at)}}</td>
+                    <td style="padding:8px 10px 8px 0">{{refStatus(r)}}</td>
+                    <td style="padding:8px 0;text-align:right;font-family:var(--mono);white-space:nowrap">
+                      <span v-if="r.reward_micro">{{money(r.reward_micro)}}</span>
+                      <span v-else class="muted">—</span>
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </template>
+          </template>
+        </template>
+
         <!-- HELP -->
         <template v-if="view==='help'">
           <!-- chooser -->
@@ -3780,6 +3856,13 @@ createApp({
       capCfg:null, capUsd:0, capBusy:false, capErr:'',
       budgets:[], budDims:[], budDim:'', budVal:'', budDaily:'', budBusy:false, budErr:'',
       bhist:{items:[],loading:false,ok:true},   // past top-ups + their invoice/receipt links; ok=false means Stripe was unreachable, amounts are still right
+      // Referral program. Seeded with the same SHAPE the API returns (terms/totals/cap present and
+      // zeroed) so the template can read ref.terms.hold_days on the very first paint — a v-if on
+      // `loading` guards the table, but the subtitle above it renders immediately.
+      ref:{loading:false,eligible:false,code:'',link:'',credit_org:null,referrals:[],
+           terms:{referrer_micro:0,referred_micro:0,min_topup_micro:0,hold_days:0},
+           totals:{signed_up:0,topped_up:0,earned_micro:0,pending_micro:0},cap:{paid:0,limit:0}},
+      refCopied:false,
       confirmDel:'', confirmLeave:false, confirmRemove:null,
       showJoin:false, joinCode:'', joinBusy:false, joinErr:'',
       secrets:[], showSecrets:false, secretRows:[{name:'',value:'',kind:'env'}], secretBusy:false, secretErr:'', runNote:'',
@@ -4776,6 +4859,29 @@ createApp({
         // return_url comes back to #billing, so the same tab is right here as it is for Checkout.
         window.location.href=out.url; }
       catch(e){ this.err='Could not open the billing portal: '+(e.detail||e.status); this.billingBusy=false; } },
+    // ---- referrals ----
+    // GET /referrals also runs the payout sweep server-side, so simply opening this page is what
+    // makes a reward whose hold has elapsed actually land. That is deliberate: treg has no
+    // scheduler, so the work rides on a request someone is already making.
+    async loadReferrals(){ if(!this.authed) return;
+      this.ref={...this.ref, loading:true};
+      // Mint the code first. It's idempotent, and doing it here (rather than at signup) means we
+      // never generate a code for the majority who never open this page.
+      await this.api('/referrals/code',{method:'POST'}).catch(()=>null);
+      const out=await this.api('/referrals').catch(()=>null);
+      if(out) this.ref={...out, loading:false}; else this.ref={...this.ref, loading:false}; },
+    async copyRefLink(){ try{ await navigator.clipboard.writeText(this.ref.link); }catch(e){}
+      this.refCopied=true; this.track('referral_link_copied');
+      setTimeout(()=>{ this.refCopied=false; }, 1600); },
+    // The row's own status, in the words a referrer thinks in. `capped`/`rejected` say WHY rather
+    // than showing a blank — "I referred someone and got nothing" is the support ticket this
+    // program generates, and the answer belongs on the page, not in an email to us.
+    refStatus(r){
+      if(r.status==='paid') return 'Paid';
+      if(r.status==='qualified') return 'Added funds — pays '+this.bhistDate(r.pays_at);
+      if(r.status==='pending') return 'Signed up';
+      if(r.status==='capped') return 'Over your limit';
+      return 'Not eligible'; },
     bhistLink(i){ return i.invoice_pdf || i.hosted_invoice_url || i.receipt_url || ''; },
     bhistLabel(i){ return (i.invoice_pdf||i.hosted_invoice_url) ? 'Invoice' : (i.receipt_url ? 'Receipt' : ''); },
     // created_at is naive UTC (the models._now convention), so it needs the Z that isoformat omits —
@@ -5391,7 +5497,7 @@ createApp({
       // working so an existing /app#usage link, and the balance card's deep link, still land right.
       if(v==='usage'){ this.actTab='usage'; v='activity'; this.loadUsage(); }
       else if(v==='activity'){ this.actTab='feed'; }
-      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage(); this.loadBilling();} if(v==='usage')this.loadUsage(); if(v==='secrets'){this.loadSecrets(); if(!this.providers.length)this.loadConnections();} if(v==='connections')this.loadConnections();
+      this.detail=null; this.view=v; if(v==='activity')this.loadCalls(); if(v==='admin')this.loadAdmin(); if(v==='orgs'){this.loadOrgAdmin(); this.loadMyUsage(); this.loadBilling();} if(v==='usage')this.loadUsage(); if(v==='secrets'){this.loadSecrets(); if(!this.providers.length)this.loadConnections();} if(v==='connections')this.loadConnections(); if(v==='referrals')this.loadReferrals();
       // push history so browser Back navigates BETWEEN views instead of leaving the app; the '/app'
       // pathname also walks back from a /app/skills/<x> detail URL so reload doesn't reopen the detail
       if(!fromPop) history.pushState({view:v}, '',
@@ -5449,7 +5555,7 @@ createApp({
     // billing lives on the Team pane's Billing tab, so it aliases there.
     viewFromHash(){ let v=(location.hash||'').replace('#','');
       if(v==='billing'){ this.orgTab='billing'; v='orgs'; }
-      return ['tools','orgs','activity','usage','admin','help','secrets','start','connections'].includes(v)?v:null; },
+      return ['tools','orgs','activity','usage','admin','help','secrets','start','connections','referrals'].includes(v)?v:null; },
     openPlatform(slug, fromPop){ this.resetConfirms();
       this.detail=null; this.platSlug=slug; this.view='platform'; this.platOpen={}; this.epOpen={}; this.epTab={}; this.platEx={}; this.platActionsOpen=false;
       this.platClearFilters(); this.platCopied='';
@@ -5990,7 +6096,7 @@ createApp({
       if(d){ this.openDetail(d.kind, d.name, true); return; }
       let v=(e.state&&e.state.view)||(location.hash||'').replace('#','')||'tools';
       if(v==='billing'){ this.orgTab='billing'; v='orgs'; }
-      if(['tools','orgs','activity','usage','admin','help','secrets','start','connections'].includes(v)) this.go(v, true);
+      if(['tools','orgs','activity','usage','admin','help','secrets','start','connections','referrals'].includes(v)) this.go(v, true);
     });
     this.meta = await fetch('/meta',{headers:{'ngrok-skip-browser-warning':'1'}}).then(r=>r.json()).catch(()=>this.meta);
     this.proxy = this.meta.public_url || location.origin;

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2977,12 +2977,15 @@ product, including per-customer usage tracking and billing.</pre>
             {{ref.terms.hold_days}} days later.</p>
 
           <p v-if="ref.loading" class="sub">Loading…</p>
-          <template v-else>
+          <!-- ONE column for the whole view. The children carry no max-width of their own: three
+               different ones is what made the card, the tiles and the table start and end at three
+               different x-positions. -->
+          <div v-else style="max-width:720px">
             <!-- Everyone with a team gets a link — including free-tier users, who on a product
                  pitched as "$1.00 free, no card" are most users and the likeliest to tell a friend.
                  This branch is now only the degenerate case (no team to pay the reward into), kept
                  because the reward has to land SOMEWHERE and a silent zero is the worst version. -->
-            <div v-if="!ref.eligible" class="card" style="max-width:620px;margin-top:14px">
+            <div v-if="!ref.eligible" class="card" style="margin-top:14px">
               <div class="lbl">Create a team to unlock your link</div>
               <p class="sub" style="margin:6px 0 12px">Referral rewards are paid as credit into a
                 team you own, so you'll need one first.</p>
@@ -2990,53 +2993,62 @@ product, including per-customer usage tracking and billing.</pre>
             </div>
 
             <template v-else>
-              <div class="card" style="max-width:620px;margin-top:14px">
+              <div class="card" style="margin-top:14px">
                 <div class="lbl">Your link</div>
                 <div style="display:flex;gap:8px;margin-top:8px">
                   <input readonly :value="ref.link" @focus="$event.target.select()"
-                         style="flex:1;font-family:var(--mono);font-size:12px">
-                  <button class="btn sm" @click="copyRefLink">{{refCopied?'Copied':'Copy'}}</button>
+                         style="flex:1;min-width:0;font-family:var(--mono);font-size:12px">
+                  <button class="btn sm" @click="copyRefLink" style="flex:none">{{refCopied?'Copied':'Copy'}}</button>
                 </div>
                 <p class="sub" style="margin:10px 0 0" v-if="ref.credit_org">
                   Your reward lands in <b>{{ref.credit_org.name}}</b>.</p>
               </div>
 
-              <div class="statgrid" style="margin-top:14px;max-width:620px">
-                <div class="stat"><div class="k">Signed up</div><div class="v">{{ref.totals.signed_up}}</div></div>
-                <div class="stat"><div class="k">Topped up</div><div class="v">{{ref.totals.topped_up}}</div></div>
-                <div class="stat"><div class="k">Earned</div><div class="v">{{money(ref.totals.earned_micro)}}</div></div>
+              <!-- `.stat` expects `.n` (the figure) then `.l` (the label), in that order — any other
+                   class names render as unstyled text, which is exactly what a hand-rolled k/v pair
+                   did here. -->
+              <!-- auto-FIT, not the sheet's auto-fill: at this width auto-fill lays out four 150px
+                   tracks and leaves the fourth empty, so three tiles stop short of the column's
+                   right edge while the card above and the table below reach it. auto-fit collapses
+                   the empty track and the three stretch to fill. -->
+              <div class="statgrid" style="margin-top:14px;grid-template-columns:repeat(auto-fit,minmax(150px,1fr))">
+                <div class="stat"><div class="n">{{ref.totals.signed_up}}</div><div class="l">signed up</div></div>
+                <div class="stat"><div class="n">{{ref.totals.topped_up}}</div><div class="l">topped up</div></div>
+                <div class="stat"><div class="n">{{money(ref.totals.earned_micro)}}</div><div class="l">earned</div></div>
               </div>
-              <p v-if="ref.totals.pending_micro" class="sub" style="margin:8px 0 0">
+              <p v-if="ref.totals.pending_micro" class="sub" style="margin:-8px 0 0">
                 {{money(ref.totals.pending_micro)}} on the way — rewards land
                 {{ref.terms.hold_days}} days after your friend adds funds.</p>
 
               <!-- The cap refusal IS the commercial conversation, same posture as a daily-cap
                    refusal: it names the limit and points at a human rather than silently paying 0. -->
               <div v-if="ref.cap.paid >= ref.cap.limit" class="card"
-                   style="max-width:620px;margin-top:14px;border-color:var(--accent)">
+                   style="margin-top:14px;border-color:var(--accent)">
                 <div class="lbl">You've hit the {{ref.cap.limit}}-referral limit</div>
                 <p class="sub" style="margin:6px 0 0">That's as far as the self-serve program goes.
                   If you're sending real volume, email <b>support@treg.to</b> — we pay partners in cash.</p>
               </div>
 
-              <div style="margin-top:18px;max-width:720px">
-                <div class="lbl">Your referrals</div>
-                <p v-if="!ref.referrals.length" class="sub" style="margin:8px 0 0">
-                  Nobody yet. Share your link above.</p>
-                <table v-else style="width:100%;margin-top:8px;border-collapse:collapse">
-                  <tr v-for="(r,i) in ref.referrals" :key="i" style="border-top:1px solid var(--line)">
-                    <td style="padding:8px 10px 8px 0">{{r.email || '—'}}</td>
-                    <td style="padding:8px 10px 8px 0" class="sub">{{bhistDate(r.signed_up_at)}}</td>
-                    <td style="padding:8px 10px 8px 0">{{refStatus(r)}}</td>
-                    <td style="padding:8px 0;text-align:right;font-family:var(--mono);white-space:nowrap">
-                      <span v-if="r.reward_micro">{{money(r.reward_micro)}}</span>
-                      <span v-else class="muted">—</span>
-                    </td>
-                  </tr>
-                </table>
-              </div>
+              <div class="grp" style="margin:20px 0 8px">Your referrals</div>
+              <p v-if="!ref.referrals.length" class="sub" style="margin:0">
+                Nobody yet. Share your link above.</p>
+              <!-- House-style table: bare `<table>` is ALREADY a card (background, border, radius)
+                   and `th,td` already carry 10px/13px padding. Overriding that padding to `8px 0`
+                   is what pushed the amount flush against the card's own right edge. -->
+              <table v-else>
+                <tr><th>Who</th><th>Signed up</th><th>Status</th><th style="text-align:right">Reward</th></tr>
+                <tr v-for="(r,i) in ref.referrals" :key="i">
+                  <td>{{r.email || '—'}}</td>
+                  <td class="sub" style="white-space:nowrap">{{bhistDate(r.signed_up_at)}}</td>
+                  <td>{{refStatus(r)}}</td>
+                  <td style="text-align:right;font-family:var(--mono);white-space:nowrap">
+                    <span v-if="r.reward_micro">{{money(r.reward_micro)}}</span>
+                    <span v-else class="muted">—</span>
+                  </td>
+                </tr>
+              </table>
             </template>
-          </template>
+          </div>
         </template>
 
         <!-- HELP -->

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2421,10 +2421,17 @@ a:hover{text-decoration-color:var(--muted)}
                       <div v-if="billing.referral_offer" style="margin-top:8px;padding:9px 12px;font-size:12.5px;
                            border:1px solid var(--green);border-radius:8px;
                            background:color-mix(in srgb,var(--green) 12%,transparent)">
-                        You were invited to treg — add
-                        <b>{{money(billing.referral_offer.min_topup_micro)}}</b> or more and we'll put
-                        <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in your balance.
-                        Whoever invited you gets {{money(billing.referral_offer.referrer_micro)}}.
+                        <!-- The referrer is MASKED (`j•••@domain`): a referral link is public, so
+                             the full address would be published to every stranger who signs up
+                             through an influencer's link. The domain is what a real friend
+                             recognises. Falls back to "to treg" if we somehow have no address. -->
+                        You were invited
+                        <template v-if="billing.referral_offer.referrer_masked">by
+                          <b>{{billing.referral_offer.referrer_masked}}</b></template>
+                        <template v-else>to treg</template>
+                        — add <b>{{money(billing.referral_offer.min_topup_micro)}}</b> or more and
+                        we'll put <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in
+                        your balance. They get {{money(billing.referral_offer.referrer_micro)}}.
                       </div>
                       <div class="fundgrid" style="margin-top:8px">
                         <button v-for="p in billing.topup.presets" :key="p" class="fundcard" :disabled="billingBusy" @click="addFunds(p)">

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2978,13 +2978,15 @@ product, including per-customer usage tracking and billing.</pre>
 
           <p v-if="ref.loading" class="sub">Loading…</p>
           <template v-else>
-            <!-- Gate 3 (the referrer must have paid us once) made VISIBLE. Unshown, someone shares a
-                 link, converts a friend, and silently earns nothing — the worst possible version. -->
+            <!-- Everyone with a team gets a link — including free-tier users, who on a product
+                 pitched as "$1.00 free, no card" are most users and the likeliest to tell a friend.
+                 This branch is now only the degenerate case (no team to pay the reward into), kept
+                 because the reward has to land SOMEWHERE and a silent zero is the worst version. -->
             <div v-if="!ref.eligible" class="card" style="max-width:620px;margin-top:14px">
-              <div class="lbl">Add funds once to unlock your link</div>
-              <p class="sub" style="margin:6px 0 12px">Referral rewards are for teams who use treg.
-                Add funds to your team and your link turns on.</p>
-              <button class="btn primary sm" @click="orgTab='billing'; go('orgs')">Add funds</button>
+              <div class="lbl">Create a team to unlock your link</div>
+              <p class="sub" style="margin:6px 0 12px">Referral rewards are paid as credit into a
+                team you own, so you'll need one first.</p>
+              <button class="btn primary sm" @click="go('orgs')">Go to teams</button>
             </div>
 
             <template v-else>
@@ -4865,9 +4867,8 @@ createApp({
     // scheduler, so the work rides on a request someone is already making.
     async loadReferrals(){ if(!this.authed) return;
       this.ref={...this.ref, loading:true};
-      // Mint the code first. It's idempotent, and doing it here (rather than at signup) means we
-      // never generate a code for the majority who never open this page.
-      await this.api('/referrals/code',{method:'POST'}).catch(()=>null);
+      // One call: GET mints the code if this is the first visit (asking for the page IS the lazy
+      // trigger), so there is no POST-then-GET round trip and no window where `link` is empty.
       const out=await this.api('/referrals').catch(()=>null);
       if(out) this.ref={...out, loading:false}; else this.ref={...this.ref, loading:false}; },
     async copyRefLink(){ try{ await navigator.clipboard.writeText(this.ref.link); }catch(e){}

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2414,10 +2414,27 @@ a:hover{text-decoration-color:var(--muted)}
                   <template v-if="billing.configured">
                     <div style="margin-top:16px;border-top:1px solid var(--line);padding-top:14px">
                       <div class="lbl">Add funds</div>
+                      <!-- A team that arrived through someone's link does not know a bonus exists.
+                           This is the one screen where saying so changes what they do, and the
+                           MINIMUM is the part that matters: the first preset ($5) is below it, so
+                           without this the most-clicked button silently forfeits the reward. -->
+                      <div v-if="billing.referral_offer" style="margin-top:8px;padding:9px 12px;font-size:12.5px;
+                           border:1px solid var(--green);border-radius:8px;
+                           background:color-mix(in srgb,var(--green) 12%,transparent)">
+                        You were invited to treg — add
+                        <b>{{money(billing.referral_offer.min_topup_micro)}}</b> or more and we'll put
+                        <b>{{money(billing.referral_offer.referred_micro)}}</b> extra in your balance.
+                        Whoever invited you gets {{money(billing.referral_offer.referrer_micro)}}.
+                      </div>
                       <div class="fundgrid" style="margin-top:8px">
                         <button v-for="p in billing.topup.presets" :key="p" class="fundcard" :disabled="billingBusy" @click="addFunds(p)">
                           <b>${{p}}</b>
-                          <span>{{billingBusy&&topupAmount===p?'Opening Stripe…':'one-time'}}</span>
+                          <!-- The bonus is named ON the qualifying buttons, not only in the note
+                               above: the amount is chosen here, and a preset that quietly forfeits
+                               it is the whole failure this is meant to prevent. -->
+                          <span v-if="billingBusy&&topupAmount===p">Opening Stripe…</span>
+                          <span v-else-if="refPresetBonus(p)" style="color:var(--green)">+{{money(refPresetBonus(p))}} bonus</span>
+                          <span v-else>one-time</span>
                         </button>
                       </div>
                     </div>
@@ -4883,6 +4900,10 @@ createApp({
       // trigger), so there is no POST-then-GET round trip and no window where `link` is empty.
       const out=await this.api('/referrals').catch(()=>null);
       if(out) this.ref={...out, loading:false}; else this.ref={...this.ref, loading:false}; },
+    // How much extra THIS preset earns a referred team, or 0. Guarded on the offer existing, so a
+    // team that arrived on its own sees the buttons exactly as before.
+    refPresetBonus(usd){ const o=this.billing&&this.billing.referral_offer;
+      return (o && usd*1000000 >= o.min_topup_micro) ? o.referred_micro : 0; },
     async copyRefLink(){ try{ await navigator.clipboard.writeText(this.ref.link); }catch(e){}
       this.refCopied=true; this.track('referral_link_copied');
       setTimeout(()=>{ this.refCopied=false; }, 1600); },

--- a/src/treg/web/privacy.html
+++ b/src/treg/web/privacy.html
@@ -179,6 +179,11 @@
     <tr><td>Google Fonts</td><td>Your IP address, when you load a treg web page</td><td>Serves the site's typefaces</td><td>USA</td></tr>
     <tr><td>Upstream APIs you connect</td><td>Whatever your call sends them</td><td>The call you asked us to make</td><td>Varies by provider</td></tr>
   </table></div>
+  <p><b>Referrals.</b> If you sign up through someone's referral link, <b>your email address is
+  shown to the person who referred you</b>, along with the date you signed up and whether your team
+  has added funds — that's how they see which of their invitations worked. Nothing else about you or
+  your usage is shared with them. If you'd rather not be visible that way, sign up without using the
+  link.</p>
   <p>We'll also disclose data where legally required, or where necessary to protect the Service or
   its users from a live security threat. If we're ever compelled to hand over data about you, we'll
   tell you unless we're legally barred from doing so.</p>
@@ -187,9 +192,14 @@
   protective.</p>
 
   <h2 class="sec" id="s7"><span class="n">07</span>Cookies</h2>
-  <p>One cookie: <code>treg_session</code>. It's HTTP-only, SameSite=Lax, and secure over HTTPS. It
-  holds a signed session reference and nothing else. It's strictly necessary to keep you signed in,
-  so there's no consent banner and nothing to opt out of short of signing out.</p>
+  <p>The main one is <code>treg_session</code>. It's HTTP-only, SameSite=Lax, and secure over HTTPS.
+  It holds a signed session reference and nothing else. It's strictly necessary to keep you signed
+  in, so there's no consent banner and nothing to opt out of short of signing out.</p>
+  <p>Two others exist only when you've done the thing that sets them, and both are HTTP-only with the
+  same flags: <code>treg_oauth_return</code> holds the page to return you to after a sign-in detour
+  (a few minutes), and <code>treg_ref</code> holds a referral code if you arrived through someone's
+  invite link, so we can credit them when you create a team (30 days). Neither identifies you, and
+  neither is used for advertising.</p>
   <p>There are no analytics, advertising, or third-party tracking cookies anywhere on the Service.</p>
 
   <h2 class="sec" id="s8"><span class="n">08</span>How we protect it</h2>

--- a/src/treg/web/privacy.html
+++ b/src/treg/web/privacy.html
@@ -184,6 +184,10 @@
   has added funds — that's how they see which of their invitations worked. Nothing else about you or
   your usage is shared with them. If you'd rather not be visible that way, sign up without using the
   link.</p>
+  <p>In the other direction we show you less: if you were referred, we tell you who invited you as a
+  <b>partial</b> address (<code>j&bull;&bull;&bull;@theirdomain.com</code>) and never in full. Referral
+  links are often shared publicly, and the full address of whoever posted one is not ours to hand to
+  everyone who clicks it.</p>
   <p>We'll also disclose data where legally required, or where necessary to protect the Service or
   its users from a live security threat. If we're ever compelled to hand over data about you, we'll
   tell you unless we're legally barred from doing so.</p>

--- a/src/treg/web/terms.html
+++ b/src/treg/web/terms.html
@@ -173,6 +173,16 @@
   turn them on and agree to the amount. Every new team starts with a small free balance.</p>
   <p>If we introduce subscription plans on top of that, we'll say so clearly in advance and no
   recurring charge will apply to you without your explicit agreement.</p>
+  <p><b>Referrals.</b> If you invite someone with your referral link, both of you may receive
+  promotional balance once their team adds funds. That balance is a <b>marketing credit, not money</b>:
+  it can only be spent on calls through treg, it is <b>never redeemable for cash and never
+  refundable</b>, and it isn't transferable between teams. Rewards are held for a short period before
+  they land, and we may withhold or reverse one — and close the account behind it — where a referral
+  looks self-dealt or artificial: inviting yourself, signing up more than once, paying with the same
+  card, or the funding payment being reversed. There's a limit on how many referrals one person can
+  be rewarded for; we'll show it to you, and we may change the rewards or end the programme at any
+  time (already-earned balance stays yours). If you'd like to refer at real volume, email us —
+  that's a separate arrangement.</p>
 
   <h2 class="sec" id="s9"><span class="n">09</span>Suspension, termination, and deletion</h2>
   <p>You can leave at any time: delete a team from the dashboard, or email us to delete your account

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -893,8 +893,11 @@ def test_referral_page_shows_why_a_referral_paid_nothing():
     assert "Over your limit" in INDEX and "Not eligible" in INDEX
 
 
-def test_referral_link_is_hidden_until_the_referrer_is_eligible():
-    """A referrer who has never topped up earns nothing (referrals.qualify gate 3). Showing them a
-    live link anyway would convert a friend and silently pay zero."""
+def test_the_referral_link_is_not_gated_behind_paying_us():
+    """Every signed-in person gets a link, free tier included — they are most of the userbase on a
+    product pitched as "$1.00 free, no card", and the likeliest to tell a friend. The `!eligible`
+    branch survives only for the degenerate case of having no team to pay a reward into, so it must
+    NOT ask anyone to add funds."""
     assert 'v-if="!ref.eligible"' in INDEX
-    assert "Add funds once to unlock your link" in INDEX
+    assert "Create a team to unlock your link" in INDEX
+    assert "Add funds once to unlock your link" not in INDEX

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -901,3 +901,45 @@ def test_the_referral_link_is_not_gated_behind_paying_us():
     assert 'v-if="!ref.eligible"' in INDEX
     assert "Create a team to unlock your link" in INDEX
     assert "Add funds once to unlock your link" not in INDEX
+
+
+def _referrals_view() -> str:
+    """The Referrals view block ONLY. Anchored on the template tag, not the bare `view==='referrals'`
+    string — the nav button matches that first and would slice from the sidebar."""
+    start = INDEX.index("<template v-if=\"view==='referrals'\">")
+    end = INDEX.index("<template v-if=\"view==='help'\">", start)
+    return INDEX[start:end]
+
+
+def test_referral_stat_tiles_use_the_sheets_own_class_names():
+    """`.stat` styles `.n` (the figure, 26px accent) and `.l` (the uppercase caption) — and nothing
+    else. A hand-rolled `.k`/`.v` pair renders as two lines of unstyled body text that still *look*
+    like content, so nothing errors and the bug ships. Order matters too: figure first."""
+    block = _referrals_view()
+    assert 'class="statgrid"' in block
+    assert block.count('<div class="n">') == 3 and block.count('<div class="l">') == 3
+    assert 'class="k"' not in block and 'class="v"' not in block
+    assert block.index('<div class="n">') < block.index('<div class="l">')
+
+
+def test_referral_stat_tiles_fill_the_column():
+    """The sheet's `.statgrid` is auto-FILL, which at this width lays out four 150px tracks and
+    leaves the fourth empty — three tiles then stop short of the right edge the card above and the
+    table below both reach. auto-fit collapses the empty track."""
+    assert "grid-template-columns:repeat(auto-fit,minmax(150px,1fr))" in _referrals_view()
+
+
+def test_referral_table_keeps_the_sheets_cell_padding():
+    """A bare `<table>` IS a card here (background, border, radius) and `th,td` already carry
+    10px/13px. Overriding that to `padding:8px 0` — copied from a table that lives INSIDE a card —
+    puts the right-aligned amount flush against the card's own edge, which reads as clipped."""
+    block = _referrals_view()
+    table = block[block.index("<table"):block.index("</table>")]
+    assert "padding:" not in table, "let th,td carry the padding"
+    assert "<th>" in table, "house tables have a header row"
+
+
+def test_the_referral_column_is_one_width():
+    """Card, tiles and table sit in a SINGLE max-width container. Three separate max-widths is what
+    made them start and end at three different x-positions."""
+    assert _referrals_view().count("max-width:") == 1

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -943,3 +943,19 @@ def test_the_referral_column_is_one_width():
     """Card, tiles and table sit in a SINGLE max-width container. Three separate max-widths is what
     made them start and end at three different x-positions."""
     assert _referrals_view().count("max-width:") == 1
+
+
+def test_the_billing_page_names_the_bonus_on_the_qualifying_presets():
+    """A referred team decides HOW MUCH to add on this screen, and the first preset ($5) is below the
+    minimum. A note alone is not enough — the amount is chosen at the buttons, so the qualifying ones
+    have to say so themselves."""
+    at = INDEX.index('<div class="fundgrid"')
+    grid = INDEX[at : INDEX.index("</div>", INDEX.index("</button>", at))]
+    assert "refPresetBonus(p)" in grid, "presets must mark which ones earn the bonus"
+    assert "billing.referral_offer" in INDEX
+
+
+def test_the_referral_offer_is_hidden_from_teams_that_were_not_referred():
+    """`v-if` on the offer object, so a team that arrived on its own sees the billing page exactly as
+    it was before this shipped."""
+    assert 'v-if="billing.referral_offer"' in INDEX

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -968,3 +968,14 @@ def test_the_billing_prompt_renders_the_masked_referrer_never_a_raw_one():
     block = INDEX[at : INDEX.index("</div>", at)]
     assert "billing.referral_offer.referrer_masked" in block
     assert "referrer_email" not in INDEX
+
+
+def test_the_referral_preset_helper_null_guards_before_reading_the_offer():
+    """`referral_offer` is null for every team that was NOT referred — most of them. Reading through
+    it throws inside a render, and a render error in Vue blanks the entire dashboard, not just the
+    row. This shipped once, as a blank billing page, when a guard clause was folded into a larger
+    expression and then edited away."""
+    at = INDEX.index("refPresetBonus(usd)")
+    body = INDEX[at : INDEX.index("},", at)]
+    assert "if(!o) return 0;" in body
+    assert body.index("if(!o) return 0;") < body.index("o.remaining_micro")

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -868,3 +868,33 @@ def test_dashboard_delete_org_sends_the_confirmation_slug():
     normalization from any deeper org route). The dashboard already makes the human type the slug —
     if this ever stops being sent, Delete org silently 422s for every dashboard user."""
     assert "'/orgs/'+this.activeOrgId+'?confirm='" in INDEX
+
+
+# --- referrals (view==='referrals') -----------------------------------------------------------
+
+
+def test_referrals_is_a_top_level_view():
+    """Nested inside another view it would render nowhere, and the nav button would look dead —
+    the exact silent failure the dialog checks above exist for."""
+    assert _enclosing_views("<template v-if=\"view==='referrals'\">") == []
+
+
+def test_referrals_is_registered_in_BOTH_view_whitelists():
+    """`go('referrals')` works on click regardless; these two lists are what make it survive a
+    RELOAD and a BACK button. One is `viewFromHash` (fresh load / deep link), the other is the
+    popstate handler. Missing either is invisible until someone refreshes the page."""
+    assert INDEX.count("'connections','referrals'") == 2
+
+
+def test_referral_page_shows_why_a_referral_paid_nothing():
+    """"I referred someone and got nothing" is the ticket this program generates. `capped` and
+    `rejected` must render a reason on the page rather than an empty cell."""
+    assert "refStatus(r)" in INDEX
+    assert "Over your limit" in INDEX and "Not eligible" in INDEX
+
+
+def test_referral_link_is_hidden_until_the_referrer_is_eligible():
+    """A referrer who has never topped up earns nothing (referrals.qualify gate 3). Showing them a
+    live link anyway would convert a friend and silently pay zero."""
+    assert 'v-if="!ref.eligible"' in INDEX
+    assert "Add funds once to unlock your link" in INDEX

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -959,3 +959,12 @@ def test_the_referral_offer_is_hidden_from_teams_that_were_not_referred():
     """`v-if` on the offer object, so a team that arrived on its own sees the billing page exactly as
     it was before this shipped."""
     assert 'v-if="billing.referral_offer"' in INDEX
+
+
+def test_the_billing_prompt_renders_the_masked_referrer_never_a_raw_one():
+    """The template must read `referrer_masked`. Reaching for any full-address field here would
+    publish an influencer's email to every stranger who signs up through their public link."""
+    at = INDEX.index("You were invited")
+    block = INDEX[at : INDEX.index("</div>", at)]
+    assert "billing.referral_offer.referrer_masked" in block
+    assert "referrer_email" not in INDEX

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -192,8 +192,10 @@ async def test_full_loop_pays_both_sides_after_the_hold(c, monkeypatch):
     await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", cents=1000, fingerprint="fp_bob")
     rows = await _referral_rows()
     assert rows[0].status == "qualified"
-    # NOTHING has been granted yet — the hold is the only clawback window that exists.
-    assert await _blocks(bob_org, "referral") == []
+    s = get_settings()
+    # The referee is paid AT ONCE — the balance is their only feedback. The referrer waits out the
+    # hold, which is now the only clawback window that remains.
+    assert [b.amount_micro for b in await _blocks(bob_org, "referral")] == [s.referral_referred_micro]
     assert await _blocks(ann_org, "referral") == []
 
     await _age_qualification()
@@ -201,7 +203,6 @@ async def test_full_loop_pays_both_sides_after_the_hold(c, monkeypatch):
     assert r.status_code == 200
     body = r.json()
 
-    s = get_settings()
     bob_blocks = await _blocks(bob_org, "referral")
     ann_blocks = await _blocks(ann_org, "referral")
     assert [b.amount_micro for b in bob_blocks] == [s.referral_referred_micro]
@@ -285,7 +286,7 @@ async def test_the_threshold_is_cumulative(c, monkeypatch):
     assert (await _referral_rows())[0].status == "pending"
     await _topup(c, monkeypatch, bob_org, pi="pi_bob_2", cents=500, fingerprint="fp_bob")
     assert (await _referral_rows())[0].status == "qualified"
-    # The offer is gone now that it has been taken, and the bonus really lands.
+    # The offer is gone (the referee's bonus is already in their balance), and the referrer's lands.
     assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is None
     await _age_qualification()
     async with session_maker() as db:
@@ -376,7 +377,11 @@ async def test_lifetime_cap_records_but_does_not_pay(c, monkeypatch):
 
 
 # ---- clawback ----------------------------------------------------------------------------------
-async def test_dispute_inside_the_hold_cancels_the_payout(c, monkeypatch):
+async def test_dispute_inside_the_hold_cancels_the_referrers_half(c, monkeypatch):
+    """The hold now protects ONE side. The referee's bonus went out on qualification and is treated
+    like any already-paid credit — logged for a human, never reversed, because no code path here may
+    drive a balance negative. Recovering half a bounty is the deliberate price of paying the referee
+    immediately, and it is why the per-card gate matters more than this window does."""
     ann_org, _, code = await _ready_referrer(c, monkeypatch)
     bob_org, _ = await _signup(c, "bob@example.com", ref=code)
     await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
@@ -388,8 +393,9 @@ async def test_dispute_inside_the_hold_cancels_the_payout(c, monkeypatch):
     await _age_qualification()
     async with session_maker() as db:
         assert await referrals.sweep(db) == 0
-    assert await _blocks(ann_org, "referral") == []
-    assert await _blocks(bob_org, "referral") == []
+    assert await _blocks(ann_org, "referral") == [], "the referrer's half never goes out"
+    s = get_settings()
+    assert [b.amount_micro for b in await _blocks(bob_org, "referral")] == [s.referral_referred_micro]
 
 
 async def test_dispute_does_not_touch_the_balance(c, monkeypatch):
@@ -479,6 +485,7 @@ async def test_a_referred_team_is_told_the_minimum_on_its_billing_page(c, monkey
                      "min_topup_micro": s.referral_min_topup_micro,
                      "topped_up_micro": 0,
                      "remaining_micro": s.referral_min_topup_micro,
+                     "hold_days": s.referral_hold_days,
                      "referrer_masked": "a•••@superdesign.dev"}
 
 
@@ -489,14 +496,54 @@ async def test_a_team_that_arrived_on_its_own_sees_no_offer(c, monkeypatch):
     assert (await c.get("/billing", headers=_h(token))).json()["referral_offer"] is None
 
 
-async def test_the_offer_disappears_once_it_has_been_taken(c, monkeypatch):
-    """Only while `pending`. After qualifying the money is already on its way through the sweep, and
-    still advertising it would read as a second bonus."""
+async def test_the_referee_is_paid_the_instant_they_qualify(c, monkeypatch):
+    """The two sides are not in the same position. The referrer has a Referrals page where a pending
+    reward is legible; the referee has none, so the BALANCE is their only feedback and a bonus that
+    is merely "coming" is indistinguishable from one that never happened. Reported exactly that way.
+    """
     _, _, code = await _ready_referrer(c, monkeypatch)
     bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
-    assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is not None
+    before = (await c.get("/billing", headers=_h(bob_token))).json()["balance_micro"]
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", cents=1000, fingerprint="fp_bob")
+    s = get_settings()
+    after = (await c.get("/billing", headers=_h(bob_token))).json()["balance_micro"]
+    assert after == before + 10_000_000 + s.referral_referred_micro, "top-up AND bonus, immediately"
+    assert [b.amount_micro for b in await _blocks(bob_org, "referral")] == [s.referral_referred_micro]
+
+
+async def test_the_referrer_still_waits_out_the_hold(c, monkeypatch):
+    """Only the referee's half goes early. Nothing about the referrer's experience needs it sooner,
+    and the hold is the only clawback window there is."""
+    ann_org, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
     await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
-    assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is None
+    assert await _blocks(ann_org, "referral") == [], "the referrer is not paid on qualification"
+    await _age_qualification()
+    async with session_maker() as db:
+        assert await referrals.sweep(db) == 1
+    s = get_settings()
+    assert [b.amount_micro for b in await _blocks(ann_org, "referral")] == [s.referral_referrer_micro]
+
+
+async def test_the_sweep_does_not_pay_the_referee_a_second_time(c, monkeypatch):
+    """`_pay` still has a referee branch as a fallback for a failed instant grant, so it must be
+    guarded on `referred_block_id` — unguarded it would hand out a second bonus a week later."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+    await _age_qualification()
+    async with session_maker() as db:
+        await referrals.sweep(db)
+    s = get_settings()
+    assert [b.amount_micro for b in await _blocks(bob_org, "referral")] == [s.referral_referred_micro]
+
+
+async def test_the_offer_says_when_each_side_is_paid(c, monkeypatch):
+    """"We'll add $5" with no timing is what made a correct payout look like a failure."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    _, bob_token = await _signup(c, "bob@example.com", ref=code)
+    offer = (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"]
+    assert offer["hold_days"] == get_settings().referral_hold_days
 
 
 async def test_the_advertised_minimum_is_the_one_qualify_enforces(c, monkeypatch):

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -449,7 +449,8 @@ async def test_a_referred_team_is_told_the_minimum_on_its_billing_page(c, monkey
     s = get_settings()
     assert offer == {"referred_micro": s.referral_referred_micro,
                      "referrer_micro": s.referral_referrer_micro,
-                     "min_topup_micro": s.referral_min_topup_micro}
+                     "min_topup_micro": s.referral_min_topup_micro,
+                     "referrer_masked": "a•••@superdesign.dev"}
 
 
 async def test_a_team_that_arrived_on_its_own_sees_no_offer(c, monkeypatch):
@@ -479,3 +480,25 @@ async def test_the_advertised_minimum_is_the_one_qualify_enforces(c, monkeypatch
     await _topup(c, monkeypatch, bob_org, pi="pi_bob", cents=cents, fingerprint="fp_bob")
     rows = await _referral_rows()
     assert rows[0].status == "qualified", "the advertised minimum must actually qualify"
+
+
+def test_the_referrer_is_named_but_never_in_full():
+    """A referral link is PUBLIC: an influencer posts theirs, and printing the full address would
+    publish their email to every stranger who signs up through it — a harvestable list at exactly the
+    volume this program is built to produce. The domain survives because that is what makes a real
+    friend recognisable; the local part collapses to one character plus a FIXED bullet run, so the
+    mask does not leak its own length."""
+    assert referrals.mask_email("jason@superdesign.dev") == "j•••@superdesign.dev"
+    assert referrals.mask_email("jz@superdesign.dev") == "j•••@superdesign.dev", "length must not leak"
+    assert referrals.mask_email("notanemail") == ""
+    assert referrals.mask_email("") == ""
+
+
+async def test_the_referee_never_receives_the_referrers_real_address(c, monkeypatch):
+    """The whole point of the mask. Asserted on the wire, not on the helper, because the leak that
+    matters is the one that ships in a response body."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    _, bob_token = await _signup(c, "bob@example.com", ref=code)
+    body = (await c.get("/billing", headers=_h(bob_token))).text
+    assert "ann@superdesign.dev" not in body
+    assert "a•••@superdesign.dev" in body

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -4,7 +4,8 @@ the ways it can be made to hand out money it shouldn't.
 Covered: the whole loop (link → cookie → signup → top-up → hold → both grants); that NOTHING is
 granted before the hold elapses and exactly one grant lands after, however many times the sweep
 runs; every abuse gate (self-referral, a signup with no top-up, a top-up below the minimum, a second
-top-up, one card claiming twice, a referrer who never paid us, the lifetime cap); the dispute
+top-up, one card claiming twice, the lifetime cap) — and that a FREE-TIER referrer is still
+paid, which is the gate we deliberately removed; the dispute
 clawback and its deliberate limit; and that one user can never see another's referrals — the single
 failure here that leaks data rather than money.
 
@@ -136,7 +137,9 @@ async def _blocks(org_id: int, kind: str) -> list[CreditBlock]:
 
 
 async def _ready_referrer(c: AsyncClient, monkeypatch, email="ann@superdesign.dev") -> tuple[int, str, str]:
-    """A referrer who has paid us once (so they are eligible) and holds a code."""
+    """A referrer holding a code. Also tops up — not because referring requires it (it does not,
+    see test_a_free_tier_referrer_still_earns), but so these tests exercise the ordinary case where
+    the referrer is also a paying team."""
     org_id, token = await _signup(c, email)
     await _topup(c, monkeypatch, org_id, pi="pi_referrer_seed", cents=2000, fingerprint="fp_referrer")
     r = await c.post("/referrals/code", headers=_h(token))
@@ -280,15 +283,26 @@ async def test_one_card_can_only_ever_claim_once(c, monkeypatch):
     assert rows[1].status == "rejected" and rows[1].reject_reason == "card_already_used"
 
 
-async def test_referrer_who_never_paid_us_earns_nothing(c, monkeypatch):
-    """Stops a throwaway account from being a referral source: a genuine referrer is already a
-    customer, so this costs them nothing."""
-    _, token = await _signup(c, "ann@superdesign.dev")
+async def test_a_free_tier_referrer_still_earns(c, monkeypatch):
+    """A referrer who has NEVER topped up is paid in full — deliberately.
+
+    There used to be a gate requiring the referrer to have paid us once. It was removed: a top-up is
+    not a cost to a self-dealer (it converts into credit they keep), so requiring one of the referrer
+    too only added a step that returns its own money — about one extra card per twenty referrals.
+    Against that it hid the link from every free-tier user, who on a product pitched as "$1.00 free,
+    no card" are most users and the likeliest to tell a friend. The card fingerprint is the gate with
+    teeth; this one cost ~90% of legitimate referrers to tax a farm ~5%."""
+    ann_org, token = await _signup(c, "ann@superdesign.dev")
     code = (await c.post("/referrals/code", headers=_h(token))).json()["code"]
     bob_org, _ = await _signup(c, "bob@example.com", ref=code)
     await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
     rows = await _referral_rows()
-    assert rows[0].status == "rejected" and rows[0].reject_reason == "referrer_never_topped_up"
+    assert rows[0].status == "qualified", "a free-tier referrer must still qualify"
+    await _age_qualification()
+    async with session_maker() as db:
+        await referrals.sweep(db)
+    s = get_settings()
+    assert [b.amount_micro for b in await _blocks(ann_org, "referral")] == [s.referral_referrer_micro]
 
 
 async def test_second_topup_does_not_qualify_again(c, monkeypatch):
@@ -386,13 +400,14 @@ async def test_referrals_page_requires_a_signed_in_person(c):
     assert (await c.post("/referrals/code")).status_code == 401
 
 
-async def test_eligibility_flips_only_after_the_referrer_pays(c, monkeypatch):
-    """The UI hides the link behind this flag, so a referrer is told to add funds rather than
-    silently earning nothing."""
-    org_id, token = await _signup(c, "ann@superdesign.dev")
-    assert (await c.get("/referrals", headers=_h(token))).json()["eligible"] is False
-    await _topup(c, monkeypatch, org_id, pi="pi_ann", cents=2000, fingerprint="fp_ann")
-    assert (await c.get("/referrals", headers=_h(token))).json()["eligible"] is True
+async def test_a_brand_new_account_gets_a_working_link_immediately(c, monkeypatch):
+    """No payment, no waiting: someone who signed up a minute ago can share their link. This is the
+    whole point of removing the top-up gate — the free-tier user IS the referrer we want."""
+    _, token = await _signup(c, "ann@superdesign.dev")
+    body = (await c.get("/referrals", headers=_h(token))).json()
+    assert body["eligible"] is True
+    assert body["link"].endswith("?ref=" + body["code"]) and body["code"]
+    assert body["credit_org"] is not None, "the reward needs somewhere to land"
 
 
 async def test_admin_report_totals_pending_before_it_is_spent(c, monkeypatch):

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -437,3 +437,45 @@ async def test_admin_report_totals_pending_before_it_is_spent(c, monkeypatch):
 async def test_admin_report_is_superadmin_only(c, monkeypatch):
     _, token, _ = await _ready_referrer(c, monkeypatch)
     assert (await c.get("/admin/referrals", headers=_h(token))).status_code == 403
+
+
+# ---- the referee's side: telling them the bonus exists -----------------------------------------
+async def test_a_referred_team_is_told_the_minimum_on_its_billing_page(c, monkeypatch):
+    """The referee does not know a bonus exists, and the FIRST top-up preset ($5) is below the
+    minimum — so without this the most-clicked button silently forfeits the reward."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    _, bob_token = await _signup(c, "bob@example.com", ref=code)
+    offer = (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"]
+    s = get_settings()
+    assert offer == {"referred_micro": s.referral_referred_micro,
+                     "referrer_micro": s.referral_referrer_micro,
+                     "min_topup_micro": s.referral_min_topup_micro}
+
+
+async def test_a_team_that_arrived_on_its_own_sees_no_offer(c, monkeypatch):
+    """Null, not a zeroed object: the billing page must look exactly as it did before this shipped
+    for the teams that were never referred."""
+    _, token = await _signup(c, "solo@example.com")
+    assert (await c.get("/billing", headers=_h(token))).json()["referral_offer"] is None
+
+
+async def test_the_offer_disappears_once_it_has_been_taken(c, monkeypatch):
+    """Only while `pending`. After qualifying the money is already on its way through the sweep, and
+    still advertising it would read as a second bonus."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
+    assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is not None
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+    assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is None
+
+
+async def test_the_advertised_minimum_is_the_one_qualify_enforces(c, monkeypatch):
+    """The offer and the gate read the same setting. If they ever diverge we would be promising a
+    bonus at an amount that does not earn one — the worst possible bug on this screen."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
+    offer = (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"]
+    cents = int(offer["min_topup_micro"] // 10_000)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", cents=cents, fingerprint="fp_bob")
+    rows = await _referral_rows()
+    assert rows[0].status == "qualified", "the advertised minimum must actually qualify"

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -261,13 +261,37 @@ async def test_self_referral_is_never_attributed(c, monkeypatch):
     assert await _referral_rows() == []
 
 
-async def test_topup_below_the_minimum_earns_nothing(c, monkeypatch):
-    """Below the minimum, buying your own bonus with your own card would turn a profit."""
+async def test_a_short_topup_leaves_the_referral_alive(c, monkeypatch):
+    """$5 is the FIRST preset on the billing page. Treating a short payment as a refusal meant the
+    most obvious button silently destroyed the reward forever — punishing the exact person we are
+    trying to convert, and removing their reason to add the rest. It stays pending."""
     _, _, code = await _ready_referrer(c, monkeypatch)
-    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
     await _topup(c, monkeypatch, bob_org, pi="pi_bob_small", cents=500, fingerprint="fp_bob")
     rows = await _referral_rows()
-    assert rows[0].status == "rejected" and rows[0].reject_reason == "topup_below_minimum"
+    assert rows[0].status == "pending" and rows[0].reject_reason == ""
+    # ...and the offer is still on screen, now asking only for the remainder.
+    offer = (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"]
+    assert offer["topped_up_micro"] == 5_000_000
+    assert offer["remaining_micro"] == get_settings().referral_min_topup_micro - 5_000_000
+
+
+async def test_the_threshold_is_cumulative(c, monkeypatch):
+    """$5 twice is the same $10 as $10 once. The money still has to arrive, so this costs nothing in
+    abuse terms — it only stops us punishing someone for paying in two goes."""
+    ann_org, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", cents=500, fingerprint="fp_bob")
+    assert (await _referral_rows())[0].status == "pending"
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_2", cents=500, fingerprint="fp_bob")
+    assert (await _referral_rows())[0].status == "qualified"
+    # The offer is gone now that it has been taken, and the bonus really lands.
+    assert (await c.get("/billing", headers=_h(bob_token))).json()["referral_offer"] is None
+    await _age_qualification()
+    async with session_maker() as db:
+        assert await referrals.sweep(db) == 1
+    s = get_settings()
+    assert [b.amount_micro for b in await _blocks(ann_org, "referral")] == [s.referral_referrer_micro]
 
 
 async def test_one_card_can_only_ever_claim_once(c, monkeypatch):
@@ -305,14 +329,17 @@ async def test_a_free_tier_referrer_still_earns(c, monkeypatch):
     assert [b.amount_micro for b in await _blocks(ann_org, "referral")] == [s.referral_referrer_micro]
 
 
-async def test_second_topup_does_not_qualify_again(c, monkeypatch):
-    """The bounty is for arriving, not for paying twice."""
+async def test_a_later_topup_cannot_earn_a_second_bounty(c, monkeypatch):
+    """`pending` is the once-only guard: `qualify` only ever selects a pending row, so once a
+    referral has been taken no further payment can re-earn it. That is what replaced the old
+    "must be the first purchase" rule, which existed for this and cost us the short-payment case."""
     _, _, code = await _ready_referrer(c, monkeypatch)
     bob_org, _ = await _signup(c, "bob@example.com", ref=code)
     await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", fingerprint="fp_bob")
-    await _topup(c, monkeypatch, bob_org, pi="pi_bob_2", fingerprint="fp_bob")
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_2", cents=5000, fingerprint="fp_bob")
     rows = await _referral_rows()
     assert len(rows) == 1 and rows[0].status == "qualified"
+    assert rows[0].qualifying_payment_intent == "pi_bob_1", "the first crossing is the one recorded"
 
 
 async def test_an_org_can_only_be_referred_once(c, monkeypatch):
@@ -450,6 +477,8 @@ async def test_a_referred_team_is_told_the_minimum_on_its_billing_page(c, monkey
     assert offer == {"referred_micro": s.referral_referred_micro,
                      "referrer_micro": s.referral_referrer_micro,
                      "min_topup_micro": s.referral_min_topup_micro,
+                     "topped_up_micro": 0,
+                     "remaining_micro": s.referral_min_topup_micro,
                      "referrer_masked": "a•••@superdesign.dev"}
 
 

--- a/tests/test_referrals.py
+++ b/tests/test_referrals.py
@@ -1,0 +1,424 @@
+"""The referral program — a door that hands out money to strangers, so these tests are mostly about
+the ways it can be made to hand out money it shouldn't.
+
+Covered: the whole loop (link → cookie → signup → top-up → hold → both grants); that NOTHING is
+granted before the hold elapses and exactly one grant lands after, however many times the sweep
+runs; every abuse gate (self-referral, a signup with no top-up, a top-up below the minimum, a second
+top-up, one card claiming twice, a referrer who never paid us, the lifetime cap); the dispute
+clawback and its deliberate limit; and that one user can never see another's referrals — the single
+failure here that leaks data rather than money.
+
+Stripe is faked exactly as in test_billing.py: `billing._sdk` is the one funnel, and webhook payloads
+are signed with the real HMAC scheme so the signature path is exercised rather than stubbed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
+
+from conftest import make_upstream
+
+from treg import billing, ledger, referrals
+from treg.api import app
+from treg.config import get_settings
+from treg.db import reset_db, session_maker
+from treg.models import CreditBlock, Org, Referral, User
+
+WHSEC = "whsec_referral_suite"
+
+
+def _h(token: str) -> dict:
+    return {"X-Treg-Token": token}
+
+
+@pytest.fixture
+async def c(monkeypatch):
+    await reset_db()
+    s = get_settings()
+    monkeypatch.setattr(s, "stripe_secret_key", "sk_test_suite", raising=False)
+    monkeypatch.setattr(s, "stripe_webhook_secret", WHSEC, raising=False)
+    billing._locks.clear()
+    billing._scheduled.clear()
+    app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as client:
+        yield client
+    await app.state.http.aclose()
+
+
+# ---- helpers -----------------------------------------------------------------------------------
+def _ref_cookie(code: str) -> dict:
+    """The parked referral code, as a request header. httpx deprecates per-request `cookies=`, and a
+    raw Cookie header is also closer to what a browser actually sends."""
+    return {"Cookie": f"{referrals_cookie()}={code}"}
+
+
+async def _signup(c: AsyncClient, email: str, *, ref: str = "") -> tuple[int, str]:
+    """Register a user (and their first team), optionally carrying a referral cookie."""
+    r = await c.post("/users", json={"email": email}, headers=_ref_cookie(ref) if ref else None)
+    assert r.status_code == 200, r.text
+    return r.json()["org_id"], r.json()["token"]
+
+
+def referrals_cookie() -> str:
+    from treg.api import REFERRAL_COOKIE
+    return REFERRAL_COOKIE
+
+
+def _sign(payload: bytes) -> str:
+    t = int(time.time())
+    mac = hmac.new(WHSEC.encode(), f"{t}.".encode() + payload, hashlib.sha256).hexdigest()
+    return f"t={t},v1={mac}"
+
+
+async def _deliver(c: AsyncClient, event: dict):
+    payload = json.dumps(event).encode()
+    return await c.post("/billing/stripe/webhook", content=payload,
+                        headers={"stripe-signature": _sign(payload), "content-type": "application/json"})
+
+
+def _checkout_event(org_id: int, *, pi: str, cents: int = 1000) -> dict:
+    """A `checkout.session.completed` — the door a FIRST top-up always comes through (auto-top-up
+    needs a card saved by an earlier manual one), and the only one that carries a fingerprint."""
+    return {"id": f"evt_{pi}", "type": "checkout.session.completed", "data": {"object": {
+        "id": f"cs_{pi}", "object": "checkout.session", "mode": "payment", "payment_status": "paid",
+        "amount_total": cents, "currency": "usd", "payment_intent": pi,
+        "metadata": {"treg_org_id": str(org_id), "treg_kind": "topup"}}}}
+
+
+def _fake_sdk(fingerprint: str | None = "fp_card_A"):
+    """Stands in for every Stripe SDK call. The PaymentIntent retrieve is the only one that matters
+    here: `_pm_and_fingerprint` expands `payment_method`, so the fake returns the expanded shape."""
+    async def sdk(fn, **kw):
+        return {"id": kw.get("id", "pi_x"), "object": "payment_intent",
+                "payment_method": {"id": "pm_1", "object": "payment_method",
+                                   "card": {"fingerprint": fingerprint} if fingerprint else {}}}
+    return sdk
+
+
+async def _topup(c: AsyncClient, monkeypatch, org_id: int, *, pi: str, cents: int = 1000,
+                 fingerprint: str | None = "fp_card_A"):
+    monkeypatch.setattr(billing, "_sdk", _fake_sdk(fingerprint))
+    r = await _deliver(c, _checkout_event(org_id, pi=pi, cents=cents))
+    assert r.status_code == 200, r.text
+    return r
+
+
+async def _referral_rows() -> list[Referral]:
+    async with session_maker() as db:
+        return list((await db.execute(select(Referral))).scalars().all())
+
+
+async def _age_qualification(days: int = 30) -> None:
+    """Backdate every qualified referral so its hold has elapsed. There is no clock to advance and
+    no scheduler to run — the hold is `qualified_at` plus a config window, so this is the whole of
+    'wait a week'."""
+    async with session_maker() as db:
+        for row in (await db.execute(select(Referral))).scalars().all():
+            if row.qualified_at:
+                row.qualified_at = row.qualified_at - timedelta(days=days)
+                db.add(row)
+        await db.commit()
+
+
+async def _blocks(org_id: int, kind: str) -> list[CreditBlock]:
+    async with session_maker() as db:
+        return list((await db.execute(
+            select(CreditBlock).where(CreditBlock.org_id == org_id, CreditBlock.kind == kind)
+        )).scalars().all())
+
+
+async def _ready_referrer(c: AsyncClient, monkeypatch, email="ann@superdesign.dev") -> tuple[int, str, str]:
+    """A referrer who has paid us once (so they are eligible) and holds a code."""
+    org_id, token = await _signup(c, email)
+    await _topup(c, monkeypatch, org_id, pi="pi_referrer_seed", cents=2000, fingerprint="fp_referrer")
+    r = await c.post("/referrals/code", headers=_h(token))
+    assert r.status_code == 200, r.text
+    return org_id, token, r.json()["code"]
+
+
+# ---- the link ----------------------------------------------------------------------------------
+async def test_ref_link_serves_the_landing_and_parks_the_code(c):
+    """`/?ref=CODE` must show the PITCH. It used to fall through to the SPA, because the landing
+    route treats any query string as the dashboard's — which would send a stranger who clicked a
+    friend's link to an empty app shell."""
+    r = await c.get("/?ref=ann-ab3cd")
+    assert r.status_code == 200
+    assert "<!doctype html" in r.text[:200].lower() or "<html" in r.text[:200].lower()
+    assert r.cookies.get(referrals_cookie()) == "ann-ab3cd"
+
+
+async def test_junk_ref_is_dropped_not_stored(c):
+    """The code reaches a database query, so it is validated on the way in AND on the way out."""
+    r = await c.get("/?ref=" + "../../etc/passwd")
+    assert r.status_code == 200
+    assert r.cookies.get(referrals_cookie()) is None
+
+
+async def test_other_query_params_still_belong_to_the_spa(c):
+    """A referral code must not hijack an invite link or an OAuth return."""
+    r = await c.get("/?ref=ann-ab3cd&invite=xyz")
+    assert r.status_code == 200
+    assert r.cookies.get(referrals_cookie()) is None
+
+
+async def test_code_is_minted_once_and_is_stable(c, monkeypatch):
+    _, token = await _signup(c, "ann@superdesign.dev")
+    first = (await c.post("/referrals/code", headers=_h(token))).json()["code"]
+    second = (await c.post("/referrals/code", headers=_h(token))).json()["code"]
+    assert first == second
+    assert referrals.normalize_code(first) == first
+    assert first.startswith("ann-")
+
+
+# ---- the happy path ----------------------------------------------------------------------------
+async def test_full_loop_pays_both_sides_after_the_hold(c, monkeypatch):
+    ann_org, ann_token, code = await _ready_referrer(c, monkeypatch)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
+
+    rows = await _referral_rows()
+    assert [r.status for r in rows] == ["pending"], "signup alone must owe nothing"
+
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", cents=1000, fingerprint="fp_bob")
+    rows = await _referral_rows()
+    assert rows[0].status == "qualified"
+    # NOTHING has been granted yet — the hold is the only clawback window that exists.
+    assert await _blocks(bob_org, "referral") == []
+    assert await _blocks(ann_org, "referral") == []
+
+    await _age_qualification()
+    r = await c.get("/referrals", headers=_h(ann_token))
+    assert r.status_code == 200
+    body = r.json()
+
+    s = get_settings()
+    bob_blocks = await _blocks(bob_org, "referral")
+    ann_blocks = await _blocks(ann_org, "referral")
+    assert [b.amount_micro for b in bob_blocks] == [s.referral_referred_micro]
+    assert [b.amount_micro for b in ann_blocks] == [s.referral_referrer_micro]
+    assert body["totals"]["earned_micro"] == s.referral_referrer_micro
+    assert body["referrals"][0]["status"] == "paid"
+    assert body["referrals"][0]["email"] == "bob@example.com"
+
+
+async def test_sweeping_twice_pays_once(c, monkeypatch):
+    """The sweep runs from every top-up AND every page load, so it is called far more often than
+    there is work. Paying twice would be the most expensive bug in the feature."""
+    ann_org, ann_token, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", fingerprint="fp_bob")
+    await _age_qualification()
+
+    async with session_maker() as db:
+        assert await referrals.sweep(db) == 1
+        assert await referrals.sweep(db) == 0
+        assert await referrals.sweep(db) == 0
+    await c.get("/referrals", headers=_h(ann_token))
+
+    assert len(await _blocks(ann_org, "referral")) == 1
+    assert len(await _blocks(bob_org, "referral")) == 1
+
+
+async def test_referral_credit_burns_before_purchased(c, monkeypatch):
+    """Referral credit is a marketing expense we can never be asked to return; purchased credit is a
+    refundable liability. Spending ours first is what keeps the disputable pool small — and an
+    unrecognised block kind would sort LAST, i.e. exactly backwards."""
+    ann_org, ann_token, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", fingerprint="fp_bob")
+    await _age_qualification()
+    # Spend $2: more than the $1 signup promo (which also sorts at 0 and is older, so it goes
+    # first), and enough to bite into the referral block — while staying well under the $10
+    # purchased block, which must not be touched at all.
+    async with session_maker() as db:
+        await referrals.sweep(db)
+        call_id = await ledger.reserve(db, bob_org, "e/1", 2_000_000)
+        await ledger.settle(db, call_id, 2_000_000)
+        blocks = {b.kind: b for b in (await db.execute(
+            select(CreditBlock).where(CreditBlock.org_id == bob_org))).scalars().all()}
+    assert blocks["promotional"].remaining_micro == 0, "the older zero-rank block goes first"
+    assert blocks["referral"].remaining_micro < blocks["referral"].amount_micro, "referral spent next"
+    assert blocks["purchased"].remaining_micro == blocks["purchased"].amount_micro, "purchased untouched"
+
+
+# ---- the abuse gates ---------------------------------------------------------------------------
+async def test_self_referral_is_never_attributed(c, monkeypatch):
+    """The cheapest attack and the most common attempt: refer yourself with a second team."""
+    _, ann_token, code = await _ready_referrer(c, monkeypatch)
+    r = await c.post("/orgs", json={"name": "Ann Second Team"},
+                     headers={**_h(ann_token), **_ref_cookie(code)})
+    assert r.status_code == 200, r.text
+    assert await _referral_rows() == []
+
+
+async def test_topup_below_the_minimum_earns_nothing(c, monkeypatch):
+    """Below the minimum, buying your own bonus with your own card would turn a profit."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_small", cents=500, fingerprint="fp_bob")
+    rows = await _referral_rows()
+    assert rows[0].status == "rejected" and rows[0].reject_reason == "topup_below_minimum"
+
+
+async def test_one_card_can_only_ever_claim_once(c, monkeypatch):
+    """An email address is free; a card is not. The fingerprint is the signal that survives a farm
+    of fresh addresses, so it is the gate that has to hold."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    cat_org, _ = await _signup(c, "cat@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_same_card")
+    await _topup(c, monkeypatch, cat_org, pi="pi_cat", fingerprint="fp_same_card")
+    rows = sorted(await _referral_rows(), key=lambda r: r.id)
+    assert rows[0].status == "qualified"
+    assert rows[1].status == "rejected" and rows[1].reject_reason == "card_already_used"
+
+
+async def test_referrer_who_never_paid_us_earns_nothing(c, monkeypatch):
+    """Stops a throwaway account from being a referral source: a genuine referrer is already a
+    customer, so this costs them nothing."""
+    _, token = await _signup(c, "ann@superdesign.dev")
+    code = (await c.post("/referrals/code", headers=_h(token))).json()["code"]
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+    rows = await _referral_rows()
+    assert rows[0].status == "rejected" and rows[0].reject_reason == "referrer_never_topped_up"
+
+
+async def test_second_topup_does_not_qualify_again(c, monkeypatch):
+    """The bounty is for arriving, not for paying twice."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_1", fingerprint="fp_bob")
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob_2", fingerprint="fp_bob")
+    rows = await _referral_rows()
+    assert len(rows) == 1 and rows[0].status == "qualified"
+
+
+async def test_an_org_can_only_be_referred_once(c, monkeypatch):
+    """The unique constraint, not `grant(once=True)`, is what arbitrates — so a second attribution
+    attempt against the same org must lose."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    _, _, dee_code = await _ready_referrer(c, monkeypatch, email="dee@superdesign.dev")
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    async with session_maker() as db:
+        bob = (await db.execute(select(User).where(User.email == "bob@example.com"))).scalars().one()
+        again = await referrals.attribute(
+            db, user=bob, org=await db.get(Org, bob_org), code=dee_code)
+    assert again is None, "the first code keeps the org"
+    rows = await _referral_rows()
+    assert len(rows) == 1 and rows[0].code == code
+
+
+async def test_lifetime_cap_records_but_does_not_pay(c, monkeypatch):
+    """At the cap the answer is `capped`, not `rejected`: this person referred someone real and
+    simply ran out of self-serve allowance. That distinction is what the support reply rests on."""
+    monkeypatch.setattr(get_settings(), "referral_cap", 1, raising=False)
+    _, ann_token, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    cat_org, _ = await _signup(c, "cat@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+    await _topup(c, monkeypatch, cat_org, pi="pi_cat", fingerprint="fp_cat")
+    rows = sorted(await _referral_rows(), key=lambda r: r.id)
+    assert rows[0].status == "qualified"
+    assert rows[1].status == "capped" and rows[1].reject_reason == "referrer_at_cap"
+    await _age_qualification()
+    async with session_maker() as db:
+        await referrals.sweep(db)
+    assert await _blocks(cat_org, "referral") == [], "a capped referral pays nobody"
+
+
+# ---- clawback ----------------------------------------------------------------------------------
+async def test_dispute_inside_the_hold_cancels_the_payout(c, monkeypatch):
+    ann_org, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+
+    r = await _deliver(c, {"id": "evt_d1", "type": "charge.dispute.created", "data": {"object": {
+        "id": "dp_1", "object": "dispute", "payment_intent": "pi_bob"}}})
+    assert r.status_code == 200 and r.json()["referrals_cancelled"] == 1
+
+    await _age_qualification()
+    async with session_maker() as db:
+        assert await referrals.sweep(db) == 0
+    assert await _blocks(ann_org, "referral") == []
+    assert await _blocks(bob_org, "referral") == []
+
+
+async def test_dispute_does_not_touch_the_balance(c, monkeypatch):
+    """The clawback cancels a BONUS, never a top-up. treg has no path that drives a balance
+    negative, and refunding a payment is a human decision — that boundary is deliberate."""
+    _, _, code = await _ready_referrer(c, monkeypatch)
+    bob_org, bob_token = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+    async with session_maker() as db:
+        before = await ledger.balance_of(db, bob_org)
+    await _deliver(c, {"id": "evt_d1", "type": "charge.refunded", "data": {"object": {
+        "id": "ch_1", "object": "charge", "payment_intent": "pi_bob"}}})
+    async with session_maker() as db:
+        assert await ledger.balance_of(db, bob_org) == before
+
+
+# ---- the read model ----------------------------------------------------------------------------
+async def test_a_user_never_sees_another_users_referrals(c, monkeypatch):
+    """This response carries the referred person's email address, so a scoping mistake leaks another
+    user's data rather than merely miscounting. The one bug here worse than losing money."""
+    _, ann_token, code = await _ready_referrer(c, monkeypatch)
+    _, dee_token, _ = await _ready_referrer(c, monkeypatch, email="dee@superdesign.dev")
+    bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+    await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+
+    ann = (await c.get("/referrals", headers=_h(ann_token))).json()
+    dee = (await c.get("/referrals", headers=_h(dee_token))).json()
+    assert [r["email"] for r in ann["referrals"]] == ["bob@example.com"]
+    assert dee["referrals"] == []
+    assert dee["totals"]["signed_up"] == 0
+
+
+async def test_referrals_page_requires_a_signed_in_person(c):
+    assert (await c.get("/referrals")).status_code == 401
+    assert (await c.post("/referrals/code")).status_code == 401
+
+
+async def test_eligibility_flips_only_after_the_referrer_pays(c, monkeypatch):
+    """The UI hides the link behind this flag, so a referrer is told to add funds rather than
+    silently earning nothing."""
+    org_id, token = await _signup(c, "ann@superdesign.dev")
+    assert (await c.get("/referrals", headers=_h(token))).json()["eligible"] is False
+    await _topup(c, monkeypatch, org_id, pi="pi_ann", cents=2000, fingerprint="fp_ann")
+    assert (await c.get("/referrals", headers=_h(token))).json()["eligible"] is True
+
+
+async def test_admin_report_totals_pending_before_it_is_spent(c, monkeypatch):
+    """`pending_payout_micro` is what the sweep will grant once holds elapse — the number that says
+    whether the program is affordable BEFORE the money leaves."""
+    monkeypatch.setenv("TREG_ADMIN_TOKEN", "adm_referrals")
+    get_settings.cache_clear()
+    # cache_clear() builds a NEW Settings, so the fixture's Stripe patches (applied to the old
+    # instance) are gone with it — and every webhook below would 400 on the signature check.
+    s = get_settings()
+    monkeypatch.setattr(s, "stripe_secret_key", "sk_test_suite", raising=False)
+    monkeypatch.setattr(s, "stripe_webhook_secret", WHSEC, raising=False)
+    try:
+        _, _, code = await _ready_referrer(c, monkeypatch)
+        bob_org, _ = await _signup(c, "bob@example.com", ref=code)
+        await _topup(c, monkeypatch, bob_org, pi="pi_bob", fingerprint="fp_bob")
+        r = await c.get("/admin/referrals", headers={"X-Treg-Token": "adm_referrals"})
+        assert r.status_code == 200, r.text
+        s = get_settings()
+        assert r.json()["counts"] == {"qualified": 1}
+        assert r.json()["pending_payout_micro"] == s.referral_referrer_micro + s.referral_referred_micro
+        assert r.json()["paid_micro"] == 0
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_admin_report_is_superadmin_only(c, monkeypatch):
+    _, token, _ = await _ready_referrer(c, monkeypatch)
+    assert (await c.get("/admin/referrals", headers=_h(token))).status_code == 403


### PR DESCRIPTION
Both sides of a referral get **$5 in credit**. The friend's team qualifies once its top-ups reach **$10**; the referee is credited **immediately**, the referrer after a **7-day hold**.

Greenfield — `grep -i "referral|affiliate|payout"` returned nothing before this.

## Why flat, and why credit

`platform_margin` is `0.0`, and "we add no markup" is a public promise (terms §08, landing 04), so there is no gross margin on a catalog call to share. The only thing treg keeps is the gap between what a team tops up and what it consumes.

A percentage of top-ups would therefore be a permanent share of pass-through GMV — and it scales the reward with effort, which is the definition of a farmable incentive. Flat figures are budgetable as CAC and bounded by construction. Symmetric so the offer is one sentence and neither side feels short-changed.

We also evaluated **Dub Partners** and decided not to buy yet: at $90/mo + 5% payout fees, what it actually sells is payout rails and 1099/W-8 compliance, which is worth nothing until real cash moves. The credit side never leaves our system. This builds the attribution log; the payout rail stays swappable.

## How it works

- `/?ref=CODE` → landing page, code parked in a `treg_ref` cookie (httponly, lax, 30d), redeemed at first team creation.
- Qualifying event is a **paid top-up**, never a signup: `promo_grant_micro` is granted per org with no per-user org cap, so a signup bounty is a faucet pointed at itself.
- The threshold is **cumulative**. A short payment leaves the row `pending` and the billing page asks for the remainder.
- Referrals page for the referrer; a prompt on the **billing page** for the referee, naming the bonus on each qualifying preset.

## Money-path notes for review

`referrals.py` decides; `ledger.py` still moves. The only crossing is `ledger.grant`, mirroring `billing.py`'s `ledger.topup`.

- **Two UNIQUE constraints on `Referral` arbitrate a double payout, not `grant(once=True)`** — `once`'s check is a SELECT with no backing index, which survives a retry but not two concurrent redemptions, and this is money owed to a third party.
- **`_pay` claims before it grants**, so the loser of a race has not already paid. The mirror failure (crash between claim and grant) pays nobody and is visible in `/admin/referrals` as a paid row with a null block id — the right way round for money.
- **`referral` joins `promotional` at rank 0 in `_KIND_ORDER`.** An unrecognised kind sorts *last*, so without this the bonus would burn after money someone actually paid us.
- **`charge.dispute.created` / `charge.refunded`** are the first reversal events treg handles. They cancel a bonus still inside the hold and nothing else — anything already granted is logged for a human, never auto-reversed, because no path here may drive a balance negative.

## Abuse model

The binding constraint on a farm is **cards, not accounts** — the card fingerprint (read via `expand=["payment_method"]` on a retrieve `_on_checkout_completed` already made) is the gate with teeth. Plus: cumulative minimum, no self-referral, and a 20-referral lifetime cap.

A "referrer must have topped up first" gate was built and then **removed**: a top-up is not a cost to a self-dealer (it converts into credit they keep), so it taxed a farm ~5% while hiding the link from every free-tier user. `money.md` records the reasoning, because it will be proposed again.

**Known gap, not built:** a platform-wide monthly payout budget. The cap is per-referrer and referrer accounts are free, so global exposure is bounded only by an attacker's card supply. Worth having before any public push.

## Privacy

The Referrals page shows referred users' **full** emails (the referrer has no other way to tell which invitations converted). The reverse direction is **masked** (`j•••@domain`) because a referral link is public and would otherwise publish an influencer's address to every stranger who clicks. `privacy.html` and `terms.html` §08 both updated; referral credit is never cash-redeemable.

## Testing

**1,757 pass**, ~50 new in `tests/test_referrals.py`. Verified end-to-end against **real Stripe** through a local `stripe listen`: a $10 top-up lands $16 immediately, $5 + $5 qualifies cumulatively, a dispute cancels the referrer's half. UI checked in a browser in light and dark, including the not-eligible, partial, and cap states.

## One unrelated fix, included to make CI green

`tests/test_oauth_billed.py::test_empty_balance_is_an_actionable_402` was failing — **confirmed failing on `origin/main` at the same commit**, verified in a clean worktree, so not introduced here. But it fails CI on this branch, and it is two lines.

It is live-affecting: `ledger.reserve` calls `db.rollback()` on `InsufficientBalance`, which expires every ORM object the session tracks — `tool` included — and the refusal-audit branch then read `tool.bindings`, raising `MissingGreenlet`. So an out-of-balance metered call returned a **500 instead of the actionable 402** an agent reads `balance_micro` and a top-up URL out of.

Fixed by computing the secret renderings before the reserve, while `tool` is still live — the same capture-early reasoning as `block_id` in `billing._credit`. The existing test already pinned the contract.

Happy to split this into its own PR if you would rather review it separately.
