### PR TITLE
feat(oauth): Meta scopes & discovery for the App Review bundle — BM-owned assets + manage tier

### DIFF
--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -152,7 +152,14 @@ module symbols:
   second credential or treg holds it) drives auto-building a callable tool on a successful connect;
   `needs_extra_credential` covers Google Ads' `developer-token` header (a second binding the operator supplies).
 - Post-connect helpers the dashboard/CLI drive: resource **discovery** (`supports_discovery`,
-  `discover_*` — which site/property/account this connection acts on), row **enrichment**
+  `discover_*` — which site/property/account this connection acts on), row **enrichment**.
+  Discovery can walk a SECOND listing (`discover_extra_path` + `discover_extra_list_paths`): Meta's
+  Business Manager owns assets on the user's behalf, so an agency member sees `[]` from
+  `/me/accounts` for exactly the Pages/Instagram accounts they manage all day — the Business walk
+  (`/me/businesses?fields=owned_pages{…},client_pages{…}`, gated on the `business_management` scope
+  now in every Facebook/Instagram capability) flattens nested lists of primary-shaped rows into the
+  same picker, deduped by id with the primary listing winning, and a failing extra listing is
+  swallowed (pre-scope connections get a clean permission error that must read as "no extra assets"),
   (`supports_enrichment`, `enrich_*` — Google Ads returns bare ids, so a per-row lookup fills the human name),
   and **identity** (`has_identity`, `identity_*` — providers with nothing to pick, like LinkedIn/X/TikTok,
   capture who consented instead). A `probe_path` gives registry tools a real health check.

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -88,6 +88,10 @@ consents, supplying nothing. The asymmetry is the point of a hosted registry: th
 platforms is the *approval* (a Google Ads developer token, Meta App Review), not the OAuth dance — treg
 has already cleared it. treg's own client id/secret load from `Settings` (named by
 `client_id_setting`/`client_secret_setting`, so they come from `.env` like every other setting).
+The Meta pair carries three tiers — read / post / **manage** (comments + DMs on Instagram; engagement,
+visitor content, metadata/webhooks, Messenger, Page video, leads_retrieval + its required
+pages_manage_ads rider, and catalog_management on Facebook Pages) — sized for the 2026-08 App Review
+bundle; `default_capability` is the broadest tier by design, so a plain Connect asks for manage.
 
 Each entry is a frozen `OAuthProvider` dataclass; `REGISTRY` is the `{service: provider}` map. Key
 module symbols:

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -459,7 +459,9 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   Slack) still lists. `connection_resources` (`GET /connections/{id}/resources`) **live-fetches** what a
   connection can act on (GSC sites, GA properties, Ads accounts), enriching id-only rows with the
   upstream's human name concurrently (`_enrich_resource_labels`) and recording the successful upstream
