### PR TITLE
feat(ads): port the conversion uploader to the Data Manager API

### DIFF
--- a/docs/context/architecture/ads-conversions.md
+++ b/docs/context/architecture/ads-conversions.md
@@ -14,10 +14,12 @@ related:
 
 # Google Ads conversion tracking
 
-Off unless `google_ads_customer_id`, `google_ads_developer_token` and `ads_conv_org_slug` are all set
-(`adsconv.enabled()`) — keeps the test suite and self-hosted instances from starting machinery that
-cannot upload. When off, `/adtrack.js` is an empty no-cache response and attribution cookies are
-ignored, so nothing is captured, queued or uploaded; the whole feature is additive.
+Off unless `google_ads_customer_id` and `ads_conv_refresh_token` are both set (`adsconv.enabled()`) —
+keeps the test suite and self-hosted instances from starting machinery that cannot upload. When off,
+`/adtrack.js` is an empty no-cache response and attribution cookies are ignored, so nothing is
+captured, queued or uploaded; the whole feature is additive. `google_ads_developer_token` is NOT part
+of this gate: Data Manager has no developer-token header, so that setting only matters for the
+read-side Ads catalog calls (`oauth_providers.GOOGLE_ADS`), a separate credential entirely (below).
 
 ## The chain: capture → store → fire → upload
 
@@ -57,15 +59,39 @@ ignored, so nothing is captured, queued or uploaded; the whole feature is additi
    six-hour delay exists because a click id may not be accepted immediately after the click; uploading
    too early can be rejected.
 
-## Authentication and manager accounts
+## Authentication: a platform credential, not a customer's OAuth connection
 
-The uploader decrypts the `google-ads` OAuth `Secret` belonging to `ads_conv_org_slug`, then sends that
-bearer token with the platform `google_ads_developer_token`. `google_ads_customer_id` is the target Ads
-account. When the OAuth identity reaches it through a manager account, configure that manager explicitly
-as `google_ads_login_customer_id`; hyphens are stripped for the request header. Never infer
-`login-customer-id` from `Secret.resource_ref`: discovery stores the selected **target client** there,
-while Google requires the **manager** account in this header. Direct client-account auth leaves the
-header unset.
+Two different purposes were once conflated here and no longer are. A **customer** connecting their
+Google Ads account (`oauth_providers.GOOGLE_ADS`) so their agent can read campaign data is one thing;
+**treg** uploading its own marketing conversions to its own ad account is another. The uploader does
+not borrow the customer-facing provider or any per-org `Secret` — it holds its own PLATFORM
+credential, `settings.ads_conv_refresh_token`, obtained once out of band by an operator via the OAuth
+playground with scope `https://www.googleapis.com/auth/datamanager`. `_auth_headers` exchanges it
+directly against `https://oauth2.googleapis.com/token` (`grant_type=refresh_token`), redeemed with
+the SAME client the refresh token was issued against — `google_ads_client_id`/`_secret`, reused from
+the read-side Ads OAuth client rather than a new one — never the shared `google_client_id` and never
+a customer's connection. `google_ads_customer_id` is the target Ads account. Data Manager takes
+neither a developer-token header nor a login-customer-id header at all: `google_ads_developer_token`
+plays no part in this path, and the manager (MCC) account moves into the request BODY as
+`destinations[].loginAccount` (`google_ads_login_customer_id`, hyphens stripped) instead — set only
+for manager-account auth; direct client auth leaves it unset. (`Secret.resource_ref`, where it
+exists on an unrelated per-org connection, is never the source for this — it names a discovered
+target client, not a manager.)
+
+The exchanged access token is cached in `adsconv` **module state** (`_cached_access_token`,
+`_token_expires_at`) and reused until within 60 seconds of its ~3599s expiry. `worker` drains every
+300s, so most drains hit the cache; re-exchanging the refresh token every pass would be wasteful and
+risks Google's refresh rate limit. `test_access_token_is_cached_and_not_re_exchanged_within_its_lifetime`
+proves a second same-window drain makes zero additional token calls. A failed exchange raises
+`RuntimeError`; `drain_once` runs inside `worker`'s try/except, so that just retries next pass rather
+than crashing the loop.
+
+Before this rework, `oauth_providers.GOOGLE_ADS` carried `datamanager` alongside `adwords` so the
+uploader could borrow a customer's OAuth connection — but `listing()` shows every provider to every
+customer, so that put a marketing-only permission on every consent screen for no reason (`adwords`
+alone was confirmed, via a `validateOnly` `userLists:mutate` call, to already cover audience/
+customer-match writes). The provider is back to exactly `adwords`; `datamanager`'s `SCOPE_LABELS`
+copy stays (harmless, and correct if the scope is ever genuinely requested).
 
 ## Idempotency: the outbox's unique constraint, not a check-then-insert
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -59,15 +59,24 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   Advertising OAuth platforms `microsoft_ads_*`, `snapchat_ads_*`, `tiktok_ads_*`, `pinterest_*` (all
   unset by default, so those providers ship **unconfigured** until a deployment registers a dev app).
   Empty for a provider ⇒ it lists as **unconfigured** rather than failing part-way through a consent.
-- **Ad conversion tracking** — `google_ads_customer_id` (the target Ads account),
-  `google_ads_developer_token`, and `ads_conv_org_slug` (which team's `google-ads` OAuth connection the
-  uploader authenticates as — a platform setting, not a per-tenant one, since treg uploads to its OWN
-  ad account). **All three** must be set or the whole feature is off (`adsconv.enabled()`): the capture
-  script is empty, attribution cookies are ignored, conversions are not queued, and the background
-  uploader is not started. For manager-account auth, set optional `google_ads_login_customer_id` to the
-  manager MCC id; direct client auth leaves it empty. Do not use the selected connection
-  `resource_ref` as the manager id—it names the target account. Self-hosters and the test suite carry
-  zero ad-conversion machinery by default. See
+- **Ad conversion tracking** — `google_ads_customer_id` (the target Ads account) and
+  `ads_conv_refresh_token` (treg's OWN long-lived refresh token for the Data Manager uploader,
+  minted once, out of band, by an operator via the OAuth playground with scope
+  `https://www.googleapis.com/auth/datamanager`, then pasted in as a platform setting). **Both**
+  must be set or the whole feature is off (`adsconv.enabled()`): the capture script is empty,
+  attribution cookies are ignored, conversions are not queued, and the background uploader is not
+  started. The refresh token is exchanged for an access token against the SAME client it was issued
+  against — `google_ads_client_id`/`_secret` above, reused here rather than duplicated — never
+  against `google_client_id` or a customer's own OAuth app; the exchanged access token is cached in
+  process memory with its expiry so the uploader (which drains every ~300s) doesn't re-exchange on
+  every pass. `google_ads_developer_token` is NOT part of this feature — Data Manager has no
+  developer-token header at all; that setting only backs the read-side Ads catalog calls through
+  `oauth_providers.GOOGLE_ADS`. For manager-account auth, set optional
+  `google_ads_login_customer_id` to the manager MCC id; direct client auth leaves it empty. This is
+  a PLATFORM credential, deliberately separate from a customer's `google-ads` OAuth connection
+  (which grants only `adwords`, never `datamanager` — that scope would otherwise show up on every
+  customer's consent screen for a permission only treg's own marketing uploader uses). Self-hosters
+  and the test suite carry zero ad-conversion machinery by default. See
   [ads-conversions](../architecture/ads-conversions.md).
 - **Landing live-wire (optional):** `demo_stripe_key` (`TREG_DEMO_STRIPE_KEY`, a Stripe **sandbox
   restricted** key) powers the landing sandbox's ONE real upstream call — a sandbox call to the exact

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -40,9 +40,9 @@ def usd_micro_to_aud_micro(usd_micro: int) -> int:
 
 
 import asyncio
-import json
 import logging
 import re
+import time
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import or_
@@ -50,15 +50,20 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from . import crypto, oauth
 from .config import get_settings
-from .models import AdConversion, Org, Secret
+from .models import AdConversion, Org
 
 
 def enabled() -> bool:
-    """Missing upload configuration = OFF. Keeps tests and self-hosted instances inert."""
+    """Missing upload configuration = OFF. Keeps tests and self-hosted instances inert.
+
+    `google_ads_developer_token` is deliberately NOT required here: it is the read-side Ads API's
+    header (see oauth_providers.GOOGLE_ADS), and Data Manager has no developer-token header at all
+    (see `_auth_headers`). `ads_conv_org_slug` is gone entirely — the uploader no longer borrows a
+    customer-facing OAuth connection; it authenticates with its own platform refresh token.
+    """
     s = get_settings()
