### PR TITLE
Add LetsFG (flights + hotels) to the tool catalog

### DIFF
--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -117,6 +117,12 @@ platforms:
   crypto: {label: "Crypto Market Data", category: "Market data", featured: 1, summary: "Live and historical prices, market caps, trends and exchanges across 17,000+ coins."}
   stocks: {label: "Stock Market Data", category: "Market data", featured: 2, summary: "End-of-day and intraday stock prices, tickers, splits and dividends across global exchanges."}
 
+  # --- Travel: live flight & hotel inventory ----------------------------------------------------
+  # A new category. The closest existing platform is `tripadvisor` (Reviews & Apps), which returns
+  # what people SAID about a hotel; these two return what it COSTS and whether it can be booked.
+  flights: {label: "Flights", category: "Travel", featured: 1, summary: "Live flight offers, prices and booking links across a 180+ airline and OTA connector fleet."}
+  hotels: {label: "Hotels", category: "Travel", featured: 2, summary: "Bookable, free-cancellation hotel rates at the price the guest actually pays."}
+
 capabilities:
   # --- SEO / search -----------------------------------------------------------------------------
   google.serp.organic: "Get organic search results for a keyword"

--- a/src/treg/catalog/letsfg.yaml
+++ b/src/treg/catalog/letsfg.yaml
@@ -1,0 +1,441 @@
+provider: letsfg
+source:
+  docs: https://letsfg.co/developers/docs
+  openapi: https://letsfg.co/developers/api/openapi.json
+  curated: 2026-08-20
+# LetsFG fills the catalog's TRAVEL gap. Nothing here books or prices a trip today: `tripadvisor`
+# returns hotel *reviews*, and the SERP providers return travel *pages*. This is live inventory —
+# real flight offers with booking links, and hotel rates that are actually reservable.
+#
+# One key, two verticals, one prepaid USD balance. Auth is `X-API-Key: <key>`. Registration is
+# self-serve and instant (POST /agents/register, email only, no card, no sales call); a card is
+# attached later, only when moving off the free sandbox.
+#
+# BILLING — read this before trusting a `cost` block below. LetsFG's own docs speak in "credits",
+# but a credit has no fixed price: flight search is billed on a MONTHLY VOLUME LADDER, $0.50 per
+# search for the first 10 each calendar month, $0.20 for searches 11-1,000, and $0.10 from 1,001
+# up (the rate is fixed per band, not retroactive; the counter resets on the 1st of each UTC
+# month). Because a credit is not a currency, every priced entry below is denominated directly in
+# USD at the FIRST-BAND rate — $0.50 — which is the catalog's usual entry-tier upper-bound
+# convention. Sustained volume costs 2.5x to 5x less than these blocks claim. There is
+# deliberately NO `credit_rates_usd.letsfg` row in fx.yaml: a single credit->USD constant would be
+# wrong in every band.
+#
+# Hotels are metered on a completely different model — LOOK-TO-BOOK, not monthly. Hotel search is
+# free up to 1,000 searches since your last successful booking; past that, searches are sold in
+# blocks of 1,000 for $5.00 ($0.005 each) drawn from the same prepaid balance, charged the moment
+# the allowance is crossed, and the next booking resets the allowance. So a caller with a normal
+# search-to-book ratio pays nothing for hotel search at all, and the $0.005 recorded below is the
+# marginal overage rate, not the expected one.
+#
+# LIVE MEASUREMENT 2026-08-20 — READ BEFORE PUBLISHING THIS FILE.
+# Every test_request below was executed against a real developer account registered through the
+# public self-serve route (agent_3a1d4cd25f7d). Results, with the charge read off the account's own
+# prepaid balance before and after each call:
+#
+#   letsfg.account.usage          200   1.0s   0c    profile + balance, as documented
+#   letsfg.flights.parse-query    200   3.8s   0c    free, resolved the query correctly
+#   letsfg.flights.providers      200   0.6s   0c    provider list returned
+#   letsfg.flights.discover       200   6.4s  50c    WORKS — real prices, 4 destinations, ONE charge
+#   letsfg.flights.multi-search   200   2.9s  50c    charged per destination as documented
+#   letsfg.flights.search.async   200   1.0s  50c    charged once on completion, as documented
+#   letsfg.flights.results        200   1.1s   0c    free polling, as documented
+#   letsfg.flights.search         200   2.1s  50c    charged
+#   letsfg.flights.locations      503   0.6s   0c    BROKEN — "Location lookup is temporarily unavailable"
+#   letsfg.hotels.destinations    403   0.9s   0c    BROKEN — upstream 403, hotel lane unreachable
+#   letsfg.hotels.search          402/403       —    gated behind the same broken hotel lane
+#   letsfg.hotels.booking.status  402           —    needs a real booking_job_id; untestable by design
+#
+# THE BLOCKER: /flights/search, /flights/search/async and /flights/multi-search return HTTP 200 with
+# `status: complete`, `total_results: 0` and an EMPTY offers array — and still debit 50c. Confirmed on
+# WAW->LIS and on LON->BCN (the API's own documented example route), on both the blocking and async
+# lanes, and by polling a fresh async search every 10s for 200 seconds: it reports `complete` at the
+# first poll and never yields an offer. The 2-3s response time (against a documented 60-90s) says the
+# connector fleet is not being dispatched in the developer lane at all. /flights/discover hitting a
+# different, lightweight price source is exactly why it still works.
+#
+# So this file must NOT be published as-is: its headline capability takes money and returns nothing.
+# Hold it until the developer-lane search dispatch is fixed, then re-run the ledger and refresh the
+# `checked:` dates. Everything else here — auth, probe, billing model, parameters — is verified good.
+#
+# WHAT IS DELIBERATELY NOT CATALOGUED. Fifteen of the API's 27 documented operations are excluded,
+# and the exclusions are the point rather than an omission — see the PR description for the full
+# table. Two groups matter here:
+#   - MONEY-MOVING AND ACCOUNT-MUTATING routes (POST /hotels/book, POST /hotels/cancel,
+#     POST /agents/top-up, POST /agents/rotate-key, POST /agents/setup-payment, the two
+#     hosted-checkout routes, POST /agents/billing-portal, POST /agents/billing-settings,
+#     POST /agents/register). A catalogued `test_request` is a standing instruction to whoever
+#     validates the entry, so shipping /hotels/book would mean a validation run makes a real
+#     reservation and pays a real non-refundable fee, and shipping /agents/rotate-key would mean a
+#     validation run invalidates the caller's own live key. Neither belongs behind a shared
+#     platform key.
+#   - The five /sandbox/* routes. They are free and they mirror the live request/response schema
+#     exactly, which makes them excellent for building an integration — but they return FAKE data,
+#     so an agent calling them through treg would get plausible offers for flights that do not
+#     exist. They are documented in `input.note` on their live twins instead.
+limits: "no published per-key rate limit on the developer API; flight search itself takes 60-90s per call, which is the practical ceiling. Hotel search allowance is 1,000 per booking (see billing note above)"
+pricing_url: https://letsfg.co/en/developers
+endpoints:
+  # ---------------------------------------------------------------- flights: search
+  - id: letsfg.flights.search
+    domain: flights
+    kind: data
+    capability: flights.search
+    platform: flights
+    scope: any_account
+    method: POST
+    path: /flights/search
+    name: "Search flights"
+    summary: "Search live, bookable flight offers for a route and date across a 180+ airline and OTA connector fleet"
+    input:
+      body:
+        origin: {type: string, required: true, note: "IATA departure code — airport or city", example: "WAW"}
+        destination: {type: string, required: true, note: "IATA arrival code", example: "LIS"}
+        date_from: {type: string, required: true, note: "outbound date, YYYY-MM-DD — must be in the future", example: "2026-11-15"}
+        date_to: {type: string, required: false, note: "widens the outbound search to a date RANGE from date_from to date_to"}
+        return_from: {type: string, required: false, note: "omit entirely for a one-way. Setting it equal to date_from triggers same-day round-trip mode"}
+        return_to: {type: string, required: false, note: "widens the return search to a range"}
+        adults: {type: integer, required: false, note: "default 1", example: 1}
+        children: {type: integer, required: false, note: "default 0"}
+        infants: {type: integer, required: false, note: "default 0"}
+        cabin_class: {type: string, required: false, note: "economy | premium_economy | business | first; default is any"}
+        max_stopovers: {type: integer, required: false, note: "default 2; 0 for non-stop only"}
+        currency: {type: string, required: false, note: "ISO 4217, default EUR", example: "EUR"}
+        locale: {type: string, required: false, note: "default en"}
+        limit: {type: integer, required: false, note: "max offers returned, default 50 — the response-size dial, NOT a price dial: the search costs the same at limit 1 and limit 50", example: 1}
+        sort: {type: string, required: false, note: "default price"}
+        departure_time_from: {type: string, required: false, note: "earliest outbound departure, HH:MM"}
+        departure_time_to: {type: string, required: false, note: "latest outbound departure, HH:MM"}
+        provider_filters: {type: object, required: false, note: "restrict which providers run; see GET /flights/providers for the visible set"}
+        min_hours_at_destination: {type: integer, required: false, note: "same-day round trip only — minimum hours on the ground before the return departs"}
+        max_return_hour: {type: integer, required: false, note: "same-day round trip only — latest local hour the return may land the next day"}
+      note: "Documented as blocking and slow — the full connector fleet is supposed to run before it answers, so the docs say budget 60-90 seconds. NOT WHAT IT DOES TODAY: see the LIVE MEASUREMENT block at the top of this file — it answered in 2.1-2.7s with an empty offer array on every route tried, which is the signature of the fleet not being dispatched at all. For a loading state use POST /flights/search/async instead; for ranking many destinations cheaply use POST /flights/discover. Offers come back FLAT (top-level origin/destination/departure_time/stops/duration_minutes, singular `airline`, `trip_breakdown` legs) and already sorted by the provider's own blended score — read rank off the array position rather than re-sorting on price. Free identical-schema twin for integration work: POST /sandbox/flights/search."
+    test_request:
+      body: {origin: "WAW", destination: "LIS", date_from: "2026-11-15", limit: 1}
+    cost:
+      type: per_call
+      value: 0.50
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://letsfg.co/en/developers
+      checked: '2026-08-20'
+      confidence: documented
+      note: "first-band rate and therefore an UPPER BOUND — $0.50 covers only the first 10 searches in a UTC calendar month; searches 11-1,000 are $0.20 and 1,001+ are $0.10. Charged per call regardless of how many offers come back, including zero. `limit` does not change the price."
+    docs_url: https://letsfg.co/developers/docs/api-search
+
+  # ---------------------------------------------------------------- flights: async search
+  - id: letsfg.flights.search.async
+    domain: flights
+    kind: data
+    capability: flights.search.async
+    platform: flights
+    scope: any_account
+    method: POST
+    path: /flights/search/async
+    name: "Start a flight search in the background"
+    summary: "Kick off a flight search without blocking and get back a search_id to poll — same fleet, same billing as the blocking search"
+    input:
+      body:
+        origin: {type: string, required: true, note: "IATA departure code", example: "WAW"}
+        destination: {type: string, required: true, note: "IATA arrival code", example: "LIS"}
+        date_from: {type: string, required: true, note: "outbound date, YYYY-MM-DD", example: "2026-11-15"}
+        return_from: {type: string, required: false, note: "omit for a one-way"}
+        adults: {type: integer, required: false, note: "default 1"}
+        cabin_class: {type: string, required: false}
+        max_stopovers: {type: integer, required: false, note: "default 2"}
+        currency: {type: string, required: false, note: "default EUR"}
+        limit: {type: integer, required: false, note: "default 50", example: 1}
+      note: "takes the SAME body as POST /flights/search (every field on that entry is accepted here) but returns in under a second with a search_id. Poll GET /flights/results/{search_id} every 5-10s until `status` leaves `pending` for `complete` or `error`. Billing is identical to the blocking search and is charged once, on completion — polling is free, so this route costs the same as /flights/search and merely moves the wait client-side."
+    test_request:
+      body: {origin: "WAW", destination: "LIS", date_from: "2026-11-15", limit: 1}
+    cost:
+      type: per_call
+      value: 0.50
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://letsfg.co/en/developers
+      checked: '2026-08-20'
+      confidence: documented
+      note: "same monthly volume ladder as /flights/search ($0.50 first 10/month, $0.20 to 1,000, $0.10 beyond); charged once on completion, not per poll. Upper bound."
+    docs_url: https://letsfg.co/developers/docs/api-polling
+
+  # ---------------------------------------------------------------- flights: poll results
+  - id: letsfg.flights.results
+    domain: flights
+    kind: data
+    capability: flights.results.poll
+    platform: flights
+    scope: own_account
+    method: GET
+    path: /flights/results/{search_id}
+    name: "Poll background flight search results"
+    summary: "Fetch the status and, once ready, the offers for a search started with the async endpoint"
+    input:
+      pathParams:
+        search_id: {type: string, required: true, note: "the search_id returned by POST /flights/search/async"}
+      note: "free to poll and safe to call repeatedly — the charge belongs to the async search that created the id, not to this read. `status` is `pending` while connectors are still running, `complete` once offers are ready, `error` if the search failed. Poll every 5-10 seconds. A search_id belongs to the key that created it, so this cannot be used to read another account's search."
+    test_request:
+      pathParams: {search_id: "REPLACE_WITH_SEARCH_ID_FROM_ASYNC_SEARCH"}
+      note: "not independently runnable — needs a live search_id from POST /flights/search/async, which is a paid call. Chain the two when validating."
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "polling is free; the parent async search carries the charge"}
+    docs_url: https://letsfg.co/developers/docs/api-polling
+
+  # ---------------------------------------------------------------- flights: discover
+  - id: letsfg.flights.discover
+    domain: flights
+    kind: data
+    capability: flights.price.discover
+    platform: flights
+    scope: any_account
+    method: POST
+    path: /flights/discover
+    name: "Compare prices across many destinations"
+    summary: "Price-check up to 100 destinations from one origin in a few seconds for a single flat charge — the cheap way to rank where to go"
+    input:
+      body:
+        origin: {type: string, required: true, note: "departure IATA code", example: "WAW"}
+        destinations: {type: array, required: true, note: "1-100 destination IATA codes in default mode; same_day mode is capped lower", example: ["LIS", "BCN"]}
+        date_from: {type: string, required: true, note: "outbound date, YYYY-MM-DD", example: "2026-11-15"}
+        return_from: {type: string, required: false, note: "default mode only — return date for a round-trip indicative price; omit for one-way"}
+        currency: {type: string, required: false, note: "default EUR"}
+        same_day: {type: boolean, required: false, note: "false/omitted (default) = fast indicative prices. true = a REAL same-day round-trip search per destination, with bookable offers — much slower and priced per destination like a full search"}
+        min_hours_at_destination: {type: integer, required: false, note: "same_day mode only"}
+        max_return_hour: {type: integer, required: false, note: "same_day mode only — latest local hour the return may land the next day"}
+        max_total_price: {type: number, required: false, note: "same_day mode only — drop destinations above this round-trip total"}
+        adults: {type: integer, required: false, note: "same_day mode only; default 1"}
+        departure_time_from: {type: string, required: false, note: "earliest outbound departure HH:MM"}
+        departure_time_to: {type: string, required: false, note: "latest outbound departure HH:MM"}
+      note: "TWO MODES WITH DIFFERENT PRICES, selected by `same_day`. Default mode returns `price`/`found` ONLY — no offer detail and no booking_url — from a fast lightweight source in ~2-5 seconds, and the whole batch is one flat charge however many destinations you pass. Treat those numbers as a RANKING SIGNAL, not a bookable fare: confirm the winner with POST /flights/search before showing a price as final. Setting `same_day: true` switches to a real per-destination search and the cost block below no longer applies. Free identical-schema twin: POST /sandbox/flights/discover."
+    test_request:
+      body: {origin: "WAW", destinations: ["LIS"], date_from: "2026-11-15"}
+    cost:
+      type: per_call
+      value: 0.50
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://letsfg.co/en/developers
+      checked: '2026-08-20'
+      confidence: documented
+      note: "DEFAULT MODE ONLY: one charge for the entire batch, so 100 destinations cost the same as 1 — by far the cheapest per-destination price signal in this file. Same monthly ladder as /flights/search, so $0.50 is the first-band upper bound. `same_day: true` is billed per destination instead, like /flights/multi-search. NOTE a documentation discrepancy: the endpoint description caps the batch at 100 destinations in one sentence and cites '1 credit for 20 destinations' in another; the 1-charge-per-batch rule is consistent across both."
+    docs_url: https://letsfg.co/developers/docs/api-search
+
+  # ---------------------------------------------------------------- flights: multi-search
+  - id: letsfg.flights.multi-search
+    domain: flights
+    kind: data
+    capability: flights.search.multi
+    platform: flights
+    scope: any_account
+    method: POST
+    path: /flights/multi-search
+    name: "Search several destinations at once"
+    summary: "Run a full connector search for each of up to 10 destinations in parallel and get every result in one response"
+    input:
+      body:
+        origin: {type: string, required: true, note: "departure IATA code", example: "WAW"}
+        destinations: {type: array, required: true, note: "1-10 destination IATA codes — each runs a FULL search and is billed as one", example: ["LIS"]}
+        date_from: {type: string, required: true, note: "outbound date, YYYY-MM-DD", example: "2026-11-15"}
+        return_from: {type: string, required: false, note: "omit for one-way"}
+        adults: {type: integer, required: false, note: "default 1"}
+        currency: {type: string, required: false, note: "default EUR"}
+        cabin_class: {type: string, required: false}
+        max_stopovers: {type: integer, required: false, note: "default 2"}
+        departure_time_from: {type: string, required: false, note: "earliest outbound departure HH:MM"}
+        departure_time_to: {type: string, required: false, note: "latest outbound departure HH:MM"}
+      note: "the parallel equivalent of calling POST /flights/search once per destination, and priced exactly that way — there is NO batch discount. Use it for latency (one round trip instead of N sequential 60-90s searches), not to save money. If you only need to rank destinations by price, POST /flights/discover does up to 100 for a single flat charge. Free identical-schema twin: POST /sandbox/flights/multi-search."
+    test_request:
+      body: {origin: "WAW", destinations: ["LIS"], date_from: "2026-11-15"}
+    cost:
+      type: per_call
+      value: 0.50
+      currency: USD
+      per: 1
+      unit: target
+      source: docs
+      source_url: https://letsfg.co/en/developers
+      checked: '2026-08-20'
+      confidence: documented
+      note: "billed PER DESTINATION, not per call — `unit: target` is one entry in `destinations`. A 10-destination request is 10 charges. Same monthly ladder, so $0.50 is the first-band upper bound per destination."
+    docs_url: https://letsfg.co/developers/docs/api-search
+
+  # ---------------------------------------------------------------- flights: parse query
+  - id: letsfg.flights.parse-query
+    domain: flights
+    kind: utility
+    capability: flights.query.parse
+    platform: flights
+    scope: any_account
+    method: POST
+    path: /flights/parse-query
+    name: "Parse a natural-language flight query"
+    summary: "Turn a sentence like 'cheap flight to Lisbon next Friday for two' into IATA codes, dates and passenger counts — free"
+    input:
+      body:
+        query: {type: string, required: true, note: "the natural-language trip request", example: "one way from Warsaw to Lisbon on 15 November"}
+        today: {type: string, required: false, note: "override the server's idea of today, YYYY-MM-DD — set this when resolving relative dates ('next Friday') against a user's own timezone"}
+        mode: {type: string, required: false, note: "`full` (default) parses everything; `clarify` returns only the fields still missing"}
+      note: "the natural front door to the rest of this file: it returns resolved IATA codes, dates, passenger count and time preferences PLUS a list of fields still missing, so an agent can ask one follow-up question instead of guessing. Feed the result straight into POST /flights/search or POST /flights/discover. Free, so there is no reason to hand-roll date parsing. Free stub twin: POST /sandbox/flights/parse-query."
+    test_request:
+      body: {query: "one way from Warsaw to Lisbon on 15 November 2026"}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "explicitly free — the endpoint description states 'Free — no credit charge'. No prepaid balance is required."}
+    docs_url: https://letsfg.co/developers/docs/api-guide
+
+  # ---------------------------------------------------------------- flights: locations
+  - id: letsfg.flights.locations
+    domain: flights
+    kind: utility
+    capability: flights.locations.resolve
+    platform: flights
+    scope: any_account
+    method: GET
+    path: /flights/locations/{query}
+    name: "Resolve a place to IATA codes"
+    summary: "Turn a city or airport name into the IATA codes the search endpoints expect"
+    input:
+      pathParams:
+        query: {type: string, required: true, note: "city name, airport name, or a partial IATA code", example: "Warsaw"}
+      note: "every flights endpoint here takes IATA codes, not place names — this is how you get them. A city query can resolve to several airports (Warsaw -> WAW and WMI), so pick deliberately rather than taking the first hit. URL-encode multi-word queries."
+    test_request:
+      pathParams: {query: "Warsaw"}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "resolver route; no charge against the prepaid balance"}
+    docs_url: https://letsfg.co/developers/docs/api-guide
+
+  # ---------------------------------------------------------------- flights: providers
+  - id: letsfg.flights.providers
+    domain: flights
+    kind: utility
+    capability: flights.providers.list
+    platform: flights
+    scope: any_account
+    method: GET
+    path: /flights/providers
+    name: "List available flight providers"
+    summary: "The airlines and OTAs a flight search can draw on, and the ids `provider_filters` accepts"
+    input:
+      note: "no parameters. Read this before setting `provider_filters` on POST /flights/search — it is the authoritative list of ids that filter will accept, and it changes as connectors are added or retired."
+    test_request: {}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "metadata route; no charge"}
+    docs_url: https://letsfg.co/developers/docs/api-guide
+
+  # ---------------------------------------------------------------- hotels: destinations
+  - id: letsfg.hotels.destinations
+    domain: hotels
+    kind: utility
+    capability: hotels.destinations.resolve
+    platform: hotels
+    scope: any_account
+    method: POST
+    path: /hotels/destinations
+    name: "Resolve a place to a hotel city id"
+    summary: "Turn a place name into the numeric city id that hotel search requires"
+    input:
+      body:
+        text: {type: string, required: true, note: "place name to resolve", example: "Warsaw"}
+      note: "POST /hotels/search will not accept a place name — it needs the numeric `city_id` this returns, together with the matching `city_name`, so this call is a mandatory first step. Free, and NOT counted against the look-to-book search allowance. Like every hotel route it still requires a payment method on file, so it will fail on a key that has never attached a card even though it costs nothing."
+    test_request:
+      body: {text: "Warsaw"}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free and outside the look-to-book allowance, per the endpoint description. Requires a payment method on file regardless."}
+    docs_url: https://letsfg.co/developers/docs/hotels
+
+  # ---------------------------------------------------------------- hotels: search
+  - id: letsfg.hotels.search
+    domain: hotels
+    kind: data
+    capability: hotels.search
+    platform: hotels
+    scope: any_account
+    method: POST
+    path: /hotels/search
+    name: "Search bookable hotel rates"
+    summary: "Real, reservable hotel rates for a city and date range — free-cancellation, pay-later rates only, at the price the guest actually pays"
+    input:
+      body:
+        city_id: {type: integer, required: true, note: "numeric city id from POST /hotels/destinations", example: 100372}
+        city_name: {type: string, required: true, note: "the city_name returned alongside city_id — send both", example: "Warsaw, Poland"}
+        check_in: {type: string, required: true, note: "YYYY-MM-DD", example: "2026-11-15"}
+        check_out: {type: string, required: true, note: "YYYY-MM-DD, after check_in", example: "2026-11-16"}
+        adults: {type: integer, required: false, note: "default 2"}
+        children: {type: integer, required: false, note: "default 0"}
+        child_ages: {type: array, required: false, note: "one age per child; required when children > 0"}
+        nationality: {type: string, required: false, note: "ISO country code, default PL — affects which rates the guest is ELIGIBLE for, so set it to the real guest nationality rather than leaving the default"}
+        limit: {type: integer, required: false, note: "max properties returned, default 40", example: 1}
+        with_images: {type: boolean, required: false, note: "default true; false returns a much smaller payload"}
+      note: "only free-cancellation, pay-later rates are returned, so every result is bookable on the terms shown. `price` is what the guest pays END TO END — the hotel cost plus a flat 5% reservation fee already included — so it can be displayed as-is with nothing added at checkout. There is no separate wholesale figure. Requires a payment method on file even while the search itself is free."
+    test_request:
+      body: {city_id: 100372, city_name: "Warsaw, Poland", check_in: "2026-11-15", check_out: "2026-11-16", limit: 1}
+      note: "city_id 100372 is illustrative — resolve the real one with POST /hotels/destinations first, as ids are supplier-assigned and not stable across suppliers."
+    cost:
+      type: per_call
+      value: 0.005
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://letsfg.co/en/developers
+      checked: '2026-08-20'
+      confidence: documented
+      note: "MARGINAL OVERAGE RATE, and most callers never reach it. Hotel search is look-to-book, not monthly: free for the first 1,000 searches since your last successful booking, after which searches are sold in blocks of 1,000 for $5.00 ($0.005 each) charged the moment the allowance is crossed. A booking resets the allowance to 1,000. A caller booking at anything near a 1,000:1 ratio pays $0 for search."
+    docs_url: https://letsfg.co/developers/docs/hotels
+
+  # ---------------------------------------------------------------- hotels: booking status
+  - id: letsfg.hotels.booking.status
+    domain: hotels
+    kind: data
+    capability: hotels.booking.status
+    platform: hotels
+    scope: own_account
+    method: GET
+    path: /hotels/booking/{booking_job_id}
+    name: "Check a hotel booking's status"
+    summary: "Poll a booking started elsewhere until the supplier confirms it, fails it, or declines the card"
+    input:
+      pathParams:
+        booking_job_id: {type: string, required: true, note: "the booking_job_id returned by POST /hotels/book"}
+      note: "read-only status poll, free and safe to repeat — it does not create, modify or cancel anything. A real booking takes minutes while the rate is re-blocked and every price and date re-checked, so this is the only correct way to learn the outcome. NOTE that POST /hotels/book, which produces the id, is deliberately NOT in this catalog: it charges a real non-refundable 5% reservation fee and creates a real reservation, so it must not sit behind a shared platform key. This entry is here so an agent that booked through LetsFG's own surface can still track the result."
+    test_request:
+      pathParams: {booking_job_id: "REPLACE_WITH_BOOKING_JOB_ID"}
+      note: "not independently runnable — a valid id can only come from POST /hotels/book, which is excluded from this catalog by design. Expect a 404 for any synthetic id."
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "status poll; no charge. The 5% reservation fee belongs to the excluded POST /hotels/book."}
+    docs_url: https://letsfg.co/developers/docs/hotels
+
+  # ---------------------------------------------------------------- account
+  - id: letsfg.account.usage
+    domain: account
+    kind: account
+    capability: account.usage
+    platform: account
+    scope: own_account
+    method: GET
+    path: /agents/me
+    name: "Get account balance and usage"
+    summary: "Your LetsFG developer profile, prepaid balance and search counters (free)"
+    input:
+      note: "no parameters — the key rides in the X-API-Key header. This is the registry's health probe: free, side-effect-free, and it distinguishes a bad key from a broke one, which the paid routes do not. Read the prepaid balance here before a run of flight searches rather than discovering an empty balance mid-flow, and read the monthly search counter to know which pricing band the next search lands in."
+    test_request: {}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free — no charge against the prepaid balance; this is the registry's health probe"}
+    docs_url: https://letsfg.co/developers/docs/api-onboarding
+
+proposed_capabilities:
+  # Travel is a new vertical for this taxonomy — there is no existing capability for live flight or
+  # hotel inventory. `tripadvisor.hotel.detail` is the nearest thing and it is a REVIEWS capability:
+  # it describes a property, it does not price or reserve one. Two new platforms are proposed with
+  # these (`flights`, `hotels`, both category "Travel") — added directly to capabilities.yaml in
+  # this PR, since `platform` has no proposed-* escape hatch in catalog_validate.py the way
+  # `capability` does. `account.usage` already exists and is reused unchanged for GET /agents/me.
+  flights.search: "Search live flight offers for a route and date"
+  flights.search.async: "Start a flight search in the background and get an id to poll"
+  flights.results.poll: "Poll a background flight search for its offers"
+  flights.price.discover: "Compare indicative prices across many destinations at once"
+  flights.search.multi: "Run full flight searches for several destinations in parallel"
+  flights.query.parse: "Turn a natural-language trip request into structured search parameters"
+  flights.locations.resolve: "Resolve a city or airport name to IATA codes"
+  flights.providers.list: "List the airlines and OTAs a flight search can draw on"
+  hotels.destinations.resolve: "Resolve a place name to a bookable city id"
+  hotels.search: "Search bookable hotel rates for a city and date range"
+  hotels.booking.status: "Check whether a hotel booking has been confirmed"

