### PR TITLE
fix(billing): Stripe SDK objects are not dicts — convert once at the _sdk boundary

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -129,6 +129,11 @@ returns 500 **on purpose**: that is how Stripe is told to retry.
 
 The Stripe SDK is synchronous, so every call goes through `_sdk()` onto a worker thread — a blocking
 network call on the event loop would stall every in-flight request, including the proxy's hot path.
+`_sdk()` also converts the SDK's return value to a plain dict (`StripeObject.to_dict()`, which is
+deep): the SDK's objects stopped subclassing dict, so `.get()` on one raises, and every consumer —
+plus every test fake, which returns plain dicts through this same funnel — reads dict-style. Keep it
+that way: a consumer written against the object API would pass prod and break the fakes, and the
+last divergence shipped a webhook handler that 500'd on every live checkout while the suite was green.
 
 `_credit` also emits the `topup_completed` product-analytics event (`analytics.capture`, PostHog),
 riding the same `fresh` flag as the receipt email so a redelivery re-emits nothing. `capture` is

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -141,9 +141,17 @@ async def _sdk(fn, /, **kwargs):
 
     The key is passed per-call (`api_key=`) rather than set on the module, so nothing depends on
     global mutable state and a test can monkeypatch this single function to intercept every call.
+
+    Returns a plain dict, never a `StripeObject`. The SDK's objects stopped subclassing dict, so
+    `.get()` on one raises ("'get' is a dict method, but a PaymentIntent is not a dict") — which is
+    exactly how every `checkout.session.completed` webhook 500'd in production while the suite,
+    whose fakes return plain dicts through this same funnel, stayed green. Every consumer of this
+    function reads dict-style; converting once here keeps them and the test fakes on one shape.
+    `to_dict()` is deep: nested objects and list `data` items all come back as plain dicts.
     """
     key = _require_configured()
-    return await anyio.to_thread.run_sync(lambda: fn(api_key=key, **kwargs))
+    result = await anyio.to_thread.run_sync(lambda: fn(api_key=key, **kwargs))
+    return result.to_dict() if isinstance(result, stripe.StripeObject) else result
 
 
 # ---- policy reads ------------------------------------------------------------------------------

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -969,3 +969,50 @@ async def test_adsconv_commit_failure_cannot_500_or_break_the_webhook(c, monkeyp
         # succeeds if the session was rolled back and made usable again.
         fresh_org = await db.get(Org, org_id)
         assert fresh_org.stripe_default_pm == "pm_card_visa"
+
+
+# ---- the SDK-boundary shape --------------------------------------------------------------------
+# stripe-python's objects stopped subclassing dict, so `.get()` on one raises "'get' is a dict
+# method, but a PaymentIntent is not a dict". Every consumer of `_sdk` reads dict-style, and the
+# fakes in this suite return plain dicts through the same funnel — which is exactly how production
+# 500'd on every `checkout.session.completed` while the suite stayed green. These tests run the
+# REAL `_sdk`, feeding it genuine `StripeObject`s, to pin the conversion at the boundary.
+
+async def test_sdk_converts_stripe_objects_to_plain_dicts(monkeypatch):
+    monkeypatch.setattr(get_settings(), "stripe_secret_key", "sk_test_suite", raising=False)
+
+    def fake_retrieve(api_key=None, **kw):
+        return stripe.PaymentIntent.construct_from(
+            {"id": "pi_shape", "payment_method": {"id": "pm_shape", "card": {"fingerprint": "fp_shape"}}},
+            api_key)
+
+    out = await billing._sdk(fake_retrieve)
+    assert type(out) is dict
+    # Deep, not shallow: the nested object and its nested object are both plain dicts too.
+    assert out.get("payment_method", {}).get("card", {}).get("fingerprint") == "fp_shape"
+
+    def fake_list(api_key=None, **kw):
+        return stripe.ListObject.construct_from(
+            {"object": "list", "has_more": False,
+             "data": [{"id": "ch_shape", "invoice": {"id": "in_shape"}}]},
+            api_key)
+
+    charges = await billing._sdk(fake_list)
+    assert type(charges) is dict
+    assert type(charges.get("data")[0]) is dict
+    assert charges["data"][0].get("invoice", {}).get("id") == "in_shape"
+
+
+async def test_pm_and_fingerprint_survives_sdk_objects(monkeypatch):
+    """The exact production crash: `_pm_and_fingerprint` on the checkout-completed path, with the
+    SDK function itself (not `_sdk`) faked, so the real funnel handles the real object shape."""
+    monkeypatch.setattr(get_settings(), "stripe_secret_key", "sk_test_suite", raising=False)
+
+    def fake_retrieve(api_key=None, id=None, expand=None):
+        return stripe.PaymentIntent.construct_from(
+            {"id": id, "payment_method": {"id": "pm_real", "card": {"fingerprint": "fp_real"}}},
+            api_key)
+
+    monkeypatch.setattr(stripe.PaymentIntent, "retrieve", staticmethod(fake_retrieve))
+    pm_id, fingerprint = await billing._pm_and_fingerprint("pi_real")
+    assert (pm_id, fingerprint) == ("pm_real", "fp_real")


### PR DESCRIPTION
## What happened

Every `checkout.session.completed` webhook has **500'd in production since the first live top-up (2026-08-11)** — 40–90 failed deliveries a day, still retrying. stripe-python's objects no longer subclass dict, so `pi.get("payment_method")` in `_pm_and_fingerprint` raises:

```
'get' is a dict method, but a PaymentIntent is not a dict. Use .to_dict() to convert it.
```

The suite stayed green the whole time because the test fakes monkeypatch `_sdk` and return **plain dicts** through the same funnel — the one shape divergence the tests couldn't see.

Nobody noticed because `payment_intent.succeeded` (which never touches that code path) silently did all the crediting. That left the money path with zero redundancy: today it cost a real customer (org 1462 `texpert`, $5 top-up, receipt 2429-4591) a **60-minute delay** — the fallback's first delivery died on DB pool exhaustion at 09:57 UTC and the money only landed on Stripe's hourly retry at 10:57, inside which window they emailed asking for a refund.

Same shape bug, same class, three more sites: the `mode=setup` SetupIntent path (`_on_setup_succeeded` via checkout), `_payment_documents` (`charges.get("data")`), and `attempt_auto_topup`'s post-charge `pi.get("status")` — meaning even a *successful* auto top-up crashed after charging the card and leaned on the webhook to credit.

## The fix

One conversion at the funnel: `_sdk()` now returns `result.to_dict()` for any `StripeObject` (`to_dict()` is deep — nested objects and list `data` items all become plain dicts). Every consumer already reads dict-style (`["id"]`, `.get()`), and the test fakes already return dicts, so this puts prod and the suite on one shape and fixes all four sites at once.

## Side effects that come back with the checkout path

- referral card-fingerprint reaches `_credit` again (the abuse gate was getting `None` on every purchase)
- `_set_default_pm` from checkout completion runs again (auto-top-up arming)
- the sustained 500 rate stops (it risked Stripe disabling the webhook endpoint)

## Tests

Two regression tests run the **real** `_sdk` fed with genuine `StripeObject`s — one at the funnel asserting deep plain-dict conversion, one reproducing the exact production crash through `_pm_and_fingerprint` with `stripe.PaymentIntent.retrieve` itself faked. Full suite: **1787 passed**.

Docs: `architecture/money.md` updated in the same commit (drift.sh mapped it).

Not addressed here (follow-up candidates): the SQLAlchemy pool exhaustion that delayed the fallback delivery, and pending `checkout.session.completed` retries will start returning 200 (idempotent no-ops — `ledger.topup` keys on the PaymentIntent id) once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)