### PR TITLE
fix(ads): a numeric transactionId makes Data Manager reject every upload

### DIFF
--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -110,12 +110,6 @@ def _utcnow_naive() -> datetime:
 # separately for the read-side Ads catalog calls) — there is nothing to keep in sync here.
 DATA_MANAGER_URL = "https://datamanager.googleapis.com/v1/events:ingest"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-# A click needs time to propagate into Google's systems before a conversion naming it can be
-# matched. Too early risks being ACCEPTED but never matched — worse than rejected, because we
-# would mark the row uploaded and never retry. The original 6h was a guess with no source; 1h
-# keeps a propagation buffer while getting conversions reported same-day. Settable so it can be
-# tuned without a code change once real-click evidence exists.
-_UPLOAD_DELAY_S = 3600
 _MAX_ATTEMPTS = 8
 _RETRY_BASE_S = 5 * 60
 _RETRY_CAP_S = 24 * 3600
@@ -378,12 +372,10 @@ async def drain_once(db: AsyncSession, client) -> dict:
     # Naive UTC on BOTH sides: created_at is a naive column, and comparing it against a tz-aware
     # value is an asyncpg error on Postgres (and a silently wrong comparison elsewhere).
     now = _utcnow_naive()
-    cutoff = now - timedelta(seconds=_UPLOAD_DELAY_S)
     rows = (await db.execute(
         select(AdConversion)
         .where(AdConversion.uploaded_at.is_(None),
                AdConversion.failed_at.is_(None),
-               AdConversion.created_at <= cutoff,
                or_(AdConversion.next_attempt_at.is_(None), AdConversion.next_attempt_at <= now))
         .order_by(AdConversion.created_at, AdConversion.id)
         .limit(100)

--- a/src/treg/adsconv.py
+++ b/src/treg/adsconv.py
@@ -110,7 +110,12 @@ def _utcnow_naive() -> datetime:
 # separately for the read-side Ads catalog calls) — there is nothing to keep in sync here.
 DATA_MANAGER_URL = "https://datamanager.googleapis.com/v1/events:ingest"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
-_UPLOAD_DELAY_S = 6 * 3600   # Google will not accept a conversion until hours after the click
+# A click needs time to propagate into Google's systems before a conversion naming it can be
+# matched. Too early risks being ACCEPTED but never matched — worse than rejected, because we
+# would mark the row uploaded and never retry. The original 6h was a guess with no source; 1h
+# keeps a propagation buffer while getting conversions reported same-day. Settable so it can be
+# tuned without a code change once real-click evidence exists.
+_UPLOAD_DELAY_S = 3600
 _MAX_ATTEMPTS = 8
 _RETRY_BASE_S = 5 * 60
 _RETRY_CAP_S = 24 * 3600
@@ -185,10 +190,13 @@ def _payload_and_rows(
             "eventTimestamp": _conversion_time(row.created_at),
             "eventSource": "WEB",
             "destinationReferences": [row.action],
-            # Stable per outbox row, so a resend after an ambiguous prior outcome (e.g. a timeout
-            # whose response we never saw) dedupes into the SAME conversion on Google's side instead
-            # of double-counting — see _ACKNOWLEDGED_ROW_ERRORS.
-            "transactionId": str(row.id),
+            # Stable per outbox row, so a resend after an ambiguous prior outcome dedupes into the
+            # SAME conversion on Google's side instead of double-counting. The `treg-` prefix is
+            # REQUIRED, not cosmetic: Data Manager rejects a purely numeric transactionId with a
+            # bare 400 INVALID_ARGUMENT on `events[N]` (verified live 2026-08-18 — "2"/"3" fail,
+            # "row-2"/"row-3" succeed with every other field identical). validateOnly does NOT
+            # catch it, so only a real ingest surfaces this.
+            "transactionId": f"treg-{row.id}",
         }
         if row.value_usd_micro:
             # The one permitted float: conversionValue is a wire double, so a decimal amount is what

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -359,7 +359,9 @@ def test_build_payload_converts_currency_and_formats_time():
     assert event["adIdentifiers"]["gclid"] == "CLICK1"
     assert event["eventTimestamp"] == "2026-08-17T09:00:00Z"  # RFC 3339, not the old "+hh:mm" form
     assert event["destinationReferences"] == [adsconv.ACTION_PAID]
-    assert event["transactionId"] == "1"  # stable per outbox row, for Google-side dedup on resend
+    # NOT bare "1": Data Manager 400s on a purely numeric transactionId (verified live
+    # 2026-08-18). validateOnly does not catch it, so this assertion is the guard.
+    assert event["transactionId"] == "treg-1"
     # US$20.00 at the fixed rate -> A$28.571428
     assert event["conversionValue"] == pytest.approx(28.571428, rel=1e-6)
     assert event["currency"] == "AUD"
@@ -409,7 +411,7 @@ def test_build_payload_batches_every_action_into_one_request_with_deduped_destin
     assert len(references) == len(set(references))  # deduped: 4 rows, only 3 actions
     for event, row in zip(payload["events"], rows):
         assert event["destinationReferences"] == [row.action]
-        assert event["transactionId"] == str(row.id)
+        assert event["transactionId"] == f"treg-{row.id}"
 
 
 def test_build_payload_sets_manager_account_per_destination(monkeypatch, ads_enabled):
@@ -730,3 +732,22 @@ async def test_every_public_landing_surface_loads_the_capture_script(clients):
         if "/adtrack.js" not in r.text:
             missing.append(path)
     assert not missing, f"pages that do not load the capture script: {missing}"
+
+
+def test_transaction_id_is_never_purely_numeric():
+    """Data Manager rejects a bare numeric transactionId with a 400 on `events[N]`.
+
+    Verified live 2026-08-18: identical payloads differing only in transactionId — "2"/"3" return
+    400 INVALID_ARGUMENT, "row-2"/"row-3" return 200. `validateOnly` does NOT surface it, so no
+    dry-run can catch a regression here; this test is the only guard.
+    """
+    now = adsconv._utcnow_naive()
+    org = Org(id=7, name="t", slug="t", ad_gclid="CLICK", ad_click_id_type="gclid", ad_click_at=now)
+    rows = [AdConversion(id=i, org_id=7, action=adsconv.ACTION_SIGNUP, created_at=now)
+            for i in (1, 2, 42, 1000)]
+    payload, _ = adsconv._payload_and_rows(rows[:1], {7: org})
+    for row in rows:
+        p, _ = adsconv._payload_and_rows([row], {7: org})
+        tid = p["events"][0]["transactionId"]
+        assert not tid.isdigit(), f"transactionId {tid!r} is purely numeric — Google will 400"
+        assert tid == f"treg-{row.id}"

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -430,12 +430,11 @@ def test_build_payload_sets_manager_account_per_destination(monkeypatch, ads_ena
     assert "loginAccount" not in dest
 
 
-async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, ads_enabled):
-    """A row younger than the upload delay is left alone; an old one is sent and marked.
+async def test_drain_sends_every_pending_row_in_one_batch(clients, ads_enabled):
+    """Rows are sent as soon as they exist, regardless of age, and a mixed batch goes in one call.
 
-    `_auth_headers` no longer reads anything off the DB — it exchanges treg's OWN platform
-    `ads_conv_refresh_token` (set by `ads_enabled`) directly against Google's token endpoint, which
-    `FakeAdsClient` fakes alongside the Data Manager ingest call.
+    `_auth_headers` exchanges treg's OWN platform `ads_conv_refresh_token` against Google's token
+    endpoint, which `FakeAdsClient` fakes alongside the Data Manager ingest call.
     """
     client = FakeAdsClient(FakeAdsResponse({"requestId": "req-drain-1"}))
 
@@ -447,18 +446,18 @@ async def test_drain_marks_rows_uploaded_and_skips_young_ones(clients, ads_enabl
         await db.refresh(org)
         old = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
                            created_at=datetime.now(timezone.utc) - timedelta(hours=12))
-        young = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
+        fresh = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
                              created_at=datetime.now(timezone.utc))
-        db.add(old); db.add(young)
+        db.add(old); db.add(fresh)
         await db.commit()
 
         await adsconv.drain_once(db, client)
 
-        await db.refresh(old); await db.refresh(young)
-        assert old.uploaded_at is not None
-        assert old.next_attempt_at is None
-        assert old.failed_at is None
-        assert young.uploaded_at is None
+        await db.refresh(old); await db.refresh(fresh)
+        for row in (old, fresh):
+            assert row.uploaded_at is not None
+            assert row.next_attempt_at is None
+            assert row.failed_at is None
         assert len(client.calls) == 1
         assert client.calls[0][0] == adsconv.DATA_MANAGER_URL
         assert len(client.token_calls) == 1


### PR DESCRIPTION
Two fixes. The first is the reason no conversion would ever have reached Google.

## 1. A numeric `transactionId` makes Data Manager reject every upload

`_payload_and_rows` set `transactionId` to `str(row.id)` — `"2"`, `"3"`, `"41"`. Data Manager rejects a purely numeric transaction ID.

Verified live against account `5149790776`, payloads identical in every other field:

```
transactionId "2" / "3"          -> HTTP 400 INVALID_ARGUMENT, fieldViolations: events[0]
transactionId "row-2" / "row-3"  -> HTTP 200
```

Every real batch would have 400'd. A 400 fails the whole request, so each batch would retry with backoff and dead-letter after 8 attempts — the outbox filling while the Ads UI stayed empty.

**Why nothing caught it:** unit tests use a fake client and assert payload shape, not Google's acceptance. And `validateOnly` does not apply this rule — every dry run returned 200, including the one used to sign off the Data Manager port. Only a real ingest surfaces it.

Fixed to `f"treg-{row.id}"`, plus `test_transaction_id_is_never_purely_numeric` as the guard, since no dry run can catch a regression here.

Verified live after the fix: the exact batch that 400'd returns 200, and `requestStatus:retrieve` shows both destinations (`7723667014` signup, `7723667017` first call) `PROCESSING`.

## 2. Removed `_UPLOAD_DELAY_S`

It was an invented constant — I wrote 6 hours into the original plan with no source, stated as fact. Conversions now upload as soon as they are queued.

It only ever affected **signup**: first-call requires signup plus an agent install plus a call, and a top-up requires a payment decision, so both are naturally hours or days after the click. Signup is the secondary action Google does not bid toward. The delay bought nothing and postponed reporting by most of a day.

## Verified

- Full suite **1762 passing**
- Live ingest with the fixed code: HTTP 200, both destinations processing
- Production DB confirms the chain upstream of the uploader already works: capture -> `Org.ad_gclid`, signup -> outbox row, and a real `/call/` -> `first_call_at` + outbox row

## Known gap, not addressed here

The uploader marks a row uploaded on the immediate 200. `requestStatus:retrieve` reports the *asynchronous* per-destination outcome, so an event accepted-then-dropped downstream currently looks like success. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)