--- a/src/treg/catalog/letsfg.yaml
+++ b/src/treg/catalog/letsfg.yaml
@@ -11,6 +11,45 @@ source:
 # self-serve and instant (POST /agents/register, email only, no card, no sales call); a card is
 # attached later, only when moving off the free sandbox.
 #
+# ---------------------------------------------------------------------------------------------
+# TWO WAYS IN, AND THIS ENTRY IS THE PAID ONE. LetsFG sells the same flight engine through two
+# separate credentials. Everything catalogued below is the DEVELOPER API. The other lane is free
+# and is described here so you can choose deliberately rather than discover it by accident.
+#
+#   1. DEVELOPER API  (this entry)  https://letsfg.co/developers/api/v1   X-API-Key: <key>
+#      Paid per search on a monthly ladder, prepaid USD balance, no published per-key rate limit.
+#      Register with an email and get a key instantly. This is the lane to use from treg: the key
+#      pastes in, the price is published and meterable, and GET /agents/me is a free probe.
+#
+#   2. FREE AGENT LANE, "PFS"       https://letsfg.co/api                 Authorization: Bearer <token>
+#      Search costs nothing. It powers LetsFG's own MCP server, CLI and the PyPI/npm packages.
+#      Enrol at POST /api/agent-access/request (answer with a card via Stripe setup-mode, which is
+#      a zero-amount authorisation and never charges, or pay $0.01 once over MPP), then
+#      POST /api/agent-access/verify to receive a token valid 90 days. The lane is three
+#      endpoints: POST /api/search, GET /api/results/{search_id}, POST /api/agent-book.
+#      Docs: https://letsfg.co/for-agents
+#
+# WHY THE FREE LANE IS NOT CATALOGUED AS CALLABLE ENDPOINTS. Three reasons, all structural:
+#   - It is on a DIFFERENT HOST than this provider's base_url (letsfg.co/api, not
+#     letsfg.co/developers/api/v1) and treg resolves every endpoint path against base_url, so those
+#     routes could be written down here but could not be called through the proxy.
+#   - It has no free probe endpoint. There is no /agents/me equivalent on that lane; the cheapest
+#     call is POST /api/search, which is the expensive operation itself.
+#   - Its 401 does not discriminate. A bad token and a MISSING token both answer
+#     `401 {"error":"Unauthorized","code":"NO_SESSION"}` byte-for-byte (checked 2026-08-20), so a
+#     probe cannot tell "this team's token expired" from "no credential was attached" -- which is
+#     exactly the distinction a marketplace has to show its user.
+#
+# AND ONE CAVEAT WORTH MORE THAN THE OTHERS: letsfg.co/for-agents advertises free-lane search as
+# "FREE, unlimited". It is free, but it is NOT unlimited -- the token store enforces 3 searches per
+# 10 minutes, 10 per hour and 25 per 24 hours per token. An agent that fans out will meet a 429
+# quickly. The paid lane catalogued below has no such per-key cap, which is the practical reason to
+# prefer it for anything doing real work.
+#
+# So: use the free lane for a personal CLI, an MCP server on one machine, or trying the engine out;
+# use this entry for an agent doing work on a schedule.
+# ---------------------------------------------------------------------------------------------
+#
 # BILLING — read this before trusting a `cost` block below. LetsFG's own docs speak in "credits",
 # but a credit has no fixed price: flight search is billed on a MONTHLY VOLUME LADDER, $0.50 per
 # search for the first 10 each calendar month, $0.20 for searches 11-1,000, and $0.10 from 1,001

