### PR TITLE
feat(catalog): a dead end names the capability siblings treg can already serve

### DIFF
--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -98,6 +98,29 @@ selected or the relay can run; the refusal is audited as `refused_by=retired`. T
 deliberate: an org's own tool named exactly like the old catalog id already resolved above and is not
 shadowed, while URL passthrough has no catalog-id shape to catch accidentally.
 
+**A dead end names its capability siblings.** Both refusals that end the ladder — the `410` tombstone
+with no `superseded_by`, and the tier-3 `404` when no credential can be found — append
+`_capability_alternatives(ep)`: the other providers catalogued for the same `capability`, cheapest
+first, each marked *callable now on treg's key* (both halves of `_platform_offer`'s tier-4 test hold)
+or *needs your own `<provider>` credential*. It is derived from `cat.endpoints`, which `_parse` has
+already stripped of marked rows, so a retirement stops being suggested the moment it is marked and no
+list is maintained by hand.
+
+Two facts motivate it. 41 of the 50 TikHub retirements have no same-provider successor, so
+`superseded_by` is structurally silent for them and a cross-provider sibling is the only migration
+path left. And on 2026-08-19 one org spent 268 calls on `meta-ad-library.meta-ads.library.search`,
+which treg holds no key for, while `scrapecreators.x.v1-facebook-adlibrary-search-ads` — the same
+capability string, on a key treg already had — answered 192 of 208 calls for fourteen other teams.
+The refusal knew the capability the whole time.
+
+This **compares, it does not route**: treg never fails over on the caller's behalf, so the refusal
+stands, nothing is substituted, and the choice stays with the caller. The helper is deliberately
+synchronous and I/O-free — observed success would need `endpoint_stats.observed` and a database
+round-trip on an error path, which is how a 404 becomes a 500, and `catalog get` already ranks the
+same siblings by observed success when the caller follows the pointer. It can only see curated
+`capability` values: an endpoint with a blank capability is invisible as an alternative, which is an
+argument for filling those in rather than for fuzzy id matching.
+
 **ACL-filtered candidates.** `_resolve_call` takes the **caller** and filters passthrough candidates by
 `_tool_usable` (project scope AND the per-tool list) **before** the longest-prefix tiebreak. A same-host
 tool the caller cannot use must not be able to cause a `409` — or win the tiebreak — for someone who

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -8580,6 +8580,11 @@ def _enforce_catalog_status(ep: dict) -> None:
         detail += f": {note}"
     if successor := str(ep.get("superseded_by") or "").strip():
         detail += f" Use {successor} instead."
+    elif alternatives := _capability_alternatives(ep):
+        # 41 of the 50 TikHub retirements have no same-provider successor, so `superseded_by` has
+        # nothing to say for them. A cross-provider sibling is the only help left — and it is the
+        # difference between a tombstone and a migration path.
+        detail += " " + " ".join(alternatives)
     else:
         detail += " No replacement is currently catalogued."
     raise HTTPException(status_code=410, detail=detail)
@@ -8851,7 +8856,50 @@ def _platform_offer(ep: dict, provider, org: Org) -> dict | None:
     return cat.cost_view(ep.get("cost"), ep["provider"]) or None
 
 
