### PR TITLE
fix(ops): provider-balance fetcher for Fiber AI

### DIFF
--- a/scripts/provider_balances.py
+++ b/scripts/provider_balances.py
@@ -237,7 +237,19 @@ async def _leadsforge(c, key):
                     f"email {d.get('emailEnrichmentPrice')} / phone {d.get('phoneNumberEnrichmentPrice')} credits"}
 
 
+async def _fiber_ai(c, key):
+    # GET /v1/get-org-credits is Fiber's free registry probe (documented in catalog/fiber-ai.yaml);
+    # it is not a catalog endpoint. `usagePeriodResetsOn` sits a century out on the trial pool, so
+    # treat `available` as a prepaid balance, not a monthly quota.
+    d = await _get(c, "https://api.fiber.ai/v1/get-org-credits", headers={"x-api-key": key})
+    org = (d.get("output") or [{}])[0]
+    resets = (org.get("usagePeriodResetsOn") or "")[:10]
+    return {"value": org.get("available"), "unit": "credits",
+            "note": f"{org.get('used')} of {org.get('max')} used; period resets {resets}"}
+
+
 BALANCE_ROUTES = {
+    "fiber_ai": _fiber_ai,
     "apollo": _apollo,
     "branddev": _branddev,
     "companyenrich": _companyenrich,


### PR DESCRIPTION
The balance loop has been alerting `fiber_ai errored: no fetcher written yet` since PR #165 merged: adding the `platform_key_fiber_ai` slot puts Fiber AI into `provider_balances.py`'s population (every `platform_key_*` field in Settings), but no fetcher existed for it.

Fiber publishes a free probe — `GET /v1/get-org-credits`, which `src/treg/catalog/fiber-ai.yaml` already documents as deliberately *not* a catalog endpoint. Verified live against the platform key: **475 credits available of 500, 25 used**, `usagePeriodResetsOn` = 2126, i.e. a prepaid trial pool rather than a monthly quota.

- `scripts/provider_balances.py` — `_fiber_ai` fetcher + route.
- `loopany/provider-balances/workflow.js` — `THRESH.fiber_ai = 50`, sized by the README's prepaid rule (a contact reveal costs 2–5 credits, so ~a day of lookups). Gate installed as task v53.
- `loopany/provider-balances/README.md` — threshold table row + the 15:00 run entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)