### PR TITLE
fix(oauth): X refresh auth dialect + GA4 split-host admin tool; report: tool-requests panel

### DIFF
--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -156,6 +156,16 @@ module symbols:
   the Basic blob for `Basic {secret}` (DataForSEO, Moz). `can_autoprovision` (has a `base_url` and either needs no
   second credential or treg holds it) drives auto-building a callable tool on a successful connect;
   `needs_extra_credential` covers Google Ads' `developer-token` header (a second binding the operator supplies).
+  **Split-host vendors get one extra Tool per host** (`extra_tools`): GA4 runs reports on
+  `analyticsdata` but lists the property ids those reports need on `analyticsadmin` — one scope covers
+  both, but `/call/` resolution is per-HOST, so without a second row the agent is walled off (admin
+  path on the data host → Google 404; admin host → treg "no registered tool"; 13 calls/7 orgs observed
+  stuck there). The extra (`<connection>-admin`) binds the SAME secret, upserts idempotently on
+  reconnect — which is also how pre-fix connections heal — and revoke already sweeps it (any tool
+  whose only binding was the deleted credential goes). `resource_example` closes the loop from the
+  other side: the moment the user picks their property (`POST /connections/{id}/resource`), the
+  template renders `{resource}`/`{resource_name}` into a ready-made call stamped into the data tool's
+  examples (marker `stamped: resource`, so re-picking replaces instead of piling up).
 - Post-connect helpers the dashboard/CLI drive: resource **discovery** (`supports_discovery`,
   `discover_*` — which site/property/account this connection acts on), row **enrichment**
   (`supports_enrichment`, `enrich_*` — Google Ads returns bare ids, so a per-row lookup fills the human name),

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -58,7 +58,12 @@ and raises a clear error when a 200 body carries no `access_token`; `_expires_at
 
 `refresh()` posts the credential's recorded `client_id_param` dialect (TikTok reads `client_key`, not
 `client_id`), snapshotted onto the blob at mint time so a refresh months later still speaks the dialect
-the grant was minted with.
+the grant was minted with. The same snapshotting covers `token_endpoint_auth_method`: X and Pinterest
+demand the secret in HTTP **Basic**, and for a while only `exchange_code` knew — so connect succeeded
+and every refresh 401'd two hours later (surfaced to callers as `502 oauth refresh failed`; ≥6 orgs
+hit it live). Now the method rides in the blob and `refresh()` honors it; a legacy blob without the
+field gets body auth, then ONE retry with Basic on a 4xx, and stamps whichever worked — existing
+broken connections self-heal on their next call, no migration.
 
 **Connect flow (mint the first token):** `consent_url(pending)` builds the provider consent URL
 (default `access_type=offline` + `prompt=consent` so a refresh token comes back); `exchange_code(pending,

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -115,7 +115,11 @@ rejects on HTTP status by default.
    count; it activates when the credentials are set.
 4. **Quirks** (all snapshotted onto `PendingOAuth`): `extra_credential_*` for a second header (Google Ads /
    Microsoft Ads `DeveloperToken`), `auth_params={}` for non-Google providers that reject `access_type`,
-   `client_id_param` (TikTok's `app_id`/`client_key`), `scope_separator`, `pkce`, `long_lived_exchange`.
+   `client_id_param` (TikTok's `app_id`/`client_key`), `scope_separator`, `pkce`, `long_lived_exchange`,
+   `token_endpoint_auth_method="client_secret_basic"` (X, Pinterest — ALSO persisted into the token blob
+   so refresh speaks the same dialect), `extra_tools` for a vendor that splits one product across hosts
+   (GA4's admin/data split — each extra host provisions a companion Tool on the same secret), and
+   `resource_example` to stamp a ready-made call onto the tool once the user picks their resource.
 5. **NON-STANDARD OAuth is not free.** TikTok Ads (`app_id`/`auth_code`, JSON-body token exchange, `code==0`
    envelope, `Access-Token` header instead of `Authorization: Bearer`) does NOT work with the standard
    `oauth.py` flow or the Bearer auto-provision binding. Add it as a **flagged placeholder** — it needs real

--- a/scripts/usage_report.py
+++ b/scripts/usage_report.py
@@ -218,6 +218,18 @@ QUERIES: dict[str, str] = {
     "clients": BASE + """
       select coalesce(client,'(unreported)') client, count(*) n, count(distinct org_id) orgs
       from c group by 1 order by 2 desc""",
+    # "The catalog doesn't have X" — filed from the web, the CLI, or by an agent over MCP.
+    # NOT windowed like everything else, and deliberately: a request is a BACKLOG ITEM, not a time
+    # series. A `--days 1` run that showed only today's would report an empty queue while a month of
+    # unanswered asks sat in the table. So every open row is listed, and `in_window` marks the new
+    # ones. `$1` is referenced only for that flag — collect() passes `since` to every query, and a
+    # statement that ignores its parameter is a protocol error, not a no-op.
+    "requests": """
+      select id, org_id, user_email, capability, query, note, contact, source, status, created_at,
+             (created_at >= $1) as in_window
+      from toolrequest
+      where status = 'open' or created_at >= $1
+      order by created_at desc limit 300""",
     "orgs": BASE + """
       select c.org_id, o.slug, count(*) calls, sum(c.spend) spend,
              sum(case when c.failed then 1 else 0 end) failed,
@@ -356,6 +368,21 @@ def print_summary(data: dict, days: int, top: int) -> None:
         for f in fails[:12]:
             print(f"  {f['n']:>5}  {f['status_code']}  {short(f['ep'], 62)}  ({f['orgs']} orgs)")
 
+    reqs = data.get("requests") or []
+    if reqs:
+        new = sum(1 for r in reqs if r["in_window"])
+        # A row with neither an email nor a contact is unanswerable — the request endpoint is
+        # deliberately anonymous-friendly, so this is the cost of that choice, stated out loud.
+        anon = sum(1 for r in reqs if not (r["user_email"] or r["contact"]))
+        print(f"\n\033[1mtool requests\033[0m  ({len(reqs)} open · {new} filed in this window · "
+              f"{anon} with no way to reply)")
+        for r in reqs[:12]:
+            who = r["user_email"] or r["contact"] or "anonymous"
+            print(f"  {r['created_at']:%m-%d %H:%M}  {r['source']:<4} {short(who, 24):<24} "
+                  f"{short(r['capability'], 58)}")
+        if len(reqs) > 12:
+            print(f"  … {len(reqs) - 12} more (the HTML lists every one)")
+
     print("\n\033[1mtop orgs\033[0m")
     for o in data["orgs"][:10]:
         print(f"  {o['calls']:>6} calls  {usd(o['spend']):>9}  {(o['slug'] or '?'):<24} "
@@ -411,6 +438,10 @@ td{padding:6px 8px;border-bottom:1px solid var(--line-soft);white-space:nowrap}
 tr:last-child td{border-bottom:0}
 td.r,th.r{text-align:right}
 td.name{white-space:normal;word-break:break-word;min-width:220px}
+/* A request filed inside the report window. The left rule carries the meaning; the tint is only a
+   hint, so this still reads on a monochrome print and in both themes. */
+tr.fresh td{background:var(--accent-soft)}
+tr.fresh td:first-child{box-shadow:inset 2px 0 0 var(--accent)}
 .bar{position:relative;display:block;height:3px;background:var(--accent-soft);border-radius:2px;margin-top:4px}
 .bar i{position:absolute;inset:0 auto 0 0;background:var(--accent);border-radius:2px}
 .pill{display:inline-block;padding:1px 7px;border-radius:10px;font-size:11px;font-weight:600;
@@ -697,6 +728,26 @@ def build_html(data: dict, days: int, top: int, since: dt.datetime, unit: str = 
         "".join(f'<tr><td>{html.escape(c["client"])}</td><td class="r num">{c["n"]:,}</td>'
                 f'<td class="r num">{c["orgs"]}</td></tr>' for c in data["clients"][:10]))
 
+    reqs = data.get("requests") or []
+    req_new = sum(1 for r in reqs if r["in_window"])
+    req_new_label = f" · {req_new} new" if req_new else ""
+    req_anon = sum(1 for r in reqs if not (r["user_email"] or r["contact"]))
+    def request_row(r: dict) -> str:
+        who = r["user_email"] or r["contact"]
+        who_cell = html.escape(who) if who else '<span class="dim">anonymous</span>'
+        detail = r["note"] or r["query"]
+        detail_html = f'<div class="dim">{html.escape(short(detail, 260))}</div>' if detail else ""
+        return (f'<tr class="{"fresh" if r["in_window"] else ""}">'
+                f'<td class="num">{r["created_at"]:%Y-%m-%d %H:%M}</td>'
+                f'<td><code>{html.escape(r["source"] or "?")}</code></td>'
+                f'<td>{who_cell}</td>'
+                f'<td class="name">{html.escape(r["capability"] or "—")}{detail_html}</td></tr>')
+
+    requests_html = table(
+        '<th>Filed</th><th>Source</th><th>Who</th><th>Asked for</th>',
+        "".join(request_row(r) for r in reqs)
+        or '<tr><td colspan="4" class="dim">No open requests.</td></tr>')
+
     details: dict[tuple[str, bool], list[dict]] = {}
     for d in data["errdetail"]:
         details.setdefault((d["ep"], d["cataloged"]), []).append(d)
@@ -735,6 +786,18 @@ def build_html(data: dict, days: int, top: int, since: dt.datetime, unit: str = 
   <div class="kpis">{kpi_html}</div>
 
   <div class="card"><h2>Volume by {unit}</h2>{svg_stacked(data["daily"], unit)}</div>
+
+  <div class="card"><h2>Tool requests — all {len(reqs)} open{req_new_label}</h2>
+    <p class="sub" style="margin:-4px 0 12px">"The catalog doesn't have X", filed from the web page,
+    the CLI, or by an agent mid-search over MCP. <b>New rows in this window are highlighted.</b>
+    Every row here stays until someone flips its <code>status</code> by hand — this is a queue, not a
+    feed, so it is listed in full regardless of the report window.<br/>
+    <b>Read them against the catalog before building anything.</b> A request for something treg
+    already serves is a <i>discovery</i> failure wearing a coverage failure's clothes, and shipping
+    the endpoint again would not have helped the person who asked.<br/>
+    {req_anon} of {len(reqs)} carry neither an email nor a contact — filing is deliberately
+    anonymous-friendly, so those asks cannot be answered even when we build the thing.</p>
+    {requests_html}</div>
 
   <div class="card"><h2>Catalog endpoints — all {len(cataloged)}</h2>
     <p class="sub" style="margin:-4px 0 12px">Calls that resolved to a catalog endpoint. The three

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -7317,13 +7317,41 @@ async def _autoprovision_provider_tool(
         existing.health_check = health_check or existing.health_check
         if examples and not existing.examples:
             existing.examples = examples
-        return
-    db.add(Tool(
-        org_id=secret.org_id, name=tool_name, owner=pending.owner,
-        base_url=provider.base_url, host=_host_of(provider.base_url),
-        bindings=bindings, health_check=health_check,
-        examples=examples,
-    ))
+    else:
+        db.add(Tool(
+            org_id=secret.org_id, name=tool_name, owner=pending.owner,
+            base_url=provider.base_url, host=_host_of(provider.base_url),
+            bindings=bindings, health_check=health_check,
+            examples=examples,
+        ))
+    # Split-host vendors (GA4: reports on analyticsdata, property listing on analyticsadmin) get
+    # one extra Tool per host, bound to the SAME secret — the scope already covers it; only /call/'s
+    # per-host resolution was in the way. Upserted with the same idempotency as the main tool, so a
+    # reconnect heals a connection made before the extra existed instead of duplicating it. Revoke
+    # needs no counterpart: it already deletes any tool whose only binding was this credential.
+    for extra in getattr(provider, "extra_tools", ()) or ():
+        extra_name = f"{tool_name}-{extra['suffix']}"
+        extra_probe = (
+            {"method": "GET", "path": extra["probe_path"], "expect_status": 200}
+            if extra.get("probe_path") else None
+        )
+        prior = (await db.execute(
+            select(Tool).where(Tool.org_id == secret.org_id, Tool.name == extra_name)
+        )).scalars().first()
+        if prior is not None:
+            prior.bindings = bindings
+            prior.base_url = extra["base_url"]
+            prior.host = _host_of(extra["base_url"])
+            prior.health_check = extra_probe or prior.health_check
+            if extra.get("examples") and not prior.examples:
+                prior.examples = extra["examples"]
+        else:
+            db.add(Tool(
+                org_id=secret.org_id, name=extra_name, owner=pending.owner,
+                base_url=extra["base_url"], host=_host_of(extra["base_url"]),
+                bindings=bindings, health_check=extra_probe,
+                examples=extra.get("examples") or [],
+            ))
 
 
 CATALOG_STAMP_CAP = 12  # a tool's examples are read by a human/agent scanning, not a full API doc
@@ -7734,6 +7762,29 @@ async def set_connection_resource(
     secret = await _owned_connection(secret_id, caller, db)
     secret.resource_ref = body.resource_ref
     secret.resource_name = body.resource_name
+    # Picking a property/site/account is the moment we finally KNOW the id every real call needs —
+    # so render it straight into the provisioned tool's examples as a ready-made call. Before this,
+    # agents went hunting for the id through the vendor's admin API mid-task (GA4: 13 calls/7 orgs
+    # dead-ended there). Re-picking replaces the stamped example rather than piling them up.
+    provider = oauth_providers.get(secret.provider) if secret.provider else None
+    tmpl = getattr(provider, "resource_example", None) if provider else None
+    if tmpl and body.resource_ref:
+        rendered = {
+            k: v.replace("{resource}", body.resource_ref)
+                .replace("{resource_name}", body.resource_name or body.resource_ref)
+            if isinstance(v, str) else v
+            for k, v in tmpl.items()
+        }
+        # The marker is what makes re-picking REPLACE: a stamp for property A and one for property B
+        # share no path, so path-matching would let them pile up, one stale and confidently wrong.
+        rendered["stamped"] = "resource"
+        tool = (await db.execute(select(Tool).where(
+            Tool.org_id == caller.org_id, Tool.name == (secret.name or provider.service)
+        ))).scalars().first()
+        if tool is not None:
+            others = [e for e in (tool.examples or [])
+                      if e.get("stamped") != "resource" and e.get("path") != tmpl["path"]]
+            tool.examples = [rendered] + others
     await db.commit()
     await db.refresh(secret)
     return oauth.connection_view(secret)

--- a/src/treg/oauth.py
+++ b/src/treg/oauth.py
@@ -68,16 +68,36 @@ async def refresh(blob: dict, client: httpx.AsyncClient) -> dict:
     # TikTok's token endpoint reads `client_key`; the blob records that at exchange time so a
     # refresh months later still speaks the dialect the grant was minted with.
     cid_param = blob.get("client_id_param") or "client_id"
-    resp = await client.post(
-        blob.get("token_uri", _DEFAULT_TOKEN_URI),
-        data={"grant_type": "refresh_token", "refresh_token": rt, cid_param: cid, "client_secret": csec},
-    )
+    token_uri = blob.get("token_uri", _DEFAULT_TOKEN_URI)
+    data = {"grant_type": "refresh_token", "refresh_token": rt, cid_param: cid}
+
+    # Client authentication must match what the provider demands, same as exchange_code: X and
+    # Pinterest REQUIRE HTTP Basic and reject a secret in the body. This bit the connect path first
+    # and was fixed there — then every X connection died ~2h later anyway, because the REFRESH
+    # still posted the secret in the body (the provider answered 401, surfaced to callers as
+    # `502 oauth refresh failed`). The method is recorded in the blob at exchange time; blobs
+    # minted before that field existed fall back to body auth, then RETRY once with Basic on a
+    # 4xx — and stamp the method that worked so the next refresh skips the dance.
+    method = blob.get("token_endpoint_auth_method")
+    async def _post(basic: bool) -> httpx.Response:
+        if basic:
+            return await client.post(token_uri, data=data, auth=(cid, csec))
+        return await client.post(token_uri, data={**data, "client_secret": csec})
+
+    tried_basic = method == "client_secret_basic"
+    resp = await _post(basic=tried_basic)
+    if resp.status_code in (400, 401) and method is None:
+        retry = await _post(basic=True)
+        if retry.is_success:
+            resp, tried_basic = retry, True
     resp.raise_for_status()
     tok = resp.json()
     access = tok.get("access_token")
     if not access:  # a 200 with an error-shaped body ({"error":"invalid_grant"}) — surface it clearly
         raise ValueError(f"token endpoint returned no access_token: {tok.get('error') or tok}")
     new = dict(blob)
+    if tried_basic and method is None:  # learned by the retry — remember it for the next refresh
+        new["token_endpoint_auth_method"] = "client_secret_basic"
     new["access_token"] = new["token"] = access  # update both common key names
     # Always stamp an expiry (fallback 1h). A provider that omits/nulls expires_in would otherwise
     # leave the token perpetually "unknown expiry" → is_stale True → a live refresh on EVERY call.
@@ -154,6 +174,11 @@ async def exchange_code(p: PendingOAuth, code: str, client: httpx.AsyncClient) -
     }
     if cid_param != "client_id":  # TikTok — refresh must post client_key, not client_id
         blob["client_id_param"] = cid_param
+    if p.token_endpoint_auth_method and p.token_endpoint_auth_method != "client_secret_post":
+        # X / Pinterest demand HTTP Basic at the token endpoint. refresh() has no PendingOAuth to
+        # ask months from now, so the blob itself must remember — omitting this is exactly the bug
+        # where connect succeeded and every refresh 401'd.
+        blob["token_endpoint_auth_method"] = p.token_endpoint_auth_method
     if getattr(p, "long_lived_exchange", False):
         blob = await _extend_meta_token(blob, client)
     return blob

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -188,6 +188,22 @@ class OAuthProvider:
     discover_id_field: str = "id"
     discover_label_field: str = ""
 
+    # Some vendors split ONE product across hosts: GA4 runs reports on analyticsdata but lists the
+    # properties those reports need on analyticsadmin. The credential already covers both — Google
+    # scopes are per-capability, not per-host — but /call/ resolution is per-HOST, so without a
+    # second Tool row the agent is trapped: the admin path 404s on the data host (Google) and the
+    # admin host 404s in treg ("no registered tool"). Observed live: 13 calls / 7 orgs stuck at
+    # exactly that wall while runReport itself worked fine. Each entry provisions one extra Tool
+    # bound to the SAME secret: {"suffix", "base_url", optional "probe_path", optional "examples"}.
+    # The suffix names it `<connection>-<suffix>` so a second account's tools stay distinct too.
+    extra_tools: tuple = ()
+
+    # Rendered into the DATA tool's examples the moment the user picks their site/property/account
+    # (`POST /connections/{id}/resource`). `{resource}` = the picked id (resource_ref) and
+    # `{resource_name}` = its human label. This closes the discovery loop from the other side:
+    # the agent reads the ready-made call off the tool instead of hunting the admin API for ids.
+    resource_example: dict | None = None
+
     # Some listings return only ids — Google Ads' listAccessibleCustomers gives
     # ["customers/6186675831", …] and nothing else. "6186675831" tells a user nothing about which
     # account they're choosing, so a provider can declare a per-row lookup for the human name.
@@ -351,8 +367,8 @@ GOOGLE_ANALYTICS = OAuthProvider(
          "note": "Data API v1beta. Body: {\"dateRanges\":[{\"startDate\":\"28daysAgo\","
                  "\"endDate\":\"yesterday\"}],\"dimensions\":[{\"name\":\"pagePath\"}],"
                  "\"metrics\":[{\"name\":\"screenPageViews\"}]}. Use 'yesterday', not 'today' "
-                 "(today is a partial day). The Admin API (property listing) is a different host — "
-                 "use `treg connections resources`."},
+                 "(today is a partial day). Don't know your property id? The companion "
+                 "`google-analytics-admin` tool lists them: GET v1beta/accountSummaries."},
     ),
     # No probe_path: the Data API is POST-only (runReport), and a probe must be a cheap GET on
     # base_url. Don't "fix" this by pointing at analyticsadmin — the probe runs against the
@@ -367,6 +383,26 @@ GOOGLE_ANALYTICS = OAuthProvider(
     discover_nested_key="propertySummaries",
     discover_id_field="property",
     discover_label_field="displayName",
+    # The Admin API as a CALLABLE tool, not just connect-time discovery. Agents need it mid-task
+    # ("which property id do I report on?"), and analytics.readonly already authorizes its reads —
+    # without this row they called admin paths on the data host (Google 404) or the admin host with
+    # no tool registered (treg 404). Both doors shut; this opens the correct one.
+    extra_tools=(
+        {"suffix": "admin",
+         "base_url": "https://analyticsadmin.googleapis.com",
+         "probe_path": "/v1beta/accountSummaries",
+         "examples": [
+             {"method": "GET", "path": "v1beta/accountSummaries",
+              "note": "Every account and GA4 property this credential can see — the property ids "
+                      "that runReport (on the google-analytics tool) needs."},
+         ]},
+    ),
+    resource_example={
+        "method": "POST", "path": "v1beta/{resource}:runReport",
+        "note": "Your property “{resource_name}”. Body: {\"dateRanges\":[{\"startDate\":"
+                "\"28daysAgo\",\"endDate\":\"yesterday\"}],\"dimensions\":[{\"name\":\"pagePath\"}],"
+                "\"metrics\":[{\"name\":\"screenPageViews\"}]}",
+    },
 )
 
 GOOGLE_BUSINESS_PROFILE = OAuthProvider(

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -609,3 +609,84 @@ def test_every_provider_has_a_logo():
 async def test_logos_are_served(clients):
     r = await clients.get("/logos/slack.svg")
     assert r.status_code == 200 and r.text.lstrip().startswith("<svg")
+
+
+# ---- split-host providers (GA4: reports vs property listing) -------------------------------
+async def test_split_host_connect_provisions_the_admin_tool_too(clients: AsyncClient, treg_google_app):
+    """GA4's property list lives on analyticsadmin while reports run on analyticsdata. One consent
+    covers both (scopes are per-capability), but /call/ resolves per HOST — so the connect must
+    yield a Tool row on each host or the agent can't discover its own property ids (observed live:
+    13 calls / 7 orgs dead-ended exactly there)."""
+    st = await _connect_byo(clients, provider="google-analytics", name="google-analytics")
+    assert st["status"] == "done"
+    tools = {t["name"]: t for t in (await clients.get("/tools")).json()}
+
+    data = tools["google-analytics"]
+    admin = tools["google-analytics-admin"]
+    assert data.get("host") == "analyticsdata.googleapis.com"
+    assert admin.get("host") == "analyticsadmin.googleapis.com"
+    # SAME credential on both — this is one connection wearing two hosts, not two connections.
+    assert admin["bindings"] == data["bindings"]
+    assert admin["bindings"][0]["secret_id"] == st["secret_id"]
+    # The admin tool can prove itself on `health --run`, and tells the agent what it is for.
+    assert admin["health_check"] == {"method": "GET", "path": "/v1beta/accountSummaries",
+                                     "expect_status": 200}
+    assert any("accountSummaries" in e.get("path", "") for e in admin["examples"])
+
+
+async def test_split_host_reconnect_rebinds_extras_without_duplicating(clients: AsyncClient, treg_google_app):
+    first = await _connect_byo(clients, provider="google-analytics", name="google-analytics")
+    await _connect_byo(clients, provider="google-analytics", name="google-analytics",
+                       connection_id=first["secret_id"])
+    admins = [t for t in (await clients.get("/tools")).json() if t["name"] == "google-analytics-admin"]
+    assert len(admins) == 1, "reconnecting must rebind the extra tool, not pile up duplicates"
+
+
+async def test_revoke_removes_the_extra_tool_too(clients: AsyncClient, treg_google_app):
+    """The admin tool's only binding is this credential — revoking must not leave it behind broken."""
+    st = await _connect_byo(clients, provider="google-analytics", name="google-analytics")
+    r = await clients.delete(f"/connections/{st['secret_id']}")
+    assert r.status_code == 200
+    names = {t["name"] for t in (await clients.get("/tools")).json()}
+    assert "google-analytics" not in names
+    assert "google-analytics-admin" not in names
+
+
+# ---- picking a resource stamps a ready-made call onto the tool -----------------------------
+async def test_pick_resource_stamps_ready_made_example(clients: AsyncClient, treg_google_app):
+    """The pick is the moment treg finally knows the property id every runReport needs — render it
+    into the tool's examples so the agent reads the call off the tool instead of hunting for ids."""
+    st = await _connect_byo(clients, provider="google-analytics", name="google-analytics")
+    sid = st["secret_id"]
+    r = await clients.post(f"/connections/{sid}/resource",
+                           json={"resource_ref": "properties/384078430", "resource_name": "Prod site"})
+    assert r.status_code == 200, r.text
+
+    tool = next(t for t in (await clients.get("/tools")).json() if t["name"] == "google-analytics")
+    stamped = [e for e in tool["examples"] if e.get("stamped") == "resource"]
+    assert len(stamped) == 1
+    assert stamped[0]["path"] == "v1beta/properties/384078430:runReport"
+    assert "Prod site" in stamped[0]["note"]
+    # the un-rendered registry template with {property_id} must not ALSO sit there confusing agents
+    assert not any("{resource}" in e.get("path", "") for e in tool["examples"])
+
+    # Re-picking a different property REPLACES the stamp — a stale id is confidently wrong.
+    await clients.post(f"/connections/{sid}/resource",
+                       json={"resource_ref": "properties/999", "resource_name": "Staging"})
+    tool = next(t for t in (await clients.get("/tools")).json() if t["name"] == "google-analytics")
+    stamped = [e for e in tool["examples"] if e.get("stamped") == "resource"]
+    assert len(stamped) == 1
+    assert stamped[0]["path"] == "v1beta/properties/999:runReport"
+
+
+async def test_pick_resource_without_template_changes_no_examples(clients: AsyncClient, treg_google_app):
+    """GSC has no resource_example (yet) — picking a site must leave its examples alone."""
+    st = await _connect_byo(clients, provider="google-search-console", name="google-search-console")
+    before = next(t for t in (await clients.get("/tools")).json()
+                  if t["name"] == "google-search-console")["examples"]
+    r = await clients.post(f"/connections/{st['secret_id']}/resource",
+                           json={"resource_ref": "sc-domain:example.com"})
+    assert r.status_code == 200
+    after = next(t for t in (await clients.get("/tools")).json()
+                 if t["name"] == "google-search-console")["examples"]
+    assert after == before

--- a/tests/test_oauth_refresh.py
+++ b/tests/test_oauth_refresh.py
@@ -60,3 +60,98 @@ async def test_refresh_persists_so_next_call_is_free(clients: AsyncClient):
     # second call: token is now fresh + persisted (expires_in 3600), still serves the refreshed one
     second = await clients.get("/call/gsc/echo")
     assert second.json()["auth"] == "Bearer REFRESHED"
+
+
+# ---- token-endpoint client authentication (X / Pinterest demand HTTP Basic) ---------------------
+# These drive oauth.refresh() directly against a strict stand-in that behaves like X: a refresh
+# posting client_secret in the body is 401'd. The proxy-level tests above can't catch this because
+# conftest's /token accepts anything — which is exactly how the bug shipped: connect worked, and
+# every refresh died two hours later in production only.
+
+import httpx
+
+from treg import oauth
+
+
+def _x_like_transport(calls: list[str]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = request.read().decode()
+        if request.headers.get("authorization", "").startswith("Basic "):
+            assert "client_secret=" not in body  # Basic AND body secret would be double-auth
+            calls.append("basic")
+            return httpx.Response(200, json={"access_token": "VIA-BASIC", "expires_in": 7200})
+        calls.append("body")
+        return httpx.Response(401, json={"error": "invalid_client"})  # X's actual behavior
+    return httpx.MockTransport(handler)
+
+
+def _basic_blob(**extra) -> dict:
+    return {"access_token": "OLD", "refresh_token": "RT", "client_id": "cid",
+            "client_secret": "csec", "token_uri": "https://x.test/2/oauth2/token", **extra}
+
+
+async def test_refresh_honors_recorded_basic_auth_method():
+    calls: list[str] = []
+    async with httpx.AsyncClient(transport=_x_like_transport(calls)) as client:
+        new = await oauth.refresh(_basic_blob(token_endpoint_auth_method="client_secret_basic"), client)
+    assert calls == ["basic"]  # no body-auth attempt at all
+    assert new["access_token"] == "VIA-BASIC"
+
+
+async def test_legacy_blob_without_method_retries_with_basic_and_learns():
+    # Connections minted before the method was persisted: first attempt is body auth (401),
+    # the retry succeeds with Basic, and the blob records what worked so next time is one call.
+    calls: list[str] = []
+    async with httpx.AsyncClient(transport=_x_like_transport(calls)) as client:
+        new = await oauth.refresh(_basic_blob(), client)
+    assert calls == ["body", "basic"]
+    assert new["access_token"] == "VIA-BASIC"
+    assert new["token_endpoint_auth_method"] == "client_secret_basic"
+
+
+async def test_refresh_body_auth_providers_unaffected():
+    # Google et al: secret in the body, no Authorization header — the pre-fix path, byte for byte.
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "authorization" not in request.headers
+        assert "client_secret=csec" in request.read().decode()
+        return httpx.Response(200, json={"access_token": "VIA-BODY", "expires_in": 3600})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        new = await oauth.refresh(_basic_blob(), client)
+    assert new["access_token"] == "VIA-BODY"
+    assert "token_endpoint_auth_method" not in new  # learned nothing; nothing failed
+
+
+async def test_exchange_code_persists_basic_auth_method_into_blob():
+    # The blob is the ONLY thing refresh() has months later — PendingOAuth is long deleted. If the
+    # method doesn't ride along here, every X/Pinterest refresh reverts to body auth and 401s.
+    from treg import crypto
+    from treg.models import PendingOAuth
+
+    p = PendingOAuth(
+        state="s", org_id=1, owner="o@x", provider="x", scopes="tweet.read",
+        auth_uri="https://x.test/authorize", token_uri="https://x.test/2/oauth2/token",
+        client_id="cid", client_secret=crypto.encrypt("csec"), redirect_uri="https://treg/cb",
+        token_endpoint_auth_method="client_secret_basic",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("authorization", "").startswith("Basic ")
+        return httpx.Response(200, json={"access_token": "A", "refresh_token": "R", "expires_in": 3600})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        blob = await oauth.exchange_code(p, "the-code", client)
+    assert blob["token_endpoint_auth_method"] == "client_secret_basic"
+
+    # And a Google-shaped pending (default method) must NOT grow the field.
+    g = PendingOAuth(
+        state="s2", org_id=1, owner="o@x", provider="google-analytics", scopes="r",
+        auth_uri="https://g.test/auth", token_uri="https://g.test/token",
+        client_id="cid", client_secret=crypto.encrypt("csec"), redirect_uri="https://treg/cb",
+    )
+
+    def g_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": "A", "refresh_token": "R", "expires_in": 3600})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(g_handler)) as client:
+        gblob = await oauth.exchange_code(g, "the-code", client)
+    assert "token_endpoint_auth_method" not in gblob


### PR DESCRIPTION
Two connector bugs found by reading 30 days of prod call records, both sitting directly in front of the best-retaining, best-paying cohort (teams with 3+ connected marketing accounts: 31% pay, 46% retain vs 16%/20% baseline) — plus the tool-requests queue surfaced in the daily report.

## 1. X/Pinterest OAuth refresh 401'd on every renewal

X demands the client secret in HTTP **Basic** at the token endpoint. `exchange_code` knew (`token_endpoint_auth_method`) but never persisted it into the blob, so `refresh()` posted the secret in the body → 401 → callers saw `502 oauth refresh failed` starting ~2h after a connect that looked healthy. **210+ calls across ≥6 orgs live.**

Fix: persist the method at exchange, honor it in refresh, and legacy blobs get one retry with Basic on a 4xx then stamp whichever worked — **existing broken connections self-heal on their next call, no migration.**

## 2. GA4: the property-listing API was unreachable both ways

One consent covers both GA4 hosts (scopes are per-capability), but `/call/` resolves per **host**. Agents hunting the property id every `runReport` needs were walled off twice: admin paths on the data host → Google 404 (10 calls / 7 orgs), the *correct* admin host → treg "no registered tool" (2 orgs who had it exactly right). runReport itself worked fine — the funnel died one step before it.

Fix:
- `OAuthProvider.extra_tools` — provision a companion Tool per extra host, bound to the **same secret**; idempotent on reconnect (which is how pre-fix connections heal); revoke already sweeps it. GA4 grows `google-analytics-admin` with an `accountSummaries` probe.
- `OAuthProvider.resource_example` — picking a property stamps a ready-made `runReport` call (real property id + label) into the data tool's examples; a `stamped: resource` marker makes re-picking replace, not pile up.

## 3. Daily report: tool-requests panel

Every open `toolrequest` row in the HTML + terminal report, un-windowed (a queue, not a feed), new-in-window rows highlighted, with the reading discipline in the header — 4 of the first 9 human requests asked for things treg already serves (discovery failures wearing coverage failures' clothes), and 22 of 31 rows carry no way to reply.

## Verification

- Full suite **1777 passed** (9 new tests: refresh dialect ×4, split-host provisioning/stamping ×5)
- **Live against real Google + real X** on the dev server: forced-expiry refresh via Basic → 200; stripped-field legacy blob → 401 → retry → 200 *and learned the field*; `accountSummaries` 200 through the companion tool **and** via URL-passthrough; pick → stamp → `runReport` 200
- Docs fragments (`architecture/auth-secrets.md`, `guides/expanding-a-category.md`) updated in the same commits as their code

Post-merge note: the 7 prod orgs with pre-fix GA connections heal on their next **reconnect** — a nudge or a small backfill would fix them sooner. X orgs heal on their next call, nothing needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