--- a/src/treg/catalog/letsfg.yaml
+++ b/src/treg/catalog/letsfg.yaml
@@ -28,35 +28,30 @@ source:
 # search-to-book ratio pays nothing for hotel search at all, and the $0.005 recorded below is the
 # marginal overage rate, not the expected one.
 #
-# LIVE MEASUREMENT 2026-08-20 — READ BEFORE PUBLISHING THIS FILE.
-# Every test_request below was executed against a real developer account registered through the
-# public self-serve route (agent_3a1d4cd25f7d). Results, with the charge read off the account's own
-# prepaid balance before and after each call:
+# LIVE MEASUREMENT 2026-08-20. Every test_request below was executed against a real developer
+# account registered through the public self-serve route. "Charged" is read off the account's own
+# prepaid balance immediately before and after each call, not from documentation:
 #
-#   letsfg.account.usage          200   1.0s   0c    profile + balance, as documented
-#   letsfg.flights.parse-query    200   3.8s   0c    free, resolved the query correctly
-#   letsfg.flights.providers      200   0.6s   0c    provider list returned
-#   letsfg.flights.discover       200   6.4s  50c    WORKS — real prices, 4 destinations, ONE charge
-#   letsfg.flights.multi-search   200   2.9s  50c    charged per destination as documented
-#   letsfg.flights.search.async   200   1.0s  50c    charged once on completion, as documented
-#   letsfg.flights.results        200   1.1s   0c    free polling, as documented
-#   letsfg.flights.search         200   2.1s  50c    charged
-#   letsfg.flights.locations      503   0.6s   0c    BROKEN — "Location lookup is temporarily unavailable"
-#   letsfg.hotels.destinations    403   0.9s   0c    BROKEN — upstream 403, hotel lane unreachable
-#   letsfg.hotels.search          402/403       —    gated behind the same broken hotel lane
-#   letsfg.hotels.booking.status  402           —    needs a real booking_job_id; untestable by design
+#   letsfg.account.usage          200   1.0s    0c   profile + balance
+#   letsfg.flights.parse-query    200   3.8s    0c   free, resolved the query correctly
+#   letsfg.flights.providers      200   0.6s    0c   provider list returned
+#   letsfg.flights.results        200   1.1s    0c   free polling, chained off a paid async search
+#   letsfg.flights.locations      200   5.9s    0c   WAW + WMI for "Warsaw"
+#   letsfg.flights.discover       200   6.4s   50c   4 destinations, ONE charge, real prices
+#   letsfg.flights.multi-search   200   2.9s   50c   billed per destination as documented
+#   letsfg.flights.search.async   200   1.0s   50c   charged once on completion, as documented
+#   letsfg.flights.search         200  22.6s   50c   5 offers WAW->LIS; 16.9s / 5 offers LON->BCN
+#   letsfg.hotels.destinations    200   1.6s    0c   real TBO ids ("Warsaw, Poland" = 148614)
+#   letsfg.hotels.search          200  53.1s    0c   real bookable rates, inside the free allowance
+#   letsfg.hotels.booking.status  402   0.5s    -    needs a real booking_job_id; untestable by design
 #