-def _marketplace_no_credential(service: str, ep_id: str, provider) -> HTTPException:
+def _capability_alternatives(ep: dict, *, limit: int = 3) -> list[str]:
+    """Other providers' endpoints for the same capability, best first — derived, never hand-written.
+
+    A dead end that names only the provider the caller asked for is the reason one org spent 268
+    calls on `meta-ad-library.meta-ads.library.search` while `scrapecreators.…-search-ads` — the
+    same `capability` string, on a key treg already holds — sat one row away answering 192 of 208
+    calls for fourteen other teams. The refusal knew the capability the whole time.
+
+    Read from `cat.endpoints`, which `_parse` has already stripped of marked rows, so a retirement
+    stops being suggested the moment it is marked and no list here needs maintaining. This
+    COMPARES, it does not route: treg never fails over on the caller's behalf (see the charter),
+    so this names the options and their prices and leaves the choice where it belongs.
+
+    Deliberately synchronous and I/O-free. Measured success would need `endpoint_stats.observed`
+    and a DB round-trip on an error path — which is how a 404 turns into a 500 — and the caller's
+    next step, `catalog get`, already ranks the same siblings by observed success.
+    """
+    capability = ep.get("capability")
+    if not capability:  # only curated capabilities can find siblings; nothing is better than a guess
+        return []
+    cat = catalog_store.load()
+    settings = get_settings()
+    ranked = []
+    for alt in cat.for_capability(capability):
+        if alt["id"] == ep["id"]:
+            continue
+        cost = cat.cost_view(alt.get("cost"), alt["provider"])
+        usd = cost.get("usd") if cost else None
+        # "Servable" is the caller's real question: not "does another row exist" but "can treg
+        # answer it for me right now". Both halves of tier 4, exactly as `_platform_offer` asks.
+        servable = bool(cat.platform_eligible(alt) and settings.platform_key_for(alt["provider"]))
+        ranked.append((not servable, usd if usd is not None else float("inf"), alt["id"], usd, servable))
+    if not ranked:
+        return []
+    ranked.sort()
+    lines = [f"another provider serves {capability}:"]
+    for _, _, alt_id, usd, servable in ranked[:limit]:
+        price = "price unknown" if usd is None else ("free" if usd == 0 else f"~${usd:g}/call")
+        how = "callable now on treg's key" if servable else f"needs your own {alt_id.split('.')[0]} credential"
+        lines.append(f"  {alt_id}  {price}  ({how})")
+    return lines
+
+
+def _marketplace_no_credential(service: str, ep_id: str, provider, ep: dict | None = None) -> HTTPException:
     """Tier 3: the actionable dead-end. Every line names a real command; a pasted-key provider
     gets the `secret add` route too (name it for the service so the ladder finds it)."""
     lines = [f"no {service} credential in this org — {ep_id} is a marketplace endpoint"]
@@ -8859,6 +8907,8 @@ def _marketplace_no_credential(service: str, ep_id: str, provider) -> HTTPExcept
     if provider.uses_pasted_secret:
         lines.append(f"  or add a key: treg secret add {service} --env-var {service.upper().replace('-', '_')}_API_KEY")
     lines.append(f"  or register the tool yourself: treg tool add {service} --base-url {provider.base_url} …")
+    if ep is not None:
+        lines.extend(_capability_alternatives(ep))
     return HTTPException(status_code=404, detail="\n".join(lines))
 
 