-    return bool(s.google_ads_customer_id and s.google_ads_developer_token and s.ads_conv_org_slug)
+    return bool(s.google_ads_customer_id and s.ads_conv_refresh_token)
 
 
 async def queue(db: AsyncSession, org: Org, action: str, *,
@@ -104,6 +109,7 @@ def _utcnow_naive() -> datetime:
 # sunset cycle (oauth_providers.GOOGLE_ADS, catalog yaml, auth-secrets.md still track that
 # separately for the read-side Ads catalog calls) — there is nothing to keep in sync here.
 DATA_MANAGER_URL = "https://datamanager.googleapis.com/v1/events:ingest"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 _UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
 _MAX_ATTEMPTS = 8
 _RETRY_BASE_S = 5 * 60
@@ -205,7 +211,48 @@ def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
     return _payload_and_rows(rows, orgs)[0]
 
 
-async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
+# Module-level cache for the platform access token: ONE credential, shared by every drain, so a
+# per-call or per-db-session cache would just re-exchange the refresh token every pass for no
+# reason. `worker` drains every 300s; a token typically lives ~3599s, so almost every pass should
+# hit this cache rather than call Google. `_token_expires_at` is a `time.time()` epoch, not a naive
+# UTC datetime (unlike the rest of this module) — it is process-local runtime state, never
+# persisted or compared against a DB column, so there is no naive/aware mismatch to guard against.
+_cached_access_token: str | None = None
+_token_expires_at: float = 0.0
+_TOKEN_SKEW_S = 60.0  # refresh this many seconds before actual expiry, same margin as oauth.py
+
+
+async def _exchange_refresh_token(client) -> tuple[str, float]:
+    """One refresh_token grant against Google's token endpoint. Raises on any failure — the caller
+    (`_auth_headers`) decides whether that's fatal to this drain; `drain_once` is called inside
+    `worker`'s try/except, so a raise here just means "retry next pass," not a crashed loop."""
+    settings = get_settings()
+    resp = await client.post(
+        GOOGLE_TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": settings.ads_conv_refresh_token,
+            "client_id": settings.google_ads_client_id,
+            "client_secret": settings.google_ads_client_secret,
+        },
+    )
+    try:
+        body = resp.json()
+    except Exception:  # noqa: BLE001 — an unparseable body is not a usable token either
+        body = {}
+    token = body.get("access_token") if isinstance(body, dict) else None
+    if not token:
+        raise RuntimeError(
+            f"ads conversion token refresh failed: {resp.status_code} {resp.text[:300]}"
+        )
+    try:
+        expires_in = float(body.get("expires_in") or 0)
+    except (TypeError, ValueError):
+        expires_in = 0.0
+    return token, time.time() + expires_in
+
+
+async def _auth_headers(client) -> dict[str, str]:
     """Bearer-only headers for a direct call to the Data Manager REST API.
 
     Data Manager has neither a developer-token header nor a login-customer-id header: the manager
@@ -214,36 +261,22 @@ async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
 
     This does NOT go through proxy.relay/injectors.py — the uploader is not a caller-issued
     `/call/` request, it's treg spending its OWN platform connection, so there is no Tool/bindings
-    row to resolve credentials from. Instead it reads the `google-ads` OAuth `Secret` stored on
-    the platform org named by `ads_conv_org_slug`, the same shape a normal registry connect
-    produces (see api.py's `/oauth/callback`, which stores `kind="oauth"` + a JSON blob). That
-    connection must hold the `datamanager` scope (oauth_providers.GOOGLE_ADS) — a connection made
-    before that scope was added only has `adwords` and needs reconnecting.
+    row (and no per-tenant Secret) to resolve credentials from. It exchanges treg's OWN long-lived
+    `settings.ads_conv_refresh_token` for an access token directly against Google's token endpoint,
+    redeemed with the same `google_ads_client_id`/`_secret` the refresh token was issued against.
+    Two different purposes stay on two different credentials: a customer connecting Google Ads
+    (oauth_providers.GOOGLE_ADS, `adwords` scope only) never touches this path, and this path never
+    touches a customer's OAuth connection.
 
-    Raises if the platform org, its google-ads connection, or a usable token is missing — the
-    caller (`drain_once`, called from `worker`'s try/except) logs that and retries next pass
-    rather than crashing the loop.
+    The access token is cached in module state with its expiry (`_cached_access_token`,
+    `_token_expires_at`) and only re-exchanged within `_TOKEN_SKEW_S` of expiring — `worker` drains
+    every few minutes, so re-exchanging on every pass would be wasteful and risks Google's refresh
+    rate limit.
     """
-    settings = get_settings()
-    org = (await db.execute(
-        select(Org).where(Org.slug == settings.ads_conv_org_slug)
-    )).scalar_one_or_none()
-    if org is None:
-        raise RuntimeError(f"ads_conv_org_slug {settings.ads_conv_org_slug!r} matches no org")
-    secret = (await db.execute(
-        select(Secret).where(Secret.org_id == org.id, Secret.provider == "google-ads",
-                              Secret.kind == "oauth")
-    )).scalars().first()
-    if secret is None:
-        raise RuntimeError(f"org {settings.ads_conv_org_slug!r} has no google-ads oauth connection")
-    # Same call health.py:205 makes from its own background task — refreshes in place if stale,
-    # no-ops for a still-valid or MANUAL-mode (non-refreshable) token.
-    await oauth.ensure_fresh(secret, db, client)
-    blob = json.loads(crypto.decrypt(secret.value))
-    token = blob.get("access_token") or blob.get("token")
-    if not token:
-        raise RuntimeError("google-ads secret decrypted with no access token")
-    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    global _cached_access_token, _token_expires_at
+    if _cached_access_token is None or time.time() > _token_expires_at - _TOKEN_SKEW_S:
+        _cached_access_token, _token_expires_at = await _exchange_refresh_token(client)
+    return {"Authorization": f"Bearer {_cached_access_token}", "Content-Type": "application/json"}
 
 
 def _retry_delay(attempts: int) -> timedelta:
@@ -362,7 +395,7 @@ async def drain_once(db: AsyncSession, client) -> dict:
     if not payload["events"]:
         await db.commit()
         return {"sent": 0, "failed": len(skipped)}
-    headers = await _auth_headers(db, client)
+    headers = await _auth_headers(client)
     resp = await client.post(DATA_MANAGER_URL, json=payload, headers=headers)
 
     try:

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -42,6 +42,7 @@ def usd_micro_to_aud_micro(usd_micro: int) -> int:
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import or_
@@ -99,30 +100,30 @@ def _utcnow_naive() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-# v21 was sunset 2026-08-05 (JSON 400 UNSUPPORTED_VERSION); every other path that names a Google
-# Ads API version in this repo (oauth_providers.GOOGLE_ADS, .agents/skills/google-ads/SKILL.md,
-# docs/context/architecture/auth-secrets.md) was repointed at v25 on 2026-08-17 — see commit
-# 6541167. The original task brief for this file still said v22 (written before that fix landed);
-# v25 is what is actually live, so that is what's pinned here. Bump all four places together next
-# time Google sunsets a version — see auth-secrets.md's note on this.
-API_VERSION = "v25"
+# Data Manager is its own product with its own `v1`, unrelated to the Google Ads REST version
+# sunset cycle (oauth_providers.GOOGLE_ADS, catalog yaml, auth-secrets.md still track that
+# separately for the read-side Ads catalog calls) — there is nothing to keep in sync here.
+DATA_MANAGER_URL = "https://datamanager.googleapis.com/v1/events:ingest"
 _UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
 _MAX_ATTEMPTS = 8
 _RETRY_BASE_S = 5 * 60
 _RETRY_CAP_S = 24 * 3600
 _CLICK_ID_FIELDS = frozenset({"gclid", "gbraid", "wbraid"})
-_ACKNOWLEDGED_ROW_ERRORS = frozenset({"CLICK_CONVERSION_ALREADY_EXISTS"})
-_RETRYABLE_ROW_ERRORS = frozenset({
-    "INTERNAL_ERROR",
-    "RESOURCE_EXHAUSTED",
-    "TEMPORARILY_UNAVAILABLE",
-    "TOO_RECENT_CONVERSION_ACTION",
-    "TOO_RECENT_EVENT",
-})
+# Data Manager has no analogue for CLICK_CONVERSION_ALREADY_EXISTS: within one conversion action it
+# dedupes silently on `events[].transactionId` (see `_payload_and_rows`) rather than erroring, so a
+# retry after an ambiguous prior outcome just gets folded into the existing conversion server-side
+# and comes back as an ordinary 200. The set stays here, empty, so the by-index classification below
+# keeps the same three-way shape (acknowledged / retryable / dead-letter) and stays extensible if
+# Google ever does surface a duplicate-style rejection.
+_ACKNOWLEDGED_ROW_ERRORS: frozenset[str] = frozenset()
+_RETRYABLE_ROW_ERRORS = frozenset({"INTERNAL_ERROR"})
+# Matches the event index out of a `google.rpc.BadRequest.FieldViolation.field` path such as
+# "events[2].userData..." or "events.events[2]...", and equally out of a `FieldWarning.fieldPath`.
+_EVENT_INDEX_RE = re.compile(r"events\[(\d+)\]")
 
 
 def _conversion_time(dt: datetime) -> str:
-    """Ads wants 'yyyy-mm-dd hh:mm:ss+hh:mm'. ISO with a 'Z' is rejected.
+    """RFC 3339, e.g. '2026-08-18T10:00:00Z'. Data Manager rejects the old 'yyyy-mm-dd hh:mm:ss+hh:mm'.
 
     `dt` comes out of the database as NAIVE UTC (see models._now), so it is stamped with UTC, not
     converted. `.astimezone()` on a naive value would read it as LOCAL time — on the Sydney deploy
