### PR TITLE
docs(vendors): vendor PRs must self-verify with evidence

### DIFF
--- a/.claude/skills/vendor-listing/SKILL.md
+++ b/.claude/skills/vendor-listing/SKILL.md
@@ -126,6 +126,35 @@ If the vendor publishes a stable OpenAPI spec with example parameter values, add
 ABOUT; normalise platform slugs across providers. Bulk-verify with
 `catalog_verify_extended.py --dry-run` first, then with an explicit `--budget`.
 
+## Reviewing a vendor-RAISED PR (they wrote the files; you verify)
+
+The same pipeline, entered from the other end. Every vendor claim is **untrusted input** — one
+vendor PR was outright malicious (#92), and an honest one shipped a docs-transcribed price 5×
+under the real charge (#141, GitHub→LinkedIn: claimed 1 credit, metered 5). The order:
+
+1. **Gate on the required PR evidence** (per `docs/VENDORS.md` items 8–9): the self-verification
+   ledger (per-endpoint status + claimed vs metered cost, dated) and the full-surface map.
+   Missing → ask for it before spending review time. A ledger that contradicts its own YAML
+   bounces the PR unreviewed.
+2. **Diff hygiene first**: expected files only (registry entry, catalog YAML, logo, two test
+   lists, fx row), data-only changes, no credential values, no `verified:` stamps or committed
+   examples (those are yours to add).
+3. **Merge it onto current main locally** before verifying — catalog PRs staleness-conflict in
+   the shared test lists and REGISTRY tuple within days.
+4. **Independently verify with a key YOU control** (steps 5–7 above): watch the bogus-key
+   rejection yourself and quote the real wire body, run `catalog_verify.py` over every
+   test_request, and reconcile every cost block against the meter (charge field / rate-card
+   endpoint / balance delta) — the vendor's ledger is a cross-check, never the source of truth.
+   Where a price disagrees, fix it from the observed charge (`source: observed`,
+   `confidence: verified`) and tell the vendor their docs are stale.
+5. **Audit the curation against their surface map**: are the free count/pre-flight routes and
+   cheapest operation tiers in? Deliberate-miss test_requests labeled, with the hit price
+   observed once? per_success semantics actually observed (a miss settling at 0)?
+6. **Finish the maintainer half they can't**: front-door counts (llms.txt, skill.md, README) +
+   `scripts/build_plugin.py`, docs drift, and — if their prices are verified/documented — the
+   optional tier-4 key slot. Land your verified version (a maintainer branch superseding their
+   PR is fine); close their PR with credit and the findings.
+
 ## Step 9 — done means
 
 - Validator exits 0; suite green; bogus-key rejection observed live

--- a/docs/VENDORS.md
+++ b/docs/VENDORS.md
@@ -56,6 +56,15 @@ Or open an issue or PR on this repo yourself, with:
 6. Your 8–15 core endpoints, each with example parameter values and a cheap test target
 7. A test credential (or a small credits grant) sent privately once we reach out — **never in
    the issue/PR** — so we can run live verification
+8. **A self-verification ledger**: before submitting, run every `test_request` live against your
+   own account and record, per endpoint, the HTTP status, the cost your YAML claims, and the cost
+   your meter actually charged (charge field, rate-card endpoint, or balance delta), dated. Docs
+   drift; meters don't — a real submission's docs-transcribed price was 5× under what the meter
+   charged. Deliberate-miss test targets must be labeled as such, with the hit price observed
+   once on a real target.
+9. **A full-surface map**: every documented operation, marked catalogued or excluded-with-reason —
+   including the free count/preview routes and your cheapest operation tiers, which are the ones
+   agents (and reviewers) look for first.
 
 The example below is the complete shape of a listing.
 
@@ -147,6 +156,12 @@ The `capability` field is what puts you on the comparison shelf: an agent asking
 your API does a job the taxonomy lacks, the file proposes it under `proposed_capabilities:`.
 
 ### 3. What we run before it merges
+
+Your self-verification ledger speeds this up but never replaces it: every claim in a vendor PR —
+prices, probe behavior, evidence — is re-checked against an **independent** live run with a
+credential we control. `verified:` stamps and example responses are ours to add, on what we
+watched succeed. A ledger that disagrees with its own YAML bounces the PR; a price that disagrees
+with our meter gets corrected from the observed charge.
 
 ```bash
 # 1. Live bogus-key test: a garbage key POSTed to /connections/token must come back rejected

--- a/src/treg/web/vendor-listing.md
+++ b/src/treg/web/vendor-listing.md
@@ -37,23 +37,54 @@ that fails them will be declined.
    (`value`, `currency`, `type`, `source`, `source_url`, `checked`, `confidence`). Follow the
    schema in the worked example.
 
-## Verify before opening the PR
+## Map the FULL surface before selecting
+
+List every documented operation your API exposes, then choose the 8–15 you catalog. The PR
+description must carry that map as a short "catalogued / excluded, because…" list — reviewers
+check curation against it, and "we didn't know it existed" is the gap this prevents. Two rules of
+thumb from listings that went well: include the **free count / preview / pre-flight routes** that
+let an agent size a query before paying for rows, and include your **cheapest tier** of an
+operation, not only the default one.
+
+## Self-verify with your OWN key before opening the PR
+
+Docs drift; meters don't. Before the PR goes up, run **every** `test_request` live against your
+own account and reconcile each `cost` block against what the meter actually charged (a per-call
+charge field in the response, a rate-card endpoint, or the balance delta). A price transcribed
+from a docs page has been wrong by 5× in a real submission — the live meter is the authority, and
+a mismatch you find now is a one-line fix instead of a review round-trip.
+
+While you're there:
+- Quote the probe's bad-key behavior **from the wire** (run it with a garbage key; record the
+  exact status and body, with the date) — not from memory or docs.
+- If a `test_request` is a **deliberate miss** (a target chosen so a pay-on-success endpoint
+  charges nothing), label it as such in the endpoint note — and observe the HIT price once on a
+  real target so the cost block's number is metered, not assumed.
 
 ```bash
 uv run --frozen python scripts/catalog_validate.py   # must exit 0
 uv run --frozen python -m pytest -q                  # must pass
 ```
 
-Do NOT stamp `verified:` on any endpoint and do NOT commit example responses — live verification
-runs on the maintainers' side with a test credential. And **never put a credential value anywhere
-in the diff**: no API keys in the YAML, the tests, the PR description, or commit messages.
+Rebase on the latest `main` right before opening — catalog files move fast and a stale branch
+conflicts in the shared test lists.
+
+Do NOT stamp `verified:` on any endpoint and do NOT commit example responses — those marks mean
+"the maintainers watched it", and they run their own verification with an independent credential
+regardless of your evidence. And **never put a credential value anywhere in the diff**: no API
+keys in the YAML, the tests, the PR description, or commit messages.
 
 ## The PR description — required
 
 - **A contact email** for your team, stated plainly (e.g. `Contact: partnerships@yourapi.com`).
   The maintainers reach out on this address to arrange a test credential for live verification —
   a PR without it cannot be verified or merged.
-- Your probe endpoint's exact bad-key behavior (status code, or the JSON field that flips).
+- **The self-verification ledger**: one line per endpoint — HTTP status of your live
+  `test_request`, the cost the YAML claims, and the cost the meter reported, with the date. This
+  is review evidence, not a substitute for the maintainers' own run — but a PR that arrives with
+  it merges much faster, and a PR whose ledger disagrees with its own YAML will be bounced.
+- **The full-surface map** — every documented operation, marked catalogued or excluded-because.
+- Your probe endpoint's exact bad-key behavior (status + body, observed on a dated live call).
 - Your pricing page URL and billing model; a machine-readable rate-card endpoint if you have one
   (that is the fastest path to treg serving your endpoints on its own key, metered).
 - Whether you publish an OpenAPI spec at a stable URL (enables a machine-generated "extended


### PR DESCRIPTION
RCA of #141 (Fiber AI). The vendor-listing contract now requires: full-surface map with exclusions, a self-verification ledger (every test_request run live on the vendor's own key, claimed vs metered cost per endpoint), wire-quoted probe behavior, labeled deliberate-miss tests with observed hit prices, and a fresh rebase — across all three vendor-facing surfaces (VENDORS.md, hosted /vendor-listing, and the operator skill, which also gains a review-side checklist for vendor-raised PRs).

Trust boundary stated explicitly: evidence speeds review, never replaces the maintainers' independent verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SnkCWqc4uDbg7FHd5wZSN