### PR TITLE
feat(catalog): log zero-result searches and surface them in the usage report

### DIFF
--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -127,6 +127,13 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   `org_id`/`user_email` — identity is attribution when the caller happens to have one, never a
   requirement, because the usual filer is an agent with zero results and no token. Reviewed by
   querying the table; a Slack notifier may hang off the insert later, but the row is the record.
+- **`SearchMiss`** — a catalog search that returned **nothing**: `query` (capped to 300 chars),
+  `source` (`api` — the HTTP route serving web + CLI + raw API — or `mcp`), `created_at`. The demand
+  signal one step before a `ToolRequest`: most agents that miss never file, so the query text is all
+  they leave. Written fire-and-forget through `audit.record_search_miss` (dropped rows cost
+  analytics, never a search) from both search paths — `GET /catalog/search` and the in-process MCP
+  `catalog_search` tool. Deliberately identity-free; surfaced by `scripts/usage_report.py`, which
+  reads misses against the catalog to split coverage gaps from naming/discovery failures.
 - **`RunRecord`** — the **server-side run** audit row (a `treg run --server` CLI execution — the "kind"
   `server_run` in usage rollups): `org_id`, `user_email`, `bundle_name` (holds the **tool** name since the
   tool-side run unification; column name is historical), `argv` (JSON — never carries a secret value;

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -41,7 +41,9 @@ nothing upstream, nothing spent), so it stays closed-world and non-destructive. 
 `POST /tool-requests` so rate limiting and field caps live in one place, forwarding the edge's
 `X-Forwarded-For` — the in-process relay would otherwise collapse every MCP caller into one
 rate-limit bucket. `catalog_search`'s zero-result hint names it, so an agent that just searched
-and found nothing can file the gap in the same session.
+and found nothing can file the gap in the same session — and the miss itself is logged as a
+`SearchMiss` row (`audit.record_search_miss`, `source="mcp"`): this tool reads the catalog
+in-process, so the HTTP route's own miss logging never sees an MCP agent's empty search.
 
 ## In-process, not over the network
 

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -243,7 +243,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   [data-model](../architecture/data-model.md)) with identity attached only when the caller happens
   to be signed in (token, or same-origin session; a cross-origin cookie POST stores anonymously
   rather than being rejected). The zero-result caller is exactly the demand signal the catalog team