@@ -131,15 +132,27 @@ def _conversion_time(dt: datetime) -> str:
     """
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _payload_and_rows(
     rows: list[AdConversion], orgs: dict[int, Org]
 ) -> tuple[dict, list[AdConversion]]:
-    """Build the request and preserve its operation-index -> outbox-row mapping."""
+    """Build the events:ingest request and preserve its operation-index -> outbox-row mapping.
+
+    Data Manager takes every destination (conversion action) and every event in ONE request, so a
+    batch spanning signup/first_call/paid rows is sent as a single call: `destinations[]` lists each
+    action touched by this batch exactly once (deduped by `reference`), and each event names the one
+    destination it belongs to via `destinationReferences`. `events[index]` stays a straight 1:1
+    mapping onto `payload_rows[index]` — `destinations` is a separate, deduped list, so it never
+    disturbs that index. `drain_once` and `_partial_failure_errors` rely on that 1:1 mapping to
+    attribute a rejected request back to the row that caused it.
+    """
     cid = get_settings().google_ads_customer_id
-    conversions = []
+    login_cid = (get_settings().google_ads_login_customer_id or "").replace("-", "").strip()
+    destinations: list[dict] = []
+    dest_index_by_action: dict[str, int] = {}
+    events = []
     payload_rows = []
     for row in rows:
         org = orgs.get(row.org_id)
@@ -148,42 +161,64 @@ def _payload_and_rows(
         click_field = org.ad_click_id_type or "gclid"  # NULL means a pre-type-migration GCLID.
         if click_field not in _CLICK_ID_FIELDS:
             click_field = "gclid"  # defensive for a manually edited legacy row
-        conv = {
-            click_field: org.ad_gclid,
-            "conversionAction": f"customers/{cid}/conversionActions/{CONVERSION_ACTION_IDS[row.action]}",
-            "conversionDateTime": _conversion_time(row.created_at),
+        if row.action not in dest_index_by_action:
+            destination = {
+                "operatingAccount": {"accountType": "GOOGLE_ADS", "accountId": cid},
+                "productDestinationId": CONVERSION_ACTION_IDS[row.action],
+                "reference": row.action,
+            }
+            # `loginAccount` is per-destination, not a header — never infer it from
+            # Secret.resource_ref (that's the target CLIENT account discovery stored, not the
+            # manager Google requires here). Direct client-account auth leaves it unset.
+            if login_cid:
+                destination["loginAccount"] = {"accountType": "GOOGLE_ADS", "accountId": login_cid}
+            dest_index_by_action[row.action] = len(destinations)
+            destinations.append(destination)
+        event = {
+            "adIdentifiers": {click_field: org.ad_gclid},
+            "eventTimestamp": _conversion_time(row.created_at),
+            "eventSource": "WEB",
+            "destinationReferences": [row.action],
+            # Stable per outbox row, so a resend after an ambiguous prior outcome (e.g. a timeout
+            # whose response we never saw) dedupes into the SAME conversion on Google's side instead
+            # of double-counting — see _ACKNOWLEDGED_ROW_ERRORS.
+            "transactionId": str(row.id),
         }
         if row.value_usd_micro:
-            # The one permitted float: the Ads API's conversionValue field is a wire double, so a
-            # decimal amount is what the JSON boundary requires. The arithmetic that produced the
-            # micro amount stayed integral (usd_micro_to_aud_micro).
-            conv["conversionValue"] = usd_micro_to_aud_micro(row.value_usd_micro) / 1_000_000
-            conv["currencyCode"] = "AUD"
-        conversions.append(conv)
+            # The one permitted float: conversionValue is a wire double, so a decimal amount is what
+            # the JSON boundary requires. The arithmetic that produced the micro amount stayed
+            # integral (usd_micro_to_aud_micro).
+            event["conversionValue"] = usd_micro_to_aud_micro(row.value_usd_micro) / 1_000_000
+            event["currency"] = "AUD"
+        events.append(event)
         payload_rows.append(row)
-    return {"conversions": conversions, "partialFailure": True}, payload_rows
+    return {"destinations": destinations, "events": events, "validateOnly": False}, payload_rows
 
 
 def build_payload(rows: list[AdConversion], orgs: dict[int, Org]) -> dict:
-    """Turn outbox rows into an uploadClickConversions body.
+    """Turn outbox rows into an events:ingest body.
 
-    `partialFailure` keeps a bad row from rejecting its siblings. `drain_once` retains the row
-    mapping from `_payload_and_rows` and reads every result before acknowledging anything.
-    Value is converted to the ACCOUNT's currency here, at upload time; the outbox stores USD so a
-    rate change never rewrites history.
+    `drain_once` retains the row mapping from `_payload_and_rows` and reads the response before
+    acknowledging anything. Value is converted to the ACCOUNT's currency here, at upload time; the
+    outbox stores USD so a rate change never rewrites history.
     """
     return _payload_and_rows(rows, orgs)[0]
 
 
 async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
-    """Bearer + developer-token (+ login-customer-id if the connection is scoped to a client
-    account under a manager), for a direct call to the Ads REST API.
+    """Bearer-only headers for a direct call to the Data Manager REST API.
+
+    Data Manager has neither a developer-token header nor a login-customer-id header: the manager
+    account is expressed per-destination as `loginAccount` in the request BODY instead (see
+    `_payload_and_rows`). Do not resurrect either header here.
 
     This does NOT go through proxy.relay/injectors.py — the uploader is not a caller-issued
     `/call/` request, it's treg spending its OWN platform connection, so there is no Tool/bindings
     row to resolve credentials from. Instead it reads the `google-ads` OAuth `Secret` stored on
     the platform org named by `ads_conv_org_slug`, the same shape a normal registry connect