-  call as proof of health; `set_connection_resource` (`POST …/resource`) pins the chosen `resource_ref`
+  call as proof of health. For providers declaring `discover_extra_path` (the Meta pair) it also walks
+  the Business graph and merges Business-owned rows after the primary ones — deduped by id, id-less
+  rows dropped, and a failing walk swallowed rather than surfaced as a 502; `set_connection_resource` (`POST …/resource`) pins the chosen `resource_ref`
   + `resource_name`. `connect_with_token` (`POST /connections/token`) connects any **pasted-secret**
   provider — a bring-your-own bot token (Slack) or an **API key** (Apollo, Hunter, TikHub, Semrush, …) —
   **verifying the credential against the provider's probe before storing** (a header- OR query-param probe,

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -7691,6 +7691,23 @@ async def connection_resources(
     rows = body.get(provider.discover_key) or []
     if provider.discover_nested_key:  # e.g. GA4 properties nested inside each account summary
         rows = [n for r in rows if isinstance(r, dict) for n in (r.get(provider.discover_nested_key) or [])]
+    # Business-owned assets (Meta): a second listing whose rows hold nested lists of
+    # primary-shaped rows — an agency member sees [] from /me/accounts yet manages everything
+    # through their Business portfolio. Best-effort by design: the primary listing has already
+    # answered, and a connection that consented before business_management existed in our scopes
+    # gets a clean permission error here, which must read as "no extra assets", not a 502.
+    if provider.discover_extra_path:
+        try:
+            extra = await request.app.state.http.get(
+                f"{provider.discovery_base.rstrip('/')}{provider.discover_extra_path}",
+                headers=disc_headers,
+            )
+            if extra.status_code < 400:
+                for holder in (extra.json().get(provider.discover_key) or []):
+                    for path in provider.discover_extra_list_paths:
+                        rows.extend(n for n in (_dig(holder, path) or []) if isinstance(n, dict))
+        except Exception:  # noqa: BLE001 — the extra listing must never break the picker
+            pass
     label_field = provider.discover_label_field or provider.discover_id_field
     resources = [
         # A row is usually an object, but some providers return bare strings — Google Ads'
@@ -7702,6 +7719,13 @@ async def connection_resources(
         else {"id": _dig(r, provider.discover_id_field), "label": _dig(r, label_field), "raw": r}
         for r in rows if isinstance(r, (dict, str))
     ]
+    if provider.discover_extra_path:
+        # A directly-managed Page is usually ALSO owned by a Business, so the two listings
+        # overlap — keep the first sighting (the primary listing's). Id-less rows go too: a
+        # Business-owned Page with no linked Instagram account digs to id None, and one None
+        # would survive dedup as a phantom picker row.
+        seen: set = set()
+        resources = [x for x in resources if x["id"] and not (x["id"] in seen or seen.add(x["id"]))]
     if provider.supports_enrichment:
         await _enrich_resource_labels(provider, resources, token, request.app.state.http)
     # Self-heal a connection whose target was chosen before we stored labels (or via the API, which

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -707,6 +707,17 @@ FACEBOOK = OAuthProvider(
     scopes={
         "read": _FB_READ,
         "post": [*_FB_READ, "pages_manage_posts"],
+        # The full account-operations tier: engagement moderation, visitor content, settings and
+        # webhook subscriptions, Messenger, native Page video, lead retrieval — which Meta only
+        # honors alongside pages_manage_ads, so the pair travels together — and the business's
+        # product catalogs. One tier rather than several because these scopes are useless alone:
+        # an agent moderating comments needs the visitor content it moderates, and an agent
+        # working leads needs the form metadata around them.
+        "manage": [
+            *_FB_READ, "pages_manage_posts", "pages_manage_engagement",
+            "pages_read_user_content", "pages_manage_metadata", "pages_messaging",
+            "publish_video", "leads_retrieval", "pages_manage_ads", "catalog_management",
+        ],
     },
     client_id_setting="meta_client_id",
     client_secret_setting="meta_client_secret",
@@ -751,6 +762,13 @@ INSTAGRAM = OAuthProvider(
         "post": [
             "instagram_basic", "instagram_manage_insights", "pages_show_list",
             "pages_read_engagement", "business_management", "instagram_content_publish",
+        ],
+        # Adds the two-way surfaces: comment moderation and direct messages. Kept off `post` so a
+        # publish-only connect never puts "manage your messages" on the consent screen.
+        "manage": [
+            "instagram_basic", "instagram_manage_insights", "pages_show_list",
+            "pages_read_engagement", "business_management", "instagram_content_publish",
+            "instagram_manage_comments", "instagram_manage_messages",
         ],
     },
     client_id_setting="meta_client_id",
@@ -1883,10 +1901,20 @@ SCOPE_LABELS: dict[str, str] = {
     "pages_read_engagement": "Read your Pages' posts, comments and reactions",
     "read_insights": "Read your Pages' reach and engagement insights",
     "pages_manage_posts": "Create, edit and delete posts on your Pages",
+    "pages_manage_engagement": "Reply to and moderate comments on your Pages' posts",
+    "pages_read_user_content": "Read what visitors post on your Pages",
+    "pages_manage_metadata": "Manage your Pages' settings and event subscriptions",
+    "pages_messaging": "Read and reply to your Pages' Messenger conversations",
+    "publish_video": "Upload videos to your Pages",
+    "leads_retrieval": "Retrieve leads from your Pages' instant forms",
+    "pages_manage_ads": "Manage ads run by your Pages",
+    "catalog_management": "Create and update your product catalogs",
     # Meta — Instagram
     "instagram_basic": "See your Instagram account, media and comments",
     "instagram_manage_insights": "Read your Instagram reach and engagement insights",
     "instagram_content_publish": "Publish posts to your Instagram account",
+    "instagram_manage_comments": "Reply to, hide and delete comments on your Instagram posts",
+    "instagram_manage_messages": "Read and reply to your Instagram direct messages",
     # Meta — Ads
     "ads_read": "Read your ad accounts, campaigns and performance",
     "business_management": "See the businesses and ad accounts you have access to",

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -187,6 +187,16 @@ class OAuthProvider:
     discover_nested_key: str = ""
     discover_id_field: str = "id"
     discover_label_field: str = ""
+    # Meta's Business Manager owns assets on the user's BEHALF: an agency member reaches a Page
+    # through business-level access with no personal role on it, so the primary listing answers []
+    # for exactly the accounts they manage all day. `discover_extra_path` is a second listing
+    # fetched the same way (same discover_key), whose rows each HOLD lists of primary-shaped rows
+    # at the dotted paths in `discover_extra_list_paths`. The flattened entries merge after the
+    # primary ones and the picker dedupes by id, so a directly-managed Page never doubles. A
+    # failing extra listing is swallowed: connections that consented before the scope it needs
+    # (business_management) simply lack it, and the primary listing has already answered.
+    discover_extra_path: str = ""
+    discover_extra_list_paths: tuple[str, ...] = ()
 
     # Some listings return only ids — Google Ads' listAccessibleCustomers gives
     # ["customers/6186675831", …] and nothing else. "6186675831" tells a user nothing about which
@@ -674,7 +684,17 @@ _META_CONSENT_NOTICE = (
 
 # pages_show_list is the floor for BOTH providers: it is what returns the Page list, and an
 # Instagram professional account is only reachable *through* the Page it is linked to.
-_FB_READ = ["pages_show_list", "pages_read_engagement", "read_insights"]
+# business_management sits next to it for the same reason it does on META_ADS: most agency-held
+# Pages and Instagram accounts are OWNED by a Business portfolio, where the member has
+# business-level access and no personal Page role — without this scope /me/businesses answers
+# "Missing Permission" and those assets are undiscoverable, so the connect consents cleanly and
+# then offers an empty picker. (The scope already has Advanced Access on our Meta app.)
+_FB_READ = ["pages_show_list", "pages_read_engagement", "read_insights", "business_management"]
+
+# One request walks the Business graph: each business row holds owned_pages and client_pages
+# (the agency case), every entry shaped exactly like a /me/accounts row — so the same
+# discover_id_field/label_field read both listings.
+_META_BIZ_PAGE_LISTS = ("owned_pages.data", "client_pages.data")
 
 FACEBOOK = OAuthProvider(
     service="facebook",
@@ -705,6 +725,8 @@ FACEBOOK = OAuthProvider(
     discover_key="data",
     discover_id_field="id",
     discover_label_field="name",
+    discover_extra_path="/me/businesses?fields=owned_pages{id,name},client_pages{id,name}",
+    discover_extra_list_paths=_META_BIZ_PAGE_LISTS,
     # /me returns the person, not the Page, and needs no extra scope — so it keeps working even for
     # a connection whose Page was later unassigned, which is exactly when you want the probe to
     # still distinguish "credential dead" from "asset gone".
@@ -719,11 +741,16 @@ INSTAGRAM = OAuthProvider(
     # instagram_basic alone cannot publish, and instagram_content_publish alone cannot read the
     # account it publishes to — Meta enforces that dependency in App Review, so post is a strict
     # superset rather than a swap.
+    # business_management is here for the same reason it is in _FB_READ: an agency member's
+    # Instagram accounts hang off Business-owned Pages that /me/accounts cannot see.
     scopes={
-        "read": ["instagram_basic", "instagram_manage_insights", "pages_show_list", "pages_read_engagement"],
+        "read": [
+            "instagram_basic", "instagram_manage_insights", "pages_show_list",
+            "pages_read_engagement", "business_management",
+        ],
         "post": [
             "instagram_basic", "instagram_manage_insights", "pages_show_list",
-            "pages_read_engagement", "instagram_content_publish",
+            "pages_read_engagement", "business_management", "instagram_content_publish",
         ],
     },
     client_id_setting="meta_client_id",
@@ -746,6 +773,13 @@ INSTAGRAM = OAuthProvider(
     discover_key="data",
     discover_id_field="instagram_business_account.id",
     discover_label_field="instagram_business_account.username",
+    # The Business walk asks for the SAME nested field, so its flattened rows are again
+    # Page-shaped and the dotted id path above reads both listings unchanged.
+    discover_extra_path=(
+        "/me/businesses?fields=owned_pages{instagram_business_account{id,username}},"
+        "client_pages{instagram_business_account{id,username}}"
+    ),
+    discover_extra_list_paths=_META_BIZ_PAGE_LISTS,
     probe_path="/me?fields=id,name",
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,51 @@ def make_upstream(hook_hits: list | None = None) -> FastAPI:
             ]
         }
 
+    @up.post("/v25.0/oauth/access_token")
+    @up.get("/v25.0/oauth/access_token")
+    async def meta_token() -> dict:
+        # Meta's token endpoint, serving both the code exchange (POST) and the long-lived
+        # fb_exchange_token swap (GET). The ASGI transport routes every host here, so the real
+        # graph.facebook.com path must exist for a registry-mode Meta connect to complete.
+        return {"access_token": "META-TOKEN", "token_type": "bearer", "expires_in": 5183944}
+
+    @up.get("/me/accounts")
+    async def meta_pages() -> dict:
+        # Meta's primary Page listing: what the user manages through a PERSONAL Page role. One row
+        # carries both the facebook shape (id/name) and the instagram shape (nested professional
+        # account), so both Meta providers can discover against the same stand-in.
+        return {
+            "data": [
+                {"id": "PAGE-DIRECT", "name": "Directly Managed Page",
+                 "instagram_business_account": {"id": "IG-DIRECT", "username": "direct_ig"}},
+            ]
+        }
+
+    @up.get("/me/businesses")
+    async def meta_businesses(request: Request):
+        # Meta's Business walk (needs business_management): each business row nests owned_pages /
+        # client_pages whose entries are shaped like /me/accounts rows. PAGE-DIRECT reappears here
+        # (a personal-role Page is usually also Business-owned) to exercise dedup, and the
+        # agency-owned Page without a linked Instagram account must drop out of the IG picker.
+        # A token containing "noscope" emulates a connection that consented before
+        # business_management was in our scopes.
+        if "noscope" in request.headers.get("authorization", ""):
+            return JSONResponse(
+                {"error": {"message": "(#100) Missing Permission", "code": 100}}, status_code=400)
+        return {
+            "data": [
+                {"id": "BIZ-1", "owned_pages": {"data": [
+                    {"id": "PAGE-DIRECT", "name": "Directly Managed Page",
+                     "instagram_business_account": {"id": "IG-DIRECT", "username": "direct_ig"}},
+                    {"id": "PAGE-NO-IG", "name": "Business Page Without Instagram"},
+                ]}},
+                {"id": "BIZ-2", "client_pages": {"data": [
+                    {"id": "PAGE-CLIENT", "name": "Agency Client Page",
+                     "instagram_business_account": {"id": "IG-CLIENT", "username": "client_ig"}},
+                ]}},
+            ]
+        }
+
     @up.get("/auth.test")
     async def slack_auth_test(request: Request):
         # Faithful Slack stand-in: it answers HTTP 200 even for a DEAD token and signals failure

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -218,6 +218,66 @@ async def test_successful_discovery_marks_the_connection_working(clients: AsyncC
     assert {c["id"]: c for c in (await clients.get("/connections")).json()}[sid]["health"] == "ok"
 
 
+# ---- Business-owned Meta assets join the picker ---------------------------------------------
+@pytest.fixture
+def treg_meta_app(monkeypatch):
+    monkeypatch.setenv("TREG_META_CLIENT_ID", "treg-meta-cid")
+    monkeypatch.setenv("TREG_META_CLIENT_SECRET", "treg-meta-csec")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _meta_test_provider(monkeypatch, service: str, **over):
+    import dataclasses
+
+    from treg import oauth_providers as P
+
+    monkeypatch.setitem(P.REGISTRY, service, dataclasses.replace(
+        P.REGISTRY[service], discover_base_url="http://upstream", **over))
+
+
+async def test_business_owned_pages_join_the_facebook_picker(clients: AsyncClient, treg_meta_app, monkeypatch):
+    """An agency member reaches most Pages through their Business portfolio, not a personal Page
+    role — /me/accounts alone answers [] for exactly the Pages they manage all day. The Business
+    walk must add owned and client Pages, without doubling a Page both listings return."""
+    _meta_test_provider(monkeypatch, "facebook")
+    st = await _connect_byo(clients, provider="facebook", name="facebook")
+    r = await clients.get(f"/connections/{st['secret_id']}/resources")
+    assert r.status_code == 200, r.text
+    got = {x["id"]: x["label"] for x in r.json()["resources"]}
+    assert got == {
+        "PAGE-DIRECT": "Directly Managed Page",  # once, though both listings return it
+        "PAGE-NO-IG": "Business Page Without Instagram",
+        "PAGE-CLIENT": "Agency Client Page",
+    }
+    assert [x["id"] for x in r.json()["resources"]][0] == "PAGE-DIRECT", \
+        "the primary listing's rows keep first position"
+
+
+async def test_business_owned_instagram_accounts_join_the_picker(clients: AsyncClient, treg_meta_app, monkeypatch):
+    """Same walk through the Instagram lens: Business-owned Pages contribute their linked
+    professional accounts, a Page without one drops out instead of surviving as an id-less
+    phantom row, and the directly-reachable account is not doubled."""
+    _meta_test_provider(monkeypatch, "instagram")
+    st = await _connect_byo(clients, provider="instagram", name="instagram")
+    r = await clients.get(f"/connections/{st['secret_id']}/resources")
+    assert r.status_code == 200, r.text
+    got = {x["id"]: x["label"] for x in r.json()["resources"]}
+    assert got == {"IG-DIRECT": "direct_ig", "IG-CLIENT": "client_ig"}
+
+
+async def test_a_failing_business_walk_leaves_the_primary_listing_intact(clients: AsyncClient, treg_meta_app, monkeypatch):
+    """Connections that consented before business_management joined our scopes get a clean
+    permission error from the Business walk. That must read as "no extra assets", never a 502 —
+    the primary listing already answered."""
+    _meta_test_provider(monkeypatch, "facebook", discover_extra_path="/no-such-listing")
+    st = await _connect_byo(clients, provider="facebook", name="facebook")
+    r = await clients.get(f"/connections/{st['secret_id']}/resources")
+    assert r.status_code == 200, r.text
+    assert [x["id"] for x in r.json()["resources"]] == ["PAGE-DIRECT"]
+
+
 # ---- disconnecting must not leave a broken tool behind -------------------------------------
 async def test_revoke_removes_the_provider_tool_it_provisioned(clients: AsyncClient, treg_google_app):
     """A tool bound to a deleted credential isn't "still configured", it's broken — and it only

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -285,6 +285,18 @@ def test_instagram_consent_never_mentions_page_publishing():
         assert "pages_manage_posts" not in cap
 
 
+def test_meta_page_discovery_can_walk_the_business_graph():
+    """Most agency-held Pages (and the Instagram accounts linked to them) are OWNED by a Business
+    portfolio, where the member has business-level access and no personal Page role. Drop
+    business_management from either capability and that user consents cleanly, then gets an empty
+    picker — the extra listing 400s and is (rightly) swallowed."""
+    for provider in (P.FACEBOOK, P.INSTAGRAM):
+        for cap in provider.scopes.values():
+            assert "business_management" in cap, provider.service
+        assert provider.discover_extra_path.startswith("/me/businesses"), provider.service
+        assert provider.discover_extra_list_paths, provider.service
+
+
 def test_meta_ads_needs_no_second_credential():
     """Google Ads is gated on a developer token from an approved manager account; Meta has no
     equivalent, so a Meta Ads connect must yield a callable tool on its own."""

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -255,12 +255,34 @@ def test_meta_providers_share_one_app():
     assert P.FACEBOOK.base_url == P.INSTAGRAM.base_url
 
 
-def test_meta_post_contains_read():
-    """satisfied_capabilities() is set containment, so a non-cumulative post would report a
-    connection that can publish but 'cannot read' — and the default capability would be wrong."""
+def test_meta_capabilities_are_cumulative():
+    """satisfied_capabilities() is set containment, so a non-cumulative tier would report a
+    connection that can publish but 'cannot read' — and the default capability would be wrong.
+    default_capability is the BROADEST tier by design (one honest consent screen beats
+    connect-twice), so adding manage moved the default there."""
     for provider in (P.FACEBOOK, P.INSTAGRAM):
         assert set(provider.scopes["read"]) < set(provider.scopes["post"]), provider.service
-        assert provider.default_capability == "post", provider.service
+        assert set(provider.scopes["post"]) < set(provider.scopes["manage"]), provider.service
+        assert provider.default_capability == "manage", provider.service
+
+
+def test_meta_messaging_stays_out_of_the_publish_tier():
+    """A publish-only connect must never put "manage your messages" (or lead retrieval, or the
+    Page's Messenger inbox) on the consent screen — the two-way surfaces live only in manage."""
+    two_way = {
+        "instagram_manage_messages", "instagram_manage_comments", "pages_messaging",
+        "pages_manage_engagement", "leads_retrieval", "catalog_management",
+    }
+    for provider in (P.FACEBOOK, P.INSTAGRAM):
+        for cap in ("read", "post"):
+            assert not two_way & set(provider.scopes[cap]), (provider.service, cap)
+
+
+def test_lead_retrieval_brings_its_required_rider():
+    """Meta only honors leads_retrieval alongside pages_manage_ads — requesting one without the
+    other consents fine and then 400s on /leads, which would demo as a broken integration."""
+    manage = set(P.FACEBOOK.scopes["manage"])
+    assert {"leads_retrieval", "pages_manage_ads"} <= manage
 
 
 def test_instagram_is_reached_through_a_page():


### PR DESCRIPTION
## Why

Two related changes sized for the upcoming Meta App Review resubmission (4 rejected permissions + the new permission bundle):

1. A user running agency-style Meta accounts reported Business-Manager-owned Pages aren't discoverable — `/me/accounts` returns `[]` and `/me/businesses` answers `(#100) Missing Permission`.
2. The App Review bundle adds comments, messaging, engagement, metadata/webhooks, Page video, lead retrieval and catalog scopes — which need a home in the provider capability model before the review screencast can show a user granting them.

## What

**Commit 1 — Business-Manager discovery**
- `business_management` joins every capability of `facebook` and `instagram` (already at Advanced Access on our Meta app — no new review needed).
- New generic `discover_extra_path` + `discover_extra_list_paths` provider fields: discovery also walks `/me/businesses?fields=owned_pages{…},client_pages{…}` and merges Business-owned rows after the primary listing — deduped by id (primary wins), id-less rows dropped (a BM Page with no linked IG account), and a failing walk swallowed (pre-scope connections must read as "no extra assets", never a 502). Traversal shape verified live against graph.facebook.com v25.0, including a real client_pages agency case.

**Commit 2 — manage tier**
- `instagram` manage = post + `instagram_manage_comments`, `instagram_manage_messages`.
- `facebook` manage = post + `pages_manage_engagement`, `pages_read_user_content`, `pages_manage_metadata`, `pages_messaging`, `publish_video`, `leads_retrieval` (+ its required `pages_manage_ads` rider), `catalog_management`.
- Two-way surfaces stay off `post` so a publish-only connect never shows "manage your messages" on consent. Web modal already renders the tier ("Full access").
- `default_capability` follows the broadest tier by design, so plain Connect asks for manage. No regression: non-admin users are gated on the same App Review either way until the bundle clears.

## Tests

- 3 new discovery tests (merge+dedup, IG traversal with id-less drop-out, failing walk stays 200) against new Meta stand-ins in the test upstream (`/me/accounts`, `/me/businesses`, token endpoint).
- Tier invariants: read < post < manage cumulative, messaging/leads/catalog never below manage, leads_retrieval travels with pages_manage_ads, business_management in every capability.
- Full suite: **1776 passed**.

## Deploy notes

- Deploy BEFORE recording the App Review screencast (consent screen must show the submitted scopes), then reconnect the demo connections once so tokens carry the new grants.
- Existing connections keep working unchanged; they gain BM discovery / new scopes only on reconnect.
- Docs updated in-commit: `architecture/auth-secrets.md`, `interface/api.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)