-  wants, so no signup wall.
+  wants, so no signup wall. The miss itself is also logged as a `SearchMiss` row (fire-and-forget
+  via `audit.record_search_miss`, from this route and from the MCP `catalog_search` tool alike) —
+  most missing agents never file a request, and the queries they leave behind are what
+  `scripts/usage_report.py` reports as un-served demand.
 - **Auth — three identity doors** (all resolve to a user via the shared `_find_or_create_user`, so
   first-proof = registration — the **user only, no auto personal org**; a brand-new user lands with zero
   teams and names their first via the mandatory welcome / `treg org create`): **GitHub** — `auth_github` (`GET /auth/github`,

--- a/scripts/usage_report.py
+++ b/scripts/usage_report.py
@@ -230,6 +230,16 @@ QUERIES: dict[str, str] = {
       from toolrequest
       where status = 'open' or created_at >= $1
       order by created_at desc limit 300""",
+    # Catalog searches that matched NOTHING, grouped by query — the demand signal one step before a
+    # tool request (most agents that miss never file one; the query text is all they leave behind).
+    # Windowed like the call panels: a miss is a time-series event, not a backlog item — the same
+    # query missing last month and this month should read as two spikes, not one eternal row.
+    "search_misses": """
+      select query, count(*) n, string_agg(distinct source, '/') sources,
+             min(created_at) first_seen, max(created_at) last_seen
+      from searchmiss
+      where created_at >= $1
+      group by 1 order by count(*) desc, max(created_at) desc limit 200""",
     "orgs": BASE + """
       select c.org_id, o.slug, count(*) calls, sum(c.spend) spend,
              sum(case when c.failed then 1 else 0 end) failed,
@@ -293,8 +303,20 @@ async def collect(since: dt.datetime, unit: str = "day") -> dict:
                                      id desc))[1], 220) sent"""
                       if has_evidence else "null::text evidence, null::text sent")
 
+            # Same probe-don't-assume dance as the evidence columns: `searchmiss` arrives with the
+            # zero-result search logging, and until that deploys the table does not exist on prod —
+            # this script must keep working from any branch against exactly that database.
+            has_misses = bool(await conn.fetchval(
+                "select 1 from information_schema.tables where table_name = 'searchmiss'"))
+            if not has_misses:
+                print("  note: no searchmiss table yet — the empty-search panel will be empty "
+                      "until the search-miss logging deploys", file=sys.stderr)
+
             out = {}
             for name, sql in QUERIES.items():
+                if name == "search_misses" and not has_misses:
+                    out[name] = []
+                    continue
                 sql = (sql.replace("{unit}", unit)
                           .replace("{evidence_cols}", ev_cols)
                           .replace("{evidence_agg}", ev_agg))
@@ -382,6 +404,16 @@ def print_summary(data: dict, days: int, top: int) -> None:
                   f"{short(r['capability'], 58)}")
         if len(reqs) > 12:
             print(f"  … {len(reqs) - 12} more (the HTML lists every one)")
+
+    misses = data.get("search_misses") or []
+    if misses:
+        hits = sum(m["n"] for m in misses)
+        print(f"\n\033[1msearches that matched nothing\033[0m  ({len(misses)} distinct queries · "
+              f"{hits} misses in this window)")
+        for m in misses[:12]:
+            print(f"  {m['n']:>5}  {m['sources']:<8} {short(m['query'], 64)}")
+        if len(misses) > 12:
+            print(f"  … {len(misses) - 12} more (the HTML lists every one)")
 
     print("\n\033[1mtop orgs\033[0m")
     for o in data["orgs"][:10]:
@@ -748,6 +780,17 @@ def build_html(data: dict, days: int, top: int, since: dt.datetime, unit: str = 
         "".join(request_row(r) for r in reqs)
         or '<tr><td colspan="4" class="dim">No open requests.</td></tr>')
 
+    misses = data.get("search_misses") or []
+    miss_total = sum(m["n"] for m in misses)
+    misses_html = table(
+        '<th class="r">Misses</th><th>Source</th><th>Query</th><th class="r">Last seen</th>',
+        "".join(f'<tr><td class="r num">{m["n"]:,}</td><td><code>{html.escape(m["sources"])}</code></td>'
+                f'<td class="name">{html.escape(m["query"])}</td>'
+                f'<td class="r num dim">{m["last_seen"]:%Y-%m-%d %H:%M}</td></tr>'
+                for m in misses)
+        or '<tr><td colspan="4" class="dim">No empty searches in this window '
+           '(or the search-miss logging has not deployed yet).</td></tr>')
+
     details: dict[tuple[str, bool], list[dict]] = {}
     for d in data["errdetail"]:
         details.setdefault((d["ep"], d["cataloged"]), []).append(d)
@@ -798,6 +841,16 @@ def build_html(data: dict, days: int, top: int, since: dt.datetime, unit: str = 
     {req_anon} of {len(reqs)} carry neither an email nor a contact — filing is deliberately
     anonymous-friendly, so those asks cannot be answered even when we build the thing.</p>
     {requests_html}</div>
+
+  <div class="card"><h2>Searches that matched nothing — {len(misses)} distinct
+    <span class="dim">· {miss_total} misses</span></h2>
+    <p class="sub" style="margin:-4px 0 12px">Every catalog search in this window that returned
+    zero results, from the API/CLI route and from agents over MCP. This is the demand signal one
+    step <b>before</b> the tool-request queue above — most agents that miss never file, so the
+    query text is all they leave behind.<br/>
+    <b>Read each against the catalog before adding anything:</b> a miss for something treg already
+    serves is a naming/discovery failure — fix the endpoint's words, not the coverage.</p>
+    {misses_html}</div>
 
   <div class="card"><h2>Catalog endpoints — all {len(cataloged)}</h2>
     <p class="sub" style="margin:-4px 0 12px">Calls that resolved to a catalog endpoint. The three

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -588,6 +588,11 @@ async def catalog_search(q: str = "", limit: int = 25,
     if not q.strip():
         hints = ["pass ?q= — e.g. /catalog/search?q=tiktok+comments"]
     elif not results:
+        # The miss IS the signal: log it (fire-and-forget, see models.SearchMiss) so the queries the
+        # catalog couldn't answer surface in the usage report next to the ToolRequests they rarely
+        # become. One source for this whole route — web, CLI and raw API all arrive here, and
+        # guessing which from headers would be a made-up column.
+        audit.record_search_miss(query=q.strip(), source="api")
         hints = [f"nothing matches all of {q!r} — drop a word, or browse `treg catalog` for the platform shelves",
                  "still missing? POST /tool-requests {\"capability\": \"<what you need>\"} — "
                  "requests steer which provider gets added next"]

--- a/src/treg/audit.py
+++ b/src/treg/audit.py
@@ -18,7 +18,7 @@ import asyncio
 import logging
 
 from .db import session_maker
-from .models import CallRecord, RunRecord
+from .models import CallRecord, RunRecord, SearchMiss
 
 _pending: set[asyncio.Task] = set()
 _MAX_CONCURRENT_WRITES = 4   # cap on audit writes holding a DB connection at once (protect the request pool)
@@ -71,6 +71,13 @@ def _known_fields(model, telemetry: dict | None) -> dict:
             "dropping unknown %s telemetry keys %s — is a migration missing?",
             model.__name__, sorted(set(telemetry) - set(known)))
     return known
+
+
+def record_search_miss(*, query: str, source: str) -> None:
+    """A catalog search that matched nothing — logged so the misses can steer ingest (see
+    models.SearchMiss). Same contract as every write here: fire-and-forget, and a dropped row
+    under load costs a data point, never a search response."""
+    _schedule(_write(SearchMiss, query=query[:300], source=source))
 
 
 def record_run(

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -48,7 +48,7 @@ from mcp.server.mcpserver import Context
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 
-from . import catalog_store
+from . import audit, catalog_store
 from .config import PUBLIC_HOST_ALIASES, get_settings
 
 # Every tool must declare what it can DO, and the review process checks these against real behaviour.
@@ -520,6 +520,10 @@ async def catalog_search(query: str, limit: int = 8) -> SearchOut:
                                f"the first {catalog_store.RERANK_BAND} equally-scoring rows — "
                                f"add a word to narrow it")
     if not results:
+        # Same miss log as GET /catalog/search (see models.SearchMiss) — this tool reads the catalog
+        # in-process, so the HTTP route's logging never sees an MCP agent's empty search.
+        if query.strip():
+            audit.record_search_miss(query=query.strip(), source="mcp")
         out["hint"] = (
             f"nothing matches all of {query!r} — drop a word, or try a different way of saying the task. "
             "If the catalog genuinely lacks it, file it with catalog_request(capability=...) — "

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -998,3 +998,22 @@ class ToolRequest(SQLModel, table=True):
     source: str = Field(default="web", index=True)  # web | cli | mcp | api
     status: str = Field(default="open", index=True)  # open | done | dismissed — flipped by hand
     created_at: datetime = Field(default_factory=_now, index=True)
+
+
+class SearchMiss(SQLModel, table=True):
+    """A catalog search that returned NOTHING — the demand signal one step before a ToolRequest.
+
+    Most agents that miss never file a request; they just rephrase or leave. The queries themselves
+    are the record of what the catalog was asked for and couldn't answer — the raw material for
+    deciding what to ingest next and for spotting discovery failures (the capability exists but the
+    words used to ask for it don't match). Written fire-and-forget through `audit` — losing a row
+    under load costs analytics, never a search.
+
+    Deliberately identity-free: the search endpoints are open, most missing callers hold no token,
+    and the query text is the signal — who asked matters only once they file a ToolRequest.
+    """
+
+    id: int | None = Field(default=None, primary_key=True)
+    query: str  # the search text that matched nothing, capped by the writer
+    source: str = Field(default="api", index=True)  # api (HTTP /catalog/search: web + CLI) | mcp
+    created_at: datetime = Field(default_factory=_now, index=True)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -130,6 +130,20 @@ async def test_search_says_so_when_nothing_matches(clients):
     assert out["count"] == 0
     assert "catalog_request" in out.get("hint", "")  # the empty result names the way to file the gap
 
+    # And the miss is the record (models.SearchMiss) — this tool reads the catalog in-process, so
+    # the HTTP route's logging never sees it; the tool must log its own.
+    from sqlmodel import select
+
+    from treg import audit
+    from treg.db import session_maker
+    from treg.models import SearchMiss
+
+    await audit.drain()
+    async with session_maker() as s:
+        (row,) = (await s.execute(select(SearchMiss))).scalars()
+    assert row.query == "zzzz-no-such-capability"
+    assert row.source == "mcp"
+
 
 async def test_catalog_request_files_the_gap_with_attribution(clients):
     """The zero-result hint's payoff: the agent can file the missing capability in the same session,

--- a/tests/test_tool_requests.py
+++ b/tests/test_tool_requests.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
+from treg import audit
 from treg.api import TOOLREQ_RATE_MAX, app
 from treg.db import session_maker
-from treg.models import ToolRequest
+from treg.models import SearchMiss, ToolRequest
 
 
 async def _fetch_rows() -> list[ToolRequest]:
@@ -87,3 +88,34 @@ async def test_the_empty_search_names_the_way_to_file_one(clients: AsyncClient):
     body = r.json()
     assert body["results"] == []
     assert any("tool-requests" in h for h in body["hints"]), body["hints"]
+
+
+async def _fetch_misses() -> list[SearchMiss]:
+    async with session_maker() as s:
+        return list((await s.execute(select(SearchMiss))).scalars())
+
+
+async def test_the_empty_search_is_logged_as_a_miss(clients: AsyncClient):
+    """The other half of discovery: most agents that miss never file, so the miss itself is the
+    record (models.SearchMiss). Written fire-and-forget — drain() flushes it for the assert."""
+    r = await clients.get("/catalog/search", params={"q": "zzzz-no-such-capability"})
+    assert r.status_code == 200 and r.json()["results"] == []
+    await audit.drain()
+    (row,) = await _fetch_misses()
+    assert row.query == "zzzz-no-such-capability"
+    assert row.source == "api"
+
+
+async def test_a_search_that_matches_logs_no_miss(clients: AsyncClient):
+    r = await clients.get("/catalog/search", params={"q": "backlinks"})
+    assert r.status_code == 200 and r.json()["results"]
+    await audit.drain()
+    assert await _fetch_misses() == []
+
+
+async def test_a_blank_search_logs_no_miss(clients: AsyncClient):
+    """No q is a browse, not a failed ask — logging it would drown the signal in noise."""
+    r = await clients.get("/catalog/search")
+    assert r.status_code == 200
+    await audit.drain()
+    assert await _fetch_misses() == []


### PR DESCRIPTION
## What

A catalog search that returns nothing is the demand signal one step before a ToolRequest — and most agents that miss never file one, so until now the query text vanished. This PR keeps it:

- **`SearchMiss` table** (`query` ≤300 chars, `source`, `created_at`) — deliberately identity-free, same anonymous-friendly reasoning as ToolRequest. New table, so `create_all` builds it; no migration block needed.
- **`audit.record_search_miss`** — fire-and-forget through the existing audit path (semaphore + shed): a dropped row costs a data point, never a search response.
- **Wired into both search paths**: `GET /catalog/search` (serves web + CLI + raw API, `source="api"`) and the in-process MCP `catalog_search` tool (`source="mcp"`), which the HTTP route's logging never sees. Blank `q` is a browse, not a miss — not logged.
- **`scripts/usage_report.py`**: new "searches that matched nothing" panel (terminal + HTML), grouped by query and **windowed** like the call panels (a miss is a time-series event, not a backlog item — unlike the requests queue). Guarded by the same probe-don't-assume dance as the evidence columns, so the script keeps working against prod from any branch until this deploys.

## Why the report note says "read against the catalog first"

A miss for something treg already serves is a naming/discovery failure wearing a coverage failure's clothes — the fix is the endpoint's words, not another ingest.

## Tests

4 new tests (API miss logged / hit not logged / blank not logged / MCP miss logged with source). Full suite: **1790 passed**. Docs fragments (data-model, api, mcp-oauth) updated in the same commit per drift.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)