-    produces (see api.py's `/oauth/callback`, which stores `kind="oauth"` + a JSON blob).
+    produces (see api.py's `/oauth/callback`, which stores `kind="oauth"` + a JSON blob). That
+    connection must hold the `datamanager` scope (oauth_providers.GOOGLE_ADS) — a connection made
+    before that scope was added only has `adwords` and needs reconnecting.
 
     Raises if the platform org, its google-ads connection, or a usable token is missing — the
     caller (`drain_once`, called from `worker`'s try/except) logs that and retries next pass
@@ -208,17 +243,7 @@ async def _auth_headers(db: AsyncSession, client) -> dict[str, str]:
     token = blob.get("access_token") or blob.get("token")
     if not token:
         raise RuntimeError("google-ads secret decrypted with no access token")
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "developer-token": settings.google_ads_developer_token,
-        "Content-Type": "application/json",
-    }
-    # `resource_ref` is the TARGET account chosen in discovery. It is not the manager account that
-    # Google requires in login-customer-id, so never infer this header from the Secret. Direct client
-    # auth omits it; manager auth configures the MCC explicitly.
-    if settings.google_ads_login_customer_id:
-        headers["login-customer-id"] = settings.google_ads_login_customer_id.replace("-", "").strip()
-    return headers
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
 def _retry_delay(attempts: int) -> timedelta:
@@ -229,33 +254,57 @@ def _retry_delay(attempts: int) -> timedelta:
 
 
 def _partial_failure_errors(body: dict) -> tuple[dict[int, list[tuple[str, str]]], list[tuple[str, str]]]:
-    """Return Google Ads partial errors keyed by conversions[index], plus batch-level details."""
+    """Parse Data Manager's error envelope for a REJECTED request (non-200 status).
+
+    Unlike ConversionUploadService, Data Manager has no partial-success envelope on a 200: as
+    `drain_once` handles separately, a 200 means the WHOLE request was accepted and every event in
+    it is acknowledged. A non-200 means the WHOLE request was rejected before anything was
+    ingested — but the standard `google.rpc.Status` error body Google returns can still say WHICH
+    row caused it, via `error.details[].fieldViolations[].field` paths like "events[2]...". A row
+    named that way is a genuine candidate for dead-lettering once it hits the attempt ceiling
+    (`drain_once`); every OTHER row in the same rejected batch was caught in the crossfire — its
+    own data was never at fault — and must keep retrying regardless of its own attempt count.
+    """
     by_index: dict[int, list[tuple[str, str]]] = {}
     general: list[tuple[str, str]] = []
-    status = body.get("partialFailureError") or {}
-    for detail in status.get("details") or []:
+    error = body.get("error") if isinstance(body, dict) else None
+    if not isinstance(error, dict):
+        return by_index, general
+    for detail in error.get("details") or []:
         if not isinstance(detail, dict):
             continue
-        for error in detail.get("errors") or []:
-            if not isinstance(error, dict):
+        for violation in detail.get("fieldViolations") or []:
+            if not isinstance(violation, dict):
                 continue
-            error_code = error.get("errorCode") or {}
-            code = next((str(v) for v in error_code.values() if v), "UNKNOWN") \
-                if isinstance(error_code, dict) else "UNKNOWN"
-            message = str(error.get("message") or status.get("message") or "partial failure")
-            index = None
-            location = error.get("location") or {}
-            for part in location.get("fieldPathElements") or []:
-                if isinstance(part, dict) and part.get("fieldName") == "conversions":
-                    candidate = part.get("index")
-                    if isinstance(candidate, int):
-                        index = candidate
-                        break
-            target = by_index.setdefault(index, []) if index is not None else general
+            code = str(violation.get("reason") or "UNKNOWN")
+            message = str(violation.get("description") or error.get("message") or "request rejected")
+            match = _EVENT_INDEX_RE.search(str(violation.get("field") or ""))
+            target = by_index.setdefault(int(match.group(1)), []) if match else general
             target.append((code, message))
-    if not by_index and not general and status:
-        general.append(("UNKNOWN", str(status.get("message") or "partial failure")))
+    if not by_index and not general and error:
+        general.append(("UNKNOWN", str(error.get("message") or "request rejected")))
     return by_index, general
+
+
+def _field_warnings_by_index(body: dict) -> dict[int, list[tuple[str, str]]]:
+    """Non-fatal per-event notes on an ACCEPTED (200) response.
+
+    Per Data Manager's own contract, a warning means "the API didn't reject the record, but had to
+    ignore part of its data" — the event is still ingested. So a row with a warning is still
+    `_acknowledge`d in `drain_once`; the text is kept on `row.error` purely for operator visibility,
+    never as a reason to retry or dead-letter.
+    """
+    by_index: dict[int, list[tuple[str, str]]] = {}
+    for warning in body.get("fieldWarnings") or []:
+        if not isinstance(warning, dict):
+            continue
+        match = _EVENT_INDEX_RE.search(str(warning.get("fieldPath") or ""))
+        if not match:
+            continue
+        code = str(warning.get("reason") or "UNKNOWN")
+        message = str(warning.get("description") or "field warning")
+        by_index.setdefault(int(match.group(1)), []).append((code, message))
+    return by_index
 
 
 def _schedule_retry(row: AdConversion, now: datetime, error: str) -> None:
@@ -277,6 +326,11 @@ async def drain_once(db: AsyncSession, client) -> dict:
     Due = not uploaded/terminal, older than the click-availability delay, and past its retry time.
     HTTP failures retry indefinitely with backoff. Per-row permanent failures are dead-lettered
     after `_MAX_ATTEMPTS`; they remain queryable with `failed_at` + the last Google error.
+
+    Data Manager's ingest response has no per-event partial-success shape the way the old
+    ConversionUploadService did: a 200 means the WHOLE request was accepted (every event in it),
+    and a non-200 means the WHOLE request was rejected (nothing in it was ingested) — see
+    `_partial_failure_errors` for how a rejection can still be traced back to one row.
     """
     if not enabled():
         return {"sent": 0, "reason": "disabled"}
@@ -305,52 +359,52 @@ async def drain_once(db: AsyncSession, client) -> dict:
         row.failed_at = now
         row.error = "outbox row has no attributable org/click id"
         db.add(row)
-    if not payload["conversions"]:
+    if not payload["events"]:
         await db.commit()
         return {"sent": 0, "failed": len(skipped)}
-    cid = get_settings().google_ads_customer_id
-    url = f"https://googleads.googleapis.com/{API_VERSION}/customers/{cid}:uploadClickConversions"
     headers = await _auth_headers(db, client)
-    resp = await client.post(url, json=payload, headers=headers)
-    if resp.status_code != 200:
-        for row in payload_rows:
-            row.attempts += 1
-            _schedule_retry(row, now, f"{resp.status_code}: {resp.text[:260]}")
-            db.add(row)
-        await db.commit()
-        return {"sent": 0, "retried": len(payload_rows), "failed": len(skipped),
-                "status": resp.status_code}
+    resp = await client.post(DATA_MANAGER_URL, json=payload, headers=headers)
 
     try:
         body = resp.json()
-    except Exception:  # noqa: BLE001 — an unexpected 200 body must not acknowledge durable rows
+    except Exception:  # noqa: BLE001 — an unparseable body must not acknowledge durable rows
         body = {}
-    results = body.get("results") if isinstance(body, dict) else None
-    indexed_errors, general_errors = _partial_failure_errors(body if isinstance(body, dict) else {})
+    if not isinstance(body, dict):
+        body = {}
+
     sent = retried = failed = 0
-    for index, row in enumerate(payload_rows):
-        row.attempts += 1
-        result = results[index] if isinstance(results, list) and index < len(results) else None
-        if isinstance(result, dict) and result:
-            _acknowledge(row, now)
-            sent += 1
+    if resp.status_code == 200:
+        request_id = body.get("requestId")
+        if not request_id:
+            # An unexpected/empty 200 body is not proof of acceptance — retry the whole batch
+            # rather than guess which rows, if any, actually landed.
+            for row in payload_rows:
+                row.attempts += 1
+                _schedule_retry(row, now, "200: missing requestId")
+                db.add(row)
+                retried += 1
         else:
+            warnings_by_index = _field_warnings_by_index(body)
+            for index, row in enumerate(payload_rows):
+                row.attempts += 1
+                _acknowledge(row, now)
+                warning = warnings_by_index.get(index)
+                if warning:
+                    row.error = ("; ".join(f"{code}: {message}" for code, message in warning))[:300]
+                sent += 1
+                db.add(row)
+    else:
+        indexed_errors, general_errors = _partial_failure_errors(body)
+        for index, row in enumerate(payload_rows):
+            row.attempts += 1
             row_errors = indexed_errors.get(index)
             errors = row_errors or general_errors
             codes = {code for code, _ in errors}
             detail = "; ".join(f"{code}: {message}" for code, message in errors) \
-                or "200: missing conversion result"
-            if codes and codes <= _ACKNOWLEDGED_ROW_ERRORS:
-                # A retry may race the prior worker's commit; Google has already stored this event.
-                _acknowledge(row, now)
-                sent += 1
-            elif (
-                row_errors is None
-                or codes & _RETRYABLE_ROW_ERRORS
-                or row.attempts < _MAX_ATTEMPTS
-            ):
-                # A missing/unparseable result or batch-level failure is not evidence that this row
-                # is permanently bad. Only an indexed row error may reach the dead-letter ceiling.
+                or f"{resp.status_code}: {resp.text[:260]}"
+            if row_errors is None or codes & _RETRYABLE_ROW_ERRORS or row.attempts < _MAX_ATTEMPTS:
+                # A row this rejection didn't name (row_errors is None) was caught in the
+                # crossfire of a sibling's bad data — never dead-letter it on that basis alone.
                 _schedule_retry(row, now, detail)
                 retried += 1
             else:
@@ -358,7 +412,7 @@ async def drain_once(db: AsyncSession, client) -> dict:
                 row.next_attempt_at = None
                 row.failed_at = now
                 failed += 1
-        db.add(row)
+            db.add(row)
     await db.commit()
     return {"sent": sent, "retried": retried, "failed": failed + len(skipped),
             "status": resp.status_code}

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -269,17 +269,23 @@ class Settings(BaseSettings):
     # can't work without this) rather than silently reusing the wrong client.
     google_ads_client_id: str = ""
     google_ads_client_secret: str = ""
-    # Google Ads conversion upload. This customer id, the developer token above, and the OAuth org
-    # slug below are all required; if any is empty the whole feature is OFF (tests stay inert and
-    # self-hosters send nothing) — the same gate shape analytics.py uses for posthog_key.
+    # Google Ads conversion upload. This customer id and the refresh token below are both required;
+    # if either is empty the whole feature is OFF (tests stay inert and self-hosters send nothing) —
+    # the same gate shape analytics.py uses for posthog_key.
     google_ads_customer_id: str = ""
     # Manager (MCC) account used to access google_ads_customer_id. Optional for direct client auth;
     # when present this is sent as login-customer-id. It cannot be inferred from Secret.resource_ref,
     # which is the TARGET client account selected in discovery, not its manager.
     google_ads_login_customer_id: str = ""
-    # Which team's google-ads OAuth connection the uploader authenticates as. treg uploads to its
-    # OWN ad account, so this is a platform setting, never a per-tenant one.
-    ads_conv_org_slug: str = ""
+    # treg's OWN long-lived refresh token for the Data Manager conversion uploader — a PLATFORM
+    # credential, obtained once, out of band, by an operator via the OAuth playground with scope
+    # https://www.googleapis.com/auth/datamanager. It is exchanged against `google_ads_client_id`/
+    # `_secret` above (the refresh token is issued against that client, so it must be redeemed with
+    # it), never against a customer's own OAuth connection: the uploader ships treg's OWN marketing
+    # conversions to treg's OWN ad account, a different purpose from a customer connecting Ads to
+    # read their campaign data, and the two must not share a credential or a consent screen. Empty
+    # = the whole feature is OFF. See docs/context/architecture/ads-conversions.md.
+    ads_conv_refresh_token: str = ""
 
     linkedin_client_id: str = ""
     linkedin_client_secret: str = ""

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -399,13 +399,12 @@ GOOGLE_ADS = OAuthProvider(
     display_name="Google Ads",
     auth_uri="https://accounts.google.com/o/oauth2/v2/auth",
     token_uri="https://oauth2.googleapis.com/token",
-    # `adwords` alone — validated empirically (a `validateOnly` userLists:mutate call returned
-    # `{}`) to already cover audience/customer-match writes, so a customer connecting Ads gains
-    # nothing from `datamanager`. That scope is real (SCOPE_LABELS keeps its copy) but belongs only
-    # to treg's OWN conversion uploader (adsconv.py), which authenticates with a platform refresh
-    # token (settings.ads_conv_refresh_token), never this customer-facing provider — see
-    # docs/context/architecture/ads-conversions.md. Do not add it back here: `listing()` shows every
-    # provider, so it would put a marketing-only permission on every customer's consent screen.
+    # `adwords` alone, deliberately. It already covers audience / customer-match writes — verified
+    # empirically, a `validateOnly` userLists:mutate returned `{}` — so a customer connecting Ads
+    # gains nothing from the Data Manager scope. treg's OWN conversion uploader (adsconv.py) needs
+    # that scope, but authenticates with a platform refresh token (settings.ads_conv_refresh_token),
+    # never this provider. Do not add it here: `listing()` shows every provider, so it would put a
+    # marketing-only permission on every customer's consent screen.
     scopes={"manage": ["https://www.googleapis.com/auth/adwords"]},
     # Ads gets its OWN OAuth client, in a DIFFERENT Cloud project from the other Google providers.
     # A Google Ads developer token is permanently paired to the first Cloud project it calls from,
@@ -1825,8 +1824,6 @@ SCOPE_LABELS: dict[str, str] = {
         "Manage your business listings, reviews and posts",
     "https://www.googleapis.com/auth/adwords":
         "Read campaigns, spend and performance, and manage campaigns",
-    "https://www.googleapis.com/auth/datamanager":
-        "Send conversion and audience events through the Data Manager API",
     # Google — YouTube
     "https://www.googleapis.com/auth/youtube.readonly":
         "See your channel, videos and playlists",

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -399,7 +399,12 @@ GOOGLE_ADS = OAuthProvider(
     display_name="Google Ads",
     auth_uri="https://accounts.google.com/o/oauth2/v2/auth",
     token_uri="https://oauth2.googleapis.com/token",
-    scopes={"manage": ["https://www.googleapis.com/auth/adwords"]},
+    # `datamanager` was added 2026-08 so the platform's own conversion uploader (adsconv.py) can
+    # call the Data Manager API — `uploadClickConversions` is closed to new integrations. Existing
+    # connections made before this change hold only `adwords` and must be reconnected to pick up
+    # the new scope; treg cannot silently upgrade a token it didn't request.
+    scopes={"manage": ["https://www.googleapis.com/auth/adwords",
+                        "https://www.googleapis.com/auth/datamanager"]},
     # Ads gets its OWN OAuth client, in a DIFFERENT Cloud project from the other Google providers.
     # A Google Ads developer token is permanently paired to the first Cloud project it calls from,
     # and the shared Google project is already welded to a different (stale) token — so Ads must
@@ -1818,6 +1823,8 @@ SCOPE_LABELS: dict[str, str] = {
         "Manage your business listings, reviews and posts",
     "https://www.googleapis.com/auth/adwords":
         "Read campaigns, spend and performance, and manage campaigns",
+    "https://www.googleapis.com/auth/datamanager":
+        "Send conversion and audience events through the Data Manager API",
     # Google — YouTube
     "https://www.googleapis.com/auth/youtube.readonly":
         "See your channel, videos and playlists",

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -399,12 +399,14 @@ GOOGLE_ADS = OAuthProvider(
     display_name="Google Ads",
     auth_uri="https://accounts.google.com/o/oauth2/v2/auth",
     token_uri="https://oauth2.googleapis.com/token",
-    # `datamanager` was added 2026-08 so the platform's own conversion uploader (adsconv.py) can
-    # call the Data Manager API — `uploadClickConversions` is closed to new integrations. Existing
-    # connections made before this change hold only `adwords` and must be reconnected to pick up
-    # the new scope; treg cannot silently upgrade a token it didn't request.
-    scopes={"manage": ["https://www.googleapis.com/auth/adwords",
-                        "https://www.googleapis.com/auth/datamanager"]},
+    # `adwords` alone — validated empirically (a `validateOnly` userLists:mutate call returned
+    # `{}`) to already cover audience/customer-match writes, so a customer connecting Ads gains
+    # nothing from `datamanager`. That scope is real (SCOPE_LABELS keeps its copy) but belongs only
+    # to treg's OWN conversion uploader (adsconv.py), which authenticates with a platform refresh
+    # token (settings.ads_conv_refresh_token), never this customer-facing provider — see
+    # docs/context/architecture/ads-conversions.md. Do not add it back here: `listing()` shows every
+    # provider, so it would put a marketing-only permission on every customer's consent screen.
+    scopes={"manage": ["https://www.googleapis.com/auth/adwords"]},
     # Ads gets its OWN OAuth client, in a DIFFERENT Cloud project from the other Google providers.
     # A Google Ads developer token is permanently paired to the first Cloud project it calls from,
     # and the shared Google project is already welded to a different (stale) token — so Ads must

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -399,12 +399,6 @@ GOOGLE_ADS = OAuthProvider(
     display_name="Google Ads",
     auth_uri="https://accounts.google.com/o/oauth2/v2/auth",
     token_uri="https://oauth2.googleapis.com/token",
-    # `adwords` alone, deliberately. It already covers audience / customer-match writes — verified
-    # empirically, a `validateOnly` userLists:mutate returned `{}` — so a customer connecting Ads
-    # gains nothing from the Data Manager scope. treg's OWN conversion uploader (adsconv.py) needs
-    # that scope, but authenticates with a platform refresh token (settings.ads_conv_refresh_token),
-    # never this provider. Do not add it here: `listing()` shows every provider, so it would put a
-    # marketing-only permission on every customer's consent screen.
     scopes={"manage": ["https://www.googleapis.com/auth/adwords"]},
     # Ads gets its OWN OAuth client, in a DIFFERENT Cloud project from the other Google providers.
     # A Google Ads developer token is permanently paired to the first Cloud project it calls from,

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -1,4 +1,5 @@
 import json
+import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -9,11 +10,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlmodel import select
 
 from conftest import make_upstream
-from treg import adsconv, crypto
+from treg import adsconv
 from treg.api import app
 from treg.config import get_settings
 from treg.db import _migrate_to_orgs, reset_db, session_maker
-from treg.models import AdConversion, Org, Secret
+from treg.models import AdConversion, Org
 
 
 def _h(token: str) -> dict:
@@ -31,13 +32,25 @@ class FakeAdsResponse:
 
 
 class FakeAdsClient:
-    def __init__(self, response: FakeAdsResponse):
-        self.response = response
-        self.calls = []
+    """Routes POSTs by URL, because one drain now makes TWO different calls: the token exchange
+    (`adsconv.GOOGLE_TOKEN_URL`) and the Data Manager ingest (`adsconv.DATA_MANAGER_URL`). Tests
+    that care about only one keep the default for the other; `token_calls`/`calls` are recorded
+    separately so a caching test can assert the exchange did NOT repeat while the ingest did."""
+    def __init__(self, data_response: FakeAdsResponse,
+                 token_response: FakeAdsResponse | None = None):
+        self.data_response = data_response
+        self.token_response = token_response or FakeAdsResponse(
+            {"access_token": "tok-test", "expires_in": 3599}
+        )
+        self.calls = []        # Data Manager events:ingest calls
+        self.token_calls = []  # oauth2.googleapis.com/token calls
 
     async def post(self, url, **kwargs):
+        if url == adsconv.GOOGLE_TOKEN_URL:
+            self.token_calls.append((url, kwargs))
+            return self.token_response
         self.calls.append((url, kwargs))
-        return self.response
+        return self.data_response
 
 
 @pytest.fixture
@@ -46,7 +59,15 @@ def ads_enabled(monkeypatch):
     monkeypatch.setattr(settings, "google_ads_customer_id", "5149790776", raising=False)
     monkeypatch.setattr(settings, "google_ads_developer_token", "dev-tok-test", raising=False)
     monkeypatch.setattr(settings, "google_ads_login_customer_id", "", raising=False)
-    monkeypatch.setattr(settings, "ads_conv_org_slug", "platform-ads", raising=False)
+    monkeypatch.setattr(settings, "google_ads_client_id", "ads-client-id-test", raising=False)
+    monkeypatch.setattr(settings, "google_ads_client_secret", "ads-client-secret-test", raising=False)
+    monkeypatch.setattr(settings, "ads_conv_refresh_token", "ads-refresh-tok-test", raising=False)
+    # The access-token cache lives in MODULE state (see adsconv._auth_headers), deliberately, so
+    # the worker doesn't re-exchange the refresh token every 300s drain. That means it persists
+    # ACROSS tests unless reset here — without this a token cached by an earlier test would make
+    # a later test's drain skip the exchange entirely and its FakeAdsClient assertions lie.
+    monkeypatch.setattr(adsconv, "_cached_access_token", None, raising=False)
+    monkeypatch.setattr(adsconv, "_token_expires_at", 0.0, raising=False)
     assert adsconv.enabled() is True
     return settings
 
@@ -56,7 +77,7 @@ def ads_disabled(monkeypatch):
     settings = get_settings()
     monkeypatch.setattr(settings, "google_ads_customer_id", "", raising=False)
     monkeypatch.setattr(settings, "google_ads_developer_token", "", raising=False)
-    monkeypatch.setattr(settings, "ads_conv_org_slug", "", raising=False)
+    monkeypatch.setattr(settings, "ads_conv_refresh_token", "", raising=False)
     assert adsconv.enabled() is False
     return settings
 
@@ -113,7 +134,7 @@ def test_action_ids_cover_every_action():
 
 @pytest.mark.parametrize(
     "setting_name",
-    ["google_ads_customer_id", "google_ads_developer_token", "ads_conv_org_slug"],
+    ["google_ads_customer_id", "ads_conv_refresh_token"],
 )
 def test_tracking_is_disabled_when_any_required_setting_is_missing(
     monkeypatch, ads_enabled, setting_name
@@ -407,13 +428,12 @@ def test_build_payload_sets_manager_account_per_destination(monkeypatch, ads_ena
     assert "loginAccount" not in dest
 
 
-async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch, ads_enabled):
+async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, ads_enabled):
     """A row younger than the upload delay is left alone; an old one is sent and marked.
 
-    _auth_headers reads a real `google-ads` oauth Secret off the platform org named by
-    `ads_conv_org_slug` (see adsconv.py) — it is not mocked away, so this sets that org up for
-    real: a slug settings can point at, and a MANUAL-mode oauth blob (no refresh_token) so
-    oauth.ensure_fresh no-ops rather than trying to hit a real token endpoint through FakeClient.
+    `_auth_headers` no longer reads anything off the DB — it exchanges treg's OWN platform
+    `ads_conv_refresh_token` (set by `ads_enabled`) directly against Google's token endpoint, which
+    `FakeAdsClient` fakes alongside the Data Manager ingest call.
     """
     client = FakeAdsClient(FakeAdsResponse({"requestId": "req-drain-1"}))
 
@@ -423,11 +443,6 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
         db.add(org)
         await db.commit()
         await db.refresh(org)
-        monkeypatch.setattr(get_settings(), "ads_conv_org_slug", org.slug, raising=False)
-        # No refresh_token/client_id/client_secret -> oauth.is_refreshable() is False -> ensure_fresh
-        # no-ops instead of calling FakeClient.post against a real token endpoint.
-        db.add(Secret(org_id=org.id, name="google-ads", kind="oauth", provider="google-ads",
-                      value=crypto.encrypt(json.dumps({"access_token": "tok-test"}))))
         old = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
                            created_at=datetime.now(timezone.utc) - timedelta(hours=12))
         young = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
@@ -444,19 +459,19 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
         assert young.uploaded_at is None
         assert len(client.calls) == 1
         assert client.calls[0][0] == adsconv.DATA_MANAGER_URL
+        assert len(client.token_calls) == 1
+        assert client.token_calls[0][0] == adsconv.GOOGLE_TOKEN_URL
 
 
-async def _seed_upload_rows(db, monkeypatch, *, actions, attempts=0):
-    """Create the platform OAuth connection and old, upload-due outbox rows."""
+async def _seed_upload_rows(db, *, actions, attempts=0):
+    """Create an ad-attributed org and old, upload-due outbox rows. No OAuth Secret is needed
+    anymore — the uploader authenticates with treg's own platform refresh token, not a per-org
+    connection (see `ads_enabled`, which sets it)."""
     org = Org(name="t", slug="t-upload-batch", ad_gclid="CLICK_BATCH",
               ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
     db.add(org)
     await db.commit()
     await db.refresh(org)
-    monkeypatch.setattr(get_settings(), "ads_conv_org_slug", org.slug, raising=False)
-    db.add(Secret(org_id=org.id, name="google-ads", kind="oauth", provider="google-ads",
-                  resource_ref="customers/5149790776",
-                  value=crypto.encrypt(json.dumps({"access_token": "tok-test"}))))
     rows = [
         AdConversion(org_id=org.id, action=action, attempts=attempts,
                      created_at=datetime.now(timezone.utc) - timedelta(hours=12))
@@ -480,9 +495,7 @@ def _rejected(*violations: dict, message: str = "There was a problem with the re
                        "details": [{"fieldViolations": list(violations)}] if violations else []}}
 
 
-async def test_drain_only_dead_letters_the_row_the_rejection_actually_names(
-    clients, monkeypatch, ads_enabled
-):
+async def test_drain_only_dead_letters_the_row_the_rejection_actually_names(clients, ads_enabled):
     """A 400 rejects the WHOLE request — nothing in it was ingested — but Google's fieldViolations
     can still say WHICH row's data caused the rejection. That row is a dead-letter candidate once it
     hits the attempt ceiling; its innocent batch-mate keeps retrying regardless of its own attempt
@@ -491,7 +504,7 @@ async def test_drain_only_dead_letters_the_row_the_rejection_actually_names(
     client = FakeAdsClient(FakeAdsResponse(body, status_code=400))
     async with session_maker() as db:
         _org, rows = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP, adsconv.ACTION_PAID), attempts=7
+            db, actions=(adsconv.ACTION_SIGNUP, adsconv.ACTION_PAID), attempts=7
         )
         result = await adsconv.drain_once(db, client)
         for row in rows:
@@ -509,15 +522,11 @@ async def test_drain_only_dead_letters_the_row_the_rejection_actually_names(
         assert "INVALID_HEX_ENCODING" in rows[1].error
 
 
-async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
-    clients, monkeypatch, ads_enabled
-):
+async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(clients, ads_enabled):
     client = FakeAdsClient(FakeAdsResponse({"error": {"code": 503, "message": "unavailable"}},
                                             status_code=503))
     async with session_maker() as db:
-        _org, (row,) = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
-        )
+        _org, (row,) = await _seed_upload_rows(db, actions=(adsconv.ACTION_SIGNUP,), attempts=7)
 
         first = await adsconv.drain_once(db, client)
         await db.refresh(row)