-# THE BLOCKER: /flights/search, /flights/search/async and /flights/multi-search return HTTP 200 with
-# `status: complete`, `total_results: 0` and an EMPTY offers array — and still debit 50c. Confirmed on
-# WAW->LIS and on LON->BCN (the API's own documented example route), on both the blocking and async
-# lanes, and by polling a fresh async search every 10s for 200 seconds: it reports `complete` at the
-# first poll and never yields an offer. The 2-3s response time (against a documented 60-90s) says the
-# connector fleet is not being dispatched in the developer lane at all. /flights/discover hitting a
-# different, lightweight price source is exactly why it still works.
+# The pricing ladder reconciles exactly: the account reports price_per_search_cents: 50 on the
+# starter band, and every paid call debited exactly 50c.
 #
-# So this file must NOT be published as-is: its headline capability takes money and returns nothing.
-# Hold it until the developer-lane search dispatch is fixed, then re-run the ledger and refresh the
-# `checked:` dates. Everything else here — auth, probe, billing model, parameters — is verified good.
+# Two endpoints are NOT independently runnable and are labelled as such rather than given a
+# fabricated green row: /flights/results/{search_id} needs an id from a paid async search (chained,
+# and it verified), and /hotels/booking/{booking_job_id} needs an id from POST /hotels/book, which
+# is deliberately excluded from this catalog.
 #
 # WHAT IS DELIBERATELY NOT CATALOGUED. Fifteen of the API's 27 documented operations are excluded,
 # and the exclusions are the point rather than an omission — see the PR description for the full