@@ -9335,7 +9385,7 @@ async def _resolve_marketplace_call(
         return MarketplaceCall(tool=virtual, tier="platform", **{
             **common, "cost_type": str(cost.get("type") or "per_call"),
             "estimate_micro": _platform_estimate_micro(cost, request.query_params, body)})
-    raise _marketplace_no_credential(service, ep["id"], provider)
+    raise _marketplace_no_credential(service, ep["id"], provider, ep)
 
 
 def _may_have_body(request: Request) -> bool:

--- a/src/treg/catalog/meta-ad-library.yaml
+++ b/src/treg/catalog/meta-ad-library.yaml
@@ -9,6 +9,18 @@
 # the access token rides as ?access_token= — treg injects it, a direct caller that omits it gets a
 # 400 with a generic OAuthException rather than a 401.
 #
+# WHICH ADS EXIST HERE AT ALL — read this before the field notes, because it decides whether a
+# query can return anything, and getting it wrong reads as "the endpoint is broken". Two regimes,
+# and an ad outside BOTH is absent from this API entirely:
+#   - ads about social issues, elections or politics: worldwide, the past seven years;
+#   - ads of ANY type: only where they were delivered to the UK or EU, and only the past year.
+# Meta states the rule on the `ad_reached_countries` parameter: "Ads that did not reach any location
+# in the EU will only return if they are about social issues, elections or politics." So a US-only
+# commercial keyword search returns NO ROWS — not thinner rows, none — and that is a correct empty
+# answer, not a failure. Meta's own page says as much: "To search for all ads currently running
+# across Meta technologies, please use the Ad Library" (the web UI), which is why the UI-scraping
+# providers below cover ads this official API structurally cannot.
+#
 # What comes back depends on WHERE the ad ran and WHAT it is about, which is the one thing that
 # repeatedly surprises people:
 #   - spend, impressions, demographic_distribution and delivery_by_region are populated ONLY for
@@ -16,13 +28,26 @@
 #   - eu_total_reach, age_country_gender_reach_breakdown and beneficiary_payers exist only for ads
 #     delivered in the EU (the DSA disclosure set) — asking for them on a US-only query returns the
 #     rows with those fields simply absent, not an error.
-#   - commercial (non-political) ads outside the EU carry creative + timing + platform data only.
+#   - commercial (non-political) ads carry creative + timing + platform data only — and, per the
+#     eligibility rule above, they are returned ONLY for UK/EU delivery in the first place.
 # Requesting a field an ad does not have never fails the call, so an empty column means "not
-# disclosed for this ad", never "wrong parameter".
+# disclosed for this ad", never "wrong parameter". An empty RESULT SET is the eligibility rule,
+# not a field question — the two failure modes look identical and are not.
 #
 # This is the any_account / competitive view of Meta ads. Your OWN spend is meta-ads.yaml.
-# apify.yaml implements the same meta-ads.library.search capability by scraping the Ad Library UI —
-# richer per-ad detail, paid per result, and unofficial; this file is official, free and thinner.
+# Two providers implement the same meta-ads.library.search capability by scraping the Ad Library UI
+# instead, which is how they cover the US commercial ads this API omits — apify.yaml (paid per
+# result, richer per-ad detail) and scrapecreators (per call, and the one carrying live production
+# evidence: 192 of 208 calls succeeded across fourteen teams in the 30 days to 2026-08-19, versus
+# zero successful calls ever recorded against this file). Both are unofficial and break when Meta
+# changes the page; this one is official, free, and narrower than its name suggests.
+#
+# ACCESS is gated on a PERSON, not on a scope: whoever mints the token must complete the
+# identity confirmation at facebook.com/ID that Meta requires to run social-issue/election ads.
+# No permission, scope or app review is involved, so no OAuth consent can grant it — which is why
+# this is a pasted-key provider rather than part of the shared Meta OAuth app. Note also that a
+# Meta USER token expires (~60 days) while a treg platform key is a static setting with no refresh
+# path, so only a non-expiring Business system-user token is a safe fit for tier 4.
 provider: meta-ad-library
 source:
   docs: https://www.facebook.com/ads/library/api/

--- a/tests/test_refusal_audit.py
+++ b/tests/test_refusal_audit.py
@@ -89,7 +89,11 @@ async def test_retired_catalog_call_is_actionable_audited_and_does_not_shadow_an
     assert response.status_code == 410, response.text
     assert response.headers["X-Treg-Error"] == "1"
     assert "collapsed" in response.json()["detail"]
-    assert "No replacement is currently catalogued" in response.json()["detail"]
+    # 41 of the 50 retirements have no same-provider successor, so `superseded_by` is silent and a
+    # cross-provider sibling is the only migration path left. This is the exact endpoint the org in
+    # the report was calling, and the alternative is the one the capability rescue restored.
+    assert "another provider serves linkedin.search.people:" in response.json()["detail"]
+    assert "justoneapi.x.linkedin-search-user-v1" in response.json()["detail"]
     assert not relayed
     (record,) = await _rows()
     assert record.status_code == 410
@@ -117,3 +121,48 @@ async def test_retired_catalog_call_is_actionable_audited_and_does_not_shadow_an
     own = await clients.get(f"/call/{endpoint}")
     assert own.status_code == 200, own.text
     assert own.json()["auth"] == "Bearer own-key"
+
+
+async def test_a_credential_dead_end_names_a_sibling_treg_can_already_serve(
+    clients: AsyncClient, monkeypatch: pytest.MonkeyPatch,
+):
+    """The 2026-08-19 report's worst refusal: one org spent 268 calls on
+    `meta-ad-library.meta-ads.library.search`, which treg holds no key for, while
+    `scrapecreators.…-search-ads` — the SAME capability, on a key treg already has — answered 192
+    of 208 calls for fourteen other teams. The refusal knew the capability the whole time and never
+    said so. Tier 3 must now name the sibling, and mark whether it is callable or needs a
+    credential, so a dead end becomes a choice rather than a wall.
+    """
+    monkeypatch.setenv("TREG_PLATFORM_KEY_SCRAPECREATORS", "platform-scrapecreators-key")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "scrapecreators")
+    A.get_settings.cache_clear()
+
+    endpoint = "meta-ad-library.meta-ads.library.search"
+    sibling = "scrapecreators.x.v1-facebook-adlibrary-search-ads"
+    # Required params are validated before the ladder is walked, so send them: this test is about
+    # the credential dead end, not about the missing-parameter refusal in front of it.
+    query = {"ad_reached_countries": '["US"]', "fields": "id,page_name", "search_terms": "coffee"}
+
+    response = await clients.get(f"/call/{endpoint}", params=query)
+    assert response.status_code == 404, response.text
+    detail = response.json()["detail"]
+    # The original advice survives — the caller may still want their own Meta token.
+    assert "no meta-ad-library credential in this org" in detail
+    assert "treg connections connect --provider meta-ad-library" in detail
+    # ...and the sibling is now offered, flagged as servable, so the caller can act immediately.
+    assert "another provider serves meta-ads.library.search:" in detail
+    assert sibling in detail
+    assert "callable now on treg's key" in detail
+    # It COMPARES, never routes: the refusal stands and nothing was silently substituted.
+    (record,) = await _rows()
+    assert record.status_code == 404 and record.refused_by == "resolution"
+    assert record.tool_name == endpoint
+
+    # A provider treg holds no key for is still worth naming, but must not claim to be callable.
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "")
+    A.get_settings.cache_clear()
+    unkeyed = (await clients.get(f"/call/{endpoint}", params=query)).json()["detail"]
+    assert sibling in unkeyed
+    assert "callable now on treg's key" not in unkeyed
+    assert "needs your own scrapecreators credential" in unkeyed
+    A.get_settings.cache_clear()