@@ -540,15 +549,11 @@ async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
         assert row.next_attempt_at is not None
 
 
-async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(
-    clients, monkeypatch, ads_enabled
-):
+async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(clients, ads_enabled):
     body = _rejected(_field_violation(0, "INVALID_HEX_ENCODING"))
     client = FakeAdsClient(FakeAdsResponse(body, status_code=400))
     async with session_maker() as db:
-        _org, (row,) = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
-        )
+        _org, (row,) = await _seed_upload_rows(db, actions=(adsconv.ACTION_SIGNUP,), attempts=7)
         result = await adsconv.drain_once(db, client)
         await db.refresh(row)
 
@@ -560,16 +565,12 @@ async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(
         assert "INVALID_HEX_ENCODING" in row.error
 
 
-async def test_unstructured_success_response_does_not_dead_letter_rows(
-    clients, monkeypatch, ads_enabled
-):
+async def test_unstructured_success_response_does_not_dead_letter_rows(clients, ads_enabled):
     """A 200 with no `requestId` is not proof anything was accepted — unlike the old API, there is
     no per-row `results` list to fall back to, so the whole batch is retried."""
     client = FakeAdsClient(FakeAdsResponse({}))
     async with session_maker() as db:
-        _org, (row,) = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
-        )
+        _org, (row,) = await _seed_upload_rows(db, actions=(adsconv.ACTION_SIGNUP,), attempts=7)
         result = await adsconv.drain_once(db, client)
         await db.refresh(row)
 