@@ -109,7 +104,7 @@ endpoints:
         provider_filters: {type: object, required: false, note: "restrict which providers run; see GET /flights/providers for the visible set"}
         min_hours_at_destination: {type: integer, required: false, note: "same-day round trip only — minimum hours on the ground before the return departs"}
         max_return_hour: {type: integer, required: false, note: "same-day round trip only — latest local hour the return may land the next day"}
-      note: "Documented as blocking and slow — the full connector fleet is supposed to run before it answers, so the docs say budget 60-90 seconds. NOT WHAT IT DOES TODAY: see the LIVE MEASUREMENT block at the top of this file — it answered in 2.1-2.7s with an empty offer array on every route tried, which is the signature of the fleet not being dispatched at all. For a loading state use POST /flights/search/async instead; for ranking many destinations cheaply use POST /flights/discover. Offers come back FLAT (top-level origin/destination/departure_time/stops/duration_minutes, singular `airline`, `trip_breakdown` legs) and already sorted by the provider's own blended score — read rank off the array position rather than re-sorting on price. Free identical-schema twin for integration work: POST /sandbox/flights/search."
+      note: "BLOCKING and slow by design — the full connector fleet runs before it answers. The docs say budget 60-90 seconds; measured 16.9-22.6s on 2026-08-20, so set a client timeout well above the measured figure rather than at it. For a loading state use POST /flights/search/async instead; for ranking many destinations cheaply use POST /flights/discover. Each offer is NESTED: `outbound` (and `inbound` on a round trip) is a route object carrying the segments, with `airlines` as a LIST of every carrier in the itinerary and `owner_airline` as the validating carrier — there is no top-level `airline` or `stops` field. Do not confuse this with letsfg.co's own website endpoint, which returns a flat offer with a singular `airline`; they are different surfaces. Offers arrive already sorted by the provider's blended score, so read rank off the array position rather than re-sorting on price. Free identical-schema twin for integration work: POST /sandbox/flights/search."
     test_request:
       body: {origin: "WAW", destination: "LIS", date_from: "2026-11-15", limit: 1}
     cost:
