### PR TITLE
fix(catalog): price X off its rate card — the catalog said free, the balance said otherwise

### DIFF
--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -117,8 +117,16 @@ module symbols:
   (`api.py` `_billed_marketplace` → the tier-4 reserve→settle path; [money](money.md)). Gated on the
   deploy opting in via `TREG_OAUTH_BILLED_PROVIDERS` (`config.oauth_billed_set` — empty means free,
   the kill-switch shape `platform_providers` uses). The rates here are the fallback for uncatalogued
-  routes; a priced `catalog/x.yaml` entry wins. `listing()` carries `metered` + `billed_rates` so the
-  dashboard can show the price BEFORE consent. A **BYO connect is never metered** — the callback
+  routes; a priced catalog entry wins — and since a `free` block has a falsy `usd`, "priced" has to be
+  read as *not free*, or a catalog that says $0 quietly bills the fallback instead. **Every X entry
+  therefore carries a real rate**, taken from X's per-resource-type rate card rather than one read
+  price and one write price (`x.yaml` curates five; `catalog_ingest.X_RATES` transcribes the card and
+  `X_ROUTE_RATES` maps the other 168 routes onto it), and `tests/test_marketplace_call.py` walks the
+  provider asserting the published number equals the reserved one. The `billed_*` fields here are the
+  fallback for a path no entry claims; **the $0.001 owned-read rate is deliberately not among them**,
+  since X grants it only to the app's own owner and a registry connect's member never is. `listing()` carries `metered` +
+  `billed_rates` so the dashboard can show the price BEFORE consent — and so the catalog's own price
+  display can stop calling a connected account free (`catMetered`, [dashboard](../interface/dashboard.md)). A **BYO connect is never metered** — the callback
   stamps `secret.provider` only in registry mode, and that attribution is the whole detection.
 - `auth_kind` = `"oauth"` (treg's app), `"token"` (Slack — a workspace-scoped bot the user creates and
   pastes; `is_token_kind`), or `"key"` (an **API-key provider** connected by pasting a key: Apollo, PDL,

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -72,6 +72,23 @@ does) gives us everything needed to generate a test request and make the call. W
 to core is the part a machine cannot do — mapping the endpoint to a capability, choosing the test
 target deliberately, and a full-fidelity example. See "bulk-verifying the extended tier" below.
 