@@ -581,9 +582,7 @@ async def test_unstructured_success_response_does_not_dead_letter_rows(
         assert row.error == "200: missing requestId"
 
 
-async def test_drain_acknowledges_rows_despite_nonfatal_field_warnings(
-    clients, monkeypatch, ads_enabled
-):
+async def test_drain_acknowledges_rows_despite_nonfatal_field_warnings(clients, ads_enabled):
     """A `fieldWarnings` entry on a 200 is explicitly non-rejecting per Data Manager's contract —
     the record was still ingested, just with part of its data ignored — so the row is uploaded, not
     retried or dead-lettered. This is Data Manager's replacement for the old API's
@@ -598,7 +597,7 @@ async def test_drain_acknowledges_rows_despite_nonfatal_field_warnings(
     }
     client = FakeAdsClient(FakeAdsResponse(body))
     async with session_maker() as db:
-        _org, (row,) = await _seed_upload_rows(db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,))
+        _org, (row,) = await _seed_upload_rows(db, actions=(adsconv.ACTION_SIGNUP,))
         result = await adsconv.drain_once(db, client)
         await db.refresh(row)
 
@@ -608,25 +607,102 @@ async def test_drain_acknowledges_rows_despite_nonfatal_field_warnings(
         assert "PARTIAL_DATA_IGNORED" in row.error  # kept for operator visibility only
 
 
-async def test_auth_headers_carry_no_developer_token_or_login_customer_id(
-    clients, monkeypatch, ads_enabled
-):
+async def test_auth_headers_carry_no_developer_token_or_login_customer_id(monkeypatch, ads_enabled):
     """Both headers the old ConversionUploadService needed are gone under Data Manager: no
     developer-token header exists at all, and the manager account moves into the request body as
     `destinations[].loginAccount` (see the build_payload manager-account test) rather than a
-    `login-customer-id` header."""
+    `login-customer-id` header. `_auth_headers` no longer touches the DB at all — it only takes the
+    httpx client for the token exchange."""
+    monkeypatch.setattr(get_settings(), "google_ads_login_customer_id", "351-912-5194", raising=False)
+    headers = await adsconv._auth_headers(FakeAdsClient(FakeAdsResponse({"requestId": "r1"})))
+    assert "login-customer-id" not in headers
+    assert "developer-token" not in headers
+    assert headers["Authorization"] == "Bearer tok-test"
+    assert headers["Content-Type"] == "application/json"
+
+
+async def test_token_exchange_uses_the_platform_refresh_token_and_ads_client(ads_enabled):
+    """The exchange must be a `grant_type=refresh_token` POST redeemed with the SAME OAuth client
+    the refresh token was issued against (`google_ads_client_id`/`_secret`) — never the shared
+    Google login client, and never anything derived from a customer's own OAuth connection. This is
+    the crux of the option-A rework: treg's marketing uploader and a customer's Ads connection are
+    two different credentials for two different purposes."""
+    client = FakeAdsClient(FakeAdsResponse({"requestId": "unused"}))
+    headers = await adsconv._auth_headers(client)
+    assert headers["Authorization"] == "Bearer tok-test"
+    assert len(client.token_calls) == 1
+    url, kwargs = client.token_calls[0]
+    assert url == adsconv.GOOGLE_TOKEN_URL
+    assert kwargs["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": ads_enabled.ads_conv_refresh_token,
+        "client_id": ads_enabled.google_ads_client_id,
+        "client_secret": ads_enabled.google_ads_client_secret,
+    }
+
+
+async def test_token_exchange_failure_raises_a_clear_error(ads_enabled):
+    """A failed exchange must raise, not silently produce a broken Authorization header —
+    `drain_once` runs inside `worker`'s try/except, so raising here just retries next pass rather
+    than crashing the loop or sending an unauthenticated request."""
+    client = FakeAdsClient(
+        FakeAdsResponse({"requestId": "unused"}),
+        token_response=FakeAdsResponse({"error": "invalid_grant"}, status_code=400),
+    )
+    with pytest.raises(RuntimeError, match="token refresh failed"):
+        await adsconv._auth_headers(client)
+    assert len(client.token_calls) == 1
+
+
+async def test_access_token_is_cached_and_not_re_exchanged_within_its_lifetime(clients, ads_enabled):
+    """The whole point of caching: the worker drains every 300s and a token lives ~3599s, so a
+    second drain in the same window must reuse the cached token rather than exchange again. This
+    test genuinely fails without the cache — remove it and `_auth_headers` calls
+    `_exchange_refresh_token` on every drain, so `token_calls` would be 2, not 1, after the second
+    drain below."""
+    client = FakeAdsClient(FakeAdsResponse({"requestId": "req-cache-1"}))
     async with session_maker() as db:
-        await _seed_upload_rows(db, monkeypatch, actions=())
-        monkeypatch.setattr(
-            get_settings(), "google_ads_login_customer_id", "351-912-5194", raising=False
-        )
-        headers = await adsconv._auth_headers(
-            db, FakeAdsClient(FakeAdsResponse({"requestId": "r1"}))
-        )
-        assert "login-customer-id" not in headers
-        assert "developer-token" not in headers
-        assert headers["Authorization"] == "Bearer tok-test"
-        assert headers["Content-Type"] == "application/json"
+        org = Org(name="t", slug="t-token-cache", ad_gclid="C",
+                  ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+        db.add(org)
+        await db.commit()
+        await db.refresh(org)
+
+        row_a = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
+                             created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+        db.add(row_a)
+        await db.commit()
+        first = await adsconv.drain_once(db, client)
+        assert first["sent"] == 1
+        assert len(client.token_calls) == 1  # first drain: exchanged once
+
+        row_b = AdConversion(org_id=org.id, action=adsconv.ACTION_FIRST_CALL,
+                             created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+        db.add(row_b)
+        await db.commit()
+        second = await adsconv.drain_once(db, client)
+        assert second["sent"] == 1
+
+        assert len(client.calls) == 2                # two ingest POSTs, one per drain
+        assert len(client.token_calls) == 1           # still only ONE exchange, ever
+        auth1 = client.calls[0][1]["headers"]["Authorization"]
+        auth2 = client.calls[1][1]["headers"]["Authorization"]
+        assert auth1 == auth2 == "Bearer tok-test"    # the second drain reused the cached token
+
+
+async def test_expired_cached_token_triggers_a_fresh_exchange(monkeypatch, ads_enabled):
+    """The cache is time-bounded, not permanent: once within `_TOKEN_SKEW_S` of expiring (or
+    already expired), `_auth_headers` must exchange again rather than keep serving a token Google
+    would reject."""
+    monkeypatch.setattr(adsconv, "_cached_access_token", "stale-token", raising=False)
+    monkeypatch.setattr(adsconv, "_token_expires_at", time.time() - 1, raising=False)
+    client = FakeAdsClient(
+        FakeAdsResponse({"requestId": "unused"}),
+        token_response=FakeAdsResponse({"access_token": "fresh-token", "expires_in": 3599}),
+    )
+    headers = await adsconv._auth_headers(client)
+    assert headers["Authorization"] == "Bearer fresh-token"
+    assert len(client.token_calls) == 1
 
 
 async def test_every_public_landing_surface_loads_the_capture_script(clients):

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -334,29 +334,77 @@ def test_build_payload_converts_currency_and_formats_time():
                        value_usd_micro=20_000_000,
                        created_at=click + timedelta(hours=6))
     payload = adsconv.build_payload([row], {1: org})
-    conv = payload["conversions"][0]
-    assert conv["gclid"] == "CLICK1"
-    assert conv["conversionAction"].endswith("/conversionActions/7723667020")
+    event = payload["events"][0]
+    assert event["adIdentifiers"]["gclid"] == "CLICK1"
+    assert event["eventTimestamp"] == "2026-08-17T09:00:00Z"  # RFC 3339, not the old "+hh:mm" form
+    assert event["destinationReferences"] == [adsconv.ACTION_PAID]
+    assert event["transactionId"] == "1"  # stable per outbox row, for Google-side dedup on resend
     # US$20.00 at the fixed rate -> A$28.571428
-    assert conv["conversionValue"] == pytest.approx(28.571428, rel=1e-6)
-    assert conv["currencyCode"] == "AUD"
-    assert payload["partialFailure"] is True
+    assert event["conversionValue"] == pytest.approx(28.571428, rel=1e-6)
+    assert event["currency"] == "AUD"
+    dest = payload["destinations"][0]
+    assert dest["productDestinationId"] == "7723667020"
+    assert dest["reference"] == adsconv.ACTION_PAID
+    assert dest["operatingAccount"] == {
+        "accountType": "GOOGLE_ADS", "accountId": get_settings().google_ads_customer_id
+    }
+    assert payload["validateOnly"] is False
 
 
 @pytest.mark.parametrize("click_field", ["gclid", "gbraid", "wbraid"])
 def test_build_payload_preserves_click_id_field(click_field):
     org = Org(id=1, name="t", slug="t", ad_gclid="CLICK1", ad_click_id_type=click_field)
     row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP)
-    conversion = adsconv.build_payload([row], {1: org})["conversions"][0]
-    assert conversion[click_field] == "CLICK1"
-    assert set(conversion) & {"gclid", "gbraid", "wbraid"} == {click_field}
+    ad_identifiers = adsconv.build_payload([row], {1: org})["events"][0]["adIdentifiers"]
+    assert ad_identifiers[click_field] == "CLICK1"
+    assert set(ad_identifiers) & {"gclid", "gbraid", "wbraid"} == {click_field}
 
 
 def test_build_payload_omits_value_for_non_revenue_actions():
     org = Org(id=1, name="t", slug="t", ad_gclid="C", ad_click_at=datetime.now(timezone.utc))
     row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP, value_usd_micro=0)