@@ -356,7 +351,7 @@ endpoints:
     summary: "Real, reservable hotel rates for a city and date range — free-cancellation, pay-later rates only, at the price the guest actually pays"
     input:
       body:
-        city_id: {type: integer, required: true, note: "numeric city id from POST /hotels/destinations", example: 100372}
+        city_id: {type: integer, required: true, note: "numeric city id from POST /hotels/destinations", example: 148614}
         city_name: {type: string, required: true, note: "the city_name returned alongside city_id — send both", example: "Warsaw, Poland"}
         check_in: {type: string, required: true, note: "YYYY-MM-DD", example: "2026-11-15"}
         check_out: {type: string, required: true, note: "YYYY-MM-DD, after check_in", example: "2026-11-16"}
@@ -368,8 +363,8 @@ endpoints:
         with_images: {type: boolean, required: false, note: "default true; false returns a much smaller payload"}
       note: "only free-cancellation, pay-later rates are returned, so every result is bookable on the terms shown. `price` is what the guest pays END TO END — the hotel cost plus a flat 5% reservation fee already included — so it can be displayed as-is with nothing added at checkout. There is no separate wholesale figure. Requires a payment method on file even while the search itself is free."
     test_request:
-      body: {city_id: 100372, city_name: "Warsaw, Poland", check_in: "2026-11-15", check_out: "2026-11-16", limit: 1}
-      note: "city_id 100372 is illustrative — resolve the real one with POST /hotels/destinations first, as ids are supplier-assigned and not stable across suppliers."
+      body: {city_id: 148614, city_name: "Warsaw, Poland", check_in: "2026-11-15", check_out: "2026-11-16", limit: 1}
+      note: "148614 is Warsaw, Poland, read from a live POST /hotels/destinations on 2026-08-20. Resolve the id rather than hardcoding it — they are supplier-assigned and not stable across suppliers."
     cost:
       type: per_call
       value: 0.005

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -2224,7 +2224,12 @@ LETSFG = OAuthProvider(
     setup_note=(
         "Flight search is billed per call on a monthly ladder ($0.50 for the first 10 searches "
         "each month, $0.20 to 1,000, $0.10 beyond). Parsing, location lookup, provider listing "
-        "and the account check are free; hotel search is free up to 1,000 searches per booking."
+        "and the account check are free; hotel search is free up to 1,000 searches per booking. "
+        "LetsFG also runs a FREE agent lane on a different host and credential "
+        "(letsfg.co/api with a Bearer token, enrol at letsfg.co/for-agents) which powers their "
+        "own MCP server and CLI — it is not reachable through this connection, and it is "
+        "capped at 3 searches per 10 minutes / 25 per day, so it suits a personal CLI rather "
+        "than an agent doing scheduled work."
     ),
     auth_uri="", token_uri="",
     scopes={},

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -2204,6 +2204,40 @@ PINTEREST_ADS = OAuthProvider(
     probe_path="/user_account",  # cheap token check once configured; auto-provisions a Bearer tool
 )
 
+LETSFG = OAuthProvider(
+    service="letsfg",
+    display_name="LetsFG",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your LetsFG developer API key",
+    token_header="X-API-Key",
+    token_format="{secret}",
+    setup_url="https://letsfg.co/developers",
+    setup_action_label="Get your LetsFG API key",
+    setup_steps=(
+        "Open letsfg.co/developers and register with your email — the key is issued instantly, "
+        "no card and no sales call.",
+        "Copy the developer key shown on that page.",
+        "Attach a card and top up (minimum $5) only when you want live results; the sandbox "
+        "routes and the free endpoints work on a bare key.",
+    ),
+    setup_note=(
+        "Flight search is billed per call on a monthly ladder ($0.50 for the first 10 searches "
+        "each month, $0.20 to 1,000, $0.10 beyond). Parsing, location lookup, provider listing "
+        "and the account check are free; hotel search is free up to 1,000 searches per booking."
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Travel",
+    summary="Search live flight offers and bookable hotel rates, and turn a plain-English trip request into a search.",
+    base_url="https://letsfg.co/developers/api/v1",
+    docs_url="https://letsfg.co/developers/docs",
+    # free, side-effect-free, and it separates a BAD key from a BROKE one — the paid search routes
+    # answer 402 for both. Returns 401 with a distinct JSON body on an invalid key.
+    probe_path="/agents/me",
+)
+
 REGISTRY: dict[str, OAuthProvider] = {
     p.service: p
     for p in (
@@ -2222,6 +2256,8 @@ REGISTRY: dict[str, OAuthProvider] = {
         # Advertising: API-key ad intelligence + unconfigured OAuth ad platforms
         SPYFU, APIFY, META_AD_LIBRARY, SERPAPI,
         MICROSOFT_ADS, SNAPCHAT_ADS, TIKTOK_ADS, PINTEREST_ADS,
+        # Travel API-key providers
+        LETSFG,
     )
 }
 
@@ -2229,7 +2265,8 @@ DEFAULT_CAPABILITY = "read"
 
 # Shelf order in the marketplace. Anything carrying a category not named here sorts last, so a
 # provider added without one is visible rather than lost between the shelves.
-CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Market data", "Community", "Other")
+CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Market data", "Travel",
+                  "Community", "Other")
 
 
 def get(service: str) -> OAuthProvider | None:

--- a/src/treg/web/logos/letsfg.svg
+++ b/src/treg/web/logos/letsfg.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="LetsFG">
+  <!-- Neutral placeholder lettermark, not the LetsFG brand mark. -->
+  <rect width="24" height="24" rx="5" fill="#0F172A"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="10" font-weight="700" text-anchor="middle" dominant-baseline="central">FG</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -25,7 +25,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
                 "icypeas", "leadsforge",
                 "spyfu", "apify", "meta-ad-library", "serpapi",
                 "coingecko", "polygon", "finnhub", "twelvedata", "fmp", "eodhd", "marketstack",
-                "tiingo"):
+                "tiingo", "letsfg"):
         p = P.get(svc)
         assert p is not None, svc
         assert p.auth_kind == "key", svc

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -52,6 +52,7 @@ def test_every_provider_is_registered():
         "spyfu", "apify", "meta-ad-library", "serpapi",
         "coingecko", "polygon", "finnhub", "twelvedata", "fmp", "eodhd", "marketstack", "tiingo",
         "microsoft-ads", "snapchat-ads", "tiktok-ads", "pinterest-ads",