### PR DESCRIPTION
> **Stacked on #154** — base is `fix/tikhub-catalog-drift`, not `main`. Merge #154 first.
>
> Flagging this loudly because this repo has already been bitten by exactly that: PR #105's retired/broken markers were merged into `fix/refusal-audit` and **never reached main**, which is why #154 had to reintroduce them three months later. If #154 lands on main first, rebase this onto main rather than merging it into a stale branch.

## Why

From the 2026-08-19 usage report: one org spent **268 calls** on `meta-ad-library.meta-ads.library.search`, which treg holds no key for. Meanwhile `scrapecreators.x.v1-facebook-adlibrary-search-ads` — the **same `capability` string**, on a key treg already had — answered **192 of 208 calls for fourteen other teams**.

The refusal knew the capability the whole time. It only ever named the provider the caller had already asked for.

## What

`_capability_alternatives(ep)` — derived from catalog data, never hand-written. Reads `cat.endpoints`, which `_parse` has already stripped of marked rows, so **a retirement stops being suggested the moment it is marked** and no list needs maintaining.

Feeds both refusals that end the ladder:
- the **tier-3 404** (no credential) — the arclabs case;
- the **410 tombstone** when `superseded_by` is silent — which is **41 of the 50** TikHub retirements from #154, where a cross-provider sibling is the only migration path that exists at all.

Output names each sibling, cheapest first, marked *callable now on treg's key* (both halves of `_platform_offer`'s tier-4 test hold) or *needs your own `<provider>` credential*.

### Design constraints

- **Compares, does not route.** Per the charter, treg never fails over on the caller's behalf. The refusal stands, nothing is substituted, the choice stays with the caller.
- **Synchronous and I/O-free.** Observed success would need `endpoint_stats.observed` and a DB round-trip *on an error path* — which is how a 404 becomes a 500. `catalog get` already ranks the same siblings by observed success when the caller follows the pointer.
- **Only sees curated `capability` values.** A blank-capability endpoint is invisible as an alternative. That's an argument for filling those in, not for fuzzy id matching — an earlier difflib pass matched linkedin→weibo and linkedin→xiaohongshu, and a wrong suggestion inside a refusal is worse than none.

## meta-ad-library correction

The file oversold what the API returns. Meta's own rule, on `ad_reached_countries`:

> *"Ads that did not reach any location in the EU will only return if they are about social issues, elections or politics."*

So a US-only commercial search returns **no rows** — the file described that as *thinner rows*, which reads as a broken endpoint. Also records the real access gate (a **person's** facebook.com/ID confirmation; no scope or app review, so no OAuth consent can grant it — that's why it's a pasted-key provider) and that a ~60-day Meta user token cannot back a static platform key with no refresh path.

**Deliberately NOT marked retired.** `/ads_archive` is live and callable by anyone with their own verified token; `status` means *provider rot*; and `catalog_drift.py` treats a marked route that still exists in the spec as a CI failure (`restored`). Marking it would be false, would remove a legitimate tier-1/2 path, and would break the drift check.

## Verification

- Suite: **1768 passed**; `catalog_validate` 2631 endpoints, 0 errors, 0 warnings; drift clean against the live TikHub spec.
- **Revert-tested both halves**: stubbing the helper to return `[]` fails both tests; forcing `servable = True` fails the servability assertion.
- The pre-existing `"No replacement is currently catalogued"` assertion for `tikhub.x.linkedin-web-search-people` **had to change** — that endpoint now points at the JustOneAPI provider #154 rescued. That's the helper working on the real reported case, not a test being loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)