-    conv = adsconv.build_payload([row], {1: org})["conversions"][0]
-    assert "conversionValue" not in conv
+    event = adsconv.build_payload([row], {1: org})["events"][0]
+    assert "conversionValue" not in event
+    assert "currency" not in event
+
+
+def test_build_payload_batches_every_action_into_one_request_with_deduped_destinations():
+    """The whole point of the Data Manager port: a mixed batch spans multiple conversion actions
+    but still goes out as ONE request, with `destinations` deduped by action and each event routed
+    to its own destination via `destinationReferences` — not one request per action."""
+    org = Org(id=1, name="t", slug="t", ad_gclid="C")
+    rows = [
+        AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP),
+        AdConversion(id=2, org_id=1, action=adsconv.ACTION_FIRST_CALL),
+        AdConversion(id=3, org_id=1, action=adsconv.ACTION_PAID, value_usd_micro=1_000_000),
+        AdConversion(id=4, org_id=1, action=adsconv.ACTION_SIGNUP),  # second signup row
+    ]
+    payload = adsconv.build_payload(rows, {1: org})
+    assert len(payload["events"]) == 4  # one event per row, no merging
+    references = [d["reference"] for d in payload["destinations"]]
+    assert sorted(references) == sorted(
+        {adsconv.ACTION_SIGNUP, adsconv.ACTION_FIRST_CALL, adsconv.ACTION_PAID}
+    )
+    assert len(references) == len(set(references))  # deduped: 4 rows, only 3 actions
+    for event, row in zip(payload["events"], rows):
+        assert event["destinationReferences"] == [row.action]
+        assert event["transactionId"] == str(row.id)
+
+
+def test_build_payload_sets_manager_account_per_destination(monkeypatch, ads_enabled):
+    """Data Manager expresses the manager (MCC) account as `destinations[].loginAccount`, not a
+    `login-customer-id` header (see `_auth_headers`) — and never off `Secret.resource_ref`, which
+    is the target CLIENT account discovery stored, not the manager."""
+    org = Org(id=1, name="t", slug="t", ad_gclid="C")
+    row = AdConversion(id=1, org_id=1, action=adsconv.ACTION_SIGNUP)
+
+    monkeypatch.setattr(get_settings(), "google_ads_login_customer_id", "351-912-5194", raising=False)
+    dest = adsconv.build_payload([row], {1: org})["destinations"][0]
+    assert dest["loginAccount"] == {"accountType": "GOOGLE_ADS", "accountId": "3519125194"}
+
+    monkeypatch.setattr(get_settings(), "google_ads_login_customer_id", "", raising=False)
+    dest = adsconv.build_payload([row], {1: org})["destinations"][0]
+    assert "loginAccount" not in dest
 
 
 async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypatch, ads_enabled):