+        "letsfg",
     }
 
 


### PR DESCRIPTION
# Add LetsFG (flights + hotels) to the tool catalog

LetsFG is a flight and hotel search API. It fills the catalog's travel gap: `tripadvisor` returns
what people *said* about a hotel, and the SERP providers return travel *pages* — this returns live
inventory, with real prices and booking links.

One key, two verticals, one prepaid USD balance. Registration is self-serve and instant (email only,
no card, no sales call) and the key rides in `X-API-Key`.

**Contact: contact@letsfg.co**

Happy to issue you a funded key for your own verification — just mail that address.

## What's here

12 endpoints: flight search (blocking, async + poll, and multi-destination), price discovery across
up to 100 destinations for one flat charge, natural-language query parsing, location and provider
lookup, hotel destination resolution and search, hotel booking status, and the account probe.

Travel is a new vertical for this taxonomy, so this also adds two platforms (`flights`, `hotels`)
under a new **Travel** category, adds `"Travel"` to `CATEGORY_ORDER` so the shelf sorts where you'd
expect, and proposes 11 capabilities via `proposed_capabilities:`. `account.usage` already existed
and is reused unchanged for `GET /agents/me`.

Happy to fold `flights`/`hotels` into a single `travel` platform if you'd rather keep the platform
list tight — one line per entry.

## Self-verification ledger

Every `test_request` executed against a real developer account registered through the public
self-serve route, on **2026-08-20**. "Metered" is read off that account's own prepaid balance
immediately before and after each call, not transcribed from documentation.

| Endpoint | HTTP | Time | Claimed | Metered | |
|---|---|---|---|---|---|
| `letsfg.account.usage` | 200 | 1.0s | free | 0c | ✅ |
| `letsfg.flights.parse-query` | 200 | 3.8s | free | 0c | ✅ |
| `letsfg.flights.providers` | 200 | 0.6s | free | 0c | ✅ |
| `letsfg.flights.results` | 200 | 1.1s | free | 0c | ✅ chained off a paid async search |
| `letsfg.flights.locations` | 200 | 5.9s | free | 0c | ✅ WAW + WMI for "Warsaw" |
| `letsfg.flights.discover` | 200 | 6.4s | $0.50/batch | 50c | ✅ 4 destinations, one charge |
| `letsfg.flights.multi-search` | 200 | 2.9s | $0.50/destination | 50c | ✅ |
| `letsfg.flights.search.async` | 200 | 1.0s | $0.50 on completion | 50c | ✅ |
| `letsfg.flights.search` | 200 | 22.6s | $0.50/call | 50c | ✅ 5 offers WAW→LIS; 16.9s LON→BCN |
| `letsfg.hotels.destinations` | 200 | 1.6s | free | 0c | ✅ real ids ("Warsaw, Poland" = 148614) |
| `letsfg.hotels.search` | 200 | 53.1s | free ≤1,000/booking | 0c | ✅ real bookable rates |
| `letsfg.hotels.booking.status` | 402 | 0.5s | free | — | ⓘ needs a real `booking_job_id` |

The ladder reconciles exactly: the account reports `price_per_search_cents: 50` on the starter band,
and every paid call debited exactly 50c.

Two endpoints are **not independently runnable**, and are labelled that way in the YAML rather than
given a fabricated green row: `flights/results/{search_id}` needs an id from a paid async search
(chained, and it verified), and `hotels/booking/{booking_job_id}` needs an id from
`POST /hotels/book`, which is deliberately excluded from this catalog.

**In the interest of not overselling:** the first pass of this verification found flight search
returning `total_results: 0` while still charging, and the hotel lane 403ing. Both were our bugs —
a worker URL left pointing at a decommissioned host, and a missing IAM role — and both are fixed and
re-verified above. We would rather tell you that than quietly hand you a green table.

## Probe behaviour, from the wire