+**An ingested price is a claim we will charge on, so a generated `free` is a bug, not a default.**
+`x.extended.yaml` shipped 168 routes priced `free` off a plan-tier model X had already abolished,
+while the proxy — which skips a `free` block, its `usd` being falsy — billed the provider fallback:
+the catalog published $0 and the balance moved $0.10. Where the upstream bills *treg* (an
+`oauth_billed` provider, [auth-secrets](auth-secrets.md)), the generator must therefore price every
+route it emits, and a test walks the provider asserting the published price equals the reserved one.
+
+The second half of that lesson cost a review round: **the fix for a blanket price is not a smaller
+blanket.** The first repair priced all 74 X writes at $0.015 — the post-creation rate — when X
+publishes a row per ACTION, and creating a list is $0.010, managing one $0.005, deleting an
+interaction $0.010. Read the rate card and transcribe it (`catalog_ingest.X_RATES` is the card,
+`X_ROUTE_RATES` the route→row mapping, and each entry's note names the row it was priced from);
+where the mapping is a judgement call, `confidence: inferred` says so and takes the dearer reading,
+because treg pays the difference. Watch for **conditional** rates in particular: X's $0.001 "owned
+read" applies only when the caller owns the developer app, which on a registry connect is treg —
+quoting it for our members under-billed the very calls we are charged the most for.
+
 Core wins on collision: `catalog_ingest.py` drops any `(method, path)` the provider's core file
 already curates, so an endpoint appears exactly once across both tiers. Promoting an extended entry
 means moving it into the core file and completing it (steps 3–8 below) — not editing it in place;

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -29,6 +29,13 @@ owner per use, so even a call on the org's *own* connection spends treg's prepai
 fail-closed daily cap, and are distinguished in ledger meta by `tier: platform` vs `tier: oauth`.
 An org's own key/credential on any *other* provider is never metered — there the org's account pays.
 
+On an oauth-billed provider a **`free` catalog price is a bug, never a fact**: the upstream charges us
+whatever the route costs, so a zero there means the entry is stale, not that the call is free. The
+estimator must fall through to the provider rate rather than reserve nothing — it used to rest on
+`0.0` being falsy, which read as both "no price recorded" and "the price is nothing", and let the
+catalog publish $0 while the balance lost the fallback. Whatever the catalog publishes for these
+providers is what the reserve takes, and a test walks the provider asserting the two agree.
+
 | Module | Job | May it write money? |
 |---|---|---|
 | `ledger.py` | the only code path that moves money | **yes — exclusively** |

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -425,9 +425,12 @@ platform without opening it, and every field comes off the `/catalog/platforms` 
   prices; it lives in the hover `title` now.
   A `price_from` that exists but publishes no number renders **nothing** — "from —" says less than
   silence. "From" is a **floor**, and an `oauth` integration among the platform's providers makes the
-  floor $0 (the account you connect is the licence): **any** OAuth provider ⇒ **"free with your
-  account"**, even when metered providers also serve the platform and publish a rate — Google Ads is
-  served by its own OAuth integration *and* by scrapers, and must not read "from $0.00188". The
+  floor $0 (the account you connect is the licence): **any** *unmetered* OAuth provider ⇒ **"free with
+  your account"**, even when metered providers also serve the platform and publish a rate — Google Ads is
+  served by its own OAuth integration *and* by scrapers, and must not read "from $0.00188". A
+  **`metered` provider is the exception, and it is not a special case so much as the same rule**: the
+  account you connect is the licence only where the licence is what you are paying for, and X bills
+  *treg's app* per use, so a connected X account changes who made the call and not who is billed. The
   metered rate moves into the tooltip ("without it, metered providers serve this from …"). A key-auth
   provider with no published rate stays silent. Note that `price_from` arrives as `null` *or* as an
   empty `{}`, and the empty object has to be normalised to null first — being truthy, it otherwise
@@ -549,7 +552,10 @@ The price column is the same unified USD as everywhere else (`capCheapest` → `
 muted `.cost-nat` suffix). Two things can never win "cheapest": an endpoint with no published rate, and a
 `quota_rows` price (a row quota is not a price, and "from —" would be worse than naming the cheapest rate
 we do know). A **connected** `own_account` or `free` row counts as **free** (`capFree`) — the OAuth account
-you already hold is the licence. When nothing is priced but a row carries a `cost.note`, the cell reads
+you already hold is the licence — **unless the provider is `metered`** (`catMetered`, from `/oauth/providers`),
+where the upstream bills treg's app per call and connecting changes nothing about the price. Reading the
+flag off the server rather than naming X here means the display follows `TREG_OAUTH_BILLED_PROVIDERS`:
+throw the kill switch and the rows go back to reading free, because they are. When nothing is priced but a row carries a `cost.note`, the cell reads
 **"see provider"** rather than an em-dash: the enrichment providers (Apollo, PDL, Hunter, Coresignal,
 Lusha, Diffbot…) bill in their own credits, so their price *is* documented, just not in dollars — and that
 is the whole People/Company half of the catalog.
@@ -637,7 +643,7 @@ shelves and their connect flow, the category heading being a real heading, the c
 (mark + name + category, the connected-state corner, the count/price footer — and NO summary
 paragraph, with the name wrapping instead of ellipsising), the
 unified-USD price rule (server `usd`, no local FX constant, native suffix, `{}`-normalisation,
-`quota_rows` excluded first) and its OAuth-only "free with your account" branch,
+`quota_rows` excluded first) and its unmetered-OAuth-only "free with your account" branch,
 the runnable green on all three of its surfaces, the stacked platform header, the always-both
 provider/endpoint counts, the credit-priced fallback ranking ahead of "price not published",
 the parameters block sitting before the example

--- a/scripts/catalog_ingest.py
+++ b/scripts/catalog_ingest.py
@@ -1514,6 +1514,140 @@ X_OWN = re.compile(
     r"|account_activity|webhooks|reverse_chronological)\b")
 
 
+# X PRICING IS PAY-PER-USE AND THE BILL LANDS ON TREG's APP, so an extended entry that says "free"
+# is not a cosmetic slip — it is a price we published and then charged against.
+#
+# X publishes a RATE CARD PER RESOURCE TYPE, not one read price and one write price
+# (docs.x.com/x-api/getting-started/pricing). Flattening it is how "create a list" ends up billed at
+# the post-creation rate — 50% over the real $0.010. The card is transcribed below verbatim so the
+# mapping can be audited against it line by line, and every route names the row it was priced from.
+#
+# OWNED READS ($0.001/resource) DO NOT APPLY TO US. The discount needs the authenticated user to be
+# "the owner of the developer app" — on a registry connect the app is treg's and the user is a
+# stranger to it, so a connected member reading their own timeline pays the ordinary Posts rate.
+# Pricing those routes at $0.001 would have under-billed the calls treg is charged the most for.
+X_PRICING_URL = "https://docs.x.com/x-api/getting-started/pricing"
+X_PRICE_CHECKED = "2026-08-18"
+
+# (value, cost type, unit) exactly as the card states it. Reads are per RESOURCE RETURNED; the
+# entries marked per_call are the card's own per-REQUEST rows (counts and trends sit in the write
+# table despite being GETs).
+X_RATES = {
+    "posts":       (0.005, "per_result", "post"),     # Posts: Read
+    "user":        (0.010, "per_result", "user"),     # User: Read / Following-Followers: Read
+    "dm_event":    (0.010, "per_result", "result"),   # DM Event: Read
+    "list":        (0.005, "per_result", "result"),   # List: Read
+    "space":       (0.005, "per_result", "result"),   # Space: Read
+    "community":   (0.005, "per_result", "result"),   # Community: Read
+    "note":        (0.005, "per_result", "result"),   # Note: Read
+    "like":        (0.001, "per_result", "result"),   # Like: Read
+    "mute":        (0.001, "per_result", "result"),   # Mute: Read
+    "block":       (0.001, "per_result", "result"),   # Block: Read
+    "counts_recent": (0.005, "per_call", "call"),     # Counts: Recent
+    "counts_all":  (0.010, "per_call", "call"),       # Counts: All
+    "trends":      (0.010, "per_call", "call"),       # Trends
+    "post_create": (0.015, "per_call", "call"),       # Post: Create ($0.200 with a URL)
+    "dm_create":   (0.015, "per_call", "call"),       # DM Interaction: Create
+    "interaction": (0.015, "per_call", "call"),       # User Interaction: Create
+    "int_delete":  (0.010, "per_call", "call"),       # Interaction: Delete
+    "content":     (0.005, "per_call", "call"),       # Content: Manage
+    "list_create": (0.010, "per_call", "call"),       # List: Create
+    "list_manage": (0.005, "per_call", "call"),       # List: Manage
+    "bookmark":    (0.005, "per_call", "call"),       # Bookmark
+    "media_meta":  (0.005, "per_call", "call"),       # Media Metadata
+    "privacy":     (0.010, "per_call", "call"),       # Privacy: Update
+    "mute_delete": (0.005, "per_call", "call"),       # Mute: Delete
+}
+# The rate a route earns when the card names no row for its resource (webhooks, subscriptions,
+# connections, stream rules, media upload, compliance jobs, analytics). It is the figure
+# `api._oauth_billed_estimate` falls back to, so the published price still equals the metered one —
+# `inferred` says we are quoting treg's fallback, not a rate X published.
+X_FALLBACK_READ, X_FALLBACK_WRITE = "posts", "post_create"
+
+# (methods, path regex, rate key, confidence). FIRST MATCH WINS, so the specific rows precede the
+# families they sit inside. `documented` means the card names this resource; `inferred` means the
+# route's resource type is a judgement call (a route returning the users who liked a post could be
+# read as User: Read or Like: Read — it takes the dearer reading, since treg pays the difference).
+X_ROUTE_RATES: list[tuple[str, str, str, str]] = [
+    # --- writes: the specific actions first -----------------------------------------------------
+    ("POST",            r"^/2/lists$",                              "list_create", "documented"),
+    ("PUT|DELETE",      r"^/2/lists/\{[^}]+\}$",                    "list_manage", "documented"),
+    ("POST|DELETE",     r"^/2/lists/\{[^}]+\}/members",             "list_manage", "documented"),
+    ("POST|DELETE",     r"/(followed_lists|pinned_lists)(/|$)",     "list_manage", "documented"),
+    ("POST|DELETE",     r"/bookmarks(/|$)",                         "bookmark",    "documented"),
+    ("POST|DELETE",     r"^/2/media/(metadata|subtitles)$",          "media_meta",  "documented"),
+    ("DELETE",          r"/muting/",                                "mute_delete", "documented"),
+    ("DELETE",          r"/(likes|retweets|following)/",            "int_delete",  "documented"),
+    ("POST",            r"/(likes|retweets|following|muting)$",     "interaction", "documented"),
+    ("POST",            r"^/2/users/\{[^}]+\}/dm/(un)?block$",       "privacy",     "inferred"),
+    ("POST",            r"^/2/dm_conversations(/|$)|^/2/chat/conversations/\{[^}]+\}/messages",
+                                                                    "dm_create",   "documented"),
+    ("POST",            r"^/2/chat/conversations",                  "dm_create",   "inferred"),
+    ("DELETE",          r"^/2/dm_events/",                          "int_delete",  "inferred"),
+    ("DELETE",          r"^/2/tweets/\{[^}]+\}$",                   "int_delete",  "inferred"),
+    ("PUT",             r"^/2/tweets/\{[^}]+\}/hidden$",            "content",     "documented"),
+    ("POST|DELETE",     r"^/2/(notes|articles|broadcasts)",          "content",     "inferred"),
+    # --- reads: per-resource rows ---------------------------------------------------------------
+    ("GET",             r"^/2/tweets/counts/recent$",               "counts_recent", "documented"),
+    ("GET",             r"^/2/tweets/counts/all$",                  "counts_all",  "documented"),
+    ("GET",             r"^/2/trends/",                             "trends",      "documented"),
+    ("GET",             r"^/2/users/personalized_trends$",          "trends",      "inferred"),
+    ("GET",             r"^/2/likes/",                              "like",        "documented"),
+    ("GET",             r"/muting$",                                "mute",        "documented"),
+    ("GET",             r"/blocking$",                              "block",       "documented"),
+    ("GET",             r"^/2/(dm_events|dm_conversations)|^/2/chat/conversations/\{[^}]+\}/events$",
+                                                                    "dm_event",    "documented"),
+    ("GET",             r"^/2/communities/",                        "community",   "documented"),
+    ("GET",             r"^/2/spaces(/|$)(?!.*\{[^}]+\}/(tweets|buyers))", "space", "documented"),
+    ("GET",             r"^/2/notes/search/",                       "note",        "documented"),
+    ("GET",             r"^/2/lists/\{[^}]+\}$",                    "list",        "documented"),
+    ("GET",             r"/(owned_lists|followed_lists|list_memberships|pinned_lists)$",
+                                                                    "list",        "documented"),
+    ("GET",             r"^/2/lists/\{[^}]+\}/(followers|members)$",  "user",        "inferred"),
+    ("GET",             r"/(followers|following)$",                 "user",        "documented"),
+    ("GET",             r"/(liking_users|retweeted_by|buyers|members|affiliates)$",
+                                                                    "user",        "inferred"),
+    ("GET",             r"^/2/users(/by|/search)?$|^/2/users/\{[^}]+\}$", "user",   "documented"),
+    ("GET",             r"^/2/tweets(/|$)(?!.*\b(analytics|label|compliance|webhooks|rules)\b)",
+                                                                    "posts",       "documented"),
+    ("GET",             r"/(liked_tweets|mentions|bookmarks|quote_tweets|retweets|reposts_of_me"
+                        r"|notes_written|posts_eligible_for_notes|reverse_chronological)$",
+                                                                    "posts",       "documented"),
+    ("GET",             r"^/2/(lists|spaces)/\{[^}]+\}/tweets$",     "posts",       "documented"),
+    ("GET",             r"^/2/news/",                               "note",        "inferred"),
+]
+_X_COMPILED = [(set(ms.split("|")), re.compile(rx), key, conf) for ms, rx, key, conf in X_ROUTE_RATES]
+
+
+def _x_cost(method: str, path: str, scope: str = "") -> dict:
+    """The rate `api._oauth_billed_estimate` will actually charge this route, written down.
+
+    Never returns `free`: nothing on X's v2 API is free to treg any more, and a `free` block here
+    both misleads the catalog reader and is skipped by the meter (its `usd` is 0, which is falsy),
+    so the two numbers silently disagree — the display says $0 and the balance says otherwise."""
+    key = conf = None
+    for methods, rx, k, c in _X_COMPILED:
+        if method in methods and rx.search(path):
+            key, conf = k, c
+            break
+    if key is None:
+        key = X_FALLBACK_READ if method == "GET" else X_FALLBACK_WRITE
+        conf = "inferred"
+    value, ctype, unit = X_RATES[key]
+    note = (f"X's rate card, {key.replace('_', ' ')}: ${value:g} "
+            f"{'per resource returned' if ctype == 'per_result' else 'per request'}")
+    if conf == "inferred":
+        note = (f"X publishes no rate for this route's resource, so treg meters it at ${value:g} "
+                f"{'per resource' if ctype == 'per_result' else 'per request'} — the same figure "
+                f"the proxy falls back to") if key in (X_FALLBACK_READ, X_FALLBACK_WRITE) else \
+               (f"{note}; which row applies is a judgement call, and this takes the dearer reading")
+    if key == "post_create" and conf == "documented":
+        note += " — $0.200 when the text carries a URL, which the proxy prices at the higher rate"
+    return {"type": ctype, "value": value, "currency": "USD", "per": 1, "unit": unit,
+            "source": "docs", "source_url": X_PRICING_URL, "checked": X_PRICE_CHECKED,
+            "confidence": conf, "note": note}
+
+
 def _x_scopes(op: dict) -> list[str]:
     for sec in op.get("security") or []:
         for name, scopes in sec.items():
@@ -1538,6 +1672,7 @@ def ingest_x(refresh: bool) -> tuple[Path, dict]:
             slug = re.sub(r"(?<!^)(?=[A-Z])", "-", opid).lower() if opid else \
                 re.sub(r"[^a-z0-9]+", "-", f"{method}-{path}".lower()).strip("-")
             summary = clean(op.get("summary") or "") or clean(op.get("description") or "") or opid
+            scope = "own_account" if (method != "GET" or X_OWN.search(path)) else "any_account"
             entry: dict = {
                 "id": f"{provider}.x.{re.sub(r'[^a-z0-9]+', '-', slug).strip('-')}",
                 "tier": "extended",
@@ -1545,9 +1680,8 @@ def ingest_x(refresh: bool) -> tuple[Path, dict]:
                 "method": method,
                 "path": path,
                 "summary": summary[:400],
-                "scope": "own_account" if (method != "GET" or X_OWN.search(path)) else "any_account",
-                "cost": {"type": "free", "value": 0.0, "currency": "USD",
-                         "note": "no per-call charge; consumed from the X API plan's monthly post cap"},
+                "scope": scope,
+                "cost": _x_cost(method, path, scope),
                 "docs_url": "https://docs.x.com/x-api",
             }
             needed = _x_scopes(op)
@@ -1589,9 +1723,17 @@ def ingest_x(refresh: bool) -> tuple[Path, dict]:
         "blocks, DMs and media upload each have their own scope. They are listed with `scope_gap:`",
         "rather than omitted, because that list IS the decision of which scopes to add to the app.",
         "",
-        "Beyond scopes, most v2 routes are gated by the ACCESS TIER of the X developer plan (Free",
-        "posts only; Basic/Pro unlock search and timelines) — the spec cannot express that, so a",
-        "listed route may still answer 403 on a Free project.",
+        "Beyond scopes, a route may still answer 403 on a project whose access the spec cannot",
+        "express — the OpenAPI document lists the whole surface, not what one app may reach.",
+        "",
+        "EVERY ENTRY IS PRICED, AND NONE OF THEM ARE FREE. X bills the APP OWNER per use (prepaid",
+        "credits, no plan tiers since Feb 2026), so a call on a registry connect spends treg's money",
+        "and is metered from the team balance. Reads are per resource RETURNED — posts $0.005, users",
+        "$0.010 — an own-account read is $0.001, and a write is $0.015 per request ($0.20 when a",
+        "post's text carries a URL). The rates are documented; which one a route earns is read off",
+        "the resource it returns, so routes returning a resource type X publishes no rate for are",
+        "marked `confidence: inferred` at the post-read rate — the same figure the proxy's fallback",
+        "charges, so the published price and the metered price cannot drift apart.",
         "",
         "scope: GET routes that read public data are `any_account`; writes and anything touching",
         "/me, DMs, bookmarks, blocks, mutes, compliance or usage are `own_account`.",

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -8715,7 +8715,12 @@ def _oauth_billed_estimate(provider, ep: dict | None, method: str, query, body: 
     default); the provider-level rates cover the extended/passthrough long tail. `unit_micro` is
     the per-resource price a `per_result` settle counts the response against."""
     cv = catalog_store.load().cost_view(ep.get("cost"), provider.service) if ep and ep.get("cost") else None
-    if cv and cv.get("usd"):
+    # A ZERO price must fall through to the provider rate, not bill zero — on an oauth-billed
+    # provider the upstream charges us whatever the catalog says, so `free` there is a catalog bug
+    # (a stale ingest), never a fact. Spelled out because it used to ride on `0.0` being falsy:
+    # the same expression read as "no price recorded" and "the price is nothing", and the catalog
+    # could publish free while the balance was debited the fallback.
+    if cv and cv.get("type") != "free" and cv.get("usd"):
         ctype = str(cv.get("type") or "per_call")
         est = _platform_estimate_micro(cv, query, body)
         if method != "GET" and provider.billed_write_link_usd and _post_has_link(body):

--- a/src/treg/catalog/x.extended.yaml
+++ b/src/treg/catalog/x.extended.yaml
@@ -12,9 +12,23 @@
 # blocks, DMs and media upload each have their own scope. They are listed with `scope_gap:`
 # rather than omitted, because that list IS the decision of which scopes to add to the app.
 # 
-# Beyond scopes, most v2 routes are gated by the ACCESS TIER of the X developer plan (Free
-# posts only; Basic/Pro unlock search and timelines) — the spec cannot express that, so a
-# listed route may still answer 403 on a Free project.
+# Beyond scopes, a route may still answer 403 on a project whose access the spec cannot
+# express — the OpenAPI document lists the whole surface, not what one app may reach.
+#
+# EVERY ENTRY IS PRICED, AND NONE OF THEM ARE FREE. X bills the APP OWNER per use (prepaid
+# credits, no plan tiers since Feb 2026), so a call on a registry connect spends treg's money and
+# is metered from the team balance. The rates come from X's RATE CARD PER RESOURCE TYPE, not one
+# read price and one write price: posts $0.005 and users $0.010 per resource returned, DM events
+# $0.010, lists/spaces/communities/notes $0.005, likes/mutes/blocks $0.001; writes are per request
+# — a post $0.015 ($0.200 with a URL), a list $0.010 to create but $0.005 to manage, an
+# interaction $0.015 to create and $0.010 to delete. `catalog_ingest.X_ROUTE_RATES` is the mapping,
+# and each entry's note names the row it was priced from.
+#
+# OWNED READS ($0.001) DO NOT APPLY HERE. That rate needs the authenticated user to own the
+# developer app; on a registry connect the app is treg's, so a member reading their own timeline
+# pays the ordinary Posts rate. `confidence: inferred` marks the routes whose resource type the
+# card does not name — those quote treg's own fallback, so the published price and the metered
+# price cannot drift apart.
 # 
 # scope: GET routes that read public data are `any_account`; writes and anything touching
 # /me, DMs, bookmarks, blocks, mutes, compliance or usage are `own_account`.
@@ -36,11 +50,16 @@ endpoints:
   summary: Get Account Activity Subscription Count
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
 - id: x.x.validate-account-activity-subscription
   kind: account
@@ -52,11 +71,16 @@ endpoints:
   summary: Validate Account Activity Subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read, dm.write'
   input:
@@ -74,11 +98,16 @@ endpoints:
   summary: Create subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read, dm.write'
   input:
@@ -101,11 +130,16 @@ endpoints:
   summary: Get Account Activity Subscriptions
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -122,11 +156,16 @@ endpoints:
   summary: Delete subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -146,11 +185,16 @@ endpoints:
   summary: Activity Stream
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -176,11 +220,16 @@ endpoints:
   summary: Delete X activity subscriptions by IDs
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -197,11 +246,16 @@ endpoints:
   summary: Get X activity subscriptions
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: like.read'
   input:
@@ -223,11 +277,16 @@ endpoints:
   summary: Create X activity subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -245,11 +304,16 @@ endpoints:
   summary: Deletes X activity subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -266,11 +330,16 @@ endpoints:
   summary: Update X activity subscription
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -292,11 +361,16 @@ endpoints:
   summary: Create draft Article
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -315,11 +389,16 @@ endpoints:
   summary: Publish Article
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -336,11 +415,16 @@ endpoints:
   summary: List scheduled broadcasts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read'
   input:
@@ -368,11 +452,16 @@ endpoints:
   summary: Create a scheduled broadcast
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read, broadcast.write'
   input:
@@ -392,11 +481,16 @@ endpoints:
   summary: Delete a scheduled broadcast
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read, broadcast.write'
   input:
@@ -418,11 +512,16 @@ endpoints:
   summary: Get a scheduled broadcast
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read'
   input:
@@ -441,11 +540,16 @@ endpoints:
   summary: Update a scheduled broadcast
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read, broadcast.write'
   input:
@@ -469,11 +573,16 @@ endpoints:
   summary: Go live on a scheduled broadcast
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read, broadcast.write'
   input:
@@ -492,11 +601,16 @@ endpoints:
   summary: Send a chat message to a live broadcast
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: broadcast.read, broadcast.write'
   input:
@@ -519,11 +633,16 @@ endpoints:
   summary: Get Chat Conversations
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -545,11 +664,16 @@ endpoints:
   summary: Create Chat Group Conversation
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -569,11 +693,16 @@ endpoints:
   summary: Initialize Chat Group
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   capability: x.chat.group.initialize
@@ -586,11 +715,16 @@ endpoints:
   summary: Get Chat Conversation
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -608,11 +742,16 @@ endpoints:
   summary: Get Chat Conversation Events
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -638,11 +777,16 @@ endpoints:
   summary: Add Conversation Keys
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -665,11 +809,16 @@ endpoints:
   summary: Add members to a Chat group conversation
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -693,11 +842,16 @@ endpoints:
   summary: Send Chat Message
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm create: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -721,11 +875,16 @@ endpoints:
   summary: Delete Chat messages
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm create: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -749,11 +908,16 @@ endpoints:
   summary: Mark Conversation as Read
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -776,11 +940,16 @@ endpoints:
   summary: Send Typing Indicator
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, dm create: $0.015 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -798,11 +967,16 @@ endpoints:
   summary: Initialize Chat Media Upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -822,11 +996,16 @@ endpoints:
   summary: Append Chat Media Upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -850,11 +1029,16 @@ endpoints:
   summary: Finalize Chat Media Upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -877,11 +1061,16 @@ endpoints:
   summary: Download Chat Media
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -902,11 +1091,16 @@ endpoints:
   summary: Search Communities
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, community: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -932,11 +1126,16 @@ endpoints:
   summary: Get Communities by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, community: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -955,11 +1154,16 @@ endpoints:
   summary: Get Compliance Jobs
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -979,11 +1183,16 @@ endpoints:
   summary: Create Compliance Job
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -1001,11 +1210,16 @@ endpoints:
   summary: Get Compliance Job by ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -1022,11 +1236,16 @@ endpoints:
   summary: Terminate multiple connections
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -1044,11 +1263,16 @@ endpoints:
   summary: Get Connection History
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1074,11 +1298,16 @@ endpoints:
   summary: Terminate all connections
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
 - id: x.x.delete-connections-by-endpoint
   kind: account
@@ -1090,11 +1319,16 @@ endpoints:
   summary: Terminate connections by endpoint
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -1111,11 +1345,16 @@ endpoints:
   summary: Create DM conversation
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm create: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -1134,11 +1373,16 @@ endpoints:
   summary: Download DM Media
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -1162,11 +1406,16 @@ endpoints:
   summary: Get Direct Messages Events by Participant ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -1196,11 +1445,16 @@ endpoints:
   summary: Create DM message by participant ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm create: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -1224,11 +1478,16 @@ endpoints:
   summary: Create Direct Messages by Conversation ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm create: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -1251,11 +1510,16 @@ endpoints:
   summary: Get Direct Messages Events by Conversation ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -1284,11 +1548,16 @@ endpoints:
   summary: Get Direct Messages Events
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -1314,11 +1583,16 @@ endpoints:
   summary: Delete DM event
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, int delete: $0.01 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read, dm.write'
   input:
@@ -1336,11 +1610,16 @@ endpoints:
   summary: Get Direct Messages Events by ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, dm event: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -1359,11 +1638,16 @@ endpoints:
   summary: Stream Likes compliance data
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.001
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, like: $0.001 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1388,11 +1672,16 @@ endpoints:
   summary: Stream all Likes
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.001
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, like: $0.001 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1441,11 +1730,16 @@ endpoints:
   summary: Stream sampled Likes
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.001
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, like: $0.001 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1495,11 +1789,16 @@ endpoints:
   summary: Create Lists
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list create: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read, list.write'
   input:
@@ -1519,11 +1818,16 @@ endpoints:
   summary: Delete List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -1541,11 +1845,16 @@ endpoints:
   summary: Get Lists by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -1564,11 +1873,16 @@ endpoints:
   summary: Update List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -1591,11 +1905,16 @@ endpoints:
   summary: Get Lists Followers
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -1621,11 +1940,16 @@ endpoints:
   summary: Get Lists Members
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -1652,11 +1976,16 @@ endpoints:
   summary: Add Lists Member
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -1680,11 +2009,16 @@ endpoints:
   summary: Remove a List member
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -1705,11 +2039,16 @@ endpoints:
   summary: Get Lists Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -1735,11 +2074,16 @@ endpoints:
   summary: Get Media by media keys
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1756,11 +2100,16 @@ endpoints:
   summary: Get Media analytics
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -1787,11 +2136,16 @@ endpoints:
   summary: Create Media metadata
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, media meta: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1811,11 +2165,16 @@ endpoints:
   summary: Delete Media subtitles
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, media meta: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1835,11 +2194,16 @@ endpoints:
   summary: Create Media subtitles
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, media meta: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1859,11 +2223,16 @@ endpoints:
   summary: Get Media upload status
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1885,11 +2254,16 @@ endpoints:
   summary: Upload media
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1909,11 +2283,16 @@ endpoints:
   summary: Initialize media upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1933,11 +2312,16 @@ endpoints:
   summary: Append Media Upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1961,11 +2345,16 @@ endpoints:
   summary: Finalize Media upload
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: media.write'
   input:
@@ -1983,11 +2372,16 @@ endpoints:
   summary: Get Media by media key
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -2004,11 +2398,16 @@ endpoints:
   summary: Search News
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, note: $0.005 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2031,11 +2430,16 @@ endpoints:
   summary: Get news stories by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, note: $0.005 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -2053,11 +2457,16 @@ endpoints:
   summary: Create Community Notes
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -2076,11 +2485,16 @@ endpoints:
   summary: Evaluate Community Notes
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -2098,11 +2512,16 @@ endpoints:
   summary: Search Community Notes Written
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, note: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2125,11 +2544,16 @@ endpoints:
   summary: Search Eligible Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, note: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2156,11 +2580,16 @@ endpoints:
   summary: Delete a Community Note
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, content: $0.005 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -2178,11 +2607,16 @@ endpoints:
   summary: Get OpenAPI Spec.
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
 - id: x.x.get-spaces-by-ids
   tier: extended
@@ -2193,11 +2627,16 @@ endpoints:
   summary: Get Spaces by IDs
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, space: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2215,11 +2654,16 @@ endpoints:
   summary: Get Spaces by Creator IDs
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, space: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2237,11 +2681,16 @@ endpoints:
   summary: Search Spaces
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, space: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2265,11 +2714,16 @@ endpoints:
   summary: Get Spaces by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, space: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2287,11 +2741,16 @@ endpoints:
   summary: Get Space ticket buyers
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2317,11 +2776,16 @@ endpoints:
   summary: Get Space Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: space.read'
   input:
@@ -2347,11 +2811,16 @@ endpoints:
   summary: Get Trends by Woeid
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, trends: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -2372,11 +2841,16 @@ endpoints:
   summary: Get Posts by IDs
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2393,11 +2867,16 @@ endpoints:
   summary: Get Posts Analytics
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2424,11 +2903,16 @@ endpoints:
   summary: Stream Posts compliance data
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2457,11 +2941,16 @@ endpoints:
   summary: Get Posts Counts All
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, counts all: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2504,11 +2993,16 @@ endpoints:
   summary: Get Posts Counts Recent
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, counts recent: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2552,11 +3046,16 @@ endpoints:
   summary: Stream all Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2609,11 +3108,16 @@ endpoints:
   summary: Stream English Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2666,11 +3170,16 @@ endpoints:
   summary: Stream Japanese Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2723,11 +3232,16 @@ endpoints:
   summary: Stream Korean Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2780,11 +3294,16 @@ endpoints:
   summary: Stream Portuguese Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2838,11 +3357,16 @@ endpoints:
   summary: Stream Post labels
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2867,11 +3391,16 @@ endpoints:
   summary: Stream sampled Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2912,11 +3441,16 @@ endpoints:
   summary: Stream 10% sampled Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -2969,11 +3503,16 @@ endpoints:
   summary: Search Posts All
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3016,11 +3555,16 @@ endpoints:
   summary: Search Posts Recent
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3064,11 +3608,16 @@ endpoints:
   summary: Stream filtered Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3119,11 +3668,16 @@ endpoints:
   summary: Get filtered-stream rules
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3148,11 +3702,16 @@ endpoints:
   summary: Update stream rules
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3178,11 +3737,16 @@ endpoints:
   summary: Get Rule Counts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3199,11 +3763,16 @@ endpoints:
   summary: Get stream links
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
 - id: x.x.delete-webhooks-stream-link
   kind: account
@@ -3215,11 +3784,16 @@ endpoints:
   summary: Delete stream link
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3236,11 +3810,16 @@ endpoints:
   summary: Create stream link
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3257,11 +3836,16 @@ endpoints:
   summary: Delete Posts
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, int delete: $0.01 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3278,11 +3862,16 @@ endpoints:
   summary: Get Posts by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3299,11 +3888,16 @@ endpoints:
   summary: Get Posts Liking Users
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: like.read'
   input:
@@ -3329,11 +3923,16 @@ endpoints:
   summary: Get Posts Quoted Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3361,11 +3960,16 @@ endpoints:
   summary: Get Posts Reposted by
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3390,11 +3994,16 @@ endpoints:
   summary: Get Posts Reposts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3420,11 +4029,16 @@ endpoints:
   summary: Hide reply
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, content: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: tweet.moderate.write'
   input:
@@ -3448,11 +4062,16 @@ endpoints:
   summary: Get Usage
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3468,11 +4087,16 @@ endpoints:
   summary: Get Users by IDs
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3489,11 +4113,16 @@ endpoints:
   summary: Get Users by Usernames
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3511,11 +4140,16 @@ endpoints:
   summary: Stream Users compliance data
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3544,11 +4178,16 @@ endpoints:
   summary: Get Trends Personalized Trends
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, trends: $0.01 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   capability: x.trending.personalized
 - id: x.x.get-users-public-keys
@@ -3561,11 +4200,16 @@ endpoints:
   summary: Get public keys
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -3582,11 +4226,16 @@ endpoints:
   summary: Get Users Reposts of Me
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: timeline.read'
   input:
@@ -3608,11 +4257,16 @@ endpoints:
   summary: Search Users
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     queryParams:
@@ -3635,11 +4289,16 @@ endpoints:
   summary: Get Users by ID
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3656,11 +4315,16 @@ endpoints:
   summary: Get Users Affiliates
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, user: $0.01 per resource returned; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -3685,11 +4349,16 @@ endpoints:
   summary: Get Users Blocking
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.001
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, block: $0.001 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: block.read'
   input:
@@ -3714,11 +4383,16 @@ endpoints:
   summary: Get Users Bookmarks
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.read'
   input:
@@ -3745,11 +4419,16 @@ endpoints:
   summary: Create Users Bookmark
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, bookmark: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.write'
   input:
@@ -3772,11 +4451,16 @@ endpoints:
   summary: Get Users Bookmark Folders
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.read'
   input:
@@ -3803,11 +4487,16 @@ endpoints:
   summary: Create Bookmark Folder
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, bookmark: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.write'
   input:
@@ -3830,11 +4519,16 @@ endpoints:
   summary: Get Users Bookmarks by Folder ID
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.read'
   input:
@@ -3864,11 +4558,16 @@ endpoints:
   summary: Delete Bookmark
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, bookmark: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: bookmark.write'
   input:
@@ -3890,11 +4589,16 @@ endpoints:
   summary: Block Users Dms
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, privacy: $0.01 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -3913,11 +4617,16 @@ endpoints:
   summary: Unblock Users Dms
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: 'X''s rate card, privacy: $0.01 per request; which row applies is a judgement call, and this takes the dearer reading'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -3935,11 +4644,16 @@ endpoints:
   summary: Get Users Followed Lists
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -3966,11 +4680,16 @@ endpoints:
   summary: Follow List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -3994,11 +4713,16 @@ endpoints:
   summary: Unfollow a List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -4019,11 +4743,16 @@ endpoints:
   summary: Get Users Followers
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: follows.read'
   input:
@@ -4049,11 +4778,16 @@ endpoints:
   summary: Get Users Following
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.01
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: user
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, user: $0.01 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: follows.read'
   input:
@@ -4080,11 +4814,16 @@ endpoints:
   summary: Follow User
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, interaction: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: follows.write'
   input:
@@ -4107,11 +4846,16 @@ endpoints:
   summary: Get Users Liked Posts
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: like.read'
   input:
@@ -4138,11 +4882,16 @@ endpoints:
   summary: Like Post
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, interaction: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: like.write'
   input:
@@ -4166,11 +4915,16 @@ endpoints:
   summary: Unlike Post
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, int delete: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: like.write'
   input:
@@ -4191,11 +4945,16 @@ endpoints:
   summary: Get Users List Memberships
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -4220,11 +4979,16 @@ endpoints:
   summary: Get Users Mentions
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -4263,11 +5027,16 @@ endpoints:
   summary: Get Users Muting
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.001
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, mute: $0.001 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: mute.read'
   input:
@@ -4293,11 +5062,16 @@ endpoints:
   summary: Mute User
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, interaction: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: mute.write'
   input:
@@ -4320,11 +5094,16 @@ endpoints:
   summary: Get Users Owned Lists
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -4350,11 +5129,16 @@ endpoints:
   summary: Get Users Pinned Lists
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.read'
   input:
@@ -4373,11 +5157,16 @@ endpoints:
   summary: Pin List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -4401,11 +5190,16 @@ endpoints:
   summary: Unpin a List
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, list manage: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: list.write'
   input:
@@ -4427,11 +5221,16 @@ endpoints:
   summary: Get public keys
   scope: any_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.read'
   input:
@@ -4449,11 +5248,16 @@ endpoints:
   summary: Add public key
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: dm.write'
   input:
@@ -4476,11 +5280,16 @@ endpoints:
   summary: Repost Post
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, interaction: $0.015 per request'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -4503,11 +5312,16 @@ endpoints:
   summary: Unrepost Post
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, int delete: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -4527,11 +5341,16 @@ endpoints:
   summary: Get Users Timeline
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, posts: $0.005 per resource returned'
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -4574,11 +5393,16 @@ endpoints:
   summary: Unfollow User
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.01
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, int delete: $0.01 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: follows.write'
   input:
@@ -4600,11 +5424,16 @@ endpoints:
   summary: Unmute User
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.005
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: documented
+    note: 'X''s rate card, mute delete: $0.005 per request'
   docs_url: https://docs.x.com/x-api
   scope_gap: 'treg''s OAuth app does not request this; needs: mute.write'
   input:
@@ -4626,11 +5455,16 @@ endpoints:
   summary: Get webhook
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_result
+    value: 0.005
     currency: USD
-    unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    per: 1
+    unit: post
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.005 per resource — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
 - id: x.x.create-webhooks
   kind: account
@@ -4642,11 +5476,16 @@ endpoints:
   summary: Create webhook
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -4664,11 +5503,16 @@ endpoints:
   summary: Create replay job for webhook
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     bodyType: json
@@ -4686,11 +5530,16 @@ endpoints:
   summary: Delete webhook
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:
@@ -4707,11 +5556,16 @@ endpoints:
   summary: Validate webhook
   scope: own_account
   cost:
-    type: free
-    value: 0
+    type: per_call
+    value: 0.015
     currency: USD
+    per: 1
     unit: call
-    note: no per-call charge; consumed from the X API plan's monthly post cap
+    source: docs
+    source_url: https://docs.x.com/x-api/getting-started/pricing
+    checked: '2026-08-18'
+    confidence: inferred
+    note: X publishes no rate for this route's resource, so treg meters it at $0.015 per request — the same figure the proxy falls back to
   docs_url: https://docs.x.com/x-api
   input:
     pathParams:

--- a/src/treg/catalog/x.yaml
+++ b/src/treg/catalog/x.yaml
@@ -8,9 +8,18 @@
 #
 # PRICING IS PAY-PER-USE AND THE BILL LANDS ON TREG. X dropped its plan tiers (Free/Basic/Pro)
 # for prepaid pay-per-use credits billed to the APP OWNER, whoever's token made the call
-# (docs.x.com/x-api/getting-started/pricing, checked 2026-08-12): reads are per RESOURCE returned
-# — posts $0.005, users $0.010, own-account reads $0.001 — and writes per request — $0.015 for a
-# post, $0.20 when its text carries a URL. 2M post reads per billing cycle; same-resource reads
+# (docs.x.com/x-api/getting-started/pricing, re-read 2026-08-18): reads are per RESOURCE returned
+# — posts $0.005, users $0.010 — and writes per request — $0.015 for a post, $0.20 when its text
+# carries a URL. The card prices EVERY resource type separately (DM events $0.010, lists and spaces
+# $0.005, likes/mutes/blocks $0.001, a list $0.010 to create but $0.005 to manage); the extended
+# file carries the rest, mapped in catalog_ingest.X_ROUTE_RATES.
+#
+# THE $0.001 "OWNED READ" RATE IS NOT OURS TO CHARGE. X grants it only when the authenticated user
+# "is the owner of the developer app" — on a registry connect the app is treg's and the member is a
+# stranger to it, so /2/users/me is an ordinary User read at $0.010. This entry said $0.001 until
+# 2026-08-18, which under-billed the calls treg is charged the most for.
+#
+# 3M post reads per billing cycle; same-resource reads
 # dedupe within a 24h UTC window (treg does not pass the dedup through — a repeat read is billed).
 # The costs below are what the proxy METERS against a team's balance when a call rides a registry
 # connect (treg's app; see oauth_providers.X.platform_billed). A BYO-app connection pays X
@@ -23,7 +32,7 @@ source:
   openapi: https://api.x.com/2/openapi.json
   curated: 2026-07-28
 
-limits: "2,000,000 post reads per monthly billing cycle, plus 15-minute request windows"
+limits: "3,000,000 post reads per monthly billing cycle, plus 15-minute request windows"
 pricing_url: https://docs.x.com/x-api/getting-started/pricing  # pay-per-use, prepaid credits, no plans
 endpoints:
   - id: x.x.user.profile
@@ -38,7 +47,7 @@ endpoints:
       queryParams:
         user.fields: {type: string, required: false, note: "comma-separated extras; public_metrics carries followers_count / following_count / tweet_count", example: "id,name,username,description,public_metrics,verified,created_at"}
       note: "the only X read route guaranteed on every access tier. Its data.id is the {id} the timeline endpoints need"
-    cost: {type: per_call, value: 0.001, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-12', confidence: documented, note: 'an OWNED read — X bills the app owner $0.001 for a user reading their own resource'}
+    cost: {type: per_result, value: 0.010, currency: USD, per: 1, unit: user, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-18', confidence: documented, note: 'one user resource at the User read rate. NOT the $0.001 owned read: that needs the caller to own the developer app, and on a registry connect the app is treg''s'}
     test_request:
       queryParams: {"user.fields": "id,name,username,description,public_metrics,verified,created_at"}
     verified: 2026-07-28
@@ -61,7 +70,7 @@ endpoints:
       queryParams:
         user.fields: {type: string, required: false, example: "id,name,username,description,public_metrics,verified,created_at"}
       note: "for several handles at once use GET /2/users/by?usernames=a,b,c (up to 100) — one request against the cap instead of 100"
-    cost: {type: per_result, value: 0.010, currency: USD, per: 1, unit: user, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-12', confidence: documented, note: 'X bills the app owner $0.010 per user resource returned; the batch route (/2/users/by?usernames=a,b,c) is priced per user too, so batching saves rate-limit windows, not money'}
+    cost: {type: per_result, value: 0.010, currency: USD, per: 1, unit: user, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-18', confidence: documented, note: 'X bills the app owner $0.010 per user resource returned; the batch route (/2/users/by?usernames=a,b,c) is priced per user too, so batching saves rate-limit windows, not money'}
     test_request:
       pathParams: {username: "elonmusk"}
       queryParams: {"user.fields": "id,name,username,description,public_metrics,verified,created_at"}
@@ -87,7 +96,7 @@ endpoints:
         tweet.fields: {type: string, required: false, note: "public_metrics carries likes/reposts/replies/impressions", example: "id,text,created_at,public_metrics,referenced_tweets"}
         start_time: {type: string, required: false, note: "RFC 3339; the timeline reaches back at most 3,200 posts regardless", example: "2026-07-01T00:00:00Z"}
       note: "each post returned is billed to the app owner at $0.005 — size max_results to what you actually need"
-    cost: {type: per_result, value: 0.005, currency: USD, per: 1, unit: post, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-12', confidence: documented, note: 'X bills the app owner $0.005 per post returned — pass max_results (5-100, default 10) deliberately; a default-sized page costs ~$0.05'}
+    cost: {type: per_result, value: 0.005, currency: USD, per: 1, unit: post, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-18', confidence: documented, note: 'X bills the app owner $0.005 per post returned — pass max_results (5-100, default 10) deliberately; a default-sized page costs ~$0.05'}
     test_request:
       pathParams: {id: "44196397"}
       queryParams: {max_results: 5, "tweet.fields": "id,text,created_at,public_metrics"}
@@ -122,7 +131,7 @@ endpoints:
         geo: {type: object, required: false, note: "{\"place_id\": \"…\"}"}
       bodyType: json
       note: "needs the `write` capability (tweet.write); a connection made with `read` answers 403. Success is HTTP 201 with {data: {id, text}} — the public URL is https://x.com/<handle>/status/<data.id>, which the API does not return. Images/video are out of reach, see the block comment above"
-    cost: {type: per_call, value: 0.015, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-12', confidence: documented, note: 'X bills the app owner $0.015 per post created — $0.20 when the text carries a URL (the proxy prices the call at the higher rate when it sees one)'}
+    cost: {type: per_call, value: 0.015, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-18', confidence: documented, note: 'X bills the app owner $0.015 per post created — $0.20 when the text carries a URL (the proxy prices the call at the higher rate when it sees one)'}
     unverified: "write action — this publishes to a real account; requires a deliberate manual test, never an automated verify run"
     docs_url: https://docs.x.com/x-api/posts/creation-of-a-post
 
@@ -143,7 +152,7 @@ endpoints:
         quote_tweet_id: {type: string, required: false, note: "quote-posts the given id instead of replying to it — use INSTEAD of `reply`, not alongside"}
       bodyType: json
       note: "to build a thread, feed each response's data.id into the next call's reply.in_reply_to_tweet_id. Replying to a post whose author restricted replies, or that was deleted, answers 403/404 — each call is all-or-nothing, so a half-posted thread stays half-posted"
-    cost: {type: per_call, value: 0.015, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-12', confidence: documented, note: 'a reply is a post creation: $0.015 to the app owner, $0.20 when the text carries a URL'}
+    cost: {type: per_call, value: 0.015, currency: USD, per: 1, unit: call, source: docs, source_url: 'https://docs.x.com/x-api/getting-started/pricing', checked: '2026-08-18', confidence: documented, note: 'a reply is a post creation: $0.015 to the app owner, $0.20 when the text carries a URL'}
     unverified: "write action — this publishes to a real account; requires a deliberate manual test, never an automated verify run"
     docs_url: https://docs.x.com/x-api/posts/creation-of-a-post
 

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -54,6 +54,7 @@ COST_SOURCES = ("rate_card_api", "docs", "observed", "vendor_email", "inferred")
 # its own meter and `unit` names that meter (see `Catalog.cost_view`).
 COST_UNITS = ("call", "result", "row", "record", "keyword", "page", "character", "review",
               "section", "employee", "GB", "ad", "month", "line", "target", "domain", "item",
+              "post", "user",
               "api_unit", "analysis_unit", "retrieval_unit", "index_item_unit", "quota_row")
 # A platform key spends OUR money on a caller's behalf, so it is allowed only where the price is
 # machine-computable and provenanced. `account`-kind routes are the provider's own bookkeeping —

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -596,10 +596,16 @@ X = OAuthProvider(
     identity_id_path="data.id",
     identity_label_path="data.username",
     # X bills treg's app per use (prepaid credits, no plans — docs.x.com/x-api/getting-started/
-    # pricing, checked 2026-08-12): posts $0.005/resource read, users $0.010, own-account reads
-    # $0.001, post writes $0.015/request — $0.20 when the text carries a URL. The curated
-    # catalog/x.yaml prices carry the per-endpoint numbers; these are the fallback for the long
-    # tail (x.extended.yaml and URL-passthrough calls).
+    # pricing, re-read 2026-08-18). The card prices EVERY resource type separately, so these two
+    # numbers are only a FALLBACK for a path no catalog entry claims (a route X ships that we have
+    # not re-ingested): the post-read rate for a GET, the post-write rate for anything else. Both
+    # catalog files now price every known route from the card itself — `catalog_ingest.X_RATES` —
+    # so the fallback should be reached rarely, and when it is, it is a signal to re-ingest.
+    # Note the exposure it carries: a fallback GET that turns out to have returned USERS was billed
+    # at $0.005 and cost us $0.010. Raising it to the dearer rate would over-bill the far more
+    # common post read, so the fix is coverage, not a bigger guess.
+    # The $0.001 "owned read" rate is deliberately absent: X grants it only to an app's OWN owner,
+    # which a registry connect's member never is.
     platform_billed=True,
     billed_read_usd=0.005,
     billed_write_usd=0.015,

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -5697,7 +5697,8 @@ createApp({
       // the tooltip) — but "from" is a floor, and the floor is free.
       const provs=(pl && pl.providers)||[];
       const hasOauth=provs.some(s=>{
-        const p=this.providers.find(x=>x.service===s); return p && p.auth_kind==='oauth'; });
+        const p=this.providers.find(x=>x.service===s);
+        return p && p.auth_kind==='oauth' && !p.metered; });
       if(hasOauth) return {free:true, text:'free with your account', paid};
       if(paid) return {free:false, text:paid, native:this.nativeAmount(pf)};
       return null; },  // priced with no published number, or key-auth with no rate — unknown, not free
@@ -5710,6 +5711,14 @@ createApp({
               p.native ? 'billed as '+p.native+' / '+this.priceUnit(pf.type)+', converted at the catalog’s FX rate' : '',
               pf.note].filter(Boolean).join(' — '); },
     catConnected(service){ return !!this.connCount[service]; },
+    // Whether a REGISTRY connection to this provider is still metered. Connecting usually ends the
+    // billing question — the account you connect is the licence — but a `metered` provider bills
+    // treg's own app per use (X since Feb 2026), so those calls are debited from the team balance
+    // no matter whose account made them. `/providers` carries the flag, and the deployment's
+    // TREG_OAUTH_BILLED_PROVIDERS decides whether it is set, so the price a browser shows follows
+    // the kill switch instead of hard-coding today's answer.
+    catMetered(service){
+      const p=this.providers.find(x=>x.service===service); return !!(p && p.metered); },
     // A platform is callable today if ANY provider serving it is connected — the card is browsing,
     // not routing, so which one it is stays a question for the platform page.
     platConnected(pl){ return ((pl&&pl.providers)||[]).some(s=>this.catConnected(s)); },
@@ -5740,7 +5749,8 @@ createApp({
       return typeof c.usd==='number' ? c.usd : null; },
     // An OAuth endpoint you have already connected costs nothing MORE to call — the account is the
     // licence — so a connected own_account row is the free path, and usually the right answer.
-    capFree(e){ return this.catConnected(e.provider) && (e.scope==='own_account' || (e.cost&&e.cost.type==='free')); },
+    capFree(e){ return this.catConnected(e.provider) && !this.catMetered(e.provider)
+      && (e.scope==='own_account' || (e.cost&&e.cost.type==='free')); },
     capCheapest(eps){
       let best=null;
       for(const e of (eps||[])){

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1167,3 +1167,144 @@ async def test_another_orgs_usage_never_burns_MY_trial(clients: AsyncClient, tri
         await db.commit()
     monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"c": 1}'))
     assert (await clients.get("/call/finnhub.quote?symbol=AAPL")).status_code == 200
+
+
+# ---- X: the catalog price and the metered price are the same number ----------------------------
+# The bug this pins: `x.extended.yaml` shipped 168 routes priced `free` (a note about the Free/Basic/
+# Pro plan caps X abolished in Feb 2026), while `_oauth_billed_estimate` skipped that block — its
+# `usd` is 0, which is falsy — and charged the provider fallback instead. The catalog said $0 and
+# the balance said $0.10, which is the one disagreement a published price must never have.
+
+def _x_endpoints():
+    from treg import catalog_store
+    return [e for e in catalog_store.load().by_id.values() if e.get("provider") == "x"]
+
+
+def test_no_x_endpoint_is_published_as_free():
+    """Nothing on X's v2 API is free to treg any more: X bills the app owner per use, so every
+    entry must carry a real rate. A `free` block here is a stale ingest, not a fact."""
+    free = [e["id"] for e in _x_endpoints() if (e.get("cost") or {}).get("type") == "free"]
+    assert not free, f"X is pay-per-use — these publish a price treg cannot honour: {free[:10]}"
+
+
+def test_x_catalog_price_equals_what_the_meter_charges():
+    """For every X route, the price the catalog publishes is the price the proxy reserves. Walked
+    over the whole provider rather than a sample, because the failure mode is one stale entry."""
+    from treg import oauth_providers
+    x = oauth_providers.get("x")
+    for ep in _x_endpoints():
+        method = (ep.get("method") or "GET").upper()
+        est, ctype, _ = A._oauth_billed_estimate(x, ep, method, {}, b"")
+        published = A._platform_estimate_micro(
+            A.catalog_store.load().cost_view(ep["cost"], "x"), {}, b"")
+        assert est == published and ctype == ep["cost"]["type"], (
+            f"{ep['id']}: catalog says {published} micro ({ep['cost']['type']}), "
+            f"meter reserves {est} micro ({ctype})")
+
+
+def test_a_zero_price_on_a_billed_provider_falls_back_rather_than_billing_zero():
+    """Belt and braces for the next stale ingest: if a `free` block ever reappears on X, the meter
+    must charge the provider rate rather than serve an upstream we get billed for at $0."""
+    from treg import oauth_providers
+    x = oauth_providers.get("x")
+    ep = {"id": "x.x.stale", "provider": "x", "method": "GET", "path": "/2/tweets",
+          "cost": {"type": "free", "value": 0, "currency": "USD", "unit": "call"}}
+    est, ctype, unit = A._oauth_billed_estimate(x, ep, "GET", {}, b"")
+    assert est > 0 and ctype == "per_result" and unit == A._usd_to_micro(x.billed_read_usd)
+
+
+# ---- X end to end: the published price is the price the balance loses --------------------------
+# Everything above tests the pricing FUNCTIONS. This walks the whole path a real X call takes —
+# registry connection → `_billed_marketplace` → reserve → relay → settle — because the free-price
+# bug was invisible to every unit test and only showed up as a number on a screen.
+
+@pytest.fixture
+def x_billed(monkeypatch):
+    """X metering on, the way prod has had it since 2026-08-18."""
+    monkeypatch.setenv("TREG_OAUTH_BILLED_PROVIDERS", "x")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _connect_x(clients: AsyncClient) -> None:
+    """A REGISTRY X connection: `secret.provider` set is what marks the bill as treg's (a BYO
+    connect leaves it empty and is never metered)."""
+    import json as _json
+
+    from treg import crypto
+    from treg.models import Secret
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        db.add(Secret(org_id=org_id, name="x", kind="oauth", provider="x",
+                      value=crypto.encrypt(_json.dumps({"access_token": "tok-test"}))))
+        await db.commit()
+
+
+async def test_a_formerly_free_x_route_now_debits_the_balance(clients: AsyncClient, x_billed,
+                                                              monkeypatch):
+    """`x.x.get-users-muting` is one of the 168 extended routes that used to publish `free`. X's card
+    prices a Mute read at $0.001 per resource, so one muted account back costs exactly that."""
+    await _connect_x(clients)
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"data": [{"id": "1"}]}'))
+    before = await _balance(clients)
+    r = await clients.get("/call/x.x.get-users-muting?id=44196397")
+    assert r.status_code == 200, r.text
+    spent = before - await _balance(clients)
+    assert spent > 0, "a route X bills us for must never be served free"
+    assert spent == 1_000, f"expected the published $0.001, spent {spent} micro-USD"
+
+
+async def test_the_rate_card_is_per_resource_type_not_one_read_and_one_write(clients: AsyncClient):
+    """The regression that shipped and was caught in review: every write billed at the post-creation
+    rate. X prices each action separately, and the catalog has to say so — creating a list is $0.010,
+    managing one $0.005, and deleting an interaction $0.010, none of them $0.015."""
+    from treg import catalog_store
+    by_id = catalog_store.load().by_id
+    assert by_id["x.x.create-lists"]["cost"]["value"] == 0.010, "List: Create is $0.010 per request"
+    assert by_id["x.x.update-lists"]["cost"]["value"] == 0.005, "List: Manage is $0.005 per request"
+    assert by_id["x.x.unfollow-user"]["cost"]["value"] == 0.010, "Interaction: Delete is $0.010"
+    assert by_id["x.x.get-users-muting"]["cost"]["value"] == 0.001, "Mute: Read is $0.001/resource"
+    assert by_id["x.x.get-direct-messages-events"]["cost"]["value"] == 0.010, "DM Event: Read is $0.010/resource"
+
+
+def test_the_owned_read_discount_is_never_claimed():
+    """$0.001 owned reads need the caller to own the developer app. On a registry connect the app is
+    treg's, so no X entry may quote that rate as a per-CALL own-account price — the way `/2/users/me`
+    did until 2026-08-18, under-billing the reads treg pays the most for."""
+    from treg import catalog_store
+    me = catalog_store.load().by_id["x.x.user.profile"]
+    assert me["cost"]["value"] == 0.010 and me["cost"]["type"] == "per_result", (
+        "/2/users/me is an ordinary User read for a registry connect")
+
+
+async def test_a_user_lookup_settles_per_user_returned(clients: AsyncClient, x_billed, monkeypatch):
+    """`per_result` settles against the RESPONSE, so the published $0.010/user is what each returned
+    user costs — three users back is $0.030, not the reserve for a full page."""
+    await _connect_x(clients)
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"data": [{"id":"1"},{"id":"2"},{"id":"3"}]}'))
+    before = await _balance(clients)
+    r = await clients.get("/call/x.x.get-users-by-ids?ids=1,2,3")
+    assert r.status_code == 200, r.text
+    assert before - await _balance(clients) == 30_000
+
+
+async def test_a_byo_x_connection_is_never_metered(clients: AsyncClient, x_billed, monkeypatch):
+    """The other half of the rule: a connection made with the org's OWN X app carries no
+    `secret.provider`, its upstream bill is already theirs, and treg must not charge for it."""
+    import json as _json
+
+    from treg import crypto
+    from treg.models import Secret
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        db.add(Secret(org_id=org_id, name="x", kind="oauth", provider="",
+                      value=crypto.encrypt(_json.dumps({"access_token": "byo-tok"}))))
+        await db.commit()
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"data": [{"id": "1"}]}'))
+    before = await _balance(clients)
+    r = await clients.get("/call/x.x.get-webhooks")
+    assert r.status_code == 200, r.text
+    assert await _balance(clients) == before, "a BYO app's bill is the org's, not ours"

--- a/tests/test_oauth_billed.py
+++ b/tests/test_oauth_billed.py
@@ -25,7 +25,10 @@ from treg.models import Org, Secret, Tool
 
 POSTS = "x.x.user.posts"        # GET /2/users/{id}/tweets — per_result $0.005/post
 POST_MICRO = 5_000
-PROFILE_MICRO = 1_000           # GET /2/users/me — per_call $0.001 (an owned read)
+# GET /2/users/me — one User resource at $0.010. NOT the $0.001 "owned read": X grants that rate
+# only when the caller owns the developer app, and on a registry connect the app is treg's, so a
+# member reading their own profile pays the ordinary rate. This said 1_000 until 2026-08-18.
+PROFILE_MICRO = 10_000
 CREATE_MICRO = 15_000           # POST /2/tweets — per_call $0.015…
 CREATE_LINK_MICRO = 200_000     # …but $0.20 when the text carries a URL
 
@@ -140,7 +143,7 @@ async def test_url_passthrough_is_priced_off_the_matched_endpoint(
     clients: AsyncClient, billed_on, monkeypatch
 ):
     """Calling the URL directly must not be a discount door: /2/users/me lands on the curated
-    own-account read and bills its per_call $0.001."""
+    profile read and bills its per_result $0.010."""
     await _connect_x(clients)
     monkeypatch.setattr(A, "relay", _stub_relay(200, b'{"data": {"id": "1"}}'))
     r = await clients.get("/call/https://api.x.com/2/users/me")


### PR DESCRIPTION
All 168 machine-ingested X routes published `cost: free`. The proxy never honoured it — a `free` block has `usd: 0`, which is falsy, so `_oauth_billed_estimate` fell through to the provider fallback and billed **$0.10** for a call the catalog advertised at **$0**.

That is the one disagreement a published price must never have, and no test caught it: the pricing functions were only ever exercised on the five curated entries.

## What was wrong

The `free` note described the Free/Basic/Pro monthly caps X abolished in **Feb 2026**. The ingest ran 2026-07-28; the pay-per-use rewrite of `x.yaml` landed 2026-08-12 and never touched the extended file.

Two more errors surfaced during review, both worse than the first:

**1. X prices per action, not per verb.** The first repair flattened all 74 writes to $0.015 — the post-creation rate. Caught in review against the live rate card:

| | first repair | X's card |
|---|---|---|
| `POST /2/lists` | $0.015 | **$0.010** (List: Create) |
| list manage / bookmarks / media metadata | $0.015 | **$0.005** |
| unfollow / unlike / unretweet | $0.015 | **$0.010** (Interaction: Delete) |
| mute / block reads | $0.010 | **$0.001** |
| DM event reads | $0.001 | **$0.010** |
| counts / trends | per result | **per request** |

**2. The $0.001 "owned read" rate is not ours to charge.** X grants it only when the caller *"is the owner of the developer app"*. On a registry connect the app is treg's and the member is a stranger to it — so `/2/users/me` is an ordinary User read at **$0.010**. It said $0.001: a **10x under-bill on the most-called X route**, and it predates this branch.

## How it's fixed

`catalog_ingest.X_RATES` transcribes the rate card verbatim; `X_ROUTE_RATES` maps each route onto a row, first match wins, and every entry's note names the row it was priced from — so the mapping is auditable line by line rather than being a number someone remembered.

Of 168 routes: **83 documented, 85 inferred**. `inferred` marks routes whose resource type the card does not name (webhooks, subscriptions, media upload, compliance) — those quote treg's own fallback, so published price and metered price agree by construction — and the genuinely ambiguous ones, which take the **dearer** reading because treg pays the difference.

Also here:
- **`capFree` / `platPrice`** stopped calling a connected account free for a `metered` provider. The flag comes from `/oauth/providers`, so the display follows `TREG_OAUTH_BILLED_PROVIDERS` instead of hard-coding today's answer.
- **`_oauth_billed_estimate`** spells out the zero-price fallthrough instead of resting on `0.0` being falsy, where "no price recorded" and "the price is nothing" were one expression.
- **`COST_UNITS` gains `post` and `user`** — `x.yaml` has used them since 2026-08-12, and the whole catalog failed `catalog_validate.py` on `main` because of it. Validator is green again.
- Post-read cap corrected to **3M**/cycle, not 2M.

## Verified live

Through the proxy against a real connected X account (`SuperDesignDev`), metering on:

| call | returned | charged | expected |
|---|---|---|---|
| `/2/users/me` | 1 user | **$0.010** | $0.010 ✅ |
| `/2/users/by` (3 usernames) | 3 users | **$0.030** | 3 × $0.010 ✅ |
| `/2/users/{id}/tweets?max_results=5` | 5 posts | **$0.025** | 5 × $0.005 ✅ |

Failure paths all settle at **zero**: a 403 (scope gap), a 400 (bad `max_results`), and a 200 with `result_count: 0` each reserved and then released. Total spend: $0.065.

`/2/users/me` charging $0.010 live is the owned-read fix confirmed against a real account — on `main` it charges $0.001.

## Tests

`1765 passed`, `catalog_validate.py` clean. Seven new tests, including one that walks **every** X endpoint asserting the published price equals the reserved one, one pinning the per-action rates, one asserting the owned-read discount is never claimed, and three end-to-end metered calls.

`tests/test_oauth_billed.py` changed by one line: `PROFILE_MICRO` 1_000 → 10_000. It encoded the same owned-read misunderstanding.

## Known, not fixed here

- **For the app owner's own account, treg now over-charges 5–10x.** X's owned-read list genuinely applies to whoever owns the app, so treg's own team connections pay $0.025 where X charges $0.005. Correct for every ordinary member; worth owner-detection only if those connections matter.
- **Prod's three X connections are all dead** — every one fails token refresh with a 401, so X metering has had nothing to meter since #101 shipped. Separate fix.
- The `inferred` rows are a reading of X's card, not measured billing. X returns no cost field or header; only the billing dashboard can settle them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