@@ -367,7 +415,7 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
     real: a slug settings can point at, and a MANUAL-mode oauth blob (no refresh_token) so
     oauth.ensure_fresh no-ops rather than trying to hit a real token endpoint through FakeClient.
     """
-    client = FakeAdsClient(FakeAdsResponse({"results": [{"gclid": "C"}]}))
+    client = FakeAdsClient(FakeAdsResponse({"requestId": "req-drain-1"}))
 
     async with session_maker() as db:
         org = Org(name="t", slug="t-drain", ad_gclid="C",
@@ -395,6 +443,7 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, monkeypat
         assert old.failed_at is None
         assert young.uploaded_at is None
         assert len(client.calls) == 1
+        assert client.calls[0][0] == adsconv.DATA_MANAGER_URL
 
 
 async def _seed_upload_rows(db, monkeypatch, *, actions, attempts=0):
@@ -418,47 +467,53 @@ async def _seed_upload_rows(db, monkeypatch, *, actions, attempts=0):
     return org, rows
 
 
-def _partial_error(index: int, code: str, message: str = "conversion rejected") -> dict:
-    return {
-        "errorCode": {"conversionUploadError": code},
-        "message": message,
-        "location": {"fieldPathElements": [{"fieldName": "conversions", "index": index}]},
-    }
+def _field_violation(index: int, reason: str, description: str = "event rejected") -> dict:
+    """A `google.rpc.BadRequest.FieldViolation` naming one row of a REJECTED (non-200) request."""
+    return {"field": f"events[{index}].adIdentifiers", "reason": reason, "description": description}
 
 
-async def test_drain_acknowledges_only_successful_rows_in_partial_response(
+def _rejected(*violations: dict, message: str = "There was a problem with the request") -> dict:
+    """The standard Google API error envelope Data Manager returns on a non-200 — the shape
+    `_partial_failure_errors` parses. No `results`/`partialFailureError` here: Data Manager has no
+    per-event success list on a 200, and no partial-failure shape at all (see adsconv.py)."""
+    return {"error": {"code": 400, "status": "INVALID_ARGUMENT", "message": message,
+                       "details": [{"fieldViolations": list(violations)}] if violations else []}}
+
+
+async def test_drain_only_dead_letters_the_row_the_rejection_actually_names(
     clients, monkeypatch, ads_enabled
 ):
-    body = {
-        "results": [{"gclid": "CLICK_BATCH"}, {}],
-        "partialFailureError": {
-            "code": 3,
-            "message": "partial failure",
-            "details": [{"errors": [_partial_error(1, "UNPARSEABLE_GCLID")]}],
-        },
-    }
-    client = FakeAdsClient(FakeAdsResponse(body))
+    """A 400 rejects the WHOLE request — nothing in it was ingested — but Google's fieldViolations
+    can still say WHICH row's data caused the rejection. That row is a dead-letter candidate once it
+    hits the attempt ceiling; its innocent batch-mate keeps retrying regardless of its own attempt
+    count, because the rejection was never about ITS data."""
+    body = _rejected(_field_violation(1, "INVALID_HEX_ENCODING", "bad gclid"))
+    client = FakeAdsClient(FakeAdsResponse(body, status_code=400))
     async with session_maker() as db:
         _org, rows = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP, adsconv.ACTION_PAID)
+            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP, adsconv.ACTION_PAID), attempts=7
         )
         result = await adsconv.drain_once(db, client)
         for row in rows:
             await db.refresh(row)
 
-        assert result == {"sent": 1, "retried": 1, "failed": 0, "status": 200}
-        assert rows[0].uploaded_at is not None
-        assert rows[0].error == ""
+        assert result == {"sent": 0, "retried": 1, "failed": 1, "status": 400}
+        # row 0 (index 0): not named in any violation -> always retried, ceiling or not.
+        assert rows[0].uploaded_at is None
+        assert rows[0].failed_at is None
+        assert rows[0].next_attempt_at is not None
+        # row 1 (index 1): named, and this call pushes it to the attempt ceiling -> dead-lettered.
         assert rows[1].uploaded_at is None
-        assert rows[1].failed_at is None
-        assert rows[1].next_attempt_at is not None
-        assert "UNPARSEABLE_GCLID" in rows[1].error
+        assert rows[1].next_attempt_at is None
+        assert rows[1].failed_at is not None
+        assert "INVALID_HEX_ENCODING" in rows[1].error
 
 
 async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
     clients, monkeypatch, ads_enabled
 ):
-    client = FakeAdsClient(FakeAdsResponse({"error": "unavailable"}, status_code=503))
+    client = FakeAdsClient(FakeAdsResponse({"error": {"code": 503, "message": "unavailable"}},
+                                            status_code=503))
     async with session_maker() as db:
         _org, (row,) = await _seed_upload_rows(
             db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
@@ -472,7 +527,8 @@ async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
         assert row.next_attempt_at is not None
 
         # Make the scheduled retry due without sleeping. A second transport failure still must not
-        # dead-letter the conversion merely because its historical attempt count is now above 8.
+        # dead-letter the conversion merely because its historical attempt count is now above 8:
+        # nothing named THIS row, so it is never a dead-letter candidate on this response alone.
         row.next_attempt_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=1)
         db.add(row)
         await db.commit()
@@ -487,14 +543,8 @@ async def test_http_failure_keeps_retrying_past_row_attempt_ceiling(
 async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(
     clients, monkeypatch, ads_enabled
 ):
-    body = {
-        "results": [{}],
-        "partialFailureError": {
-            "code": 3,
-            "details": [{"errors": [_partial_error(0, "UNPARSEABLE_GCLID")]}],
-        },
-    }
-    client = FakeAdsClient(FakeAdsResponse(body))
+    body = _rejected(_field_violation(0, "INVALID_HEX_ENCODING"))
+    client = FakeAdsClient(FakeAdsResponse(body, status_code=400))
     async with session_maker() as db:
         _org, (row,) = await _seed_upload_rows(
             db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,), attempts=7
@@ -507,12 +557,14 @@ async def test_permanent_row_failure_is_dead_lettered_after_attempt_ceiling(
         assert row.uploaded_at is None
         assert row.next_attempt_at is None
         assert row.failed_at is not None
-        assert "UNPARSEABLE_GCLID" in row.error
+        assert "INVALID_HEX_ENCODING" in row.error
 
 
 async def test_unstructured_success_response_does_not_dead_letter_rows(
     clients, monkeypatch, ads_enabled
 ):
+    """A 200 with no `requestId` is not proof anything was accepted — unlike the old API, there is
+    no per-row `results` list to fall back to, so the whole batch is retried."""
     client = FakeAdsClient(FakeAdsResponse({}))
     async with session_maker() as db:
         _org, (row,) = await _seed_upload_rows(
@@ -526,48 +578,55 @@ async def test_unstructured_success_response_does_not_dead_letter_rows(
         assert row.uploaded_at is None
         assert row.failed_at is None
         assert row.next_attempt_at is not None
-        assert row.error == "200: missing conversion result"
+        assert row.error == "200: missing requestId"
 
 
-async def test_duplicate_row_response_is_acknowledged(clients, monkeypatch, ads_enabled):
+async def test_drain_acknowledges_rows_despite_nonfatal_field_warnings(
+    clients, monkeypatch, ads_enabled
+):
+    """A `fieldWarnings` entry on a 200 is explicitly non-rejecting per Data Manager's contract —
+    the record was still ingested, just with part of its data ignored — so the row is uploaded, not
+    retried or dead-lettered. This is Data Manager's replacement for the old API's
+    CLICK_CONVERSION_ALREADY_EXISTS acknowledge-anyway path: there is no error to special-case
+    because Google now just accepts (and dedupes by `transactionId`) rather than rejecting."""
     body = {
-        "results": [{}],
-        "partialFailureError": {
-            "code": 3,
-            "details": [{"errors": [_partial_error(0, "CLICK_CONVERSION_ALREADY_EXISTS")]}],
-        },
+        "requestId": "req-warn-1",
+        "fieldWarnings": [
+            {"fieldPath": "events[0].userData", "reason": "PARTIAL_DATA_IGNORED",
+             "description": "some identifiers ignored"},
+        ],
     }
     client = FakeAdsClient(FakeAdsResponse(body))
     async with session_maker() as db:
-        _org, (row,) = await _seed_upload_rows(
-            db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,)
-        )
+        _org, (row,) = await _seed_upload_rows(db, monkeypatch, actions=(adsconv.ACTION_SIGNUP,))
         result = await adsconv.drain_once(db, client)
         await db.refresh(row)
 
         assert result["sent"] == 1
         assert row.uploaded_at is not None
-        assert row.error == ""
+        assert row.failed_at is None
+        assert "PARTIAL_DATA_IGNORED" in row.error  # kept for operator visibility only
 
 
-async def test_auth_uses_explicit_manager_account_not_target_resource_ref(
+async def test_auth_headers_carry_no_developer_token_or_login_customer_id(
     clients, monkeypatch, ads_enabled
 ):
+    """Both headers the old ConversionUploadService needed are gone under Data Manager: no
+    developer-token header exists at all, and the manager account moves into the request body as
+    `destinations[].loginAccount` (see the build_payload manager-account test) rather than a
+    `login-customer-id` header."""
     async with session_maker() as db:
         await _seed_upload_rows(db, monkeypatch, actions=())
         monkeypatch.setattr(
             get_settings(), "google_ads_login_customer_id", "351-912-5194", raising=False
         )
         headers = await adsconv._auth_headers(
-            db, FakeAdsClient(FakeAdsResponse({"results": []}))
-        )
-        assert headers["login-customer-id"] == "3519125194"
-
-        monkeypatch.setattr(get_settings(), "google_ads_login_customer_id", "", raising=False)
-        headers = await adsconv._auth_headers(
-            db, FakeAdsClient(FakeAdsResponse({"results": []}))
+            db, FakeAdsClient(FakeAdsResponse({"requestId": "r1"}))
         )
         assert "login-customer-id" not in headers
+        assert "developer-token" not in headers
+        assert headers["Authorization"] == "Bearer tok-test"
+        assert headers["Content-Type"] == "application/json"
 
 
 async def test_every_public_landing_surface_loads_the_capture_script(clients):


### PR DESCRIPTION
## Why

`ConversionUploadService.uploadClickConversions` — the endpoint #144's uploader calls — is **closed to new integrations**. Verified live against account `5149790776`:

```
notAllowlistedError: CUSTOMER_NOT_ALLOWLISTED_FOR_THIS_FEATURE
"New integrations for uploading click conversions should use the Data Manager API.
 Usage of ConversionUploadService.UploadClickConversions is limited to existing users."
```

As shipped, **no conversion would ever have reached Google** — the outbox would fill and every row fail permanently.

That same call proved the credential path is **correct**: it authenticated, reached Google, and was rejected on a business rule rather than a `401`. `login-customer-id` — the one inference in #144 never verified against a live account — is confirmed fine. So this is a transport change, not an auth investigation.

## What changed

| | before | after |
|---|---|---|
| Endpoint | `googleads.googleapis.com/v25/…:uploadClickConversions` | `datamanager.googleapis.com/v1/events:ingest` |
| Scope | `…/auth/adwords` | **+ `…/auth/datamanager`** |
| Developer token | required | not required — header removed |
| `login-customer-id` | header | per-destination `loginAccount` in the body |
| Timestamp | `Y-m-d H:M:S+00:00` | RFC 3339 |
| Value | currency units | unchanged |

**One request for a mixed batch.** Data Manager accepts many conversion actions per call, which the old API could not. `destinations[]` is deduped by `reference`; `events[]` stays 1:1 with outbox rows so a partial failure still attributes to the row that caused it.

**Added: a stable `transactionId` per outbox row**, so a resend after an ambiguous outcome (a timeout whose response we never saw) dedupes into the same conversion on Google's side rather than double-counting.

Untouched: the outbox table, all three fire sites, dedupe, retry/dead-lettering, and the integer money math.

## Requires a human step before it works

The connection holds `…/auth/adwords` only. **Google Ads must be reconnected in treg** to grant `…/auth/datamanager`. No code can grant itself a scope. After that, a `validateOnly` call can confirm acceptance without recording anything.

## Verified

- Targeted **38 passed**; full suite **1768 passed**
- No live call yet — the scope isn't granted, so any live attempt fails on permission by design

## One thing I'm not certain about

A full-suite run showed `test_billing.py::test_topup_completed_fires_once_across_redelivery` failing once. It passes in isolation, passes across the whole billing file, and did not reproduce on a second full run (1768 passed). This PR touches no billing code, and that test asserts on the async batched analytics path. Recording it rather than calling it resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)