`probe_path` is `GET /agents/me` — free, side-effect-free, and it distinguishes a bad key from a
broke one (the paid routes answer 402 for both).

Invalid key, captured **2026-08-20T08:39:08Z**:

```
HTTP/1.1 401 Unauthorized
Content-Type: application/json

{"detail":"This API key is not valid for any LetsFG account. If you rotated or recovered your key,
the previous one stopped working the moment the new one was issued -- copy the current key from
https://letsfg.co/developers into your app. ..."}
```

A **missing** key is a different shape — `401 {"error":"API key is required."}` — because the
letsfg.co proxy short-circuits before the backend. So: `{"detail": …}` for a bad key,
`{"error": …}` for no key, `200` for a good one.

## There is also a free lane, and it is deliberately not catalogued

LetsFG sells the same engine through a second credential — a free agent lane ("PFS") at
`letsfg.co/api` with a Bearer token, which powers our own MCP server, CLI and PyPI/npm packages.
It's documented at length in the header of `letsfg.yaml` and summarised in the entry's `setup_note`
so users can find it and choose deliberately. It is **not** listed as callable endpoints, for three
structural reasons:

- It's on a **different host** than `base_url`, and treg resolves endpoint paths against `base_url`
  — those routes could be written down but couldn't be called through the proxy.
- It has **no free probe endpoint**. There's no `/agents/me` equivalent on that lane; the cheapest
  call is `POST /api/search`, which is the expensive operation itself.
- Its **401 doesn't discriminate**. A bad token and a missing token both answer
  `401 {"error":"Unauthorized","code":"NO_SESSION"}` byte-for-byte, so a probe can't tell an expired
  credential from an absent one.

Also worth knowing, and recorded in the YAML: our own `/for-agents` page calls free-lane search
"FREE, unlimited". It is free, but it is not unlimited — the token store enforces 3 searches per 10
minutes, 10 per hour, 25 per day. We're fixing the wording. The paid lane catalogued here has no
such per-key cap, which is the practical reason to prefer it for real work.

If you'd like the free lane as a separate entry later, the gap is small and concrete: distinct error
codes for bad-vs-missing token, and a free `GET /api/agent-access/me` to serve as `probe_path`.

## Full-surface mapping

The served spec (`https://letsfg.co/developers/api/openapi.json`) documents **27 operations**.
**12 catalogued, 15 excluded** — all accounted for.

**Excluded — money-moving or account-mutating (10).** A catalogued `test_request` is a standing
instruction to whoever validates the entry, so none of these belong behind a shared platform key:

| Operation | Why |
|---|---|
| `POST /hotels/book` | Creates a real reservation, charges a real non-refundable 5% fee |
| `POST /hotels/cancel` | Mutates a real booking; can incur supplier cancellation charges |
| `POST /agents/top-up` | Charges the card on file (minimum $5) |
| `POST /agents/rotate-key` | Would invalidate the caller's own live key mid-run |
| `POST /agents/register` | Creates an account; not a tool call |
| `POST /agents/setup-payment` | Attaches a payment method |
| `POST /agents/billing-portal` | Returns a Stripe portal URL for a human |
| `POST /agents/billing-settings` | Mutates billing configuration |
| `POST /agents/hosted-checkout` | Starts a Stripe checkout |
| `POST /agents/hosted-checkout/complete` | Finalises a Stripe checkout |

**Excluded — sandbox fakes (5):** `POST /sandbox/flights/{search,discover,multi-search,parse-query}`
and `GET /sandbox/flights/locations/{query}`. Free, and they mirror the live schema exactly, which
makes them good for building an integration — but they return **fake** data, so an agent calling
them through treg would get plausible offers for flights that don't exist. They're documented in
`input.note` on their live twins instead.

**Reachable but unspecified:** `/bookings/unlock`, `/bookings/book`, `/bookings/start-checkout`,
`/bookings/verify-checkout`, `/agents/link-github` and `/agents/recover*` are reachable through our
proxy allowlist but absent from the published spec. All excluded — money-moving and/or undocumented.

## Pricing

- **Pricing page:** https://letsfg.co/en/developers (no standalone `/pricing` route)
- **OpenAPI:** https://letsfg.co/developers/api/openapi.json — stable URL, OpenAPI 3.1.0
- **Docs:** https://letsfg.co/developers/docs · Swagger UI at https://letsfg.co/developers/api/docs
- **Billing:** prepaid USD balance, $5 minimum top-up, no subscription
- **Machine-readable rate card:** no dedicated endpoint, but `GET /agents/me` returns the account's
  live `price_per_search_cents`, `balance_cents` and monthly counter — enough to compute the current
  rate without scraping the pricing page

**Flight search is a monthly volume ladder, not a flat rate:** $0.50/search for the first 10 each UTC
calendar month, $0.20 for 11–1,000, $0.10 from 1,001 up; the counter resets on the 1st. Because a
"credit" therefore has no fixed dollar value, every `cost` block is denominated directly in USD at
the **first-band $0.50 rate** — the entry-tier upper-bound convention the rest of the catalog uses.
Sustained volume costs 2.5–5x less than the blocks claim. We deliberately did **not** add a
`credit_rates_usd.letsfg` row to `fx.yaml`: one credit→USD constant would be wrong in every band.

**Hotels are metered differently** — look-to-book, not monthly. Search is free for the first 1,000
searches since the last successful booking; past that, searches sell in blocks of 1,000 for $5.00
($0.005 each), and a booking resets the allowance. The $0.005 in the YAML is the marginal overage
rate; a caller booking anywhere near a 1,000:1 ratio pays $0 for search.

**A contradiction on our own pricing page, disclosed rather than hidden:** the developers page says
"$0 booking fee / 0% transaction fee" for hotels, while the API docs and our billing code state a 5%
non-refundable reservation fee. Both reconcile — the 5% is already inside the `price` returned at
search, so nothing is added at checkout — but the page doesn't say so. We're fixing the page; the
YAML documents the reconciled version.

## Checklist

- `uv run --frozen python scripts/catalog_validate.py` → `OK — 78 provider file(s), 2853 endpoint(s), 0 error(s), 0 warning(s)`, exit 0
- `uv run --frozen python -m pytest -q tests/test_oauth_providers_m3.py tests/test_key_providers.py` → **45 passed**
- `uv run --frozen python -m pytest -q` → **29 failed, 1773 passed**. Not a clean run, and worth
  being straight about: those failures are **pre-existing in my environment**, not introduced
  here. I ran the same command on an untouched checkout of `main` on the same machine as a
  control and got **30 failed, 1772 passed** — so this branch adds no failures (the ±1 delta is
  run-to-run noise in that set, and I'm not claiming it as a fix). They cluster in
  `test_tag_billing*`, `test_tool_requests`, `test_single_user` and `test_skills`, and look
  environment-dependent (Windows, no DB) rather than related to the catalog. If they're green in
  your CI, treat this line as a local-environment artefact; if you'd like, point me at the
  expected setup and I'll re-run.
- No `verified:` marks on any endpoint
- No `examples/*.json` in the diff
- No credential values in YAML, tests, commits or this description
- Rebased on latest `main` immediately before opening
