### PR TITLE
fix(billing): settle misses at zero + plan-gate badges + jobs coverage

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -553,6 +553,18 @@ needs a non-empty note; `status_note` and `superseded_by` cannot float without `
 successor must be a different, existing, live catalog id. A marked id is therefore an explanation,
 not an alias chain or a route treg will still spend against.
 
+### `platform_blocked:` — works upstream, but not on treg's plan
+
+A third state sits between "offer" and "tombstone": the route works and the price is real, but
+treg's own subscription cannot serve it — Akta answers every alternative-data call (jobs, posts,
+website-traffic, employee-reviews, headcount-trends, product-reviews) on the shared key with a
+free 403 "Your current subscription does not include access to this endpoint". Marking those
+`status: broken` would be a lie (a caller's OWN key on a bigger plan serves them fine) and leaving
+them unmarked sold them as platform offers — a customer ran a whole evaluation lane into that wall
+of 403s before learning the gate existed. `platform_blocked: <reason>` keeps the row in discovery
+but makes `platform_eligible()` refuse it, and the reason rides on the served row so every surface
+can say "bring your own key" *before* the call instead of relaying the 403 after it.
+
 - **Platform is the system the data is ABOUT**, not the API family it lives under: DataForSEO's
   `/v3/merchant/amazon/products/live/advanced` is `amazon`, not `merchant`. Anything not tied to
   one system is `web`. Every new slug goes into `capabilities.yaml`'s `platforms` in the same

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -259,6 +259,19 @@ search the 20-row default page — $0.0490 for results nobody got, 20x the publi
 while `limit=1` on a domain that did answer settled at a tenth of the credit Hunter actually took.
 Where a provider's real rule is "whole units, rounded up, free on a miss", only the body knows.
 
+The same family carries two more derived rules. **Hunter's email finder** is the flat case: one whole
+search credit when an email comes back, nothing on a miss — Hunter documents a miss as free, but a
+miss still answers HTTP 200 with `email: null`, so the estimate billed the full $0.0245 for a name
+Hunter had nothing on (a customer measured exactly this against the catalog's own "a miss is free"
+note). **TikHub** reports billing in prose instead of a number: its envelope says whether the request
+incurs a charge. A 2xx whose payload is an embedded error ("dead_page", a job listing that
+redirected away) still says it will be charged, and TikHub really does charge us for it — verified
+live 2026-07-30 — so those settle at the estimate *faithfully*; only the explicit no-charge phrasing
+settles at zero. The distinction matters when a caller disputes a dead-page charge: for Hunter the
+old behaviour was an over-charge and is now fixed, for TikHub the charge is a passthrough of a real
+upstream cost, and the answer is to probe with a provider whose misses are free (scrapecreators
+404s cost nothing) before spending TikHub calls on unverified slugs.
+
 Closing the hold runs on its **own session** (the request's may be mid-rollback from the very error
 being released for) and **never raises** — the caller already has their answer, and a ledger hiccup
 must not turn a served call into a 500. A hold that fails to close is not lost money either: the

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -238,6 +238,9 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   discovery list. Calling it—or asking `/catalog/endpoints/{id}/access` whether it is callable—returns
   an actionable 410. The `/call/` refusal is recorded with `refused_by=retired` and never reaches a
   provider credential or relay.
+  A row can also carry `platform_blocked` — the route works upstream but treg's own subscription
+  cannot serve it (Akta's alternative-data tier). Those rows STAY in discovery (a caller's own key
+  may serve them) but are never platform offers, and the reason string rides on the served row.
   A zero-result search additionally points at **`POST /tool-requests`** (open, per-IP rate-limited,
   fields capped): file what the catalog is missing — stored as a `ToolRequest` row (see
   [data-model](../architecture/data-model.md)) with identity attached only when the caller happens

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -10053,9 +10053,16 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes) -> int | None:
         enrich, an empty `organizations` page on search) and charges nothing for it, so status-based
         billing alone would bill the caller for a response Apollo gave away. The body says whether
         the charged thing came back; when it didn't, the call settles at 0.
-      - hunter (domain search only): DERIVED too, and for the opposite reason — its price is not
+      - hunter (domain search): DERIVED too, and for the opposite reason — its price is not
         per row but one whole SEARCH credit per 10 emails returned, rounded up, with an empty
         domain free. `data.emails` is the only place that number exists.
+      - hunter (email finder): DERIVED, the flat case — one whole SEARCH credit when an email is
+        found, nothing on a miss ("a miss is free", per Hunter's own pricing), yet a miss still
+        answers HTTP 200, so the estimate billed the full credit for a name Hunter had nothing on.
+      - tikhub: REPORTED in prose rather than a number. Every envelope says whether the call is
+        billed; only the explicit no-charge phrasing settles at zero, because TikHub really does
+        charge for a 2xx whose payload is an embedded error (verified live 2026-07-30 — see
+        docs/context/architecture/catalog.md, "the provider decides what counts as success").
 
     Everyone else settles at the estimate. This is the same signal the catalog's `observed_cost`
     harvests, which is what lets phase 5's drift detector compare the two numbers directly."""
@@ -10105,6 +10112,30 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes) -> int | None:
         if isinstance(emails, list) and rate:
             credits = -(-len(emails) // 10)  # whole credits, rounded up; no emails = no charge
             return int(credits * rate * 1_000_000 + 0.5)
+        return None
+    if provider == "hunter" and mk.endpoint_id == "hunter.people.email.find":
+        # DERIVED, the flat case of the same family: the finder takes ONE whole search credit when
+        # it finds an email and nothing when it doesn't — the catalog note says "a miss is free" in
+        # as many words, yet a miss still answers HTTP 200 with `email: null`, so settling at the
+        # estimate billed the full credit ($0.0245) for a name Hunter had nothing on. A body
+        # without the `email` key (an error shape) still falls back to the estimate.
+        data = doc.get("data")
+        rate = catalog_store.load().credit_rates.get("hunter")
+        if isinstance(data, dict) and "email" in data and rate:
+            return int(rate * 1_000_000 + 0.5) if data["email"] else 0
+        return None
+    if provider == "tikhub":
+        # REPORTED in prose rather than a number: every TikHub envelope states whether the call is
+        # billed. A 2xx whose payload is an embedded error still says "This request will incur a
+        # charge." and TikHub really does charge us for it (verified live 2026-07-30 — see
+        # docs/context/architecture/catalog.md, "the provider decides what counts as success"), so
+        # a dead page settling at the estimate is faithful, not an over-charge. Only the explicit
+        # no-charge phrasing settles at zero; anything else stays at the estimate.
+        msg = doc.get("message")
+        if isinstance(msg, str):
+            low = msg.lower()
+            if "won't be charged" in low or "will not be charged" in low or "not incur" in low:
+                return 0
         return None
     if provider == "apollo":
         # Only the shapes whose billing rule is documented and body-decidable: company enrichment

--- a/src/treg/catalog/akta.extended.yaml
+++ b/src/treg/catalog/akta.extended.yaml
@@ -49,6 +49,7 @@ endpoints:
     checked: '2026-07-28'
     confidence: documented
     note: 0.0 credits for the product-list-only call (no `products` param); 1.5 credits per 50 reviews returned once `products` is passed — value here is the marginal per-50-reviews rate that applies once billed
+  platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
   docs_url: https://docs.akta.pro/api-reference/alternative-data/product-reviews
   skipped: not called — $1.5000 would exceed this run's $0.12 budget
 - id: akta.x.jobs
@@ -91,6 +92,7 @@ endpoints:
     checked: '2026-07-28'
     confidence: documented
     note: 4 Akta credits per 10 job listings returned (llms-full.txt sample response)
+  platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
   docs_url: https://docs.akta.pro/api-reference/alternative-data/job-posts
   skipped: not called — $4.0000 would exceed this run's $0.12 budget
 - id: akta.x.social-posts
@@ -133,6 +135,7 @@ endpoints:
     checked: '2026-07-28'
     confidence: documented
     note: 1 Akta credit per 10 posts returned (llms-full.txt sample response)
+  platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
   docs_url: https://docs.akta.pro/api-reference/alternative-data/social-posts
   skipped: not called — $1.0000 would exceed this run's $0.12 budget
 - id: akta.x.website-traffic
@@ -165,6 +168,7 @@ endpoints:
     checked: '2026-07-28'
     confidence: documented
     note: 1.5 Akta credits per request (llms-full.txt sample response)
+  platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
   docs_url: https://docs.akta.pro/api-reference/alternative-data/website-traffic
   skipped: not called — $1.5000 would exceed this run's $0.12 budget
 - id: akta.x.company-addition

--- a/src/treg/catalog/akta.yaml
+++ b/src/treg/catalog/akta.yaml
@@ -152,6 +152,7 @@ endpoints:
       queryParams: {company: "canva.com"}
     cost: {type: per_success, value: 2.5, currency: credit, per: 1, unit: call, source: docs, source_url: 'https://docs.akta.pro/getting-started/pricing', checked: '2026-07-28', confidence: documented, note: 2.5 Akta credits per request}
     unverified: "http 403 {\"detail\": \"Your current subscription does not include access to this endpoint.\"} — re-probed 2026-07-31, identical response, so the plan gate has not moved. An account-tier gap, not a call error: every /company/{jobs,posts,website-traffic,employee-reviews,headcount-trends,product-reviews-with-products} route on this key returns the same message, and a 403 consumes no credits"
+    platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
     docs_url: https://docs.akta.pro/api-reference/alternative-data/headcount-trends
 
   - id: akta.companies.reviews
@@ -173,6 +174,7 @@ endpoints:
       queryParams: {company: "canva.com", limit: 1}
     cost: {type: per_result, value: 1.5, currency: credit, per: 50, unit: review, source: docs, source_url: 'https://docs.akta.pro/getting-started/pricing', checked: '2026-07-28', confidence: documented, note: 1.5 Akta credits per 50 reviews returned}
     unverified: "http 403 {\"detail\": \"Your current subscription does not include access to this endpoint.\"} — re-probed 2026-07-31, unchanged. Account-tier gap, same message as the other alternative-data routes; the 403 is free, so re-probing costs nothing"
+    platform_blocked: "upstream 403 'Your current subscription does not include access to this endpoint' on treg's shared Akta key (alternative-data tier; re-probed 2026-07-31). Works with your own Akta key on a plan that includes Alternative Signals."
     docs_url: https://docs.akta.pro/api-reference/alternative-data/employee-reviews
 
   - id: akta.companies.industry.resolve

--- a/src/treg/catalog/apify.yaml
+++ b/src/treg/catalog/apify.yaml
@@ -116,6 +116,40 @@ endpoints:
       this capability; it is the catalog's ONLY route to tiktok-ads.library.search"
     docs_url: https://apify.com/s-r/tiktok-ads-library
 
+  - id: apify.linkedin.search.jobs
+    capability: linkedin.search.jobs
+    platform: linkedin
+    scope: any_account
+    method: POST
+    path: /actors/harvestapi~linkedin-job-search/run-sync-get-dataset-items
+    name: "Search LinkedIn job postings"
+    summary: "Scrape LinkedIn job postings by title, company, location or filters — the hiring-signal search that also answers 'what is this company hiring for' via the company filter"
+    input:
+      queryParams:
+        maxItems: {type: integer, required: false, note: "SERVER-SIDE result cap for pay-per-result actors — the only hard spend limit; set it on every call", example: 25}
+        maxTotalChargeUsd: {type: number, required: false, note: "alternative hard cap, in dollars", example: 0.05}
+        timeout: {type: integer, required: false, note: "seconds before the synchronous run is cut off; Apify closes the connection at 300s regardless", example: 120}
+      body:
+        jobTitles: {type: "array[string]", required: true, note: "job-search queries; supports boolean operators. To list ALL of one company's openings, pass a broad query here and pin `company`", example: ["software engineer"]}
+        company: {type: "array[string]", required: false, note: "restrict to these companies — names or LinkedIn company URLs", example: ["Netflix"]}
+        locations: {type: "array[string]", required: false, note: "LinkedIn location names; free text must match LinkedIn's autocomplete", example: ["San Francisco"]}
+        workplaceType: {type: "array[string]", required: false, note: "Remote / Hybrid / On-site"}
+        employmentType: {type: "array[string]", required: false, note: "Full-time / Part-time / Contract"}
+        experienceLevel: {type: "array[string]", required: false, note: "Entry / Mid / Senior"}
+        postedLimit: {type: string, required: false, note: "Past hour / Past 24 hours / Past week / Past month"}
+        sortBy: {type: string, required: false, note: "date | relevance"}
+        maxItems: {type: integer, required: false, note: "jobs per query; 0 means every available page (LinkedIn caps at 40 pages ≈ 1,000). Pair with the query-string maxItems, which is the enforced ceiling", example: 25}
+        page: {type: integer, required: false, note: "starting page, 25 jobs per page"}
+      bodyType: json
+      note: "the response is the dataset items array directly — no run envelope. Community actor scraping LinkedIn's public job search: no LinkedIn login needed, but expect the flakiness every LinkedIn scraper shows — retry before concluding a company has no openings"
+    test_request:
+      queryParams: {maxItems: 1, maxTotalChargeUsd: 0.05, timeout: 180}
+      body: {jobTitles: ["attorney"], locations: ["Miami, Florida"], maxItems: 1}
+    cost: {type: per_result, value: 0.001, currency: USD, per: 1, unit: result, source: docs, source_url: 'https://apify.com/harvestapi/linkedin-job-search', checked: '2026-08-20', confidence: documented, note: 'pay-per-event: $1.00 per 1,000 jobs published on the actor page, no platform usage charge on top. Charged per dataset item produced — cap every call with maxItems and read usageTotalUsd from GET /v2/actor-runs after a big pull'}
+    verified: 2026-08-20
+    example_response: examples/apify.linkedin.search.jobs.json
+    docs_url: https://apify.com/harvestapi/linkedin-job-search
+
   - id: apify.web.scrape.job.start
     kind: utility
     capability: web.scrape.job.start

--- a/src/treg/catalog/apollo.yaml
+++ b/src/treg/catalog/apollo.yaml
@@ -135,7 +135,7 @@ endpoints:
     method: POST
     path: /mixed_companies/search
     name: "Search companies by industry, size or tech"
-    summary: "Search Apollo's companies by industry, headcount, revenue, funding or technology"
+    summary: "Search Apollo's companies by industry, headcount, revenue, funding or technology — hits carry 6/12/24-month headcount growth, the hiring/growth signal"
     input:
       queryParams:
         "q_organization_domains_list[]": {type: "array[string]", required: false, note: "restrict to these domains; max 1,000", example: ["apollo.io"]}
@@ -162,6 +162,75 @@ endpoints:
       confidence: documented
       note: 1 credit per PAGE returned (0 when there are no results) — not per company. Fewer, fuller pages therefore cost less than many small ones, the opposite of most providers in this catalog.
     docs_url: https://docs.apollo.io/reference/organization-search
+
+  - id: apollo.companies.jobs
+    domain: companies
+    capability: companies.jobs
+    platform: companies
+    scope: any_account
+    method: GET
+    path: /organizations/{organization_id}/job_postings
+    name: "List a company's open job postings"
+    summary: "List a company's open job postings — title, location and posting dates — the direct hiring signal"
+    input:
+      pathParams:
+        organization_id: {type: string, required: true, note: "Apollo company id — resolve it first with apollo.companies.search (or the free apollo.people.search, whose hits carry organization_id)"}
+      queryParams:
+        page: {type: integer, required: false, example: 1}
+        per_page: {type: integer, required: false, note: "the charge is per PAGE, so a larger per_page is cheaper per posting", example: 25}
+      note: "two-step by design: this endpoint takes an Apollo id, not a name or domain — resolve the company first. Display limit 10,000 records; rate limit ~600 calls/hour (plan-dependent)"
+    test_request:
+      pathParams: {organization_id: "55694053736964214d541c00"}
+      queryParams: {per_page: 2}
+    cost:
+      type: per_call
+      value: 1
+      currency: credit
+      per: 1
+      unit: page
+      source: docs
+      source_url: https://www.apollo.io/pricing
+      checked: '2026-08-20'
+      confidence: documented
+      note: 1 credit per PAGE returned, same page rule as company search.
+    verified: 2026-08-20
+    example_response: examples/apollo.companies.jobs.json
+    docs_url: https://docs.apollo.io/reference/organization-jobs-postings
+
+  - id: apollo.companies.news
+    domain: companies
+    capability: companies.news
+    platform: companies
+    scope: any_account
+    method: POST
+    path: /news_articles/search
+    name: "Search news about companies"
+    summary: "Search news articles about specific companies — hires, funding and other signal categories"
+    input:
+      queryParams:
+        "organization_ids[]": {type: "array[string]", required: true, note: "Apollo company ids to search news for — resolve with apollo.companies.search first"}
+        "categories[]": {type: "array[string]", required: false, note: "event categories, e.g. hires, investment"}
+        "published_at[min]": {type: string, required: false, note: "YYYY-MM-DD", example: "2026-01-01"}
+        "published_at[max]": {type: string, required: false, note: "YYYY-MM-DD"}
+        page: {type: integer, required: false, example: 1}
+        per_page: {type: integer, required: false, note: "up to 25 per page; the charge is per PAGE", example: 25}
+      note: "query-string params on a POST, arrays in field[]=value form — the same parameter-location trap as the rest of this provider. A company with no coverage answers 200 with an empty news_articles page, not an error"
+    test_request:
+      queryParams: {"organization_ids[]": ["5d0a0fbff6512580bf33a120"], per_page: 2}
+    cost:
+      type: per_call
+      value: 1
+      currency: credit
+      per: 1
+      unit: page
+      source: docs
+      source_url: https://www.apollo.io/pricing
+      checked: '2026-08-20'
+      confidence: documented
+      note: 1 credit per PAGE returned, up to 25 articles per page.
+    verified: 2026-08-20
+    example_response: examples/apollo.companies.news.json
+    docs_url: https://docs.apollo.io/reference/news-articles-search
 
   - id: apollo.people.bulk_enrich
     domain: contacts

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -247,8 +247,9 @@ capabilities:
   # merged from seo-tool + enrichment proposed_capabilities (2026-07-28)
   app-store.search.apps: "Search apps by keyword"
   companies.email_pattern: "Find a company's work-email format"
-  companies.headcount_trend: "Headcount over time & by department"
+  companies.headcount_trend: "Headcount growth over time & by department"
   companies.industry.resolve: "Map free text to industry codes"
+  companies.jobs: "A company's open job postings"
   companies.news: "Recent news & signals about a company"
   companies.reviews: "Read employee reviews of a company"
   google-play.search.apps: "Search apps by keyword"

--- a/src/treg/catalog/examples/apify.linkedin.search.jobs.json
+++ b/src/treg/catalog/examples/apify.linkedin.search.jobs.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "4453802117",
+    "title": "Sr. Corporate Counsel",
+    "linkedinUrl": "https://www.linkedin.com/jobs/view/4453802117/",
+    "jobState": "LISTED",
+    "postedDate": "2026-08-19T20:42:39.000Z",
+    "headerCaptionText": "Backblaze\nUnited States\n3 hours ago\nBe among the first 25 applicants\nSee who Backblaze has hired for this role",
+    "descriptionText": "Senior Corporate Counsel\n\nAbout Backblaze\n\nBackblaze is a public company that makes storing and using data astonishingly easy. … [description truncated for the example — the live response carries the full posting text]",
+    "_scrubbed": true
+  }
+]

--- a/src/treg/catalog/examples/apollo.companies.jobs.json
+++ b/src/treg/catalog/examples/apollo.companies.jobs.json
@@ -1,0 +1,26 @@
+{
+  "organization_job_postings": [
+    {
+      "id": "6a77fb8c46d00b0001f9073e",
+      "title": "Chief Operating Officer - Law Firm",
+      "url": "https://how-to-manage-a-small-law-firm.breezy.hr/p/ce59be36cb60-chief-operating-officer-law-firm",
+      "city": "Fort Lauderdale",
+      "state": "Florida",
+      "country": "United States",
+      "last_seen_at": "2026-08-18T18:47:16.000+00:00",
+      "posted_at": "2026-08-08T11:07:33.000+00:00"
+    },
+    {
+      "id": "6a66cbf4fe3efa00011b0b09",
+      "title": "Human Resource Director",
+      "url": "https://how-to-manage-a-small-law-firm.breezy.hr/p/cedce1c59f98-human-resource-director",
+      "city": "Miami",
+      "state": "Florida",
+      "country": "United States",
+      "last_seen_at": "2026-08-18T20:04:29.000+00:00",
+      "posted_at": "2026-07-25T11:01:36.000+00:00"
+    }
+  ],
+  "pagination": {"page": 1, "per_page": 2, "total_entries": 12, "total_pages": 6},
+  "_scrubbed": true
+}

--- a/src/treg/catalog/examples/apollo.companies.news.json
+++ b/src/treg/catalog/examples/apollo.companies.news.json
@@ -1,0 +1,16 @@
+{
+  "pagination": {"page": 1, "per_page": 2, "total_entries": 858, "total_pages": 429},
+  "news_articles": [
+    {
+      "id": "6a856d0e113a7b001ccd40f0",
+      "url": "https://toscale.io/news-aggregator/krakens-krak-app-rolls-out-cry43201a017fd-964f-7498-8bf4-9a87197c84b5",
+      "domain": "toscale.io",
+      "title": "Kraken's Krak app rolls out crypto debit card in the U.S. with Stripe.",
+      "snippet": "By partnering with Stripe, a major player in online payment processing, Kraken leverages established infrastructure to ensure reliability and broad acceptance.",
+      "organization_ids": ["54a11e1a69702da753c06201", "5d0a0fbff6512580bf33a120"],
+      "published_at": "2026-08-19T01:45:12.000+00:00",
+      "event_categories": ["partners_with"]
+    }
+  ],
+  "_scrubbed": true
+}

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -154,6 +154,11 @@ class Catalog:
         # never an offer treg may spend against, even if its historical price remains complete.
         if endpoint.get("status"):
             return False
+        # Blocked on treg's own plan: the route works, the price is real, and the shared key
+        # still cannot serve it — a documented upstream "your subscription does not include this
+        # endpoint". Discovery keeps the row (a caller's own key may serve it); the offer doesn't.
+        if endpoint.get("platform_blocked"):
+            return False
         cost = self.cost_view(endpoint.get("cost"), endpoint.get("provider"))
         if not cost or cost.get("usd") is None:
             return False
@@ -408,6 +413,11 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # `by_id`, but remove it from discovery and return the migration story on direct lookup.
         "status": str(raw.get("status") or "").strip().lower(),
         "status_note": str(raw.get("status_note") or "").strip(),
+        # A route that WORKS upstream but that treg's own plan/subscription cannot serve (a
+        # provider tier the shared key lacks). Unlike `status` it stays in discovery — a team's
+        # own key may well serve it — but it is never a platform offer, and the reason rides on
+        # the row so an agent learns "bring your own key" BEFORE the 403, not from it.
+        "platform_blocked": str(raw.get("platform_blocked") or "").strip(),
         "superseded_by": str(raw.get("superseded_by") or "").strip(),
         "docs_url": raw.get("docs_url") or "",
         "example_file": _example_file(raw, directory),
@@ -466,6 +476,9 @@ def endpoint_view(ep: dict, provider_display: str, cat: Catalog | None = None) -
         # a fact about the row that decides whether the caller needs a credential at all, so it
         # rides on the row rather than being re-derived per client (see `Catalog.platform_eligible`)
         "platform_eligible": cat.platform_eligible(ep) if cat else None,
+        # WHY the platform can't serve an otherwise-working route (plan/tier gap on treg's own
+        # subscription) — so "bring your own key" is said up front instead of discovered via a 403.
+        "platform_blocked": ep.get("platform_blocked") or None,
         # "no match" semantics, when the endpoint has them — an agent that reads `miss` stops
         # treating an expected empty answer as a failed call (and stops retrying it).
         "miss": ep.get("miss"),

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -61,8 +61,8 @@ async def test_platform_detail_groups_the_same_job_across_providers(clients: Asy
     ep = next(e for e in profile["endpoints"] if e["provider"] == "tikhub")
     assert set(ep) == {"id", "provider", "provider_display", "name", "summary", "method", "path",
                        "scope", "tier", "kind", "domain", "call_template", "cost", "verified", "docs_url",
-                       "has_example", "input", "platform_eligible", "test_request", "miss",
-                       "status", "status_note", "superseded_by"}
+                       "has_example", "input", "platform_eligible", "platform_blocked",
+                       "test_request", "miss", "status", "status_note", "superseded_by"}
     assert ep["kind"] == "data", "an endpoint with no explicit kind is data (the browse surface)"
     assert ep["provider_display"] == P.get("tikhub").display_name
     assert ep["method"] == "GET" and ep["path"].startswith("/")
@@ -485,6 +485,14 @@ async def test_platform_eligibility_refuses_everything_it_cannot_prove():
     # eligible one would put treg's own key behind a route the provider has already removed.
     assert not cat.platform_eligible({**ok, "status": "retired"}), "a retired route is not an offer"
     assert not cat.platform_eligible({**ok, "status": "broken"}), "a broken route is not an offer"
+    # A plan-gated route works upstream but treg's own subscription cannot serve it — a customer
+    # discovered exactly this the hard way, via a run of 403s on akta's alternative-data family.
+    # It stays discoverable (a team's OWN key on a bigger plan serves it) but is never an offer.
+    assert not cat.platform_eligible({**ok, "platform_blocked": "plan gate"}), \
+        "a plan-gated route is not an offer, however well priced"
+    blocked = cat.by_id["akta.companies.headcount_trend"]
+    assert blocked["platform_blocked"], "the akta alt-signals family carries its plan-gate reason"
+    assert not cat.platform_eligible(blocked)
 
 
 async def test_eligibility_rides_on_the_served_row(clients: AsyncClient):

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -500,6 +500,39 @@ def test_hunter_domain_search_settles_on_the_emails_it_returned():
         "only domain search bills per 10 returned; every other hunter route settles at its estimate"
 
 
+def test_hunter_email_finder_miss_is_free():
+    """The finder's rule is flat: one whole SEARCH credit when an email comes back, nothing on a
+    miss — Hunter's pricing says a miss is free, but a miss still answers HTTP 200 with
+    `email: null`, so settling at the estimate billed the full credit for a name Hunter had
+    nothing on. The body is the only place the found/missed distinction exists."""
+    credit = 24_500  # $0.0245/credit (fx.yaml, Starter $49/mo / 2,000 credits)
+    f = _mk("hunter", endpoint_id="hunter.people.email.find", cost_type="per_success")
+    assert A._observed_cost_micro(f, b'{"data": {"email": "a@x.com", "score": 92}}') == credit
+    assert A._observed_cost_micro(f, b'{"data": {"email": null, "score": null}}') == 0, \
+        "a miss is free — the catalog says so and Hunter bills so"
+    assert A._observed_cost_micro(f, b'{"data": {"email": "", "score": null}}') == 0, \
+        "an empty string is a miss too"
+    assert A._observed_cost_micro(f, b'{"errors": [{"code": "wrong_params"}]}') is None, \
+        "no email key at all: we never learned the outcome, settle at the estimate"
+    assert A._observed_cost_micro(f, b"not json") is None
+
+
+def test_tikhub_envelope_no_charge_settles_at_zero():
+    """TikHub reports billing in prose, not a number: a 2xx whose payload is an embedded error
+    still says the request will incur a charge — and TikHub really does charge us for it
+    (verified live 2026-07-30), so those settle at the estimate, faithfully. Only the explicit
+    no-charge phrasing settles at zero."""
+    t = _mk("tikhub", cost_type="per_success")
+    assert A._observed_cost_micro(t, b'{"code": 200, "message": "Request successful. This request will incur a charge.", "data": {}}') is None, \
+        "a billed answer settles at the estimate — that IS what TikHub takes"
+    assert A._observed_cost_micro(t, b'{"code": 200, "message": "Request successful. This request will incur a charge.", "data": {"error": "dead_page"}}') is None, \
+        "a dead page TikHub bills us for is passed through, not eaten"
+    assert A._observed_cost_micro(t, b'{"code": 400, "message": "Request failed. You won\'t be charged for this request.", "data": null}') == 0
+    assert A._observed_cost_micro(t, b'{"code": 200, "message": "This request will not incur charges.", "data": {}}') == 0
+    assert A._observed_cost_micro(t, b'{"code": 200, "data": {}}') is None, "no message: estimate"
+    assert A._observed_cost_micro(t, b"not json") is None
+
+
 async def test_hunter_zero_result_search_costs_nothing(clients: AsyncClient, platform_on, monkeypatch):
     """End to end, the bug this fixes: four domain searches that returned no emails each settled at
     $0.0490 — the 20-row default page assumption × the per-row price — for results nobody received."""
@@ -518,6 +551,32 @@ async def test_hunter_zero_result_search_costs_nothing(clients: AsyncClient, pla
          "meta": {"results": 2207}}).encode()))
     assert (await clients.get("/call/hunter.companies.emails?domain=stripe.com&limit=1")).status_code == 200
     assert await _balance(clients) == before - 24_500, "one email is one whole search credit"
+
+
+async def test_hunter_email_finder_no_match_costs_nothing(clients: AsyncClient, platform_on, monkeypatch):
+    """End to end, the finder half of the same bug: a no-match answers HTTP 200 with `email: null`
+    and Hunter charges nothing for it, but the settle used the estimate and billed the full
+    $0.0245 search credit — the exact over-charge a customer measured against the catalog note
+    'a miss is free'."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_HUNTER", "PLATFORM-HUNTER-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub,scrapecreators,dataforseo,brightdata,hunter")
+    get_settings.cache_clear()
+    monkeypatch.setattr(A, "relay", _fake_relay(200, json.dumps(
+        {"data": {"first_name": "Nobody", "last_name": "Here", "email": None, "score": None,
+                  "domain": "nobody.example", "sources": []},
+         "meta": {"params": {"full_name": "Nobody Here", "domain": "nobody.example"}}}).encode()))
+    before = await _balance(clients)
+    r = await clients.get("/call/hunter.people.email.find?domain=nobody.example&full_name=Nobody%20Here")
+    assert r.status_code == 200
+    assert await _balance(clients) == before, "a miss is free — the balance must not move"
+    assert (await _telemetry(clients))["cost_observed_micro"] == 0
+
+    monkeypatch.setattr(A, "relay", _fake_relay(200, json.dumps(
+        {"data": {"first_name": "Patrick", "last_name": "Collison", "email": "p@stripe.com",
+                  "score": 92, "domain": "stripe.com", "sources": []},
+         "meta": {"params": {"full_name": "Patrick Collison", "domain": "stripe.com"}}}).encode()))
+    assert (await clients.get("/call/hunter.people.email.find?domain=stripe.com&full_name=Patrick%20Collison")).status_code == 200
+    assert await _balance(clients) == before - 24_500, "a found email is one whole search credit"
 
 
 async def test_daily_cap_fails_closed(clients: AsyncClient, platform_on, monkeypatch):


### PR DESCRIPTION
A customer evaluation (2026-08-12) surfaced three classes of problem; each commit fixes one.

## 1. Billing on misses (`fix(billing)`)

- `hunter.people.email.find`: Hunter documents a no-match as free, but a miss answers HTTP 200 with `email: null`, so every miss settled at the full $0.0245 estimate — the exact over-charge the customer measured. Follows the 61b5d0f pattern: settle on `data.email` (one whole credit when found, zero when not).
- `tikhub`: the envelope reports billing in prose. A 2xx with an embedded error still says "will incur a charge" and TikHub really charges us for it (verified 2026-07-30, catalog.md), so those keep settling at the estimate — faithfully. Only the explicit no-charge phrasing now settles at zero.
- New unit + end-to-end tests; `money.md` updated in the same commit.

## 2. `platform_blocked` catalog marker (`feat(catalog)`)

Akta answers its whole alternative-data family (jobs, headcount-trends, reviews, posts, traffic) on treg's shared key with a free 403 "your subscription does not include this endpoint" — documented in the yaml since July, yet still served as platform offers. The customer ran a whole evaluation lane into that wall. Neither `retired` nor `broken` fits (a team's own key on a bigger plan serves these fine), so the new marker keeps the row in discovery, makes `platform_eligible()` refuse it, and rides the reason on the served row.

## 3. Jobs coverage + discoverability (`feat(catalog)`)

Jobs was the thinnest capability: TikHub's linkedin family half-retired (v2 search-jobs 400s even on TikHub's own demo params — twice, 2026-08-20), Akta plan-gated, leadmagic the only live path and undiscoverable by natural phrasing. Three additions, **all live-verified 2026-08-20** with captured examples:

- `apify.linkedin.search.jobs` (harvestapi actor, $0.001/result — returned a real posting)
- `apollo.companies.jobs` (1 credit/page — returned 12 real postings via the search→id→postings flow)
- `apollo.companies.news` (1 credit/page — 858 articles for stripe.com; empty-page-not-error shape noted)

Plus keyword enrichment so the phrasings that returned 0 results now rank the working endpoints first.

## Verification

Full suite green (1793 passed), `catalog_validate.py` OK, drift.sh fragments updated in the same commits (`money.md`, `catalog.md`, `api.md`). Deploy note: confirm 61b5d0f also reaches prod with this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)