### PR TITLE
fix(catalog): honor retired markers on /call/, and mark TikHub's 50 dead routes

### DIFF
--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -1,0 +1,21 @@
+name: Catalog drift
+
+on:
+  schedule:
+    - cron: "15 2 * * *"  # daily, after providers' common UTC maintenance window
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  tikhub:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+      - name: Compare TikHub catalog with its public OpenAPI spec
+        run: uv run --frozen python scripts/catalog_drift.py tikhub

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -18,7 +18,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 |---|---|---|
 | [Google Ads conversion tracking — capture, outbox, upload](architecture/ads-conversions.md) | shipped | adsconv.py, adtrack.js |
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
-| [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog_store.py, endpoint_stats.py |
+| [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog-drift.yml, catalog_drift.py, catalog_validate.py, justoneapi.extended.yaml, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | models.py, db.py, referrals.py, audit.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -2,6 +2,11 @@
 title: Endpoint catalog — what you can DO with a connected key, and which provider should do it
 status: shipped
 sources:
+  - .github/workflows/catalog-drift.yml
+  - scripts/catalog_drift.py
+  - scripts/catalog_validate.py
+  - src/treg/catalog/justoneapi.extended.yaml
+  - src/treg/catalog/tikhub.extended.yaml
   - src/treg/catalog_store.py
   - src/treg/endpoint_stats.py
 related:
@@ -38,6 +43,7 @@ src/treg/catalog/
   <service>.extended.yaml  # EXTENDED tier — machine-generated full endpoint surface
   examples/<endpoint-id>.json  # truncated, scrubbed real responses captured at verify time
 scripts/
+  catalog_drift.py            # path+method drift against providers' public OpenAPI documents
   catalog_validate.py         # schema + referential checks (run in CI / after any edit)
   catalog_verify.py           # live-tests CORE endpoints with a real credential; writes examples/
   catalog_verify_extended.py  # the same for the extended tier, in bulk, under a spend cap
@@ -506,15 +512,47 @@ The 2026-08-17 TikTok-Ads breakage was first written up here as an ingester defe
 the correction matters more than the original claim. Those twelve routes really were `GET` when
 ingested: TikHub's July spec says `get`, and the captured `example_response` is a **real billed 200
 from a GET on 2026-07-27**. TikHub moved them to POST some time after. The catalog did not mis-read
-the provider — it went stale, and **nothing re-checks a provider's spec for drift**.
+the provider — it went stale, and at the time **nothing re-checked a provider's spec for drift**.
 
-That reframes the fix. Preferring the spec over the probe is a genuine hardening, but it only helps
+That reframed the fix. Preferring the spec over the probe is a genuine hardening, but it only helps
 *at re-ingest time*, and only if the cached spec was refreshed — the cache under
 `~/.cache/treg-catalog-ingest` is what an unqualified `catalog_ingest.py <provider>` reads, so a
 re-run against a months-old cache faithfully reproduces months-old truth. A `verified:` stamp is
-evidence about the day it was written and nothing after it. Detecting drift (re-fetching specs and
-diffing method/path against the checked-in tier) is unbuilt; until it exists, an endpoint failing
-`405`/`404` in the wild is the first signal we get.
+evidence about the day it was written and nothing after it.
+
+`scripts/catalog_drift.py` now closes that gap without making a paid API call: it discovers public
+OpenAPI documents from each provider file's source provenance, downloads the document with no
+credential, and compares every checked-in `(path, method)`. Plain JSON is preferred; the same
+`salvage_json_map` used by the ingester recovers a complete `paths` map from a truncated document,
+and YAML OpenAPI is accepted too. An unmarked missing path, method change, or marked route that has
+reappeared exits non-zero. Known absent marked rows are reported as `acknowledged`, not drift. The
+daily `catalog-drift.yml` workflow currently runs TikHub—the provider with demonstrated production
+rot—and the script remains provider-general for every catalog file that cites a public OpenAPI URL.
+
+### Retired and broken endpoints are tombstones, not offers
+
+Provider rot must not turn an id an agent cached yesterday into either a bare provider 404 or an
+unexplained registry 404. Keep the row and add:
+
+```yaml
+status: retired                 # or broken
+status_note: why it is gone and what changed
+superseded_by: provider.live-id # optional; only when the operation is genuinely equivalent
+```
+
+`catalog_store._parse` always retains the normalised row in `by_id`, so direct endpoint inspection
+can return its story, but excludes it from `endpoints`, the source for search, browse, capability
+counts and platform eligibility. On a direct endpoint-id call, `_resolve_marketplace_call` raises an
+actionable 410 before choosing or loading any credential; the pre-relay audit class is `retired`.
+`/catalog/endpoints/{id}/access` applies the same gate. This is catalog fallback only: an org tool
+whose exact name matches the retired id resolves first and remains callable, and URL passthrough
+never enters catalog lookup.
+
+The validator treats the marker as a contract: only `retired` and `broken` are valid; every marker
+needs a non-empty note; `status_note` and `superseded_by` cannot float without `status`; and a
+successor must be a different, existing, live catalog id. A marked id is therefore an explanation,
+not an alias chain or a route treg will still spend against.
+
 - **Platform is the system the data is ABOUT**, not the API family it lives under: DataForSEO's
   `/v3/merchant/amazon/products/live/advanced` is `amazon`, not `merchant`. Anything not tied to
   one system is `web`. Every new slug goes into `capabilities.yaml`'s `platforms` in the same

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -91,6 +91,13 @@ same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the pe
   `base_url + path`. **No path → the base URL itself, without a trailing slash** — a tool pinned to a
   full resource (`.../v1/charges`) must relay as-is, since Stripe `404`s `/v1/charges/`.
 
+If both shapes miss with 404, a dotted target gets one final lookup in the endpoint catalog. A live
+row enters `_resolve_marketplace_call` and its credential ladder. A `retired`/`broken` tombstone is
+instead refused with 410, its `status_note`, and its optional `superseded_by`, before credentials are
+selected or the relay can run; the refusal is audited as `refused_by=retired`. This ordering is
+deliberate: an org's own tool named exactly like the old catalog id already resolved above and is not
+shadowed, while URL passthrough has no catalog-id shape to catch accidentally.
+
 **ACL-filtered candidates.** `_resolve_call` takes the **caller** and filters passthrough candidates by
 `_tool_usable` (project scope AND the per-tool list) **before** the longest-prefix tiebreak. A same-host
 tool the caller cannot use must not be able to cause a `409` — or win the tiebreak — for someone who

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -233,7 +233,11 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   `catalog_store.near_ids()` matches on segment overlap ignoring the tier marker; no near miss means
   an empty list and a search hint, never a confidently wrong suggestion. `/call/` answers the same
   way for a dotted target that misses — the branch where money is on the line used to reply "no tool
-  … in this org", describing the wrong half of treg.
+  … in this org", describing the wrong half of treg. A known endpoint marked `retired` or `broken`
+  remains inspectable here with `status_note` and optional `superseded_by`, but is absent from every
+  discovery list. Calling it—or asking `/catalog/endpoints/{id}/access` whether it is callable—returns
+  an actionable 410. The `/call/` refusal is recorded with `refused_by=retired` and never reaches a
+  provider credential or relay.
   A zero-result search additionally points at **`POST /tool-requests`** (open, per-IP rate-limited,
   fields capped): file what the catalog is missing — stored as a `ToolRequest` row (see
   [data-model](../architecture/data-model.md)) with identity attached only when the caller happens
@@ -479,7 +483,8 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
 - **Health:** `run_health` (`POST /health/run`) → `health.run_all`; `get_health` (`GET /health`) now
   returns `health._view(s)` plus a `needs_reconnect` flag (`health.needs_reconnect`) so a credential treg
   can't renew announces itself before it dies.
-- **The proxy:** `call_tool` (`* /call/{rest:path}`) → `_resolve_call` → `_enforce_daily_cap` (the
+- **The proxy:** `call_tool` (`* /call/{rest:path}`) → `_resolve_call` → (on a dotted 404,
+  catalog lookup + retirement gate + credential ladder) → `_enforce_daily_cap` (the
   per-user daily cap; 429 when over) → (public-demo token → `_enforce_public_demo_ip_cap`) → load secrets
   (+ `ensure_fresh`) → `relay()` → `audit.record_call`. A **platform binding** carries no `secret_id`
   (its value comes from settings at relay time), so secret-loading now skips `secret_id is None`. Detail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# `scripts/` is standalone tooling, not part of the shipped package (the wheel is `src/treg` only),
+# but tests import from it — `from scripts import catalog_drift`. Only `python -m pytest` puts the
+# working directory on sys.path; CI runs plain `uv run pytest`, where that import is a
+# ModuleNotFoundError at collection. Say it here so both invocations agree, rather than adding
+# `scripts/__init__.py` and changing what the sdist thinks it contains.
+pythonpath = ["."]
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/catalog_drift.py
+++ b/scripts/catalog_drift.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Compare catalogued path+method pairs with providers' public OpenAPI documents.
+
+No credential is sent and no provider endpoint is called: this reads documentation only. Marked
+retirements remain in YAML by design, so an absent marked route is acknowledged; an unmarked absent
+route, a method change, or a marked route that has reappeared makes the command fail.
+
+Usage:
+    uv run --frozen python scripts/catalog_drift.py
+    uv run --frozen python scripts/catalog_drift.py tikhub
+    uv run --frozen python scripts/catalog_drift.py tikhub --spec-file /tmp/openapi.json
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import sys
+import urllib.request
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "src" / "treg" / "catalog"
+HTTP_METHODS = {"get", "post", "put", "patch", "delete", "head", "options", "trace"}
+
+# TikHub's origin has historically truncated openapi.json mid-document. Its `paths` map precedes
+# the truncation, and the ingester's shared salvage routine is the one parser already maintained for
+# that shape. Import it rather than growing a second almost-identical recovery algorithm.
+try:  # Running as a script puts `scripts/` on sys.path; importing in tests puts the repo root there.
+    from catalog_ingest import salvage_json_map  # type: ignore[import-not-found]  # noqa: E402
+except ModuleNotFoundError:
+    from scripts.catalog_ingest import salvage_json_map  # noqa: E402
+
+
+class UnsupportedSpec(ValueError):
+    """The linked document is a different API-description format (for example Google Discovery)."""
+
+
+@dataclass
+class Drift:
+    provider: str
+    catalogued: int
+    spec_paths: int
+    ok: list[dict] = field(default_factory=list)
+    dead_path: list[dict] = field(default_factory=list)
+    method_rot: list[tuple[dict, list[str]]] = field(default_factory=list)
+    acknowledged: list[dict] = field(default_factory=list)
+    restored: list[dict] = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.dead_path or self.method_rot or self.restored)
+
+
+def _github_raw(url: str) -> str:
+    """Turn a GitHub blob citation into the document it cites."""
+    prefix = "https://github.com/"
+    if url.startswith(prefix) and "/blob/" in url:
+        repo_path, _, file_path = url[len(prefix):].partition("/blob/")
+        branch, _, file_path = file_path.partition("/")
+        return f"https://raw.githubusercontent.com/{repo_path}/{branch}/{file_path}"
+    return url
+
+
+def discover_specs(catalog_dir: Path) -> dict[str, str]:
+    """Find one public spec per provider from catalog source provenance."""
+    found: dict[str, str] = {}
+    files = sorted(p for p in catalog_dir.glob("*.yaml")
+                   if p.name not in {"capabilities.yaml", "fx.yaml"})
+    # Core files sort before `.extended` and their explicit `source.openapi` is the curated choice.
+    for path in files:
+        data = yaml.safe_load(path.read_text()) or {}
+        if not isinstance(data, dict) or not data.get("provider"):
+            continue
+        provider = str(data["provider"])
+        source = data.get("source") or {}
+        explicit = source.get("openapi") if isinstance(source, dict) else None
+        candidates = [explicit] if isinstance(explicit, str) and explicit.strip() else []
+        if not candidates and isinstance(source, dict):
+            candidates = [u for u in source.get("spec_urls") or []
+                          if isinstance(u, str) and "openapi" in u.lower()
+                          and not any(mark in u for mark in ("<", ">", "{", "}"))]
+        if candidates:
+            found.setdefault(provider, _github_raw(candidates[0]))
+    return found
+
+
+def provider_endpoints(provider: str, catalog_dir: Path = CATALOG) -> list[dict]:
+    rows: list[dict] = []
+    for path in sorted(catalog_dir.glob(f"{provider}*.yaml")):
+        if path.stem.removesuffix(".extended") != provider:
+            continue
+        data = yaml.safe_load(path.read_text()) or {}
+        if isinstance(data, dict) and data.get("provider") == provider:
+            rows.extend(ep for ep in data.get("endpoints") or [] if isinstance(ep, dict))
+    return rows
+
+
+def fetch(url: str) -> str:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "treg-catalog-drift/1", "Accept": "application/json, text/yaml, */*"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read().decode("utf-8", "replace")
+
+
+def parse_spec(text: str) -> tuple[dict, str]:
+    """Return an OpenAPI paths map and the parser mode used."""
+    document = None
+    try:
+        document = json.loads(text)
+        mode = "json"
+    except json.JSONDecodeError as json_error:
+        try:
+            paths = salvage_json_map(text, "paths")
+            return paths, f"salvaged-json ({json_error.msg} at byte {json_error.pos})"
+        except (ValueError, json.JSONDecodeError):
+            try:
+                document = yaml.safe_load(text)
+                mode = "yaml"
+            except yaml.YAMLError as yaml_error:
+                raise ValueError(f"not JSON or YAML: {yaml_error}") from yaml_error
+    if not isinstance(document, dict):
+        raise ValueError("spec root is not a mapping")
+    paths = document.get("paths")
+    if not isinstance(paths, dict):
+        if "resources" in document and "rootUrl" in document:
+            raise UnsupportedSpec("Google Discovery document (not OpenAPI paths)")
+        raise ValueError("spec has no paths mapping")
+    return paths, mode
+
+
+def compare(provider: str, endpoints: list[dict], paths: dict) -> Drift:
+    result = Drift(provider=provider, catalogued=len(endpoints), spec_paths=len(paths))
+    for ep in endpoints:
+        item = paths.get(ep.get("path"))
+        marked = bool(str(ep.get("status") or "").strip())
+        if not isinstance(item, dict):
+            (result.acknowledged if marked else result.dead_path).append(ep)
+            continue
+        method = str(ep.get("method") or "GET").lower()
+        available = sorted(k.upper() for k in item if k.lower() in HTTP_METHODS)
+        if method not in {str(k).lower() for k in item}:
+            if marked:
+                result.acknowledged.append(ep)
+            else:
+                result.method_rot.append((ep, available))
+        elif marked:
+            result.restored.append(ep)
+        else:
+            result.ok.append(ep)
+    return result
+
+
+def _print_result(result: Drift, source: str, mode: str) -> None:
+    print(f"{result.provider}: {result.catalogued} catalogued, {len(result.ok)} ok, "
+          f"{len(result.dead_path)} dead-path, {len(result.method_rot)} method-rot, "
+          f"{len(result.acknowledged)} acknowledged, {len(result.restored)} restored "
+          f"(spec paths={result.spec_paths}, parser={mode}, source={source})")
+    for ep in result.dead_path:
+        print(f"  DEAD {ep.get('method')} {ep.get('path')}  {ep.get('id')}")
+    for ep, methods in result.method_rot:
+        print(f"  METHOD {ep.get('method')} -> {'/'.join(methods) or 'none'} "
+              f"{ep.get('path')}  {ep.get('id')}")
+    for ep in result.restored:
+        print(f"  RESTORED {ep.get('method')} {ep.get('path')}  {ep.get('id')} "
+              f"(catalog status={ep.get('status')})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("providers", nargs="*", help="provider service(s); default: every discovered spec")
+    parser.add_argument("--spec-file", type=Path,
+                        help="read this local spec (requires exactly one provider; useful offline)")
+    parser.add_argument("--catalog-dir", type=Path, default=CATALOG)
+    args = parser.parse_args(argv)
+
+    specs = discover_specs(args.catalog_dir)
+    selected = args.providers or sorted(specs)
+    if args.spec_file and len(selected) != 1:
+        parser.error("--spec-file requires exactly one provider")
+    unknown = [provider for provider in selected if provider not in specs]
+    if unknown:
+        parser.error("no public OpenAPI source for: " + ", ".join(unknown))
+
+    failed = False
+    errors = False
+    checked = 0
+    for provider in selected:
+        source = str(args.spec_file) if args.spec_file else specs[provider]
+        try:
+            text = args.spec_file.read_text() if args.spec_file else fetch(source)
+            paths, mode = parse_spec(text)
+        except UnsupportedSpec as exc:
+            print(f"SKIP {provider}: {exc} ({source})")
+            continue
+        except (OSError, ValueError) as exc:
+            print(f"ERROR {provider}: {exc} ({source})", file=sys.stderr)
+            errors = True
+            continue
+        result = compare(provider, provider_endpoints(provider, args.catalog_dir), paths)
+        _print_result(result, source, mode)
+        failed = failed or result.failed
+        checked += 1
+    if errors:
+        return 2
+    if not checked:
+        print("ERROR no OpenAPI providers were checked", file=sys.stderr)
+        return 2
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -70,6 +70,7 @@ TIERS = {"core", "extended"}
 # what an endpoint IS (marketplace browse surface vs. plumbing). Optional — absent reads as "data" —
 # but a stated one must be from this set. See docs/context/architecture/catalog.md.
 KINDS = {"data", "action", "account", "utility"}
+ENDPOINT_STATUSES = {"retired", "broken"}
 QUERY_ARRAY_ENCODINGS = {"json", "comma", "repeated"}
 # the section heading an endpoint files under on its platform page — one lowercase word
 DOMAIN = re.compile(r"[a-z][a-z0-9_]*")
@@ -104,6 +105,31 @@ def looks_like_secret(match: str) -> bool:
 
 def fail(errors: list[str], where: str, msg: str) -> None:
     errors.append(f"{where}: {msg}")
+
+
+def check_status_marker(ep: dict, where: str, endpoint_status: dict[str, str],
+                        errors: list[str]) -> None:
+    """Validate the migration marker and its cross-catalog successor reference."""
+    status = str(ep.get("status") or "").strip()
+    note = str(ep.get("status_note") or "").strip()
+    successor = str(ep.get("superseded_by") or "").strip()
+    if status and status not in ENDPOINT_STATUSES:
+        fail(errors, where, f"status '{status}' not one of {sorted(ENDPOINT_STATUSES)}")
+    if status and not note:
+        fail(errors, where, "status requires a non-empty status_note explaining the retirement")
+    if not status and note:
+        fail(errors, where, "status_note requires status: retired or status: broken")
+    if not status and successor:
+        fail(errors, where, "superseded_by requires status: retired or status: broken")
+    if not successor:
+        return
+    if successor == ep.get("id"):
+        fail(errors, where, "superseded_by cannot point to the endpoint itself")
+    elif successor not in endpoint_status:
+        fail(errors, where, f"superseded_by target '{successor}' is not a catalog endpoint id")
+    elif endpoint_status[successor]:
+        fail(errors, where, f"superseded_by target '{successor}' is itself "
+                            f"{endpoint_status[successor]} — replacements must be live")
 
 
 def _as_date(value) -> dt.date | None:
@@ -258,7 +284,19 @@ def main(argv: list[str]) -> int:
     from treg.oauth_providers import REGISTRY  # noqa: E402
 
     only = set(argv)
-    files = sorted(p for p in CATALOG.glob("*.yaml") if p.name not in ("capabilities.yaml", "fx.yaml"))
+    all_files = sorted(p for p in CATALOG.glob("*.yaml")
+                       if p.name not in ("capabilities.yaml", "fx.yaml"))
+    # Successors can appear later in the same file or in another provider. Build the reference map
+    # before validating any row; a one-pass lookup would make validity depend on filename order.
+    endpoint_status: dict[str, str] = {}
+    for path in all_files:
+        data = yaml.safe_load(path.read_text()) or {}
+        if not isinstance(data, dict):
+            continue
+        for ep in data.get("endpoints") or []:
+            if isinstance(ep, dict) and ep.get("id"):
+                endpoint_status[str(ep["id"])] = str(ep.get("status") or "").strip()
+    files = list(all_files)
     # "tikhub" selects tikhub.yaml AND tikhub.extended.yaml — a service is both its tiers
     service_of = {p: p.stem.removesuffix(".extended") for p in files}
     if only:
@@ -349,6 +387,7 @@ def main(argv: list[str]) -> int:
                 fail(errors, where, f"bad scope '{ep.get('scope')}'")
             if ep.get("method") not in METHODS:
                 fail(errors, where, f"bad method '{ep.get('method')}'")
+            check_status_marker(ep, where, endpoint_status, errors)
             inp = ep.get("input") or {}
             default_array_encoding = inp.get("queryArrayEncoding")
             if (default_array_encoding is not None

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -332,7 +332,7 @@ def _refusal_kind(status_code: int) -> str | None:
     must not be counted as a treg refusal."""
     if status_code >= 500:
         return None
-    return {401: "auth", 402: "balance", 403: "policy", 404: "resolution",
+    return {401: "auth", 402: "balance", 403: "policy", 404: "resolution", 410: "retired",
             429: "cap"}.get(status_code, "request")
 
 
@@ -8565,6 +8565,26 @@ def _catalog_endpoint_for(rest: str) -> dict | None:
     return catalog_store.load().by_id.get(rest)
 
 
+def _enforce_catalog_status(ep: dict) -> None:
+    """Refuse a catalog id the provider has retired or broken, with its migration story.
+
+    This runs only after `_resolve_call` has failed and `_catalog_endpoint_for` has identified a
+    real catalog id. A team's own tool with the same name therefore still wins, and URL-passthrough
+    calls never enter this path at all.
+    """
+    status = str(ep.get("status") or "").strip().lower()
+    if not status:
+        return
+    detail = f"{ep['id']} is {status}"
+    if note := str(ep.get("status_note") or "").strip():
+        detail += f": {note}"
+    if successor := str(ep.get("superseded_by") or "").strip():
+        detail += f" Use {successor} instead."
+    else:
+        detail += " No replacement is currently catalogued."
+    raise HTTPException(status_code=410, detail=detail)
+
+
 async def _marketplace_secret(service: str, org_id: int, db: AsyncSession) -> Secret | None:
     """Tier 2's credential: an org secret tagged with this provider (registry connects), else one
     NAMED exactly for it (`treg secret add tikhub …`). Newest wins — a reconnect supersedes."""
@@ -9266,6 +9286,7 @@ async def _resolve_marketplace_call(
     NOTHING is reserved here. Resolution only PRICES the call; `call_tool` reserves after the deny
     rules and caps have had their say, so a refused call never has to un-hold money."""
     await _enforce_capability_pin(ep, caller, db)
+    _enforce_catalog_status(ep)
     service = ep["provider"]
     provider = oauth_providers.get(service)
     if provider is None or not provider.base_url:
@@ -9336,6 +9357,7 @@ async def catalog_endpoint_access(
     ep = catalog_store.load().by_id.get(endpoint_id)
     if ep is None:
         raise HTTPException(status_code=404, detail=f"unknown endpoint {endpoint_id!r}")
+    _enforce_catalog_status(ep)
     service = ep["provider"]
     provider = oauth_providers.get(service)
     if provider is None or not provider.base_url:

--- a/src/treg/catalog/justoneapi.extended.yaml
+++ b/src/treg/catalog/justoneapi.extended.yaml
@@ -5828,6 +5828,7 @@ endpoints:
   example_response: examples/justoneapi.x.linkedin-get-user-posts-v1.json
 - id: justoneapi.x.linkedin-search-user-v1
   tier: extended
+  capability: linkedin.search.people
   platform: linkedin
   method: GET
   path: /api/linkedin/search-user/v1

--- a/src/treg/catalog/tikhub.extended.yaml
+++ b/src/treg/catalog/tikhub.extended.yaml
@@ -8254,6 +8254,8 @@ endpoints:
   example_response: examples/tikhub.x.douyin-search-fetch-video-search-v2.json
   capability: douyin.search.videos
 - id: tikhub.x.douyin-search-fetch-vision-search
+  status: retired
+  status_note: "TikHub removed this Douyin route and publishes no route with the same resource name (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: douyin
   method: POST
@@ -17944,6 +17946,8 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.lemon8-app-get-user-ids.json
 - id: tikhub.x.linkedin-web-get-ad-detail
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -17974,6 +17978,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-ad-detail.json
   capability: linkedin.ad.detail
 - id: tikhub.x.linkedin-web-get-comments-replies
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18007,6 +18013,8 @@ endpoints:
         note: Previous replies token
   untestable: no documented value for required comment_id, previous_replies_token
 - id: tikhub.x.linkedin-web-get-company-affiliated-pages
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18037,6 +18045,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-affiliated-pages.json
   capability: linkedin.company.affiliated_pages
 - id: tikhub.x.linkedin-web-get-company-associated-member-insights
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18067,6 +18077,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-associated-member-insights.json
   capability: linkedin.company.employee_insights
 - id: tikhub.x.linkedin-web-get-company-job-count
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18097,6 +18109,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-job-count.json
   capability: linkedin.company.jobs
 - id: tikhub.x.linkedin-web-get-company-jobs
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18165,6 +18179,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-jobs.json
   capability: linkedin.company.jobs
 - id: tikhub.x.linkedin-web-get-company-people
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18201,6 +18217,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-people.json
   capability: linkedin.company.people
 - id: tikhub.x.linkedin-web-get-company-posts
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-company-posts
   tier: extended
   platform: linkedin
   method: GET
@@ -18243,6 +18262,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-posts.json
   capability: linkedin.company.posts
 - id: tikhub.x.linkedin-web-get-company-profile
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-company-profile
   tier: extended
   platform: linkedin
   method: GET
@@ -18277,6 +18299,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-company-profile.json
   capability: linkedin.company.profile
 - id: tikhub.x.linkedin-web-get-group-info
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18301,6 +18325,8 @@ endpoints:
         note: Group ID
   untestable: no documented value for required group_id
 - id: tikhub.x.linkedin-web-get-group-posts
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18330,6 +18356,9 @@ endpoints:
         example: '1'
   untestable: no documented value for required group_id
 - id: tikhub.x.linkedin-web-get-job-detail
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-job-detail
   tier: extended
   platform: linkedin
   method: GET
@@ -18364,6 +18393,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-job-detail.json
   capability: linkedin.job.detail
 - id: tikhub.x.linkedin-web-get-post-comments
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-post-comments
   tier: extended
   platform: linkedin
   method: GET
@@ -18408,6 +18440,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-post-comments.json
   capability: linkedin.post.comments
 - id: tikhub.x.linkedin-web-get-post-detail
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-post-detail
   tier: extended
   platform: linkedin
   method: GET
@@ -18438,6 +18473,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-post-detail.json
   capability: linkedin.post.detail
 - id: tikhub.x.linkedin-web-get-post-reactions
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18479,6 +18516,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-post-reactions.json
   capability: linkedin.post.reactions
 - id: tikhub.x.linkedin-web-get-post-reposts
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18519,6 +18558,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-post-reposts.json
   capability: linkedin.post.reposts
 - id: tikhub.x.linkedin-web-get-user-about
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18548,6 +18589,8 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.linkedin-web-get-user-about.json
 - id: tikhub.x.linkedin-web-get-user-certifications
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18584,6 +18627,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-certifications.json
   capability: linkedin.user.certifications
 - id: tikhub.x.linkedin-web-get-user-comments
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18624,6 +18669,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-comments.json
   capability: linkedin.user.comments
 - id: tikhub.x.linkedin-web-get-user-contact
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18650,6 +18697,8 @@ endpoints:
   capability: linkedin.user.contact
   untestable: returns a named private individual's personal email and phone — no example may be committed to a public repo (route itself works)
 - id: tikhub.x.linkedin-web-get-user-educations
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18686,6 +18735,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-educations.json
   capability: linkedin.user.education
 - id: tikhub.x.linkedin-web-get-user-experience
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18722,6 +18773,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-experience.json
   capability: linkedin.user.experience
 - id: tikhub.x.linkedin-web-get-user-follower-and-connection
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18752,6 +18805,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-follower-and-connection.json
   capability: linkedin.user.followers
 - id: tikhub.x.linkedin-web-get-user-honors
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18788,6 +18843,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-honors.json
   capability: linkedin.user.honors
 - id: tikhub.x.linkedin-web-get-user-images
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18828,6 +18885,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-images.json
   capability: linkedin.user.images
 - id: tikhub.x.linkedin-web-get-user-interests-companies
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18864,6 +18923,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-interests-companies.json
   capability: linkedin.user.interests
 - id: tikhub.x.linkedin-web-get-user-interests-groups
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -18900,6 +18961,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-interests-groups.json
   capability: linkedin.user.interests
 - id: tikhub.x.linkedin-web-get-user-posts
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-user-posts
   tier: extended
   platform: linkedin
   method: GET
@@ -18940,6 +19004,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-posts.json
   capability: linkedin.user.posts
 - id: tikhub.x.linkedin-web-get-user-profile
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-get-user-profile
   tier: extended
   platform: linkedin
   method: GET
@@ -19010,6 +19077,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-profile.json
   capability: linkedin.user.profile
 - id: tikhub.x.linkedin-web-get-user-publications
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19046,6 +19115,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-publications.json
   capability: linkedin.user.publications
 - id: tikhub.x.linkedin-web-get-user-reactions
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19086,6 +19157,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-reactions.json
   capability: linkedin.user.reactions
 - id: tikhub.x.linkedin-web-get-user-recommendations
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19132,6 +19205,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-recommendations.json
   capability: linkedin.user.recommendations
 - id: tikhub.x.linkedin-web-get-user-skills
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19168,6 +19243,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-skills.json
   capability: linkedin.user.skills
 - id: tikhub.x.linkedin-web-get-user-videos
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19208,6 +19285,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-videos.json
   capability: linkedin.user.videos
 - id: tikhub.x.linkedin-web-get-user-volunteers
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19244,6 +19323,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-get-user-volunteers.json
   capability: linkedin.user.volunteering
 - id: tikhub.x.linkedin-web-search-ads
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19292,6 +19373,9 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-ads.json
   capability: linkedin.search.ads
 - id: tikhub.x.linkedin-web-search-jobs
+  status: retired
+  status_note: "TikHub retired linkedin/web when it collapsed LinkedIn into eight linkedin/web_v2 routes; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.linkedin-web-v2-search-jobs
   tier: extended
   platform: linkedin
   method: GET
@@ -19376,6 +19460,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-jobs.json
   capability: linkedin.search.jobs
 - id: tikhub.x.linkedin-web-search-location
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19405,6 +19491,8 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.linkedin-web-search-location.json
 - id: tikhub.x.linkedin-web-search-people
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19489,6 +19577,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-people.json
   capability: linkedin.search.people
 - id: tikhub.x.linkedin-web-search-posts
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19545,6 +19635,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-posts.json
   capability: linkedin.search.posts
 - id: tikhub.x.linkedin-web-search-schools
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19581,6 +19673,8 @@ endpoints:
   example_response: examples/tikhub.x.linkedin-web-search-schools.json
   capability: linkedin.search.schools
 - id: tikhub.x.linkedin-web-search-suggestion-industry
+  status: retired
+  status_note: "TikHub removed this route when it collapsed linkedin/web into eight linkedin/web_v2 routes; no equivalent route remains (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19610,6 +19704,8 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.linkedin-web-search-suggestion-industry.json
 - id: tikhub.x.linkedin-web-v2-get-author-articles
+  status: retired
+  status_note: "TikHub removed this linkedin/web_v2 route; it is not among the eight remaining LinkedIn routes and has no equivalent (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19639,6 +19735,7 @@ endpoints:
   untestable: no documented value for required url
 - id: tikhub.x.linkedin-web-v2-get-company-posts
   tier: extended
+  capability: linkedin.company.posts
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_company_posts
@@ -19763,8 +19860,47 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.linkedin-web-v2-get-post-detail.json
   capability: linkedin.post.detail
+- id: tikhub.x.linkedin-web-v2-get-post-comments
+  tier: extended
+  capability: linkedin.post.comments
+  platform: linkedin
+  method: GET
+  path: /api/v1/linkedin/web_v2/get_post_comments
+  name: Get post comments
+  summary: Fetch comments of a LinkedIn post by its activity URN.
+  input:
+    queryParams:
+      urn:
+        type: string
+        required: true
+        note: Numeric activity URN from the LinkedIn post URL.
+        example: '7267273010393358336'
+      sort_by:
+        type: string
+        required: false
+        note: Most relevant (default) or Most recent.
+      page:
+        type: integer
+        required: false
+        note: Page number, starting at 1.
+        example: 1
+      pagination_token:
+        type: string
+        required: false
+        note: Pagination token returned by the previous response.
+      share_urn:
+        type: string
+        required: false
+        note: Optional share URN for shared posts.
+  test_request:
+    queryParams:
+      urn: '7267273010393358336'
+      sort_by: Most relevant
+      page: 1
+  skipped: not called with a credential during the drift repair; the route is present in TikHub's 2026-08-17 OpenAPI snapshot
 - id: tikhub.x.linkedin-web-v2-get-user-posts
   tier: extended
+  capability: linkedin.user.posts
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_user_posts
@@ -19831,6 +19967,7 @@ endpoints:
   capability: linkedin.user.profile
 - id: tikhub.x.linkedin-web-v2-search-jobs
   tier: extended
+  capability: linkedin.search.jobs
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/search_jobs
@@ -19893,6 +20030,8 @@ endpoints:
       keyword: data analyst
   unverified: 'http 400: Request failed. Please retry. Check the docs below to verify your parameters, te'
 - id: tikhub.x.linkedin-web-v2-search-jobs-by-url
+  status: retired
+  status_note: "TikHub removed this linkedin/web_v2 route; it is not among the eight remaining LinkedIn routes and has no equivalent (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -19921,6 +20060,8 @@ endpoints:
       url: https://www.linkedin.com/jobs/search?keywords=Software&location=New%20York
   unverified: 'http 400: Request failed. Please retry. Check the docs below to verify your parameters, te'
 - id: tikhub.x.linkedin-web-v2-search-users
+  status: retired
+  status_note: "TikHub removed this linkedin/web_v2 route; it is not among the eight remaining LinkedIn routes and has no equivalent (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: linkedin
   method: GET
@@ -23891,6 +24032,9 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.tiktok-app-v3-fetch-share-short-link.json
 - id: tikhub.x.tiktok-app-v3-fetch-shop-id-by-share-link
+  status: retired
+  status_note: "TikHub retired this TikTok App V3 shop route and moved the same operation to tiktok/shop/web; use the replacement below (OpenAPI snapshot fetched 2026-08-17)."
+  superseded_by: tikhub.x.tiktok-shop-web-fetch-shop-id-by-share-link
   tier: extended
   platform: tiktok
   method: GET
@@ -23919,6 +24063,8 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.tiktok-app-v3-fetch-shop-id-by-share-link.json
 - id: tikhub.x.tiktok-app-v3-fetch-shop-info
+  status: retired
+  status_note: "TikHub removed this TikTok route and publishes no route with the same resource name (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: tiktok
   method: GET
@@ -27529,6 +27675,8 @@ endpoints:
   example_response: examples/tikhub.x.tiktok-ads-search-ads.json
   capability: tiktok-ads.library.search
 - id: tikhub.x.tiktok-app-v3-fetch-shop-home
+  status: retired
+  status_note: "TikHub removed this TikTok route and publishes no route with the same resource name (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: tiktok-shop
   method: GET
@@ -27564,6 +27712,8 @@ endpoints:
   example_response: examples/tikhub.x.tiktok-app-v3-fetch-shop-home.json
   capability: tiktok-shop.shop.detail
 - id: tikhub.x.tiktok-app-v3-fetch-shop-home-page-list
+  status: retired
+  status_note: "TikHub removed this TikTok route and publishes no route with the same resource name (OpenAPI snapshot fetched 2026-08-17)."
   tier: extended
   platform: tiktok-shop
   method: GET

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -150,6 +150,10 @@ class Catalog:
         unbilled under per_success/per_result, and the fail-closed daily cap bounds the rest —
         coverage beats caution now that the ladder and settle logic are proven.
         """
+        # A marked row is retained only to explain a cached id and point at its replacement. It is
+        # never an offer treg may spend against, even if its historical price remains complete.
+        if endpoint.get("status"):
+            return False
         cost = self.cost_view(endpoint.get("cost"), endpoint.get("provider"))
         if not cost or cost.get("usd") is None:
             return False
@@ -229,7 +233,12 @@ def _parse(directory: Path) -> Catalog:
             if ep["id"] in by_id:  # first file wins; ids are unique by validator contract
                 continue
             by_id[ep["id"]] = ep
-            endpoints.append(ep)
+            # Marked endpoints stay addressable by id so a caller holding yesterday's id gets the
+            # provider's retirement story and replacement. Browse/search/census all read
+            # `endpoints`, so omitting the row here removes it from every discovery surface without
+            # turning a known retirement into an unexplained 404.
+            if not ep["status"]:
+                endpoints.append(ep)
 
     for ep in endpoints:  # a platform seen only in provider files still deserves a label
         platforms.setdefault(ep["platform"], {"label": ep["platform"], "category": "Other"})
@@ -395,6 +404,11 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # 404s a person it has no record of). Only endpoints with evidenced miss semantics carry
         # it; for everything else an error status means what it says.
         "miss": raw.get("miss") or None,
+        # A provider can retire/move a route after an agent has cached its id. Keep that id in
+        # `by_id`, but remove it from discovery and return the migration story on direct lookup.
+        "status": str(raw.get("status") or "").strip().lower(),
+        "status_note": str(raw.get("status_note") or "").strip(),
+        "superseded_by": str(raw.get("superseded_by") or "").strip(),
         "docs_url": raw.get("docs_url") or "",
         "example_file": _example_file(raw, directory),
     }
@@ -455,6 +469,10 @@ def endpoint_view(ep: dict, provider_display: str, cat: Catalog | None = None) -
         # "no match" semantics, when the endpoint has them — an agent that reads `miss` stops
         # treating an expected empty answer as a failed call (and stops retrying it).
         "miss": ep.get("miss"),
+        # Only direct-id lookups can return a marked row; discovery surfaces never include one.
+        "status": ep.get("status") or None,
+        "status_note": ep.get("status_note") or None,
+        "superseded_by": ep.get("superseded_by") or None,
         "verified": ep["verified"],
         "docs_url": ep["docs_url"],
         "has_example": bool(ep["example_file"]),

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -61,7 +61,8 @@ async def test_platform_detail_groups_the_same_job_across_providers(clients: Asy
     ep = next(e for e in profile["endpoints"] if e["provider"] == "tikhub")
     assert set(ep) == {"id", "provider", "provider_display", "name", "summary", "method", "path",
                        "scope", "tier", "kind", "domain", "call_template", "cost", "verified", "docs_url",
-                       "has_example", "input", "platform_eligible", "test_request", "miss"}
+                       "has_example", "input", "platform_eligible", "test_request", "miss",
+                       "status", "status_note", "superseded_by"}
     assert ep["kind"] == "data", "an endpoint with no explicit kind is data (the browse surface)"
     assert ep["provider_display"] == P.get("tikhub").display_name
     assert ep["method"] == "GET" and ep["path"].startswith("/")
@@ -337,6 +338,45 @@ async def test_endpoint_detail_answers_everything_in_one_call(clients: AsyncClie
     assert isinstance(body["example_response"], (dict, list)), "inline, so parsing needs no second call"
 
 
+async def test_retired_rows_leave_discovery_but_keep_an_actionable_direct_lookup(clients: AsyncClient):
+    """A cached endpoint id needs its migration story, while a new agent must never discover it."""
+    retired = "tikhub.x.linkedin-web-search-jobs"
+    successor = "tikhub.x.linkedin-web-v2-search-jobs"
+    cat = cs.load()
+    assert retired in cat.by_id
+    assert retired not in {ep["id"] for ep in cat.endpoints}
+    assert cat.by_id[retired]["status"] == "retired"
+    assert cat.by_id[retired]["superseded_by"] == successor
+    assert not cat.by_id[successor]["status"]
+
+    detail = (await clients.get(f"/catalog/endpoints/{retired}")).json()["endpoint"]
+    assert detail["status"] == "retired"
+    assert "collapsed" in detail["status_note"]
+    assert detail["superseded_by"] == successor
+    search = (await clients.get("/catalog/search", params={"q": retired})).json()
+    assert retired not in {row["id"] for row in search["results"]}
+
+
+def test_tikhub_drift_repair_preserves_markers_and_rescues_only_real_jobs():
+    cat = cs.load()
+    marked = [ep for ep in cat.by_id.values()
+              if ep["provider"] == "tikhub" and ep.get("status")]
+    assert len(marked) == 50
+    assert {ep["status"] for ep in marked} == {"retired"}
+    assert sum(bool(ep.get("superseded_by")) for ep in marked) == 9
+    assert all(ep.get("status_note") for ep in marked)
+    assert all(ep["superseded_by"] in cat.by_id and
+               not cat.by_id[ep["superseded_by"]].get("status")
+               for ep in marked if ep.get("superseded_by"))
+
+    people = cat.by_id["justoneapi.x.linkedin-search-user-v1"]
+    assert people["capability"] == "linkedin.search.people"
+    comments = cat.by_id["tikhub.x.linkedin-web-v2-get-post-comments"]
+    assert comments["path"] == "/api/v1/linkedin/web_v2/get_post_comments"
+    assert comments["method"] == "GET"
+    assert comments["capability"] == "linkedin.post.comments"
+
+
 async def test_call_template_carries_method_and_body_for_a_post(clients: AsyncClient):
     body = (await clients.get("/catalog/endpoints/dataforseo.web.backlinks.summary")).json()
     tmpl = body["call_template"]
@@ -440,6 +480,11 @@ async def test_platform_eligibility_refuses_everything_it_cannot_prove():
     assert cat.platform_eligible({**ok, "verified": None}), \
         "2026-07-31 policy: the live-called stamp is no longer required — a broken route fails unbilled"
     assert not cat.platform_eligible({**ok, "cost": None}), "no price block ⇒ refuse, not free"
+    # `ok` is fully priced, so status is the ONLY axis left to explain a refusal here. A marked row
+    # keeps its historical price — it is retained to explain a cached id, not to be sold — and an
+    # eligible one would put treg's own key behind a route the provider has already removed.
+    assert not cat.platform_eligible({**ok, "status": "retired"}), "a retired route is not an offer"
+    assert not cat.platform_eligible({**ok, "status": "broken"}), "a broken route is not an offer"
 
 
 async def test_eligibility_rides_on_the_served_row(clients: AsyncClient):

--- a/tests/test_catalog_drift.py
+++ b/tests/test_catalog_drift.py
@@ -1,0 +1,27 @@
+from scripts import catalog_drift as drift
+
+
+def test_truncated_openapi_is_salvaged_and_classified_without_fuzzy_matching():
+    text = ('{"openapi":"3.0.0","paths":{'
+            '"/live":{"get":{}},"/wrong-method":{"post":{}},'
+            '"/restored":{"get":{}}},"components":')
+    paths, mode = drift.parse_spec(text)
+    assert mode.startswith("salvaged-json")
+    assert set(paths) == {"/live", "/wrong-method", "/restored"}
+
+    endpoints = [
+        {"id": "p.live", "path": "/live", "method": "GET"},
+        {"id": "p.dead", "path": "/missing", "method": "GET"},
+        {"id": "p.method", "path": "/wrong-method", "method": "GET"},
+        {"id": "p.ack", "path": "/retired", "method": "GET", "status": "retired"},
+        {"id": "p.restored", "path": "/restored", "method": "GET", "status": "retired"},
+    ]
+    result = drift.compare("p", endpoints, paths)
+    assert [ep["id"] for ep in result.ok] == ["p.live"]
+    assert [ep["id"] for ep in result.dead_path] == ["p.dead"]
+    assert [(ep["id"], methods) for ep, methods in result.method_rot] == [
+        ("p.method", ["POST"]),
+    ]
+    assert [ep["id"] for ep in result.acknowledged] == ["p.ack"]
+    assert [ep["id"] for ep in result.restored] == ["p.restored"]
+    assert result.failed

--- a/tests/test_catalog_validate.py
+++ b/tests/test_catalog_validate.py
@@ -1,0 +1,33 @@
+from scripts import catalog_validate as validator
+
+
+def test_status_marker_references_must_exist_and_end_at_a_live_endpoint():
+    statuses = {"provider.old": "retired", "provider.live": "", "provider.dead": "broken"}
+
+    errors: list[str] = []
+    validator.check_status_marker(
+        {"id": "provider.old", "status": "retired", "status_note": "moved",
+         "superseded_by": "provider.live"},
+        "catalog:provider.old", statuses, errors,
+    )
+    assert errors == []
+
+    broken: list[str] = []
+    validator.check_status_marker(
+        {"id": "provider.old", "status": "retired", "status_note": "",
+         "superseded_by": "provider.missing"},
+        "catalog:provider.old", statuses, broken,
+    )
+    validator.check_status_marker(
+        {"id": "provider.old", "status": "retired", "status_note": "moved",
+         "superseded_by": "provider.dead"},
+        "catalog:provider.old", statuses, broken,
+    )
+    validator.check_status_marker(
+        {"id": "provider.old", "status": "Retired", "status_note": "wrong spelling"},
+        "catalog:provider.old", statuses, broken,
+    )
+    assert any("requires a non-empty status_note" in error for error in broken)
+    assert any("is not a catalog endpoint id" in error for error in broken)
+    assert any("is itself broken" in error for error in broken)
+    assert any("status 'Retired' not one of" in error for error in broken)

--- a/tests/test_refusal_audit.py
+++ b/tests/test_refusal_audit.py
@@ -10,8 +10,10 @@ case: 309 pre-relay refusals read as "Hunter is failing" until the rows were re-
 from __future__ import annotations
 
 from httpx import AsyncClient
+import pytest
 from sqlmodel import select
 
+from treg import api as A
 from treg import audit
 from treg.db import session_maker
 from treg.models import CallRecord
@@ -66,3 +68,52 @@ async def test_refusals_reach_the_caller_in_the_audit_log(clients: AsyncClient):
     await audit.drain()
     (row,) = (await clients.get("/calls")).json()
     assert row["refused_by"] == "resolution"
+
+
+async def test_retired_catalog_call_is_actionable_audited_and_does_not_shadow_an_own_tool(
+    clients: AsyncClient, monkeypatch: pytest.MonkeyPatch,
+):
+    endpoint = "tikhub.x.linkedin-web-search-people"
+    await clients.post("/secrets", json={"name": "tikhub", "value": "provider-key"})
+
+    relayed = False
+
+    async def unexpected_relay(*args, **kwargs):
+        nonlocal relayed
+        relayed = True
+        pytest.fail("a retired catalog row reached the upstream relay")
+
+    real_relay = A.relay
+    monkeypatch.setattr(A, "relay", unexpected_relay)
+    response = await clients.get(f"/call/{endpoint}")
+    assert response.status_code == 410, response.text
+    assert response.headers["X-Treg-Error"] == "1"
+    assert "collapsed" in response.json()["detail"]
+    assert "No replacement is currently catalogued" in response.json()["detail"]
+    assert not relayed
+    (record,) = await _rows()
+    assert record.status_code == 410
+    assert record.tool_name == endpoint
+    assert record.refused_by == "retired"
+
+    moved = "tikhub.x.linkedin-web-search-jobs"
+    replacement = "tikhub.x.linkedin-web-v2-search-jobs"
+    moved_response = await clients.get(f"/call/{moved}")
+    assert moved_response.status_code == 410
+    assert replacement in moved_response.json()["detail"]
+    assert [row.refused_by for row in await _rows()] == ["retired", "retired"]
+
+    access = await clients.get(f"/catalog/endpoints/{endpoint}/access")
+    assert access.status_code == 410
+
+    # Tier 1 remains authoritative: a team can deliberately register this exact name, and the
+    # initial own-tool resolution succeeds before catalog fallback or its retirement gate exists.
+    monkeypatch.setattr(A, "relay", real_relay)
+    secret = (await clients.post("/secrets", json={"name": "own", "value": "own-key"})).json()
+    created = await clients.post("/tools", json={
+        "name": endpoint, "base_url": "http://upstream", "secret_id": secret["id"],
+    })
+    assert created.status_code == 200, created.text
+    own = await clients.get(f"/call/{endpoint}")
+    assert own.status_code == 200, own.text
+    assert own.json()["auth"] == "Bearer own-key"


### PR DESCRIPTION
## Why

`hcl-software` burned 47 calls in one day on `tikhub.x.linkedin-web-search-people` — a route TikHub removed when it collapsed `linkedin/web` (45 routes) into an eight-route `linkedin/web_v2`. The 2026-08-17 bug sweep already recorded that **50 catalogued paths were no longer in the spec, and left them served**. It has now reached a paying enrichment org.

Found by drilling into the daily usage report (`scripts/usage_report.py --days 1`): 7,630 calls, 8.9% provider-failed, worst org failing 46% of its calls.

## The part that wasn't obvious

**PR #105's retired/broken markers never reached `main`.** They were merged into `fix/refusal-audit`, which is itself unmerged:

```
6ce5999 ancestor of main?  NO
gh pr view 105 → "baseRefName": "fix/refusal-audit", "state": "MERGED"
```

So this reintroduces the marker fields, the discovery filter and the direct-lookup story — plus the piece #105 never had: **`/call/` now refuses a marked id with its migration story** instead of relaying into a dead upstream.

That last part is the one that actually fixes the reported symptom. Marking alone would not have helped `hcl-software` at all, because an agent calling a cached id never reads a browse surface.

## What's in it

- **`/call/` gate** — 410 + `refused_by=retired`, so a retirement is its own class in the daily report instead of falling into `"request"` via the dict default.
- **`platform_eligible` refuses a marked row** — a retained price exists to explain a cached id; it is not an offer treg may spend its own key against.
- **50 TikHub routes marked** — 9 with a real successor, 41 with none. TikHub didn't rename `linkedin/web`, it *collapsed* it: every granular profile section and every search verb except `search_jobs` is gone.
- **Capability rescue** — `linkedin.search.people` was orphaned (its only provider was the dead route); relabelled onto the live, unlabelled `justoneapi.x.linkedin-search-user-v1`. Its `unverified` evidence is kept rather than overclaimed.
- **`linkedin/web_v2/get_post_comments`** — live upstream, was never catalogued. Added.
- **`scripts/catalog_drift.py` + CI** — compares catalogued path+method against providers' published OpenAPI docs. No credential, no provider call, $0. The root cause was that *nothing re-checked a spec for drift*; the first signal was a user hitting a 404 in the wild.
- **Validator rules** for `status` / `superseded_by`, so a typo'd successor can't silently point at nothing.

Deliberately **not** deleting the dead YAML — marking-not-deleting is the point of the #105 design: a deleted id becomes an unexplained 404, the exact failure the marker prevents. And no TikHub re-ingest: that strips cost provenance from all 986 entries, re-maps 7 endpoints onto a new platform, and rewrites 660 summaries.

## Verification

Validated against the **live** TikHub spec:

```
tikhub: 1002 catalogued, 952 ok, 0 dead-path, 0 method-rot, 50 acknowledged, 0 restored
```

The markers exactly cover live drift, and nothing was wrongly marked.

- Suite: **1767 passed**
- `catalog_validate`: 2631 endpoints, **0 errors, 0 warnings**
- All 9 `superseded_by` targets resolve to live rows
- **Each defence revert-tested** — removing the call-path gate, the discovery filter, the access-route gate, or the `platform_eligible` guard each fails a test. The eligibility guard was initially unpinned and passed with the guard removed; assertions were added until it failed.

## Known limits

- 21 capabilities remain genuinely orphaned — no provider serves them. Left orphaned rather than papered over with invented capabilities.
- No price invented for the new comments route: callable with an org credential, not eligible for treg-funded spend without rate-card evidence.
- `meta-ad-library` untouched — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)