### PR TITLE
feat(catalog): search-friendly names for all 2,600 endpoints + the algorithm fixes they exposed

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -299,6 +299,32 @@ Three things follow, and they are the whole point of the field:
 
 `catalog_validate.py` only checks the value when present: a stated `kind` must be one of the four.
 
+### Naming — `name` is the search surface we own
+
+`summary` is the provider's text, verbatim; `name` is OURS, and since 2026-08-20 it is searched
+(same weight as summary). That makes it the one per-endpoint field where curation may put the
+words agents type. The formula: **job + the input the caller must hold + top output facets**, ≤60
+characters, and it must read as a natural title — it is the row heading on every surface.
+
+    Linkedin: get company profile (web_v2)   ->  LinkedIn company profile by URL or slug — headcount, industry
+    Get user profile                         ->  TikTok user profile by username — followers, bio, stats
+
+The rules (applied catalog-wide in the 2026-08-20 rewrite; every new provider follows them):
+
+1. Name the JOB in task words — never the vendor's operation title or version codes.
+2. Say the INPUT ("by name", "by domain", "by ASIN", "by LinkedIn URL"). Agents search by what
+   they hold; only the caller knows its inputs — that doctrine applies to naming too.
+3. Say the top OUTPUTS when people search by them ("headcount", "reviews", "hiring signal").
+4. One concept, one word, catalog-wide: always "postings", never sometimes "vacancies";
+   `aliases.yaml` covers the agent's side, our side must be consistent.
+5. Prefer the longer word form — "postings" contains "posting"; substring matching never works
+   backward.
+6. No dead words: "API", "data", "get", "fetch", "endpoint" are soft tokens worth nothing.
+7. No stuffing. If it does not read as a title, it is wrong. Overflow vocabulary belongs in the
+   capability description (weight 3, shared by the group) or `aliases.yaml`, never in the name.
+8. TRUTH over vocabulary: derive the name only from the row's own summary, path and input fields.
+   A name claiming an output the endpoint does not return is a lie an agent will spend money on.
+
 ### Cost — the file keeps the billing unit, the server computes USD
 
 A `cost` block stays in whatever unit the PROVIDER bills in; that is the number that stays correct

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -861,15 +861,27 @@ idf — "by" matches 558 endpoints and is worth ~nothing, "postings" matches 4 a
 That asymmetry is also what keeps the miss allowance safe: dropping a rare word costs more score
 than dropping filler, so full-match fluff cannot outrank a near-match on substance. Rows matching
 the same tokens in the same fields still sum identical floats, so the tie band below keeps working.
-Two query-side layers close what scoring alone cannot. Function words ("on", "this", "what") are
-dropped before the miss allowance is computed — they select nothing, but each one raised the number
-of real words a row had to match. And `aliases.yaml` bridges vocabulary: substring containment only
-works in one direction, so "cryptocurrency" never finds the catalog's "crypto" without the map. A
-token matches under its own spelling or any curated alias, same field weight. The file is
+Query-side layers close what scoring alone cannot. Function words ("on", "this", "what") and
+single-letter tokens ("K&L" tokenizes to k + l, df 2,000+) are dropped before the miss allowance is
+computed — they select nothing, but each one raised the number of real words a row had to match.
+Tokens matching over `SOFT_DF_SHARE` (25%) of the catalog ("data" 33%, "api" 50%, "get" 40%) are
+SOFT: they still add score where they match, but a row is never punished for missing them — a
+statistical stopword list no hand list would keep up with. And `aliases.yaml` bridges vocabulary:
+substring containment only works in one direction, so "cryptocurrency" never finds the catalog's
+"crypto" without the map. A token matches under its own spelling or any curated alias, same field
+weight. NOUNS ONLY: aliasing a verb to a commoner verb poisons the key (`lookup: [search, find]`
+inflated lookup's match set 27 → 689 endpoints and destroyed its ranking power). The file is
 query-side only — it rewrites no provider text, survives every re-ingest, and the validator
 (`check_aliases`) rejects entries that could not survive the tokenizer and warns on aliases whose
 target occurs nowhere in the catalog. The SearchMiss log is its feed: a zero-result query whose
 words name an existing endpoint in different vocabulary is one row here.
+
+A zero-result answer surfaces its `near_misses` — the rows that just missed the admission gate,
+with the exact words each one matched and missed ("apollo.companies.jobs matches job, hiring,
+signal; misses law, firm"). The matcher had already computed this; discarding it and answering
+with prose was the least useful thing the data allowed. Served structured over MCP (`near`), in
+the HTTP route's `near` + a hint line, and as "almost:" lines in the CLI — the caller is usually
+an LLM, and told exactly what to drop it re-queries correctly on the next call.
 
 `scripts/search_bench.py` is the labeled replay (30 agent-shaped queries): sentence-style hit@8 went
 14% → 100% (hit@1 64%, MRR .766) with the 8 short-query regression rows byte-identical. The residue

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -902,6 +902,12 @@ query-side only — it rewrites no provider text, survives every re-ingest, and 
 target occurs nowhere in the catalog. The SearchMiss log is its feed: a zero-result query whose
 words name an existing endpoint in different vocabulary is one row here.
 
+A query token that IS a platform slug ("tiktok", "linkedin") is the caller's hard filter, but idf
+prices it low — half the catalog serves the big platforms — so rows matching a rarer facet word
+("followers") outranked rows matching the asked-for platform. Platform-slug tokens therefore score
+DOUBLE where they match; rows matching the same tokens in the same fields still sum identical
+floats, so the tie band survives.
+
 A zero-result answer surfaces its `near_misses` — the rows that just missed the admission gate,
 with the exact words each one matched and missed ("apollo.companies.jobs matches job, hiring,
 signal; misses law, firm"). The matcher had already computed this; discarding it and answering

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -220,8 +220,11 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   capability_description, platform, platform_label, score}`. Ranking is plain token containment
   (`catalog_store.search`, no deps, no embeddings): **most** query tokens must match — a query may miss
   one token in three, so a second word still narrows (1–2 words: all required) while an agent's
-  seven-word sentence survives its filler. Function words are dropped first, and a token also matches
-  through its `aliases.yaml` synonyms ("cryptocurrency" → "crypto"), at the same weight. Each matched
+  seven-word sentence survives its filler. Function words, single letters and tokens matching >25%
+  of the catalog are never REQUIRED (the last still score where they match), and a token also matches
+  through its `aliases.yaml` synonyms ("cryptocurrency" → "crypto"), at the same weight. A
+  zero-result answer carries `near` — the rows just under the gate and the exact unmatched words —
+  over MCP, the HTTP route, and as "almost:" lines in `treg catalog search`. Each matched
   token scores its best field weight — capability id/description + platform label/slug (3) >
   summary (2) > id/path/provider (1) — times its BM25 idf, so rare words decide the order. Ties —
   still the COMMON case, since rows matching the same tokens in the same fields sum identical

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -226,7 +226,8 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
   zero-result answer carries `near` — the rows just under the gate and the exact unmatched words —
   over MCP, the HTTP route, and as "almost:" lines in `treg catalog search`. Each matched
   token scores its best field weight — capability id/description + platform label/slug (3) >
-  summary (2) > id/path/provider (1) — times its BM25 idf, so rare words decide the order. Ties —
+  summary (2) > id/path/provider (1) — times its BM25 idf, so rare words decide the order (a
+  platform-slug token scores double where it matches — the platform is the caller's hard filter). Ties —
   still the COMMON case, since rows matching the same tokens in the same fields sum identical
   floats — are then settled by `catalog_store.rerank()` over
   the band `rank_band()` returns (the whole equal-scoring group at the cut, capped at `RERANK_BAND`

--- a/scripts/search_bench.py
+++ b/scripts/search_bench.py
@@ -108,7 +108,9 @@ CASES = [
       "predictleads.companies.job_openings", "predictleads.jobs.discover"}),
     ("sentence", "K&L Gates company lookup", "family:companies.enrich"),
     ("sentence", "resolve company name to linkedin slug",
-     {"scrapecreators.x.v1-linkedin-company", "apollo.companies.enrich"}),
+     {"scrapecreators.x.v1-linkedin-company", "apollo.companies.enrich",
+      "leadsforge.people.identity.resolve.bulk", "fiber-ai.people.identity.resolve",
+      "icypeas.people.identity.resolve"}),
     # -- short: the refinement style the old rule served well (regression guard) --
     ("short", "tiktok comments", "family:tiktok comment"),
     ("short", "ad library",

--- a/scripts/search_bench.py
+++ b/scripts/search_bench.py
@@ -103,6 +103,12 @@ CASES = [
       "justoneapi.x.amazon-get-product-detail-v1"}),
     ("sentence", "trending repositories on github this week",
      {"scrapecreators.x.v1-github-trending-repositories"}),
+    ("sentence", "law firm job openings hiring signal",
+     {"apollo.companies.jobs", "leadmagic.x.jobs-search-v3", "apify.linkedin.search.jobs",
+      "predictleads.companies.job_openings", "predictleads.jobs.discover"}),
+    ("sentence", "K&L Gates company lookup", "family:companies.enrich"),
+    ("sentence", "resolve company name to linkedin slug",
+     {"scrapecreators.x.v1-linkedin-company", "apollo.companies.enrich"}),
     # -- short: the refinement style the old rule served well (regression guard) --
     ("short", "tiktok comments", "family:tiktok comment"),
     ("short", "ad library",

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -608,7 +608,17 @@ async def catalog_search(q: str = "", limit: int = 25,
             # by nothing in particular — say so instead of letting it read as a ranked answer.
             hints.append(f"{q!r} matches too broadly to rank on measured reliability past the first "
                          f"{catalog_store.RERANK_BAND} equally-scoring rows — add a word to narrow it")
-    return {"query": q, "count": len(results), "total": total, "results": results, "hints": hints}
+    out = {"query": q, "count": len(results), "total": total, "results": results, "hints": hints}
+    if not results and q.strip():
+        # the rows that JUST missed the admission gate and which words they missed — an agent (or
+        # the CLI display) turns this straight into the corrected query
+        near = catalog_store.near_misses(q, cat)
+        if near:
+            out["near"] = near
+            first = near[0]
+            hints.insert(1, f"nearest: {first['endpoint_id']} matches "
+                            f"{', '.join(first['matches'])} but not {', '.join(first['missing'])}")
+    return out
 
 
 @app.get("/catalog/endpoints/{endpoint_id}")

--- a/src/treg/catalog/akta.extended.yaml
+++ b/src/treg/catalog/akta.extended.yaml
@@ -12,7 +12,7 @@ endpoints:
   platform: companies
   method: GET
   path: /v1/company/product-reviews/
-  name: Get a company's product catalog and reviews
+  name: "Company product catalog and reviews by website — ratings"
   summary: Fetches a company's product catalog and detailed reviews per product including ratings, star distribution, pros, cons, pricing and individual review content.
   input:
     queryParams:
@@ -58,7 +58,7 @@ endpoints:
   platform: companies
   method: GET
   path: /v1/company/jobs/
-  name: Get a company's live job postings
+  name: "Company live job postings by website — LinkedIn, Indeed"
   summary: Fetches live LinkedIn and Indeed job listings for a company, including title, location, description, compensation, experience level, and extracted key skills.
   input:
     queryParams:
@@ -101,7 +101,7 @@ endpoints:
   platform: companies
   method: GET
   path: /v1/company/posts/
-  name: Get a company's social media posts
+  name: "A company's social media posts with engagement metrics"
   summary: Fetches social media posts published by a company, including content type, text, publish date, paid/repost flags, an AI classification, and detailed engagement metrics.
   input:
     queryParams:
@@ -144,7 +144,7 @@ endpoints:
   platform: companies
   method: GET
   path: /v1/company/website-traffic/
-  name: Get a company's website traffic signals
+  name: "Company website traffic — visits, sources, engagement"
   summary: Fetches a company's website traffic signals, including engagement metrics, historical monthly visit estimates, and a breakdown of traffic by acquisition source.
   input:
     queryParams:
@@ -177,7 +177,7 @@ endpoints:
   platform: companies
   method: POST
   path: /v1/company/addition-requests/
-  name: Request a missing company be added
+  name: "Request a company be added to Akta — free"
   summary: Submits a company that is not yet in akta.pro's database to be added, returning a request ID to track, or the existing company if it is already present. This is a free endpoint — it does not consume API credits.
   input:
     body:
@@ -207,7 +207,7 @@ endpoints:
   platform: companies
   method: GET
   path: /v1/status/{request_id}/
-  name: Check an async request's status
+  name: "Check an async Akta request by request id"
   summary: Returns the current status of an asynchronous request, such as a company addition request, by its request ID. This is a free endpoint — it does not consume API credits.
   input:
     pathParams:

--- a/src/treg/catalog/akta.yaml
+++ b/src/treg/catalog/akta.yaml
@@ -47,7 +47,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/company/enrichment/
-    name: "Enrich a company from its website"
+    name: "Company enrichment by website — firmographics, tech stack"
     summary: "Enrich a company from its website — firmographics, financials, tech stack, management"
     input:
       queryParams:
@@ -78,7 +78,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/company/search/
-    name: "Look up a company's Akta id"
+    name: "Company name or domain to Akta id — free lookup"
     summary: "Look up a company by name or domain for its Akta id (free — costs 0 credits)"
     input:
       queryParams:
@@ -98,7 +98,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/news/
-    name: "Get recent company or industry news"
+    name: "Recent company or industry news, scored for sentiment"
     summary: "Get recent news about a company or industry, scored for sentiment and significance"
     input:
       queryParams:
@@ -142,7 +142,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/company/headcount-trends/
-    name: "Get company headcount trends by department"
+    name: "Company headcount trend by website — department split"
     summary: "See how a company's headcount has moved over time and how staff split across departments"
     input:
       queryParams:
@@ -162,7 +162,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/company/employee-reviews/
-    name: "Get company employee reviews"
+    name: "Employee reviews and ratings for a company by website"
     summary: "Read employee reviews and ratings for a company"
     input:
       queryParams:
@@ -184,7 +184,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/industry/search/
-    name: "Resolve industry text to Akta codes"
+    name: "Resolve industry text to Akta industry codes — free"
     summary: "Turn a free-text industry description into Akta's standard industry codes (free)"
     input:
       queryParams:

--- a/src/treg/catalog/aliases.yaml
+++ b/src/treg/catalog/aliases.yaml
@@ -11,7 +11,11 @@
 # Curation rules (enforced by scripts/catalog_validate.py check_aliases):
 #   - keys and values are lowercase single words (they pass through the same tokenizer as queries);
 #   - a value must actually occur in the catalog's text, or the alias is dead weight (warning);
-#   - no self-reference.
+#   - no self-reference;
+#   - NOUNS ONLY, and the target must be a selective word. Aliasing a verb to a commoner verb
+#     poisons the key: `lookup: [search, find]` inflated lookup's match set from 27 endpoints to
+#     689 and destroyed its ranking power (found 2026-08-20). Generic verbs are the algorithm's
+#     job (soft tokens), not this file's.
 # Feed: the SearchMiss log (models.SearchMiss) — a logged zero-result query whose words name an
 # existing endpoint in different vocabulary is exactly one row here. Add the word agents USED as
 # the key, the word the catalog HAS as the value.
@@ -35,14 +39,18 @@ aliases:
   screenshot: [screen]
   # people & companies
   person: [people]
+  firm: [company]
+  firms: [company]
   employee: [employees, headcount]
   staff: [employees, headcount]
   firmographic: [company]
   firmographics: [company]
+  # jobs
+  openings: [postings]
+  opening: [postings]
+  vacancies: [postings, jobs]
+  vacancy: [postings, jobs]
   # platform shorthands agents use
   ig: [instagram]
   yt: [youtube]
   fb: [facebook]
-  # actions
-  scrape: [fetch, get]
-  lookup: [search, find]

--- a/src/treg/catalog/apify.yaml
+++ b/src/treg/catalog/apify.yaml
@@ -50,7 +50,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /actors/apify~facebook-ads-scraper/run-sync-get-dataset-items
-    name: "Search Facebook and Instagram ad library"
+    name: "Scrape the Meta ad library by Page or search URL"
     summary: "Scrape publicly running Facebook and Instagram ads for a page or Ad Library search"
     input:
       queryParams:
@@ -83,7 +83,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /actors/s-r~tiktok-ads-library/run-sync-get-dataset-items
-    name: "Search TikTok ad library by keyword"
+    name: "Scrape the TikTok ad library by keyword"
     summary: "Scrape publicly running TikTok ads from TikTok's ad library by keyword or advertiser"
     input:
       queryParams:
@@ -122,7 +122,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /actors/harvestapi~linkedin-job-search/run-sync-get-dataset-items
-    name: "Search LinkedIn job postings"
+    name: "LinkedIn job postings by title, company or location"
     summary: "Scrape LinkedIn job postings by title, company, location or filters — the hiring-signal search that also answers 'what is this company hiring for' via the company filter"
     input:
       queryParams:
@@ -157,7 +157,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /actors/{actor_id}/runs
-    name: "Start a background scraper run"
+    name: "Start an Apify actor run in the background"
     summary: "Start a scraper run in the background and get back its run id"
     input:
       pathParams:
@@ -186,7 +186,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /actor-runs/{run_id}
-    name: "Check scraper run status"
+    name: "Check an Apify actor run by run id"
     summary: "Check whether a background scraper run has finished"
     input:
       pathParams:
@@ -208,7 +208,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /datasets/{dataset_id}/items
-    name: "Download scraper run results"
+    name: "Download an Apify run's results by dataset id"
     summary: "Download the results of a finished scraper run"
     input:
       pathParams:
@@ -235,7 +235,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /users/me
-    name: "Check plan and usage"
+    name: "Your Apify plan, credits and monthly limits"
     summary: "Check your Apify plan, credit usage and remaining monthly limits"
     input:
       note: "no parameters. Returns the account's plan, monthly usage in USD and the limits it is measured against — the pre-flight check before a large pay-per-result pull, and the cheapest way to prove a token is valid (a bad token 401s here)"

--- a/src/treg/catalog/apollo.yaml
+++ b/src/treg/catalog/apollo.yaml
@@ -39,7 +39,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /people/match
-    name: "Enrich a person by email or LinkedIn"
+    name: "Enrich a person by email, LinkedIn URL or name + company"
     summary: "Enrich a person from an email, LinkedIn URL or name + company — title, contact details"
     input:
       queryParams:
@@ -78,7 +78,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /mixed_people/api_search
-    name: "Search contacts by title, company or location"
+    name: "Search people by title, seniority, company or location"
     summary: "Search Apollo's 200M+ contacts by title, seniority, company, location or tech (free)"
     input:
       queryParams:
@@ -105,7 +105,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /organizations/enrich
-    name: "Enrich a company by domain or name"
+    name: "Enrich a company by domain, name or LinkedIn URL"
     summary: "Enrich a company from domain, name or LinkedIn — industry, headcount, revenue, funding"
     input:
       queryParams:
@@ -134,7 +134,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /mixed_companies/search
-    name: "Search companies by industry, size or tech"
+    name: "Search companies by industry or tech — headcount growth"
     summary: "Search Apollo's companies by industry, headcount, revenue, funding or technology — hits carry 6/12/24-month headcount growth, the hiring/growth signal"
     input:
       queryParams:
@@ -170,7 +170,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /organizations/{organization_id}/job_postings
-    name: "List a company's open job postings"
+    name: "A company's job postings by Apollo id — hiring signal"
     summary: "List a company's open job postings — title, location and posting dates — the direct hiring signal"
     input:
       pathParams:
@@ -204,7 +204,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /news_articles/search
-    name: "Search news about companies"
+    name: "News about a company by Apollo id — hires, funding"
     summary: "Search news articles about specific companies — hires, funding and other signal categories"
     input:
       queryParams:
@@ -239,7 +239,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /people/bulk_match
-    name: "Enrich multiple people in one batch"
+    name: "Bulk-enrich up to 10 people by email, LinkedIn URL or name"
     summary: "Enrich up to 10 people in one call, using the same identifiers as single-person enrichment"
     input:
       bodyType: json

--- a/src/treg/catalog/branddev.yaml
+++ b/src/treg/catalog/branddev.yaml
@@ -37,7 +37,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve
-    name: "Brand profile by domain"
+    name: "Brand profile by domain — logos, colors, socials, headcount"
     summary: "Retrieve logos, colors, fonts, slogan, description, socials, address, headcount and industry for a domain"
     input:
       queryParams:
@@ -60,7 +60,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve-simplified
-    name: "Brand assets by domain (logos & colors only)"
+    name: "Brand logos, colors and backdrops by domain"
     summary: "The visual half of the brand record — logos, backdrops and the color palette — without the description, socials or firmographics"
     input:
       queryParams:
@@ -81,7 +81,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve-by-name
-    name: "Brand profile by company name"
+    name: "Brand profile by company name — logos, colors, socials"
     summary: "Resolve a company name to its domain and return the full brand record — logos, colors, description, socials, industry"
     input:
       queryParams:
@@ -104,7 +104,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve-by-email
-    name: "Brand profile from a work email"
+    name: "Company brand profile by work email"
     summary: "Turn a work email address into the employer's brand record — the signup-form enrichment call"
     input:
       queryParams:
@@ -126,7 +126,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve-by-ticker
-    name: "Brand profile by stock ticker"
+    name: "Brand profile by stock ticker — logo and colors"
     summary: "Resolve a listed company's ticker to its domain and brand record — logo and colors for a portfolio or watchlist UI"
     input:
       queryParams:
@@ -148,7 +148,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/retrieve-by-isin
-    name: "Brand profile by ISIN"
+    name: "Brand profile by ISIN security identifier"
     summary: "Resolve an ISIN security identifier to the issuing company's domain and brand record"
     input:
       queryParams:
@@ -190,7 +190,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/naics
-    name: "Classify a company into NAICS codes"
+    name: "NAICS industry codes by domain or description"
     summary: "Map a domain or a free-text company description to 2022 NAICS industry codes with a confidence label"
     input:
       queryParams:
@@ -210,7 +210,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/styleguide
-    name: "Extract a website's design system"
+    name: "Extract a website's design system by domain — CSS"
     summary: "Colors, type scale, spacing, shadows and component styles (button, card, input) lifted from a live site, each with ready-to-paste CSS"
     input:
       queryParams:
@@ -231,7 +231,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/fonts
-    name: "Detect the fonts a website uses"
+    name: "Detect a website's fonts by domain — files per weight"
     summary: "Every font family a site loads, with fallback stacks, share of elements and words, and direct links to the font files by weight"
     input:
       queryParams:
@@ -252,7 +252,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /brand/screenshot
-    name: "Screenshot a company's website"
+    name: "Screenshot a company's website by domain"
     summary: "A 1920x1080 viewport or full-page PNG of a company's site, returned as a cached CDN URL"
     input:
       queryParams:
@@ -275,7 +275,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /brand/ai/query
-    name: "Ask for named datapoints about a company"
+    name: "Extract named datapoints from a company site by domain"
     summary: "Define the fields you want — name, description, type and an example each — and get them extracted from the company's own website, with the URLs used"
     input:
       body:
@@ -301,7 +301,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /brand/ai/products
-    name: "Extract a company's products and prices"
+    name: "Extract products and prices from a company site by domain"
     summary: "Build a structured product/plan catalog from a company's site — name, price, currency, billing frequency, pricing model, features, audience and URL"
     input:
       body:

--- a/src/treg/catalog/brightdata.extended.yaml
+++ b/src/treg/catalog/brightdata.extended.yaml
@@ -41,7 +41,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Detail
+  name: "Instagram post details by URL"
   summary: Instagram - Posts
   input:
     queryParams:
@@ -91,7 +91,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Comments
+  name: "Instagram post comments by post URL"
   summary: Instagram - Comments
   input:
     queryParams:
@@ -132,7 +132,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Reel Detail
+  name: "Instagram reel details by URL"
   summary: Instagram - Reels
   input:
     queryParams:
@@ -173,7 +173,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Hashtag Info
+  name: "Instagram hashtag details by hashtag page URL"
   summary: Instagram hashtag information
   input:
     queryParams:
@@ -215,7 +215,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Profile
+  name: "TikTok profile by URL"
   summary: TikTok - Profiles
   input:
     queryParams:
@@ -265,7 +265,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Video Detail
+  name: "TikTok video details by URL"
   summary: TikTok - Posts
   input:
     queryParams:
@@ -307,7 +307,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Video Comments
+  name: "TikTok video comments by video URL"
   summary: TikTok - Comments
   input:
     queryParams:
@@ -348,7 +348,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Shop Product Detail
+  name: "TikTok Shop product details by URL"
   summary: TikTok Shop
   input:
     queryParams:
@@ -390,7 +390,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Company Profile
+  name: "LinkedIn company profile by company page URL"
   summary: LinkedIn company information
   input:
     queryParams:
@@ -432,7 +432,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Detail
+  name: "LinkedIn post details by URL"
   summary: LinkedIn posts
   input:
     queryParams:
@@ -474,7 +474,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Job Listing Detail
+  name: "LinkedIn job posting details by listing URL"
   summary: Linkedin job listings information
   input:
     queryParams:
@@ -515,7 +515,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Profile
+  name: "Facebook profile or Page by URL"
   summary: Facebook - Profiles
   input:
     queryParams:
@@ -566,7 +566,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Page Posts
+  name: "Facebook Page posts by Page URL"
   summary: Facebook - Pages Posts by Profile URL
   input:
     queryParams:
@@ -607,7 +607,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Detail
+  name: "Facebook post details by post URL"
   summary: Facebook - Posts by post URL
   input:
     queryParams:
@@ -650,7 +650,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Comments
+  name: "Facebook post comments by post URL"
   summary: Facebook - Comments
   input:
     queryParams:
@@ -691,7 +691,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Marketplace Listing
+  name: "Facebook Marketplace listing by URL"
   summary: Facebook Marketplace
   input:
     queryParams:
@@ -734,7 +734,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Product Detail
+  name: "Amazon product details by product URL"
   summary: Amazon products
   input:
     queryParams:
@@ -783,7 +783,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Product Reviews
+  name: "Amazon product reviews by product URL"
   summary: Amazon Reviews
   input:
     queryParams:
@@ -825,7 +825,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Best Sellers List
+  name: "Amazon best-seller products by category URL"
   summary: Amazon best seller products
   input:
     queryParams:
@@ -866,7 +866,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Seller Profile
+  name: "Amazon seller profile by storefront URL"
   summary: Amazon sellers info
   input:
     queryParams:
@@ -908,7 +908,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Profile
+  name: "X (Twitter) profile by URL"
   summary: X (formerly Twitter) - Profiles
   input:
     queryParams:
@@ -958,7 +958,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Detail
+  name: "X (Twitter) post details by URL"
   summary: X (formerly Twitter) - Posts
   input:
     queryParams:
@@ -1000,7 +1000,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Channel Profile
+  name: "YouTube channel profile by URL"
   summary: YouTube - Channels
   input:
     queryParams:
@@ -1050,7 +1050,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Video Detail
+  name: "YouTube video details by URL"
   summary: Youtube - Videos posts
   input:
     queryParams:
@@ -1092,7 +1092,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Video Comments
+  name: "YouTube video comments by video URL"
   summary: Youtube - Comments
   input:
     queryParams:
@@ -1134,7 +1134,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Detail
+  name: "Reddit post details by thread URL"
   summary: Reddit - Posts
   input:
     queryParams:
@@ -1176,7 +1176,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Post Comments
+  name: "Reddit post comments by post URL"
   summary: Reddit - Comments
   input:
     queryParams:
@@ -1217,7 +1217,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Product Detail
+  name: "Walmart product details by product URL"
   summary: Walmart - products
   input:
     queryParams:
@@ -1259,7 +1259,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Product Reviews
+  name: "Walmart product reviews by product URL"
   summary: Walmart Reviews
   input:
     queryParams:
@@ -1301,7 +1301,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Listing Detail
+  name: "eBay listing details by URL"
   summary: eBay
   input:
     queryParams:
@@ -1343,7 +1343,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Business Profile
+  name: "Yelp business profile by page URL"
   summary: Yelp businesses overview
   input:
     queryParams:
@@ -1385,7 +1385,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Business Reviews
+  name: "Yelp business reviews by page URL"
   summary: Yelp businesses reviews
   input:
     queryParams:
@@ -1427,7 +1427,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Hotel Detail
+  name: "Tripadvisor hotel listing by URL"
   summary: Tripadvisor Hotel Listings
   input:
     queryParams:
@@ -1469,7 +1469,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Business Reviews
+  name: "Trustpilot business reviews by profile URL"
   summary: Trustpilot business reviews
   input:
     queryParams:
@@ -1511,7 +1511,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: App Detail
+  name: "Google Play app listing by URL"
   summary: Google Play Store
   input:
     queryParams:
@@ -1560,7 +1560,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: App Reviews
+  name: "Google Play app reviews by listing URL"
   summary: Google Play Store reviews
   input:
     queryParams:
@@ -1601,7 +1601,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: App Detail
+  name: "Apple App Store app listing by URL"
   summary: Apple App Store
   input:
     queryParams:
@@ -1642,7 +1642,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: App Reviews
+  name: "Apple App Store app reviews by listing URL"
   summary: Apple App Store reviews
   input:
     queryParams:
@@ -1684,7 +1684,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Title Detail
+  name: "IMDb title details by URL"
   summary: IMDB media
   input:
     queryParams:
@@ -1726,7 +1726,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Note Detail
+  name: "Xiaohongshu post details by URL"
   summary: Xiaohongshu - posts
   input:
     queryParams:
@@ -1768,7 +1768,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Profile
+  name: "Threads profile by URL"
   summary: Threads - Profiles
   input:
     queryParams:
@@ -1810,7 +1810,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Channel Info
+  name: "Telegram channel details by URL"
   summary: Telegram
   input:
     queryParams:
@@ -1853,7 +1853,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Company Profile
+  name: "Crunchbase company profile by page URL"
   summary: Crunchbase companies information
   input:
     queryParams:
@@ -1895,7 +1895,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Company Profile
+  name: "Glassdoor company profile by page URL"
   summary: Glassdoor companies information (Public web data)
   input:
     queryParams:
@@ -1938,7 +1938,7 @@ endpoints:
   scope: any_account
   method: POST
   path: /datasets/v3/scrape
-  name: Company Reviews
+  name: "Glassdoor company reviews by page URL"
   summary: Glassdoor companies reviews
   input:
     queryParams:

--- a/src/treg/catalog/brightdata.yaml
+++ b/src/treg/catalog/brightdata.yaml
@@ -45,7 +45,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /datasets/v3/scrape
-    name: "Scrape URLs into structured records"
+    name: "Scrape URLs into structured records in one call"
     summary: "Scrape one or more URLs into structured records and get them back in the same call"
     input:
       queryParams:
@@ -71,7 +71,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /datasets/v3/trigger
-    name: "Start async scrape job for URLs"
+    name: "Start an async scrape of a URL batch — snapshot id"
     summary: "Start an asynchronous scraping job over a batch of URLs and get a snapshot id back"
     input:
       queryParams:
@@ -106,7 +106,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /datasets/v3/progress/{snapshot_id}
-    name: "Check async scrape job status"
+    name: "Check an async scrape job by snapshot id"
     summary: "Check whether an asynchronous scraping job has finished"
     input:
       pathParams:
@@ -125,7 +125,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /datasets/v3/snapshot/{snapshot_id}
-    name: "Download async scrape job results"
+    name: "Download scraped records by snapshot id"
     summary: "Download the records produced by a finished scraping job"
     input:
       pathParams:
@@ -150,7 +150,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /datasets/v3/scrape
-    name: "Get Instagram user profile"
+    name: "Instagram profile by URL — followers, bio, verification"
     summary: "Get the public profile of an Instagram user (followers, bio, verification)"
     input:
       queryParams:
@@ -174,7 +174,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /datasets/v3/scrape
-    name: "Get LinkedIn member profile"
+    name: "LinkedIn member profile by URL — headline, experience"
     summary: "Get a public LinkedIn member profile (headline, experience, education)"
     input:
       queryParams:
@@ -199,7 +199,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /datasets/list
-    name: "List available datasets and scrapers"
+    name: "List available Bright Data datasets and their ids"
     summary: "List the datasets and scrapers your Bright Data account can run, with their ids"
     input:
       note: "how you discover the dataset_id every other endpoint here needs, without hardcoding ids from blog posts. Returns id, name and size per dataset, covering the Web Scraper API datasets across 250+ domains. NOTE the path sits outside the /datasets/v3/ family the rest of this file uses, and differs from the /datasets/v3/datasets guess recorded as brightdata's probe_path in oauth_providers.py — reconcile the two once a token is available"

--- a/src/treg/catalog/coingecko.yaml
+++ b/src/treg/catalog/coingecko.yaml
@@ -20,7 +20,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /simple/price
-    name: "Live price of one or more coins"
+    name: "Current crypto price by coin id — market cap, 24h change"
     summary: "Current price for up to hundreds of coins at once, in any quote currency, with optional market cap, 24h volume and 24h change"
     input:
       queryParams:
@@ -42,7 +42,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /simple/supported_vs_currencies
-    name: "List supported quote currencies"
+    name: "List supported quote currencies (fiat, BTC, ETH)"
     summary: "Every vs_currency the price endpoints accept (fiat, BTC, ETH and more)"
     input:
       note: "no parameters"
@@ -59,7 +59,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /coins/markets
-    name: "Top coins with market data"
+    name: "Top crypto coins ranked by market cap — price, 24h change"
     summary: "Coins ranked by market cap (or volume), each with price, market cap, 24h change, supply and ATH — the one-call market overview"
     input:
       queryParams:
@@ -82,7 +82,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /coins/{coin_id}
-    name: "Full profile of one coin"
+    name: "Full crypto coin profile by coin id — links, market data"
     summary: "Everything about one coin: description, links, market data, supply, ATH/ATL — heavy response, use the flags to slim it"
     input:
       queryParams:
@@ -105,7 +105,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /coins/{coin_id}/market_chart
-    name: "Price history of a coin"
+    name: "Crypto price history by coin id — market cap, volume series"
     summary: "Historical price, market cap and volume series for a coin over N days (auto granularity: 5-minutely under 1 day, hourly under 90, daily beyond)"
     input:
       queryParams:
@@ -126,7 +126,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /coins/{coin_id}/history
-    name: "Coin snapshot on a specific date"
+    name: "Crypto coin snapshot on a date — price, market cap, volume"
     summary: "Price, market cap and volume of a coin on one historical date"
     input:
       queryParams:
@@ -146,7 +146,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /coins/{coin_id}/ohlc
-    name: "OHLC candles for a coin"
+    name: "Crypto OHLC candles by coin id over N days"
     summary: "Open/high/low/close candles over N days (30-minutely under 2 days, 4-hourly to 30, daily beyond)"
     input:
       queryParams:
@@ -166,7 +166,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Search coins, exchanges and categories"
+    name: "Search crypto coins and exchanges by name or ticker"
     summary: "Resolve a name or ticker to CoinGecko ids — the id-lookup for every other endpoint"
     input:
       queryParams:
@@ -184,7 +184,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search/trending
-    name: "Trending coins right now"
+    name: "Trending crypto coins and NFTs — most searched in 24h"
     summary: "The coins, NFTs and categories most searched on CoinGecko in the last 24 hours"
     input:
       note: "no parameters"
@@ -201,7 +201,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /global
-    name: "Global crypto market stats"
+    name: "Global crypto market stats — total cap, BTC dominance"
     summary: "Total market cap, 24h volume, BTC dominance and active coin count across the whole market"
     input:
       note: "no parameters"
@@ -218,7 +218,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /exchanges
-    name: "Crypto exchanges with volume and trust"
+    name: "Crypto exchanges ranked by trust score — volume, country"
     summary: "Exchanges ranked by trust score, each with 24h BTC volume, country and year established"
     input:
       queryParams:

--- a/src/treg/catalog/companyenrich.yaml
+++ b/src/treg/catalog/companyenrich.yaml
@@ -145,7 +145,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /companies/enrich/batch
-    name: "Enrich up to 50 companies in one request"
+    name: "Enrich up to 50 companies by domain in one call"
     summary: "Enriches a list of companies using their domain names — up to 50 domains per request"
     input:
       body:
@@ -177,7 +177,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies
-    name: "Get a company by its id"
+    name: "A company record by CompanyEnrich id"
     summary: "Gets a company information by its CompanyEnrich ID"
     input:
       queryParams:
@@ -239,7 +239,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/autocomplete
-    name: "Autocomplete a company domain"
+    name: "Resolve a company name to its domain (free autocomplete)"
     summary: "Returns a list of companies matching the given partial domain name — up to 10 companies per request"
     input:
       queryParams:
@@ -399,7 +399,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /companies/similar
-    name: "Find companies similar to a seed company"
+    name: "Lookalike companies for a seed domain or id"
     summary: "Finds similar companies to the given company by id or domain — at most 100 companies are returned per request"
     input:
       body:
@@ -436,7 +436,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /companies/similar/scroll
-    name: "Scroll similar-company results past 10,000 rows"
+    name: "Scroll lookalike-company results past 10,000 rows"
     summary: "Finds similar companies with cursor-based pagination — allows paginating into more than 10.000 results"
     input:
       body:
@@ -468,7 +468,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /companies/similar/count
-    name: "Count similar companies (free)"
+    name: "Count lookalike companies for a seed (free)"
     summary: "Returns the total count of similar companies matching the given search criteria without retrieving the actual results"
     input:
       body:
@@ -722,7 +722,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /people
-    name: "Get a person by their id"
+    name: "A person record by CompanyEnrich id"
     summary: "Gets person information by its CompanyEnrich ID"
     input:
       queryParams:
@@ -785,7 +785,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /people/email
-    name: "Resolve a person's work email (beta)"
+    name: "Find a person's work email by person id (beta)"
     summary: "Resolves a work email address for a single person on a specific domain"
     input:
       queryParams:
@@ -1156,7 +1156,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /geo/cities
-    name: "Search cities"
+    name: "Search cities by name"
     summary: "Searches cities by name or country codes — returns up to 100 cities per page"
     input:
       body:

--- a/src/treg/catalog/coresignal.yaml
+++ b/src/treg/catalog/coresignal.yaml
@@ -41,7 +41,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /company_multi_source/enrich
-    name: "Enrich a company by website or LinkedIn URL"
+    name: "Enrich a company by website — funding, headcount"
     summary: "Enrich a company from its website or LinkedIn URL — firmographics, funding, headcount"
     input:
       queryParams:
@@ -68,7 +68,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /company_multi_source/search/es_dsl
-    name: "Search companies by filter"
+    name: "Search companies by industry, size or country — ids, free"
     summary: "Find companies by Elasticsearch filter (industry, size, country) — ids only, free"
     input:
       bodyType: json
@@ -85,7 +85,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /company_multi_source/collect/{id}
-    name: "Get a company's full record"
+    name: "A company's full record by Coresignal id"
     summary: "Read one company's full record by the id a company search returned"
     input:
       pathParams:
@@ -111,7 +111,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /employee_multi_source/collect/{identifier}
-    name: "Get a person's full profile"
+    name: "A person's full profile by LinkedIn URL or id"
     summary: "One person's full record — role, employer, work history, education — by LinkedIn URL or id"
     input:
       pathParams:
@@ -137,7 +137,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /employee_multi_source/search/es_dsl
-    name: "Search people by filter"
+    name: "Search people by title, employer or country — ids, free"
     summary: "Find people by Elasticsearch filter (title, employer, country) — ids only, free"
     input:
       bodyType: json

--- a/src/treg/catalog/crunchbase.yaml
+++ b/src/treg/catalog/crunchbase.yaml
@@ -28,7 +28,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /entities/organizations/{entity_id}
-    name: "Get a company's Crunchbase profile"
+    name: "A company's Crunchbase profile by permalink — funding"
     summary: "A company's Crunchbase profile — funding total, categories, headcount, founders"
     input:
       pathParams:
@@ -56,7 +56,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /searches/organizations
-    name: "Search companies by industry and funding"
+    name: "Search companies by industry, funding or headcount"
     summary: "Search Crunchbase companies by industry, funding, headcount, location or founding date"
     input:
       bodyType: json
@@ -87,7 +87,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /entities/people/{entity_id}
-    name: "Get a person's Crunchbase profile"
+    name: "A person's Crunchbase profile by permalink"
     summary: "A person's Crunchbase profile — current and past roles, companies founded, investments"
     input:
       pathParams:
@@ -114,7 +114,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /searches/people
-    name: "Search people by role or company"
+    name: "Search people by role, location or company"
     summary: "Search Crunchbase people by role, location or the company they are tied to"
     input:
       bodyType: json

--- a/src/treg/catalog/dataforseo.extended.yaml
+++ b/src/treg/catalog/dataforseo.extended.yaml
@@ -24,7 +24,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/ai_keyword_data/keywords_search_volume/live
-  name: AI search volume for keywords
+  name: "AI search volume for keywords across AI tools"
   summary: This endpoint provides search volume data for your target keywords, reflecting their estimated usage in AI tools.
   input:
     bodyType: json
@@ -79,7 +79,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/historical/live
-  name: Monthly history of LLM mentions
+  name: "Monthly LLM mention history for a keyword or domain"
   summary: Live LLM Mentions Historical endpoint provides month-by-month historical metrics for mentions of the keywords or domains specified in the target array of the request.
   input:
     bodyType: json
@@ -154,7 +154,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/multi_target_metrics/live
-  name: LLM mention metrics by custom group
+  name: "LLM mention metrics for many keywords or domains, grouped"
   summary: Live LLM Mentions Multi-Target Metrics endpoint provides aggregated metrics grouped by custom keys for mentions of the keywords or domains specified in the target array of the request.
   input:
     bodyType: json
@@ -270,7 +270,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/search_mentions/live
-  name: Search mentions inside AI answers
+  name: "Search LLM mentions of a keyword or domain in AI answers"
   summary: Live LLM Mentions Search endpoint provides mention data and related metrics from AI searches.
   input:
     bodyType: json
@@ -373,7 +373,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/target_metrics/live
-  name: LLM mention metrics for a target
+  name: "LLM mention metrics for a keyword or domain"
   summary: Live LLM Mentions Target Metrics endpoint provides aggregated metrics for mentions of the keywords or domains specified in the target array of the request.
   input:
     bodyType: json
@@ -458,7 +458,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/target_metrics_lite/live
-  name: LLM mention metrics for a target (lite)
+  name: "LLM mention metrics for a keyword or domain, lite"
   summary: Live LLM Mentions Target Metrics Lite endpoint is the simplified version of the Target Metrics endpoint and provides a simplified view of aggregated LLM mentions for keywords and domains specified in the target array of the request.
   input:
     bodyType: json
@@ -551,7 +551,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/timeseries_delta/live
-  name: Change in LLM mentions between dates
+  name: "Change in LLM mentions between two dates for a target"
   summary: The Live LLM Mentions Timeseries Delta endpoint provides the difference in historical mentions and AI search volume data between two specified dates.
   input:
     bodyType: json
@@ -636,7 +636,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/timeseries_new_lost/live
-  name: New and lost LLM mentions
+  name: "New and lost LLM mentions for a keyword or domain"
   summary: This endpoint will provide you with the number of new and lost LLM mentions, as well as ai_search_volume for the domain or keyword specified in the target field.
   input:
     bodyType: json
@@ -721,7 +721,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_brand_categories/live
-  name: Top mentioned brand categories
+  name: "Top brand categories in LLM mentions of a target"
   summary: Live LLM Mentions Top Mentioned Brand Categories endpoint provides aggregated LLM mentions metrics grouped by the most frequently mentioned brand categories for the specified target.
   input:
     bodyType: json
@@ -836,7 +836,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_brand_categories_lite/live
-  name: Top mentioned brand categories (lite)
+  name: "Top brand categories in LLM mentions of a target, lite"
   summary: Live LLM Mentions Top Mentioned Brand Categories Lite endpoint is the simplified version of the Top Mentioned Brand Categories endpoint and provides a simplified view of aggregated LLM mentions metrics grouped by the most frequently mentioned brand categories for the specified target.
   input:
     bodyType: json
@@ -951,7 +951,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_brands/live
-  name: Top mentioned brands
+  name: "Top brands in LLM mentions of a keyword or domain"
   summary: Live LLM Mentions Top Mentioned Brands endpoint provides aggregated LLM mentions metrics grouped by the most frequently mentioned brands for the specified target.
   input:
     bodyType: json
@@ -1066,7 +1066,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_brands_lite/live
-  name: Top mentioned brands (lite)
+  name: "Top brands in LLM mentions of a keyword or domain, lite"
   summary: Live LLM Mentions Top Mentioned Brands Lite endpoint is the simplified version of the Top Mentioned Brands endpoint and provides a simplified view of aggregated LLM mentions metrics grouped by the most frequently mentioned brands for the specified target.
   input:
     bodyType: json
@@ -1181,7 +1181,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_domains/live
-  name: Top mentioned domains
+  name: "Top domains in LLM mentions of a keyword or domain"
   summary: Live LLM Mentions Top Mentioned Domains endpoint provides aggregated LLM mentions metrics grouped by the most frequently mentioned domains for the specified target.
   input:
     bodyType: json
@@ -1302,7 +1302,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_domains_lite/live
-  name: Top mentioned domains (lite)
+  name: "Top domains in LLM mentions of a keyword or domain, lite"
   summary: Live LLM Mentions Top Mentioned Domains Lite endpoint is the simplified version of the Top Mentioned Domains endpoint and provides a simplified view of aggregated LLM mentions metrics grouped by the most frequently mentioned domains for the specified target.
   input:
     bodyType: json
@@ -1423,7 +1423,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_pages/live
-  name: Top mentioned pages
+  name: "Top pages in LLM mentions of a keyword or domain"
   summary: Live LLM Mentions Top Mentioned Pages endpoint provides aggregated LLM mentions metrics grouped by the most frequently mentioned pages for the specified target.
   input:
     bodyType: json
@@ -1544,7 +1544,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/llm_mentions/top_mentioned_pages_lite/live
-  name: Top mentioned pages (lite)
+  name: "Top pages in LLM mentions of a keyword or domain, lite"
   summary: Live LLM Mentions Top Mentioned Pages Lite endpoint is a simplified version of the Top Mentioned Pages that provides a simplified view of aggregated LLM mentions metrics grouped by the most frequently mentioned pages for the specified target.
   input:
     bodyType: json
@@ -1665,7 +1665,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/bulk_search_volume/live
-  name: Bulk keyword search volume
+  name: "Amazon search volume for up to 1000 keywords"
   summary: This endpoint will provide you with search volume values for a maximum of 1,000 keywords in one API request.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/bulk_search_volume/live/
   input:
@@ -1723,7 +1723,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/product_competitors/live
-  name: Products competing with an ASIN
+  name: "Amazon products competing with an ASIN in search"
   summary: This endpoint will provide you with a list of products that intersect with a target asin in Amazon SERPs.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/product_competitors/live/
   input:
@@ -1790,7 +1790,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/product_keyword_intersections/live
-  name: Keywords two products both rank for
+  name: "Amazon keywords where several ASINs rank together"
   summary: This endpoint will provide you with a list of keywords for which the target products intersect in Amazon SERP.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/product_keyword_intersections/live/
   input:
@@ -1868,7 +1868,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/product_rank_overview/live
-  name: Organic and paid rank for products
+  name: "Amazon organic and paid rank for products by ASIN"
   summary: This endpoint will provide you with ranking data from organic and paid Amazon SERPs for the target products.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/product_rank_overview/live/
   input:
@@ -1924,7 +1924,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/ranked_keywords/live
-  name: Keywords a product ranks for
+  name: "Amazon keywords a product ranks for, by ASIN"
   summary: This endpoint will provide you with a list of keywords the target product ranks for on Amazon.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/ranked_keywords/live/
   input:
@@ -1995,7 +1995,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /dataforseo_labs/amazon/related_keywords/live
-  name: Related searches for a keyword
+  name: "Amazon related-search keywords for a seed keyword"
   summary: The Related Keywords endpoint provides keywords appearing in the "Related Searches" section on Amazon.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/amazon/related_keywords/live/
   input:
@@ -2070,7 +2070,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /merchant/amazon/asin/live/advanced
-  name: List ASINs for product variations
+  name: "Amazon ASINs for all variations of a product, live"
   summary: This endpoint will provide you with a full list of ASINs assigned to different modifications of a product.
   input:
     bodyType: json
@@ -2131,7 +2131,7 @@ endpoints:
   method: GET
   path: /merchant/amazon/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Amazon location codes by country"
   summary: You will receive the list of supported Amazon locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/merchant/amazon/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -2140,7 +2140,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /merchant/amazon/products/live/advanced
-  name: Search product listings by keyword
+  name: "Amazon product search results for a keyword, live"
   summary: This endpoint provides results from Amazon product listings according to the specified keyword (product name), location, and language parameters.
   input:
     bodyType: json
@@ -2231,7 +2231,7 @@ endpoints:
   platform: amazon
   method: POST
   path: /merchant/amazon/sellers/live/advanced
-  name: List sellers of a product
+  name: "Amazon sellers of a product by ASIN, live"
   summary: This endpoint provides a list of sellers of the specified product on Amazon.
   input:
     bodyType: json
@@ -2290,7 +2290,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /app_data/apple/app_info/task_post
-  name: App listing details (async batch)
+  name: "App Store app details by app id (async task)"
   summary: This endpoint will provide you with information about the App Store application specified in the app_id field of the POST request.
   docs_url: https://docs.dataforseo.com/v3/app_data/apple/app_info/task_post/
   input:
@@ -2357,7 +2357,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /app_data/apple/app_list/task_post
-  name: Top charts app list (async batch)
+  name: "App Store top chart apps by collection (async task)"
   summary: This endpoint will provide you with a list of mobile applications published in the top app charts on the App Store platform.
   docs_url: https://docs.dataforseo.com/v3/app_data/apple/app_list/task_post/
   input:
@@ -2436,7 +2436,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /app_data/apple/app_listings/search/live
-  name: Search app listings
+  name: "Search App Store apps — rating, reviews count, price"
   summary: 'This endpoint will provide you with a list of apps published on App Store along with additional information: its ID, icon, reviews count, rating, price, and other data.'
   docs_url: https://docs.dataforseo.com/v3/app_data/apple/app_listings/search/live/
   input:
@@ -2515,7 +2515,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /app_data/apple/app_reviews/task_post
-  name: Reviews for an app (async batch)
+  name: "App Store reviews for an app by app id (async task)"
   summary: This endpoint will provide you with reviews published on the App Store platform for the app specified in the app_id field.
   docs_url: https://docs.dataforseo.com/v3/app_data/apple/app_reviews/task_post/
   input:
@@ -2592,7 +2592,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /app_data/apple/app_searches/task_post
-  name: Apps ranking for a keyword (async batch)
+  name: "App Store apps ranking for a keyword (async task)"
   summary: This endpoint will provide you with a list of apps ranking on the App Store for the specified keyword.
   docs_url: https://docs.dataforseo.com/v3/app_data/apple/app_searches/task_post/
   input:
@@ -2665,7 +2665,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /dataforseo_labs/apple/app_competitors/live
-  name: Apps competing with a target app
+  name: "App Store apps competing with an app, by app id"
   summary: This endpoint will provide you with a list of mobile applications that intersect with the target app for its ranking keywords on App Store.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/apple/app_competitors/live/
   input:
@@ -2734,7 +2734,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /dataforseo_labs/apple/app_intersection/live
-  name: Keywords several apps both rank for
+  name: "Keywords several App Store apps rank for together"
   summary: This endpoint will provide you with a list of keywords for which the mobile applications specified in the app_ids object rank within the same App Store SERP.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/apple/app_intersection/live/
   input:
@@ -2807,7 +2807,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /dataforseo_labs/apple/bulk_app_metrics/live
-  name: Bulk ranking metrics for apps
+  name: "Ranking metrics for up to 1000 App Store apps"
   summary: This endpoint will provide you with ranking metrics for up to 1000 App Store applications.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/apple/bulk_app_metrics/live/
   input:
@@ -2862,7 +2862,7 @@ endpoints:
   platform: app-store
   method: POST
   path: /dataforseo_labs/apple/keywords_for_app/live
-  name: Keywords an app ranks for
+  name: "Keywords an App Store app ranks for, by app id"
   summary: This endpoint will provide you with a list of keywords for which the target app ranks on App Store.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/apple/keywords_for_app/live/
   input:
@@ -2933,7 +2933,7 @@ endpoints:
   method: GET
   path: /serp/baidu/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Baidu location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/baidu/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -2942,7 +2942,7 @@ endpoints:
   platform: baidu
   method: POST
   path: /serp/baidu/organic/task_post
-  name: Organic search results (async batch)
+  name: "Baidu organic search results for a keyword (async task)"
   summary: Baidu SERP API provides top 10 search engine results.
   docs_url: https://docs.dataforseo.com/v3/serp/baidu/organic/task_post/
   input:
@@ -3050,7 +3050,7 @@ endpoints:
   method: GET
   path: /keywords_data/bing/audience_estimation/industries
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List targetable industries
+  name: "Bing Ads industries for audience targeting"
   summary: By calling this API you will receive the list of industries with industry_id supported by Bing Ads Audience Estimation endpoint.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/audience_estimation/industries/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -3061,7 +3061,7 @@ endpoints:
   method: GET
   path: /keywords_data/bing/audience_estimation/job_functions
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List targetable job functions
+  name: "Bing Ads job functions for audience targeting"
   summary: By calling this API you will receive the list of job functions with job_function_id supported by Bing Ads Audience Estimation endpoint.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/audience_estimation/job_functions/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -3070,7 +3070,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/audience_estimation/live
-  name: Estimate ad audience size
+  name: "Bing Ads audience size estimate for campaign targeting"
   summary: This endpoint provides estimated audience size for an ad campaign based on specified targeting criteria.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/audience_estimation/live/
   input:
@@ -3156,7 +3156,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/keyword_performance/live
-  name: Keyword performance stats
+  name: "Bing keyword performance stats for a keyword list"
   summary: You can receive a set of keyword performance stats for a group of keywords depending on the specified match type, location and language parameters.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/keyword_performance/live/
   input:
@@ -3226,7 +3226,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/keywords_for_keywords/live
-  name: Related keywords for seed keywords
+  name: "Bing keyword ideas from seed keywords"
   summary: This endpoint will select the relevant keywords for the specified ones.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/keywords_for_keywords/live/
   input:
@@ -3312,7 +3312,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/keywords_for_site/live
-  name: Keywords relevant to a site
+  name: "Bing keywords for a site — volume, CPC, competition"
   summary: This endpoint will provide you with a list of keywords relevant to the specified URL along with their search volume for the last month, search volume trend for up to 24 past months (for estimating search volume dynamics), current cost-per-click and competition values for paid search.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/keywords_for_site/live/
   input:
@@ -3392,7 +3392,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/search_volume/live
-  name: Keyword search volume and CPC
+  name: "Bing search volume, CPC and competition for keywords"
   summary: This endpoint will provide you with search volume data for the last month, search volume trend for up to 24 past months (that will let you estimate search volume dynamics), current cost-per-click and competition values for paid search.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/search_volume/live/
   input:
@@ -3474,7 +3474,7 @@ endpoints:
   platform: bing
   method: POST
   path: /keywords_data/bing/search_volume_history/live
-  name: Historical keyword search volume
+  name: "Bing historical search volume for up to 1000 keywords"
   summary: This endpoint will provide you with historical search volume data for up to 1000 keywords in one request.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/bing/search_volume_history/live/
   input:
@@ -3550,7 +3550,7 @@ endpoints:
   method: GET
   path: /serp/bing/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Bing location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/bing/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -3559,7 +3559,7 @@ endpoints:
   platform: bing
   method: POST
   path: /serp/bing/organic/live/advanced
-  name: Organic search results (advanced)
+  name: "Bing organic results for a keyword — full SERP features"
   summary: Live SERP provides real-time data on top 100 search engine results for the specified keyword, search engine, and location.
   docs_url: https://docs.dataforseo.com/v3/serp/bing/organic/live/advanced/
   input:
@@ -3671,7 +3671,7 @@ endpoints:
   platform: bing
   method: POST
   path: /serp/bing/organic/live/regular
-  name: Organic search results (regular)
+  name: "Bing organic search results for a keyword, live"
   summary: Live SERP provides real-time data on search engine results for the specified keyword, search engine, and location.
   docs_url: https://docs.dataforseo.com/v3/serp/bing/organic/live/regular/
   input:
@@ -3767,7 +3767,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/chat_gpt/llm_responses/live
-  name: "Get a ChatGPT answer"
+  name: "ChatGPT answer to a prompt, live"
   summary: Live ChatGPT LLM Responses endpoint allows you to retrieve structured responses from a specific ChatGPT AI model, based on the input parameters.
   input:
     bodyType: json
@@ -3864,7 +3864,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/chat_gpt/llm_scraper/live/advanced
-  name: "Scrape ChatGPT search results"
+  name: "ChatGPT search results for a keyword, live"
   summary: Live ChatGPT LLM Scraper endpoint provides results from ChatGPT searches.
   input:
     bodyType: json
@@ -3921,7 +3921,7 @@ endpoints:
   method: GET
   path: /ai_optimization/chat_gpt/llm_scraper/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "ChatGPT search location codes by country"
   summary: You will receive the list of locations by this API call.
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
 - id: dataforseo.x.ai-optimization-claude-llm-responses-live
@@ -3929,7 +3929,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/claude/llm_responses/live
-  name: "Get a Claude answer"
+  name: "Claude answer to a prompt, live"
   summary: Live Claude LLM Responses endpoint allows you to retrieve structured responses from a specific Claude model, based on the input parameters.
   input:
     bodyType: json
@@ -4026,7 +4026,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/gemini/llm_responses/live
-  name: "Get a Gemini answer"
+  name: "Gemini answer to a prompt, live"
   summary: Live Gemini LLM Responses endpoint allows you to retrieve structured responses from a specific Gemini AI model, based on the input parameters.
   input:
     bodyType: json
@@ -4111,7 +4111,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/gemini/llm_scraper/live/advanced
-  name: "Scrape Gemini search results"
+  name: "Gemini search results for a keyword, live"
   summary: Live Gemini LLM Scraper endpoint provides structured results from Gemini.
   input:
     bodyType: json
@@ -4166,7 +4166,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/extended_reviews/task_post
-  name: Reviews from Google and other sites (async batch)
+  name: "Business reviews from Google and other sites (async task)"
   summary: This endpoint provides results from the “Reviews” element of Google SERPs, including not only Google user reviews but also reviews from other reputable sources (e.g., TripAdvisor, Yelp, Trustpilot).
   input:
     bodyType: json
@@ -4244,7 +4244,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/hotel_info/live/advanced
-  name: Hotel listing details
+  name: "Google Hotels details by hotel id — rating, prices"
   summary: 'Google Hotel Info will provide you with structured data available for a specific hotel entity on the Google Hotels platform: such as service description, location details, rating, amenities, reviews, images, prices, and more.'
   input:
     bodyType: json
@@ -4334,7 +4334,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/hotel_searches/live
-  name: Search hotel listings
+  name: "Google Hotels search results for a keyword, live"
   summary: Hotel Searches API provides results containing information about different hotels listed on Google Hotels.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/hotel_searches/live/
   input:
@@ -4467,7 +4467,7 @@ endpoints:
   method: GET
   path: /business_data/google/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Google Business location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -4476,7 +4476,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/my_business_info/live
-  name: Business profile details
+  name: "Google Business Profile details by business name, live"
   summary: Business Data API provides results containing information about specific business entity from Google.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/my_business_info/live/
   input:
@@ -4531,7 +4531,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/my_business_updates/task_post
-  name: Latest business profile posts (async batch)
+  name: "Google Business Profile posts for a business (async task)"
   summary: This endpoints provides the latest updates of a specific business entity from Google SERP.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/my_business_updates/task_post/
   input:
@@ -4602,7 +4602,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/questions_and_answers/live
-  name: Questions and answers on a business
+  name: "Questions and answers on a Google Business listing, live"
   summary: This endpoint will provide you with a detailed overview of questions and answers associated with a specific business entity listed on Google My Business.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/questions_and_answers/live/
   input:
@@ -4661,7 +4661,7 @@ endpoints:
   platform: google
   method: POST
   path: /business_data/google/reviews/task_post
-  name: Business reviews (async batch)
+  name: "Google reviews for a business (async task)"
   summary: This endpoint provides results from the “Reviews” element of Google SERPs.
   docs_url: https://docs.dataforseo.com/v3/business_data/google/reviews/task_post/
   input:
@@ -4748,7 +4748,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/app_competitors/live
-  name: Apps competing with a target app
+  name: "Google Play apps competing with an app, by app id"
   summary: This endpoint will provide you with a list of mobile applications that intersect with the target app for its ranking keywords on Google Play.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/app_competitors/live/
   input:
@@ -4817,7 +4817,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/app_intersection/live
-  name: Keywords several apps both rank for
+  name: "Keywords several Google Play apps rank for together"
   summary: This endpoint will provide you with a list of keywords for which the mobile applications specified in the app_ids object rank within the same Google Play SERP.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/app_intersection/live/
   input:
@@ -4892,7 +4892,7 @@ endpoints:
   method: GET
   path: /dataforseo_labs/google/available_history
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List available history dates
+  name: "Available dates for domain metrics history"
   summary: By calling this endpoint, you will find obtain a list of dates available for setting in the first_date and second_date fields of the Domain Metrics by Categories endpoint.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/available_history/live/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -4901,7 +4901,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/bulk_app_metrics/live
-  name: Bulk ranking metrics for apps
+  name: "Ranking metrics for up to 1000 Google Play apps"
   summary: This endpoint will provide you with ranking metrics for up to 1000 Google Play applications.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/bulk_app_metrics/live/
   input:
@@ -4956,7 +4956,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/bulk_keyword_difficulty/live
-  name: Bulk keyword difficulty scores
+  name: "Keyword difficulty scores for up to 1000 keywords"
   summary: This endpoint will provide you with the Keyword Difficulty metric for a maximum of 1,000 keywords in one API request.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/bulk_keyword_difficulty/live/
   input:
@@ -5013,7 +5013,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/bulk_traffic_estimation/live
-  name: Bulk traffic estimates for domains
+  name: "Monthly traffic estimates for up to 1000 domains"
   summary: This endpoint will provide you with estimated monthly traffic volumes for up to 1,000 domains, subdomains, or webpages.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/bulk_traffic_estimation/live/
   input:
@@ -5084,7 +5084,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/categories_for_domain/live
-  name: Product categories a domain ranks in
+  name: "Google product categories a domain ranks in"
   summary: This endpoint will provide you with Google product or service categories that include keywords the domain ranks for in search.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/categories_for_domain/live/
   input:
@@ -5179,7 +5179,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/categories_for_keywords/live
-  name: Product categories for keywords
+  name: "Google product categories for keywords"
   summary: This endpoint will provide you with Google product and service categories related for each specified keyword.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/categories_for_keywords/live/
   input:
@@ -5226,7 +5226,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/competitors_domain/live
-  name: Competing domains with traffic data
+  name: "Competitor domains of a domain — rank and traffic"
   summary: This endpoint will provide you with a full overview of ranking and traffic data of the competitor domains from organic and paid search.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/competitors_domain/live/
   input:
@@ -5331,7 +5331,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/domain_intersection/live
-  name: Keywords two domains both rank for
+  name: "Keywords two domains both rank for in Google"
   summary: This endpoint will provide you with the keywords for which both specified domains rank within the same SERP.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/domain_intersection/live/
   input:
@@ -5424,7 +5424,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/domain_metrics_by_categories/live
-  name: Domain metric trends by category
+  name: "Domain metric trends for product categories"
   summary: This endpoint will provide you with dynamics of change in metrics of domains relevant to the specified product and service categories.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/domain_metrics_by_categories/live/
   input:
@@ -5533,7 +5533,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/domain_rank_overview/live
-  name: Organic and paid rank overview
+  name: "Google rank and traffic overview for a domain"
   summary: This endpoint will provide you with ranking and traffic data from organic and paid search for the specified domain.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/domain_rank_overview/live/
   input:
@@ -5596,7 +5596,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/historical_bulk_traffic_estimation/live
-  name: Historical traffic estimates in bulk
+  name: "Historical monthly traffic for up to 1000 domains"
   summary: This endpoint will provide you with historical monthly traffic volumes for up to 1,000 domains collected within the specified time range through October 2020.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/historical_bulk_traffic_estimation/live/
   input:
@@ -5679,7 +5679,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/historical_keyword_data/live
-  name: Historical keyword metrics
+  name: "Google historical search volume and CPC for keywords"
   summary: This endpoint provides Google historical keyword data for specified keywords, including search volume, cost-per-click, competition values for paid search, monthly searches, and search volume trends.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/historical_keyword_data/live/
   input:
@@ -5732,7 +5732,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/historical_rank_overview/live
-  name: Historical rank and traffic overview
+  name: "Historical Google rank and traffic for a domain"
   summary: This endpoint will provide you with historical data on rankings and traffic of the specified domain, such as domain ranking distribution in SERPs and estimated monthly traffic volume for both organic and paid results.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/historical_rank_overview/live/
   input:
@@ -5807,7 +5807,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/historical_serps/live
-  name: Past search results for a keyword
+  name: "Past Google search results for a keyword, by date range"
   summary: This endpoint will provide you with Google SERPs collected within the specified time frame.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/historical_serps/live/
   input:
@@ -5870,7 +5870,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keyword_ideas/live
-  name: Keyword ideas from related categories
+  name: "Google keyword ideas for seed keywords, by category"
   summary: The Keyword Ideas endpoint provides search terms that are relevant to the product or service categories of the specified keywords.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keyword_ideas/live/
   input:
@@ -5965,7 +5965,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keyword_overview/live
-  name: Keyword metrics overview
+  name: "Google keyword overview for a list of keywords"
   summary: This endpoint provides Google keyword data for specified keywords.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keyword_overview/live/
   input:
@@ -6030,7 +6030,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keyword_suggestions/live
-  name: Keyword suggestions from a seed
+  name: "Google keyword suggestions containing a seed keyword"
   summary: The Keyword Suggestions endpoint provides search queries that include the specified seed keyword.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keyword_suggestions/live/
   input:
@@ -6127,7 +6127,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keywords_for_app/live
-  name: Keywords an app ranks for
+  name: "Keywords a Google Play app ranks for, by app id"
   summary: This endpoint will provide you with a list of keywords for which the target app ranks on Google Play.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keywords_for_app/live/
   input:
@@ -6196,7 +6196,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keywords_for_categories/live
-  name: Keywords in product categories
+  name: "Keywords for Google product categories"
   summary: This endpoint will provide you with a list of keywords relevant to the specified product categories.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keywords_for_categories/live/
   input:
@@ -6291,7 +6291,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/keywords_for_site/live
-  name: Keywords a site ranks for
+  name: "Keywords relevant to a domain in Google"
   summary: The Keywords For Site endpoint will provide you with a list of keywords relevant to the target domain.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/keywords_for_site/live/
   input:
@@ -6388,7 +6388,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/page_intersection/live
-  name: Keywords two pages both rank for
+  name: "Keywords several pages rank for together, by URL"
   summary: This endpoint will provide you with the keywords for which specified pages rank within the same SERP.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/page_intersection/live/
   input:
@@ -6491,7 +6491,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/relevant_pages/live
-  name: Top ranking pages of a domain
+  name: "Top ranking pages of a domain in Google"
   summary: GoogleRelevantPagesLive
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/relevant_pages/live/
   input:
@@ -6592,7 +6592,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/search_intent/live
-  name: Search intent for keywords
+  name: "Search intent for up to 1000 keywords"
   summary: This endpoint will provide you with search intent data for up to 1,000 keywords.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/search_intent/live/
   input:
@@ -6641,7 +6641,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/serp_competitors/live
-  name: Domains ranking for your keywords
+  name: "Domains ranking in Google for your keywords"
   summary: This endpoint will provide you with a list of domains ranking for the keywords you specify.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/serp_competitors/live/
   input:
@@ -6724,7 +6724,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/subdomains/live
-  name: Subdomains with ranking distribution
+  name: "Subdomains of a domain with Google rank distribution"
   summary: This endpoint will provide you with a list of subdomains of the specified domain, along with the ranking distribution across organic and paid search.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/subdomains/live/
   input:
@@ -6823,7 +6823,7 @@ endpoints:
   platform: google
   method: POST
   path: /dataforseo_labs/google/top_searches/live
-  name: Browse the keyword database
+  name: "Top Google searches from the 7B keyword database"
   summary: The Top Searches endpoint of DataForSEO Labs API can provide you with over 7 billion keywords from the DataForSEO Keyword Database.
   docs_url: https://docs.dataforseo.com/v3/dataforseo_labs/google/top_searches/live/
   input:
@@ -6902,7 +6902,7 @@ endpoints:
   platform: google
   method: POST
   path: /keywords_data/google_ads/ad_traffic_by_keywords/live
-  name: Forecast ad traffic for keywords
+  name: "Google Ads traffic forecast for keywords and bid"
   summary: GoogleAdsAdTrafficByKeywordsLive
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_ads/ad_traffic_by_keywords/live/
   input:
@@ -6987,7 +6987,7 @@ endpoints:
   platform: google
   method: POST
   path: /keywords_data/google_ads/keywords_for_keywords/live
-  name: Related keywords with Ads metrics
+  name: "Google Ads keyword ideas from seed keywords"
   summary: Note that Google Ads Keywords Data API is based on the latest version of the Google Ads API that has replaced legacy Google AdWords API.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_ads/keywords_for_keywords/live/
   input:
@@ -7064,7 +7064,7 @@ endpoints:
   platform: google
   method: POST
   path: /keywords_data/google_ads/keywords_for_site/live
-  name: Site keywords with Ads metrics
+  name: "Google Ads keyword ideas for a site, by domain"
   summary: Note that Google Ads Keywords Data API is based on the latest version of the Google Ads API that has replaced legacy Google AdWords API.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_ads/keywords_for_site/live/
   input:
@@ -7143,7 +7143,7 @@ endpoints:
   method: GET
   path: /keywords_data/google_ads/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List Ads targeting locations
+  name: "Google Ads location codes by country"
   summary: We use Google Geographical Targeting.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_ads/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -7152,7 +7152,7 @@ endpoints:
   platform: google
   method: POST
   path: /keywords_data/google_trends/explore/live
-  name: Keyword popularity over time
+  name: "Google Trends keyword popularity over time"
   summary: This endpoint will provide you with the keyword popularity data from the ‘Explore’ feature of Google Trends.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_trends/explore/live/
   input:
@@ -7239,7 +7239,7 @@ endpoints:
   method: GET
   path: /keywords_data/google_trends/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List Trends locations
+  name: "Google Trends location codes by country"
   summary: GoogleTrendsLocationsCountry
   docs_url: https://docs.dataforseo.com/v3/keywords_data/google_trends/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -7250,7 +7250,7 @@ endpoints:
   method: GET
   path: /merchant/google/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List Shopping locations
+  name: "Google Shopping location codes by country"
   summary: MerchantGoogleLocationsCountry
   docs_url: https://docs.dataforseo.com/v3/merchant/google/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -7259,7 +7259,7 @@ endpoints:
   platform: google
   method: POST
   path: /merchant/google/product_info/task_post
-  name: Shopping product details (async batch)
+  name: "Google Shopping product details by id (async task)"
   summary: This endpoint provides data on a product listed on Google Shopping, including product description, images, rating, variations, specifications and sellers.
   docs_url: https://docs.dataforseo.com/v3/merchant/google/product_info/task_post/
   input:
@@ -7342,7 +7342,7 @@ endpoints:
   platform: google
   method: POST
   path: /merchant/google/products/task_post
-  name: Search Shopping products (async batch)
+  name: "Google Shopping results for a keyword (async task)"
   summary: Google Shopping Products endpoint will provide you with the list of products found on Google Shopping for the specified query.
   docs_url: https://docs.dataforseo.com/v3/merchant/google/products/task_post/
   input:
@@ -7449,7 +7449,7 @@ endpoints:
   method: GET
   path: /merchant/google/sellers/ad_url/{shop_ad_aclk}
   cost: {type: per_call, value: 1e-06, currency: USD, per: 1, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', confidence: verified, note: 'read from our own account rate card'}
-  name: Resolve a Shopping ad's full URL
+  name: "Resolve a Google Shopping ad to its full URL"
   summary: Google Shopping Sellers Ad URL is designed to provide you with a full URL of the advertisement containing all additional parameters set by the seller.
   docs_url: https://docs.dataforseo.com/v3/merchant/google/sellers/ad_url/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -7458,7 +7458,7 @@ endpoints:
   platform: google
   method: POST
   path: /merchant/google/sellers/task_post
-  name: Top sellers for a product (async batch)
+  name: "Google Shopping sellers for a product (async task)"
   summary: Google Shopping Sellers endpoint will provide you with the list of top 10 sellers that listed the specified product on Google Shopping.
   docs_url: https://docs.dataforseo.com/v3/merchant/google/sellers/task_post/
   input:
@@ -7557,7 +7557,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/ai_summary
-  name: Summarize a search results page
+  name: "AI summary of a fetched SERP by task id and prompt"
   summary: The purpose of the Live SERP API AI Summary endpoint is to provide a summary of the content found on any SERP and generate a response based on the user’s specified prompt.
   docs_url: https://docs.dataforseo.com/v3/serp/ai_summary/
   input:
@@ -7606,7 +7606,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/ads_advertisers/task_post
-  name: Find advertisers in Ads Transparency (async batch)
+  name: "Google Ads Transparency advertisers by keyword (async task)"
   summary: Google Ads Advertisers provides information on advertisers that run campaigns on Google Ads based on the Ads Transparency platform.
   input:
     bodyType: json
@@ -7666,7 +7666,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/ads_search/task_post
-  name: Search ads in Ads Transparency (async batch)
+  name: "Google Ads Transparency ads by advertiser (async task)"
   summary: Google Ads Search provides information on ads that are run by advertisers on Google Ads.
   input:
     bodyType: json
@@ -7756,7 +7756,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/ai_mode/live/advanced
-  name: Search results from AI Mode
+  name: "Google AI Mode results for a keyword, live"
   summary: Google AI Mode SERP API provides search results from the AI Mode feature of Google Search.
   input:
     bodyType: json
@@ -7834,7 +7834,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/autocomplete/live/advanced
-  name: Autocomplete suggestions for a query
+  name: "Google autocomplete suggestions for a keyword, live"
   summary: Google Autocomplete is a feature within Google Search that improves the search experience by allowing users to complete searches they started to type.
   input:
     bodyType: json
@@ -7894,7 +7894,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/dataset_info/live/advanced
-  name: Details for a dataset listing
+  name: "Google Dataset details by dataset id, live"
   summary: Live Google Dataset Info provides real-time data on the dataset you specify in the request.
   input:
     bodyType: json
@@ -7940,7 +7940,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/dataset_search/live/advanced
-  name: Search dataset results
+  name: "Google Dataset search results for a keyword, live"
   summary: Live Google Dataset Search provides real-time data on the top 20 Google Dataset search engine results.
   input:
     bodyType: json
@@ -8028,7 +8028,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/events/live/advanced
-  name: Search local events
+  name: "Google Events results for a keyword and location, live"
   summary: Live Google Events SERP provides real-time data from Google Events Search for the specified keyword and location.
   input:
     bodyType: json
@@ -8102,7 +8102,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/finance_explore/live/advanced
-  name: Finance Explore tab results
+  name: "Google Finance Explore tab results, live"
   summary: Live Google Finance Explore provides real-time data from the ‘Explore’ tab of Google Finance.
   input:
     bodyType: json
@@ -8158,7 +8158,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/finance_markets/live/advanced
-  name: Finance Markets tab results
+  name: "Google Finance Markets tab results, live"
   summary: Live Google Finance Markets provides real-time data from the ‘Markets’ tab of Google Finance.
   input:
     bodyType: json
@@ -8214,7 +8214,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/finance_quote/live/advanced
-  name: Quote data for a ticker
+  name: "Google Finance quote for a ticker, live"
   summary: Live Google Finance Quote provides real-time data from the ‘Quote’ tab of Google Finance.
   input:
     bodyType: json
@@ -8276,7 +8276,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/finance_ticker_search/live/advanced
-  name: Search financial instruments
+  name: "Google Finance ticker search by company name, live"
   summary: Live Google Finance Ticker Search allows you to search for financial instruments available on Google Finance along with additional information.
   input:
     bodyType: json
@@ -8332,7 +8332,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/images/live/advanced
-  name: Image search results
+  name: "Google Images results for a keyword, live"
   summary: Live Google Images SERP provides real-time data on top 100 images results for the specified keyword, search engine, and location.
   input:
     bodyType: json
@@ -8410,7 +8410,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/jobs/task_post
-  name: Job search results (async batch)
+  name: "Google Jobs postings for a keyword (async task)"
   summary: This endpoint will provide you with SERP data from the Google Jobs search engine.
   input:
     bodyType: json
@@ -8488,7 +8488,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/local_finder/live/advanced
-  name: Local finder search results
+  name: "Google Local Finder results for a keyword, live"
   summary: Live Google Local_finder SERP provides real-time search engine results for the specified keyword and location.
   input:
     bodyType: json
@@ -8572,7 +8572,7 @@ endpoints:
   method: GET
   path: /serp/google/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Google SERP location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/google/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -8581,7 +8581,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/maps/live/advanced
-  name: Maps search results
+  name: "Google Maps results for a keyword and location, live"
   summary: Live Google Maps SERP provides real-time data on top 100 search engine results for the specified keyword, search engine, and location.
   input:
     bodyType: json
@@ -8667,7 +8667,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/news/live/advanced
-  name: News search results
+  name: "Google News results for a keyword, live"
   summary: Live Google News SERP provides real-time data on top search engine results for the specified keyword, search engine, and location.
   input:
     bodyType: json
@@ -8757,7 +8757,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/organic/live/advanced
-  name: Organic search results (advanced)
+  name: "Google organic results for a keyword — full SERP features"
   summary: Live SERP provides real-time data on top search engine results for the specified keyword, search engine, and location.
   input:
     bodyType: json
@@ -8901,7 +8901,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/google/search_by_image/task_post
-  name: Reverse image search (async batch)
+  name: "Google reverse image search by image URL (async task)"
   summary: Google Search By Image SERP API provides up to top 100 search engine results based on the image you specified.
   input:
     bodyType: json
@@ -8999,7 +8999,7 @@ endpoints:
   platform: google
   method: POST
   path: /serp/screenshot
-  name: Screenshot a search results page
+  name: "Screenshot of a fetched SERP by task id"
   summary: Using the Live Page Screenshot endpoint, you can capture a screenshot of any SERP page.
   docs_url: https://docs.dataforseo.com/v3/serp/screenshot/
   input:
@@ -9048,7 +9048,7 @@ endpoints:
   platform: google-play
   method: POST
   path: /app_data/google/app_info/task_post
-  name: App listing details (async batch)
+  name: "Google Play app details by app id (async task)"
   summary: This endpoint will provide you with information about the Google Play application specified in the app_id field of the POST request.
   docs_url: https://docs.dataforseo.com/v3/app_data/google/app_info/task_post/
   input:
@@ -9115,7 +9115,7 @@ endpoints:
   platform: google-play
   method: POST
   path: /app_data/google/app_list/task_post
-  name: Top charts app list (async batch)
+  name: "Google Play top chart apps by collection (async task)"
   summary: This endpoint will provide you with a list of mobile applications published in the top charts on the Google Play platform.
   docs_url: https://docs.dataforseo.com/v3/app_data/google/app_list/task_post/
   input:
@@ -9196,7 +9196,7 @@ endpoints:
   platform: google-play
   method: POST
   path: /app_data/google/app_listings/search/live
-  name: Search app listings
+  name: "Search Google Play apps — rating, reviews count, price"
   summary: 'This endpoint will provide you with a list of apps published on Google Play along with additional information: its ID, icon, reviews count, rating, price, and other data.'
   docs_url: https://docs.dataforseo.com/v3/app_data/google/app_listings/search/live/
   input:
@@ -9275,7 +9275,7 @@ endpoints:
   platform: google-play
   method: POST
   path: /app_data/google/app_reviews/task_post
-  name: Reviews for an app (async batch)
+  name: "Google Play reviews for an app by app id (async task)"
   summary: This endpoint will provide you with reviews published on the Google Play platform for the app specified in the app_id field.
   docs_url: https://docs.dataforseo.com/v3/app_data/google/app_reviews/task_post/
   input:
@@ -9356,7 +9356,7 @@ endpoints:
   platform: google-play
   method: POST
   path: /app_data/google/app_searches/task_post
-  name: Apps ranking for a keyword (async batch)
+  name: "Google Play apps ranking for a keyword (async task)"
   summary: This endpoint will provide you with a list of apps ranking on Google Play for the specified keyword.
   docs_url: https://docs.dataforseo.com/v3/app_data/google/app_searches/task_post/
   input:
@@ -9431,7 +9431,7 @@ endpoints:
   method: GET
   path: /app_data/google/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Google Play location codes by country"
   summary: By calling this endpoint you will receive the list of Google locations supported in App Data API.
   docs_url: https://docs.dataforseo.com/v3/app_data/google/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -9440,7 +9440,7 @@ endpoints:
   platform: naver
   method: POST
   path: /serp/naver/organic/task_post
-  name: Organic search results (async batch)
+  name: "Naver organic search results for a keyword (async task)"
   summary: Naver SERP API provides top 15 search engine results.
   docs_url: https://docs.dataforseo.com/v3/serp/naver/organic/task_post/
   input:
@@ -9536,7 +9536,7 @@ endpoints:
   platform: ai-search
   method: POST
   path: /ai_optimization/perplexity/llm_responses/live
-  name: "Get a Perplexity answer"
+  name: "Perplexity answer to a prompt, live"
   summary: Live Perplexity LLM Responses endpoint allows you to retrieve structured responses from a specific Perplexity AI model, based on the input parameters.
   input:
     bodyType: json
@@ -9619,7 +9619,7 @@ endpoints:
   method: GET
   path: /serp/seznam/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Seznam location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/seznam/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -9628,7 +9628,7 @@ endpoints:
   platform: seznam
   method: POST
   path: /serp/seznam/organic/task_post
-  name: Organic search results (async batch)
+  name: "Seznam organic search results for a keyword (async task)"
   summary: Seznam SERP API provides top 10 search engine results from one of the most popular search engines in the Czech Republic.
   docs_url: https://docs.dataforseo.com/v3/serp/seznam/organic/task_post/
   input:
@@ -9742,7 +9742,7 @@ endpoints:
   method: GET
   path: /business_data/tripadvisor/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Tripadvisor location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/business_data/tripadvisor/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -9751,7 +9751,7 @@ endpoints:
   platform: tripadvisor
   method: POST
   path: /business_data/tripadvisor/reviews/task_post
-  name: Business reviews (async batch)
+  name: "Tripadvisor reviews for a business (async task)"
   summary: This endpoint provides results from the “Reviews” element on the Tripadvisor platform.
   docs_url: https://docs.dataforseo.com/v3/business_data/tripadvisor/reviews/task_post/
   input:
@@ -9849,7 +9849,7 @@ endpoints:
   platform: tripadvisor
   method: POST
   path: /business_data/tripadvisor/search/task_post
-  name: Search business profiles (async batch)
+  name: "Search Tripadvisor business profiles (async task)"
   summary: This endpoint provides a list of business profiles listed on the Tripadvisor platform.
   docs_url: https://docs.dataforseo.com/v3/business_data/tripadvisor/search/task_post/
   input:
@@ -9909,7 +9909,7 @@ endpoints:
   platform: trustpilot
   method: POST
   path: /business_data/trustpilot/reviews/task_post
-  name: Business reviews (async batch)
+  name: "Trustpilot reviews for a business by domain (async task)"
   summary: This endpoint provides reviews published on the Trustpilot platform for the local establishment specified in the domain field.
   docs_url: https://docs.dataforseo.com/v3/business_data/trustpilot/reviews/task_post/
   input:
@@ -9963,7 +9963,7 @@ endpoints:
   platform: trustpilot
   method: POST
   path: /business_data/trustpilot/search/task_post
-  name: Search business profiles (async batch)
+  name: "Search Trustpilot business profiles (async task)"
   summary: This endpoint provides a list of business profiles listed on the Trustpilot platform.
   docs_url: https://docs.dataforseo.com/v3/business_data/trustpilot/search/task_post/
   input:
@@ -10013,7 +10013,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_backlinks/live
-  name: Backlink counts for many targets
+  name: "Backlink counts for many domains or pages"
   summary: This endpoint will provide you with the number of backlinks pointing to domains, subdomains, and pages specified in the targets array.
   input:
     bodyType: json
@@ -10063,7 +10063,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_new_lost_backlinks/live
-  name: New and lost backlink counts in bulk
+  name: "New and lost backlink counts for many domains"
   summary: This endpoint will provide you with the number of new and lost backlinks for the domains, subdomains, and pages specified in the targets array.
   input:
     bodyType: json
@@ -10119,7 +10119,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_new_lost_referring_domains/live
-  name: New and lost referring domains in bulk
+  name: "New and lost referring domain counts for many domains"
   summary: This endpoint will provide you with the number of referring domains pointing to the domains, subdomains and pages specified in the targets array.
   input:
     bodyType: json
@@ -10175,7 +10175,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_pages_summary/live
-  name: Backlink summary for many pages
+  name: "Backlink summary for up to 1000 pages or domains"
   summary: This endpoint will provide you with a comprehensive overview of backlinks and related data for a bulk of up to 1000 pages, domains, or subdomains.
   input:
     bodyType: json
@@ -10217,7 +10217,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_referring_domains/live
-  name: Referring domain counts in bulk
+  name: "Referring domain counts for many domains or pages"
   summary: This endpoint will provide you with the number of referring domains pointing to domains, subdomains, and pages specified in the targets array.
   docs_url: https://docs.dataforseo.com/v3/backlinks/bulk_referring_domains/live/
   input:
@@ -10268,7 +10268,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/bulk_spam_score/live
-  name: Spam scores for many targets
+  name: "Spam scores for many domains or pages"
   summary: This endpoint will provide you with spam scores of the domains, subdomains, and pages you specified in the targets array.
   docs_url: https://docs.dataforseo.com/v3/backlinks/bulk_spam_score/live/
   input:
@@ -10319,7 +10319,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/domain_intersection/live
-  name: Domains linking to both targets
+  name: "Domains linking to several targets at once"
   summary: This endpoint will provide you with the list of domains pointing to the specified websites.
   input:
     bodyType: json
@@ -10419,7 +10419,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/domain_pages/live
-  name: Pages of a domain with backlink data
+  name: "Pages of a domain with backlinks per page"
   summary: This endpoint will provide you with a detailed overview of domain pages with backlink data for each page.
   docs_url: https://docs.dataforseo.com/v3/backlinks/domain_pages/live/
   input:
@@ -10508,7 +10508,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/domain_pages_summary/live
-  name: Backlink summary per page of a domain
+  name: "Backlink summary for every page of a domain"
   summary: This endpoint will provide you with detailed summary data on all backlinks and related metrics for each page of the target domain or subdomain you specify.
   docs_url: https://docs.dataforseo.com/v3/backlinks/domain_pages_summary/live/
   input:
@@ -10589,7 +10589,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/history/live
-  name: Backlink history since 2019
+  name: "Backlink history for a domain back to 2019"
   summary: This endpoint will provide you with historical backlinks data back to the beginning of 2019.
   input:
     bodyType: json
@@ -10637,7 +10637,7 @@ endpoints:
   method: GET
   path: /backlinks/index
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Size of the backlink index
+  name: "Backlink index totals — backlinks, domains, pages"
   summary: This endpoint will provide you with the total number of backlinks, domains, and pages our database contains for the moment when you make a request.
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
 - id: dataforseo.x.backlinks-page-intersection-live
@@ -10645,7 +10645,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/page_intersection/live
-  name: Pages linking to all given targets
+  name: "Pages linking to several targets at once"
   summary: This endpoint will provide you with the list of referring pages pointing to the specified targets.
   docs_url: https://docs.dataforseo.com/v3/backlinks/page_intersection/live/
   input:
@@ -10754,7 +10754,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/referring_networks/live
-  name: Referring IPs and subnets
+  name: "Referring IPs and subnets for a domain or page"
   summary: This endpoint will provide you with a detailed overview of referring IPs and subnets pointing to the target you specify.
   docs_url: https://docs.dataforseo.com/v3/backlinks/referring_networks/live/
   input:
@@ -10859,7 +10859,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/timeseries_new_lost_summary/live
-  name: New and lost backlinks over time
+  name: "New and lost backlinks over time for a domain"
   summary: This endpoint will provide you with the number of new and lost backlinks and referring domains for the domain specified in the target field.
   docs_url: https://docs.dataforseo.com/v3/backlinks/timeseries_new_lost_summary/live/
   input:
@@ -10912,7 +10912,7 @@ endpoints:
   platform: web
   method: POST
   path: /backlinks/timeseries_summary/live
-  name: Backlink metrics between two dates
+  name: "Backlink totals over time for a domain, by date range"
   summary: This endpoint will provide you with an overview of backlink data for the target domain available during a period between the two indicated dates.
   docs_url: https://docs.dataforseo.com/v3/backlinks/timeseries_summary/live/
   input:
@@ -10969,7 +10969,7 @@ endpoints:
   platform: web
   method: POST
   path: /business_data/business_listings/categories_aggregation/live
-  name: Count businesses by related category
+  name: "Business listing counts by related category"
   summary: Business Listings Categories Aggregation endpoint provides results containing information about groups of related categories along with the number of entities in each category.
   input:
     bodyType: json
@@ -11051,7 +11051,7 @@ endpoints:
   platform: web
   method: POST
   path: /business_data/business_listings/search/live
-  name: Search businesses on Maps by category
+  name: "Search Google Maps businesses by category and location"
   summary: Business Listings Search API provides results containing information about business entities listed on Google Maps in the specified categories.
   input:
     bodyType: json
@@ -11141,7 +11141,7 @@ endpoints:
   platform: pinterest
   method: POST
   path: /business_data/social_media/pinterest/live
-  name: Pin counts for URLs
+  name: "Pinterest pins made from a list of URLs"
   summary: Social Media Pinterest API will provide you with data on pins made from the specified URLs.
   docs_url: https://docs.dataforseo.com/v3/business_data/social_media/pinterest/live/
   input:
@@ -11180,7 +11180,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/category_trends/live
-  name: Citation trends for a category
+  name: "Citation trends for a category over a date range"
   summary: This endpoint will provide you with data on all citations in the target category for the indicated date range.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/category_trends/live/
   input:
@@ -11249,7 +11249,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/phrase_trends/live
-  name: Citation trends for a keyword
+  name: "Citation trends for a keyword over a date range"
   summary: This endpoint will provide you with data on all citations of the target keyword for the indicated date range.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/phrase_trends/live/
   input:
@@ -11322,7 +11322,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/rating_distribution/live
-  name: Rating distribution for a keyword
+  name: "Rating distribution of citations for a keyword"
   summary: This endpoint will provide you with rating distribution data for the keyword and other parameters specified in the request.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/rating_distribution/live/
   input:
@@ -11389,7 +11389,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/search/live
-  name: Search citations of a keyword
+  name: "Search citations of a keyword"
   summary: This endpoint will provide you with detailed citation data available for the target keyword.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/search/live/
   input:
@@ -11488,7 +11488,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/sentiment_analysis/live
-  name: Sentiment of citations for a keyword
+  name: "Sentiment of citations for a keyword"
   summary: This endpoint will provide you with sentiment analysis data for the citations available for the target keyword.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/sentiment_analysis/live/
   input:
@@ -11549,7 +11549,7 @@ endpoints:
   platform: web
   method: POST
   path: /content_analysis/summary/live
-  name: Citation overview for a keyword
+  name: "Citation overview for a keyword"
   summary: This endpoint will provide you with an overview of citation data available for the target keyword.
   docs_url: https://docs.dataforseo.com/v3/content_analysis/summary/live/
   input:
@@ -11624,7 +11624,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/aggregation_technologies/live
-  name: Technologies used alongside yours
+  name: "Technologies used alongside a given technology"
   summary: The Aggregation Technologies endpoint will provide you with a list of the most popular technologies websites use alongside the technologies you specify.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/aggregation_technologies/live/
   input:
@@ -11729,7 +11729,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/domain_technologies/live
-  name: Technologies a domain uses
+  name: "Technologies a website uses, by domain"
   summary: Using this endpoint you will get a list of technologies used in a particular domain.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/domain_technologies/live/
   input:
@@ -11756,7 +11756,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/domains_by_html_terms/live
-  name: Find domains by homepage HTML terms
+  name: "Find domains by HTML terms on their homepage"
   summary: This endpoint provides domains based on the HTML terms they use on their homepage.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/domains_by_html_terms/live/
   input:
@@ -11821,7 +11821,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/domains_by_technology/live
-  name: Find domains by technology used
+  name: "Find domains using a given technology"
   summary: This endpoint provides domains based on the technology they use.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/domains_by_technology/live/
   input:
@@ -11914,7 +11914,7 @@ endpoints:
   method: GET
   path: /domain_analytics/technologies/technologies
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List all known technologies
+  name: "Full list of technologies by group and category"
   summary: This endpoint will provide you with the full list of available technologies structured by technology groups and categories each particular technology belongs to.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/technologies/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -11923,7 +11923,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/technologies_summary/live
-  name: Domain counts per technology
+  name: "Domain counts for a technology, by country and language"
   summary: The Technologies Summary endpoint will provide you with the number of domains across different countries and languages that use the specified technology names, technology groups, or technology categories.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/technologies_summary/live/
   input:
@@ -12006,7 +12006,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/technologies/technology_stats/live
-  name: Technology adoption over time
+  name: "Domain counts for a technology over time"
   summary: The Technology Stats endpoint will provide you with historical data on the number of domains across different countries and languages that use the specified technology.
   docs_url: https://docs.dataforseo.com/v3/domain_analytics/technologies/technology_stats/live/
   input:
@@ -12049,7 +12049,7 @@ endpoints:
   platform: web
   method: POST
   path: /domain_analytics/whois/overview/live
-  name: Whois with traffic and backlink stats
+  name: "Whois records with backlink and traffic stats, filtered"
   summary: This endpoint will provide you with Whois data enriched with backlink stats, and ranking and traffic info from organic and paid search results.
   input:
     bodyType: json
@@ -12105,7 +12105,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/clickstream_data/bulk_search_volume/live
-  name: Bulk clickstream search volume
+  name: "Clickstream search volume for up to 1000 keywords"
   summary: The Bulk Clickstream Search Volume endpoint of DataForSEO Keywords Data API is designed to provide clickstream-based search volume data for up to 1000 keywords in a single Live request.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/clickstream_data/bulk_search_volume/live/
   input:
@@ -12154,7 +12154,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/clickstream_data/dataforseo_search_volume/live
-  name: Clickstream search volume for keywords
+  name: "Search volume for keywords, clickstream optional"
   summary: ClickstreamDataDataforseoSearchVolumeLive
   docs_url: https://docs.dataforseo.com/v3/keywords_data/clickstream_data/dataforseo_search_volume/live/
   input:
@@ -12217,7 +12217,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/clickstream_data/global_search_volume/live
-  name: Global clickstream search volume
+  name: "Global clickstream search volume for up to 1000 keywords"
   summary: The Clickstream Global Search Volume endpoint of DataForSEO Keywords Data API is designed to provide clickstream-based search volume data for up to 1000 keywords in a single Live request.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/clickstream_data/global_search_volume/live/
   input:
@@ -12256,7 +12256,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/dataforseo_trends/demography/live
-  name: Keyword popularity by age and gender
+  name: "Keyword popularity by age and gender, DataForSEO Trends"
   summary: This endpoint will provide you with the demographic breakdown (by age and gender) of keyword popularity per each specified term based on DataForSEO Trends data.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/dataforseo_trends/demography/live/
   input:
@@ -12323,7 +12323,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/dataforseo_trends/explore/live
-  name: Keyword popularity over time
+  name: "DataForSEO Trends keyword popularity over time"
   summary: This endpoint will provide you with the keyword popularity data from DataForSEO Trends.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/dataforseo_trends/explore/live/
   input:
@@ -12386,7 +12386,7 @@ endpoints:
   method: GET
   path: /keywords_data/dataforseo_trends/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List Trends locations
+  name: "DataForSEO Trends location codes by country"
   summary: You will receive the list of DataForSEO Trends locations by calling this API.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/dataforseo_trends/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -12395,7 +12395,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/dataforseo_trends/merged_data/live
-  name: Keyword popularity across sources
+  name: "Keyword popularity merged across trend sources"
   summary: This endpoint will provide you with the keyword popularity data from DataForSEO Trends.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/dataforseo_trends/merged_data/live/
   input:
@@ -12462,7 +12462,7 @@ endpoints:
   platform: web
   method: POST
   path: /keywords_data/dataforseo_trends/subregion_interests/live
-  name: Keyword popularity by subregion
+  name: "Keyword popularity by subregion, DataForSEO Trends"
   summary: This endpoint will provide you with location-specific keyword popularity data from DataForSEO Trends.
   docs_url: https://docs.dataforseo.com/v3/keywords_data/dataforseo_trends/subregion_interests/live/
   input:
@@ -12529,7 +12529,7 @@ endpoints:
   platform: web
   method: POST
   path: /on_page/content_parsing
-  name: Parse page content (async batch)
+  name: "Parsed page content from a crawl, by task id and URL"
   summary: This endpoint allows parsing the content on any page you specify and will return the structured content of the target page, including link URLs, anchors, headings, and textual content.
   docs_url: https://docs.dataforseo.com/v3/on_page/content_parsing/
   input:
@@ -12566,7 +12566,7 @@ endpoints:
   platform: web
   method: POST
   path: /on_page/content_parsing/live
-  name: Parse page content
+  name: "Parse a page into links, headings and text, live"
   summary: This endpoint allows parsing the content on any page you specify and will return the structured content of the target page, including link URLs, anchors, headings, and textual content.
   docs_url: https://docs.dataforseo.com/v3/on_page/content_parsing/live/
   input:
@@ -12641,7 +12641,7 @@ endpoints:
   method: POST
   path: /on_page/duplicate_content
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Pages with duplicate content
+  name: "Pages with duplicate content in a crawl, by URL"
   summary: This endpoint returns a list of pages that have content similar to the page specified in the request.
   docs_url: https://docs.dataforseo.com/v3/on_page/duplicate_content/
   input:
@@ -12681,7 +12681,7 @@ endpoints:
   method: POST
   path: /on_page/duplicate_tags
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Pages with duplicate titles or tags
+  name: "Pages with duplicate title or meta tags in a crawl"
   summary: This endpoint returns a list of pages that contain duplicate title or description tags.
   docs_url: https://docs.dataforseo.com/v3/on_page/duplicate_tags/
   input:
@@ -12722,7 +12722,7 @@ endpoints:
   method: POST
   path: /on_page/keyword_density
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Keyword density on a page or site
+  name: "Keyword density on a crawled site or page"
   summary: This endpoint will provide you with keyword density and keyword frequency data for terms appearing on the specified website or web page.
   docs_url: https://docs.dataforseo.com/v3/on_page/keyword_density/
   input:
@@ -12772,7 +12772,7 @@ endpoints:
   method: GET
   path: /on_page/lighthouse/audits
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List Lighthouse audit checks
+  name: "Available Lighthouse audit checks"
   summary: The OnPage Lighthouse API is based on Google’s open-source Lighthouse project and provides data on the quality of web pages.
   docs_url: https://docs.dataforseo.com/v3/on_page/lighthouse/audits/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -12781,7 +12781,7 @@ endpoints:
   platform: web
   method: POST
   path: /on_page/lighthouse/live/json
-  name: Run a Lighthouse audit
+  name: "Lighthouse audit for a URL, live"
   summary: The OnPage Lighthouse API is based on Google’s open-source Lighthouse project for measuring the quality of web pages and web apps.
   input:
     bodyType: json
@@ -12857,7 +12857,7 @@ endpoints:
   method: POST
   path: /on_page/links
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Internal and external links found
+  name: "Internal and external links from a site crawl"
   summary: This endpoint will provide you with a list of internal and external links detected on a target website.
   docs_url: https://docs.dataforseo.com/v3/on_page/links/
   input:
@@ -12913,7 +12913,7 @@ endpoints:
   platform: web
   method: POST
   path: /on_page/microdata
-  name: Validate JSON-LD and Microdata
+  name: "Validate JSON-LD and microdata on a crawled page"
   summary: This endpoint is designed to validate structured JSON-LD data and Microdata.
   docs_url: https://docs.dataforseo.com/v3/on_page/microdata/
   input:
@@ -12941,7 +12941,7 @@ endpoints:
   method: POST
   path: /on_page/non_indexable
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Pages blocked from indexing
+  name: "Non-indexable pages found in a site crawl"
   summary: This endpoint returns a list of pages that are blocked from being indexed by Google and other search engines through robots.txt, HTTP headers, or meta tags settings.
   docs_url: https://docs.dataforseo.com/v3/on_page/non_indexable/
   input:
@@ -12981,7 +12981,7 @@ endpoints:
   method: POST
   path: /on_page/page_screenshot
   cost: {type: per_result, value: 0.0048, currency: USD, per: 1, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', confidence: verified, note: 'read from our own account rate card'}
-  name: Screenshot a webpage
+  name: "Full-page screenshot of any URL"
   summary: Using this endpoint, you can capture a full high-quality screenshot of any webpage.
   docs_url: https://docs.dataforseo.com/v3/on_page/page_screenshot/
   input:
@@ -13040,7 +13040,7 @@ endpoints:
   method: POST
   path: /on_page/pages
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Crawled pages with on-page checks
+  name: "Crawled pages with on-page checks, by task id"
   summary: This endpoint returns a list of crawled pages with on-page check-ups and other metrics related to the page performance.
   docs_url: https://docs.dataforseo.com/v3/on_page/pages/
   input:
@@ -13094,7 +13094,7 @@ endpoints:
   method: POST
   path: /on_page/pages_by_resource
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Pages using a given resource
+  name: "Pages using a given resource, from a site crawl"
   summary: This endpoint will return the list of pages where a specific resource is located.
   docs_url: https://docs.dataforseo.com/v3/on_page/page_by_resource/
   input:
@@ -13138,7 +13138,7 @@ endpoints:
   method: POST
   path: /on_page/raw_html
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Raw HTML of a page
+  name: "Raw HTML of a crawled page, by task id and URL"
   summary: This endpoint returns the HTML of a page you indicate in the request.
   docs_url: https://docs.dataforseo.com/v3/on_page/raw_html/
   input:
@@ -13162,7 +13162,7 @@ endpoints:
   method: POST
   path: /on_page/redirect_chains
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Redirect chains found on a site
+  name: "Redirect chains found in a site crawl"
   summary: Redirect chains occur when there are at least two redirects between the initial URL and the destination URL.
   docs_url: https://docs.dataforseo.com/v3/on_page/redirect_chains/
   input:
@@ -13202,7 +13202,7 @@ endpoints:
   method: POST
   path: /on_page/resources
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Images, scripts and other resources
+  name: "Site resources from a crawl — images, scripts, broken"
   summary: This endpoint will provide you with a list of resources, including images, scripts, stylesheets, and broken elements.
   docs_url: https://docs.dataforseo.com/v3/on_page/resources/
   input:
@@ -13264,7 +13264,7 @@ endpoints:
   method: GET
   path: /on_page/summary/{id}
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Crawl summary for a site
+  name: "Site crawl summary and issues, by task id"
   summary: Using this function, you can get the overall information on a website as well as drill down into exact on-page issues of a website that has been scanned.
   docs_url: https://docs.dataforseo.com/v3/on_page/summary/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -13273,7 +13273,7 @@ endpoints:
   platform: web
   method: POST
   path: /on_page/task_post
-  name: Start a site crawl
+  name: "Start a site crawl for on-page audit, by domain"
   summary: OnPage API checks websites for 60+ customizable on-page parameters defines and displays all found flaws and opportunities for optimization so that you can easily fix them.
   docs_url: https://docs.dataforseo.com/v3/on_page/task_post/
   input:
@@ -13481,7 +13481,7 @@ endpoints:
   method: POST
   path: /on_page/uncrawlable_resources
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Resources that could not be crawled
+  name: "Uncrawlable resources found in a site crawl"
   summary: This endpoint returns a list of resources detected on the target website that could not be crawled due to a content type inconsistency.
   input:
     bodyType: json
@@ -13524,7 +13524,7 @@ endpoints:
   method: POST
   path: /on_page/waterfall
   cost: {type: free, value: 0, currency: USD, unit: call, source: rate_card_api, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: Page load timing waterfall
+  name: "Page load waterfall timings for a crawled page"
   summary: This endpoint is designed to provide you with the page speed insights.
   docs_url: https://docs.dataforseo.com/v3/on_page/waterfall/
   input:
@@ -13553,7 +13553,7 @@ endpoints:
   method: GET
   path: /serp/yahoo/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "Yahoo location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/yahoo/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -13562,7 +13562,7 @@ endpoints:
   platform: yahoo
   method: POST
   path: /serp/yahoo/organic/live/advanced
-  name: Organic search results (advanced)
+  name: "Yahoo organic results for a keyword — full SERP features"
   summary: Live SERP provides real-time data on top search engine results.
   docs_url: https://docs.dataforseo.com/v3/serp/yahoo/organic/live/advanced/
   input:
@@ -13662,7 +13662,7 @@ endpoints:
   platform: yahoo
   method: POST
   path: /serp/yahoo/organic/live/regular
-  name: Organic search results (regular)
+  name: "Yahoo organic search results for a keyword, live"
   summary: Live Yahoo SERP provides real-time data on search engine results for the specified keyword, search engine, and location.
   docs_url: https://docs.dataforseo.com/v3/serp/yahoo/organic/live/regular/
   input:
@@ -13764,7 +13764,7 @@ endpoints:
   method: GET
   path: /serp/youtube/locations/{country}
   cost: {type: free, value: 0, currency: USD, unit: call, source: observed, source_url: 'https://api.dataforseo.com/v3/appendix/user_data', checked: '2026-08-07', note: 'DataForSEO reports cost 0 for this route on our own account — reference/utility data, not metered'}
-  name: List supported locations
+  name: "YouTube location codes by country"
   summary: You will receive the list of locations by this API call.
   docs_url: https://docs.dataforseo.com/v3/serp/youtube/locations/
   untestable: the OpenAPI spec ships no example request body for this route, so no test request could be generated
@@ -13773,7 +13773,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /serp/youtube/organic/live/advanced
-  name: Video search results
+  name: "YouTube search results for a keyword, live"
   summary: Live SERP provides real-time data on the top 20 blocks of YouTube search engine results.
   docs_url: https://docs.dataforseo.com/v3/serp/youtube/organic/live/advanced/
   input:
@@ -13840,7 +13840,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /serp/youtube/video_comments/live/advanced
-  name: Comments on a video
+  name: "YouTube comments for a video by video id, live"
   summary: Live YouTube Comments provides real-time data on comments on the video you specify in the request.
   docs_url: https://docs.dataforseo.com/v3/serp/youtube/video_comments/live/advanced/
   input:
@@ -13903,7 +13903,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /serp/youtube/video_info/live/advanced
-  name: Video details and stats
+  name: "YouTube video details by video id, live"
   summary: Live YouTube Video Info provides real-time data on the video you specify in the request.
   docs_url: https://docs.dataforseo.com/v3/serp/youtube/video_info/live/advanced/
   input:
@@ -13962,7 +13962,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /serp/youtube/video_subtitles/live/advanced
-  name: Subtitles for a video
+  name: "YouTube subtitles for a video by video id, live"
   summary: Live YouTube Subtitles provides real-time data on subtitles in the video you specify in the request.
   docs_url: https://docs.dataforseo.com/v3/serp/youtube/video_subtitles/live/advanced/
   input:

--- a/src/treg/catalog/dataforseo.yaml
+++ b/src/treg/catalog/dataforseo.yaml
@@ -71,7 +71,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/summary/live
-    name: "Get backlink summary for a domain"
+    name: "Backlink profile of a domain — counts, rank, spam score"
     summary: "Aggregate backlink profile of a domain or URL — counts, rank, spam score, breakdowns"
     input:
       bodyType: json
@@ -101,7 +101,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/backlinks/live
-    name: "List backlinks for a domain"
+    name: "Backlinks pointing to a domain or URL — anchor, rank"
     summary: "Individual backlinks — source page, anchor, follow status, first seen, page/domain rank"
     input:
       bodyType: json
@@ -132,7 +132,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/referring_domains/live
-    name: "List referring domains for a target"
+    name: "Referring domains for a domain or URL — counts, rank"
     summary: "Referring domains linking to a target, with backlink counts, rank and first/last seen"
     input:
       bodyType: json
@@ -163,7 +163,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/anchors/live
-    name: "List anchor text distribution"
+    name: "Anchor text distribution of backlinks for a domain"
     summary: "Anchor-text distribution — backlink and referring-domain counts per anchor"
     input:
       bodyType: json
@@ -198,7 +198,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/bulk_ranks/live
-    name: "Get bulk backlink rank scores"
+    name: "Backlink authority rank for up to 1000 domains or URLs"
     summary: "Backlink-derived authority rank (0-1000) for up to 1000 domains or pages per call"
     input:
       bodyType: json
@@ -222,7 +222,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /backlinks/competitors/live
-    name: "Find backlink competitors for a domain"
+    name: "Domains sharing backlink sources with a domain"
     summary: "Domains sharing referring domains with the target, ranked by overlap"
     input:
       bodyType: json
@@ -252,7 +252,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /serp/google/organic/live/regular
-    name: "Get live Google search results"
+    name: "Google organic search results for a keyword, live"
     summary: "Live Google organic results for a keyword — rank, title, URL, snippet — by location"
     input:
       bodyType: json
@@ -287,7 +287,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /keywords_data/google_ads/search_volume/live
-    name: "Get keyword search volume and CPC"
+    name: "Google search volume and CPC for up to 1000 keywords"
     summary: "Google Ads search volume, CPC, competition and 12-month trend for up to 1000 keywords"
     input:
       bodyType: json
@@ -317,7 +317,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /dataforseo_labs/google/related_keywords/live
-    name: "Get related keyword ideas"
+    name: "Related keyword ideas for a seed — volume, CPC, difficulty"
     summary: "Related keyword ideas from Google's related-searches graph, with volume, CPC, difficulty"
     input:
       bodyType: json
@@ -351,7 +351,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /dataforseo_labs/google/ranked_keywords/live
-    name: "List keywords a domain ranks for"
+    name: "Keywords a domain ranks for in Google — position, volume"
     summary: "Keywords a domain or URL ranks for in Google, with position, volume and SERP element"
     input:
       bodyType: json
@@ -384,7 +384,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /on_page/instant_pages
-    name: "Audit a single page on demand"
+    name: "Instant on-page audit of a URL — timings, meta, score"
     summary: "Crawl one URL on demand — status code, load timings, on-page score, meta and content"
     input:
       bodyType: json
@@ -418,7 +418,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /appendix/user_data
-    name: "Get account usage and limits"
+    name: "DataForSEO account balance and rate limits"
     summary: "Your own DataForSEO account — remaining balance, plan limits and per-API rate limits"
     input:
       note: "no parameters; GET with HTTP Basic auth only. Unlike every other endpoint here it is GET, takes no task array, and costs nothing (`cost: 0`)"

--- a/src/treg/catalog/diffbot.extended.yaml
+++ b/src/treg/catalog/diffbot.extended.yaml
@@ -89,7 +89,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/analyze
-    name: "Auto-detect and extract any page"
+    name: "Auto-detect a page type and extract it by URL"
     summary: "Automatically identifies the type of page being processed and routes it through the relevant Diffbot API"
     input:
       queryParams:
@@ -129,7 +129,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/article
-    name: "Extract an article page"
+    name: "Extract article text, author and date from a URL"
     summary: "Extracts clean article text, author, date, images, tags, sentiment and NLP facts from a news or blog page"
     input:
       queryParams:
@@ -173,7 +173,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/product
-    name: "Extract a product page"
+    name: "Extract product name, price and reviews from a URL"
     summary: "Extracts product name, price, SKU, images, specs and reviews from an e-commerce page"
     input:
       queryParams:
@@ -211,7 +211,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/image
-    name: "Extract images from a page"
+    name: "Extract a page's images by URL, with dimensions"
     summary: "Extracts the primary and secondary images from a page, with dimensions and metadata"
     input:
       queryParams:
@@ -248,7 +248,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/video
-    name: "Extract video page metadata"
+    name: "Extract video title, duration and embed URL from a page"
     summary: "Extracts title, embed/player URL, duration, thumbnail and metadata from a video page"
     input:
       queryParams:
@@ -285,7 +285,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/discussion
-    name: "Extract a forum or comment thread"
+    name: "Extract forum posts and comments from a thread URL"
     summary: "Extracts individual posts, authors, dates and sentiment from a forum thread or comment section"
     input:
       queryParams:
@@ -324,7 +324,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/job
-    name: "Extract a job listing page"
+    name: "Extract a job posting page by URL — title, salary"
     summary: "Extracts job title, employer, location, salary and description from a job posting page"
     input:
       queryParams:
@@ -361,7 +361,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/list
-    name: "Extract links from a list/index page"
+    name: "Extract linked items from an index page by URL"
     summary: "Extracts the list of linked items (with titles, dates, images) from an index or category page"
     input:
       queryParams:
@@ -398,7 +398,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/event
-    name: "Extract an event page"
+    name: "Extract event name, date and venue from a page URL"
     summary: "Extracts event name, date, venue, price and organizer from an event listing page"
     input:
       queryParams:
@@ -437,7 +437,7 @@ endpoints:
     host: api.diffbot.com
     method: POST
     path: /v3/crawl
-    name: "Start a crawl job"
+    name: "Start a site crawl job from seed URLs"
     summary: "Spiders a site for links and pages, running each discovered page through an Extract API and compiling results into a searchable collection"
     input:
       bodyType: form
@@ -500,7 +500,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/crawl/data
-    name: "Download crawl job results"
+    name: "Download a crawl job's results as JSON or CSV"
     summary: "Downloads the extracted results of a crawl job as JSON or CSV, or a diagnostic URL report"
     input:
       queryParams:
@@ -520,7 +520,7 @@ endpoints:
     host: api.diffbot.com
     method: POST
     path: /v3/bulk
-    name: "Start a bulk extract job"
+    name: "Start a bulk extract job from a list of URLs"
     summary: "Sends a large, explicit list of URLs through an Extract API asynchronously and compiles the results into one collection — unlike Crawl, it does not discover links"
     input:
       bodyType: form
@@ -555,7 +555,7 @@ endpoints:
     host: api.diffbot.com
     method: GET
     path: /v3/bulk/data
-    name: "Download bulk job results"
+    name: "Download a bulk extract job's results as JSON or CSV"
     summary: "Downloads the extracted results of a bulk job as JSON or CSV, or a diagnostic URL report"
     input:
       queryParams:
@@ -573,7 +573,7 @@ endpoints:
     host: llm.diffbot.com
     method: GET
     path: /api/v1/web_search/
-    name: "Web search for LLM context"
+    name: "Web search shaped for an LLM context window"
     summary: "Search the web and return results shaped for feeding into an LLM context window"
     input:
       queryParams:
@@ -593,7 +593,7 @@ endpoints:
     host: nl.diffbot.com
     method: POST
     path: /v1/
-    name: "Extract entities, sentiment & facts from text"
+    name: "Extract entities, sentiment and facts from text"
     summary: "Runs a pre-trained classifier, named-entity recognizer, sentence tokenizer and sentiment analyzer over submitted text or a URL"
     input:
       bodyType: json

--- a/src/treg/catalog/diffbot.yaml
+++ b/src/treg/catalog/diffbot.yaml
@@ -39,7 +39,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /enhance
-    name: "Enrich a company profile"
+    name: "Enrich a company by website, name or ticker"
     summary: "Enrich a company from website, name or ticker — industry, revenue, headcount, rivals"
     input:
       queryParams:
@@ -85,7 +85,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /enhance
-    name: "Enrich a person profile"
+    name: "Enrich a person by name, email or employer"
     summary: "Enrich a person from name, email or employer — role, employment history, profiles"
     input:
       queryParams:
@@ -128,7 +128,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /dql
-    name: "Search companies"
+    name: "Search companies by DQL filter — industry, revenue"
     summary: "Search the Diffbot Knowledge Graph for companies by DQL filter (industry, revenue)"
     input:
       queryParams:
@@ -165,7 +165,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /dql
-    name: "Search people"
+    name: "Search people by DQL filter — role, employer, skills"
     summary: "Search the Diffbot Knowledge Graph for people by DQL filter (role, employer, skills)"
     input:
       queryParams:
@@ -200,7 +200,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /enhance/bulk
-    name: "Bulk enrich companies/people"
+    name: "Bulk-enrich companies or people (async job)"
     summary: "Enrich many companies or people in one asynchronous job instead of one call each"
     input:
       bodyType: json

--- a/src/treg/catalog/eodhd.yaml
+++ b/src/treg/catalog/eodhd.yaml
@@ -17,7 +17,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /eod/{symbol}
-    name: "End-of-day price history"
+    name: "End-of-day stock prices by ticker — OHLCV, 70+ exchanges"
     summary: "Daily OHLCV for a symbol across 70+ global exchanges — symbol carries the exchange suffix (AAPL.US, BMW.XETRA)"
     input:
       queryParams:
@@ -38,7 +38,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /real-time/{symbol}
-    name: "Delayed live quote"
+    name: "Delayed stock quote by ticker — price, day change"
     summary: "The current (15-20min delayed) quote for a symbol, with day change"
     input:
       queryParams:
@@ -56,7 +56,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /exchanges-list/
-    name: "Exchange directory"
+    name: "Stock exchange directory — codes, countries, currencies"
     summary: "Every exchange EODHD covers, with code, country and currency — the suffix directory for the symbol format"
     input:
       queryParams:

--- a/src/treg/catalog/facebook.extended.yaml
+++ b/src/treg/catalog/facebook.extended.yaml
@@ -36,7 +36,7 @@ endpoints:
   platform: facebook
   method: DELETE
   path: /{comment_id}
-  name: "Delete a comment"
+  name: "Delete a comment on your Facebook Page"
   summary: Delete a comment on the Page's content
   scope: own_account
   cost:
@@ -54,7 +54,7 @@ endpoints:
   platform: facebook
   method: POST
   path: /{comment_id}/comments
-  name: "Reply to a comment"
+  name: "Reply to a comment as your Facebook Page"
   summary: Reply to a comment as the Page
   scope: own_account
   cost:
@@ -72,7 +72,7 @@ endpoints:
   platform: facebook
   method: POST
   path: /{comment_id}?is_hidden=true
-  name: "Hide a comment"
+  name: "Hide a comment on your Facebook Page"
   summary: Hide a comment on the Page's content
   scope: own_account
   cost:
@@ -89,7 +89,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}
-  name: "Get Page profile details"
+  name: "Your Facebook Page profile — name, category, fan count"
   summary: The Page itself — name, category, about, fan_count, link, verification status, hours
   scope: own_account
   cost:
@@ -105,7 +105,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/albums
-  name: "List Page photo albums"
+  name: "Photo albums on your Facebook Page"
   summary: The Page's photo albums and their counts
   scope: own_account
   cost:
@@ -121,7 +121,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/conversations
-  name: "List Page Messenger conversations"
+  name: "Messenger threads with your Facebook Page"
   summary: Messenger threads with the Page, with participants and updated_time
   scope: own_account
   cost:
@@ -138,7 +138,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/events
-  name: "List events created by a Page"
+  name: "Events your Facebook Page created, with attendance"
   summary: Events the Page has created, with time, place and attendance counts
   scope: own_account
   cost:
@@ -154,7 +154,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/feed
-  name: "Get Page feed posts"
+  name: "Your Facebook Page feed — own posts plus visitor posts"
   summary: 'The Page''s feed: its own posts plus visitor posts, with message, created_time and attachments'
   scope: own_account
   cost:
@@ -170,7 +170,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/leadgen_forms
-  name: "List Page lead-ad forms"
+  name: "Lead-ad forms on your Facebook Page"
   summary: Lead-ad forms attached to the Page, and their fields
   scope: own_account
   cost:
@@ -187,7 +187,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/live_videos
-  name: "List Page live broadcasts"
+  name: "Live broadcasts on your Facebook Page"
   summary: Live broadcasts on the Page, past and current, with status and viewer counts
   scope: own_account
   cost:
@@ -203,7 +203,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/photos
-  name: "List photos uploaded to a Page"
+  name: "Photos uploaded to your Facebook Page"
   summary: Photos uploaded to the Page, with images, alt text and created_time
   scope: own_account
   cost:
@@ -219,7 +219,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/published_posts
-  name: "List published Page posts"
+  name: "Posts your Facebook Page itself published"
   summary: Only the posts the Page itself published, including ones published via the API
   scope: own_account
   cost:
@@ -235,7 +235,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/ratings
-  name: "List Page ratings and reviews"
+  name: "Ratings and reviews left on your Facebook Page"
   summary: Recommendations and reviews left on the Page, with rating, review text and reviewer
   scope: own_account
   cost:
@@ -251,7 +251,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/roles
-  name: "List Page admins"
+  name: "Admins of your Facebook Page and their roles"
   summary: Who administers the Page and at what role level
   scope: own_account
   cost:
@@ -268,7 +268,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/settings
-  name: "Get Page settings"
+  name: "Your Facebook Page settings — messaging, tagging"
   summary: The Page's own settings — messaging, tagging and visitor-post permissions
   scope: own_account
   cost:
@@ -284,7 +284,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/tagged
-  name: "List posts tagging the Page"
+  name: "Posts by others that tag your Facebook Page"
   summary: Posts by other people that tagged this Page
   scope: own_account
   cost:
@@ -300,7 +300,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}/videos
-  name: "List videos on a Page"
+  name: "Videos on your Facebook Page"
   summary: Videos on the Page, with title, description, length and permalink
   scope: own_account
   cost:
@@ -316,7 +316,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{page_id}?fields=instagram_business_account
-  name: "Get linked Instagram business account"
+  name: "Instagram account linked to your Facebook Page"
   summary: The Instagram professional account linked to this Page — the id every Instagram call needs
   scope: own_account
   cost:
@@ -333,7 +333,7 @@ endpoints:
   platform: facebook
   method: DELETE
   path: /{post_id}
-  name: "Delete a post"
+  name: "Delete a post from your Facebook Page"
   summary: Delete one of the Page's posts
   scope: own_account
   cost:
@@ -349,7 +349,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}
-  name: "Get a single post"
+  name: "One Facebook Page post — message, permalink, attachments"
   summary: A single post — message, created_time, permalink_url, attachments and privacy
   scope: own_account
   cost:
@@ -366,7 +366,7 @@ endpoints:
   platform: facebook
   method: POST
   path: /{post_id}
-  name: "Update a post"
+  name: "Edit a published Facebook Page post's message"
   summary: Edit a published post's message
   scope: own_account
   cost:
@@ -382,7 +382,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}/comments
-  name: "List comments on a post"
+  name: "Comments on a Facebook Page post"
   summary: Comments on a post, with message, from, like_count and comment_count
   scope: own_account
   cost:
@@ -398,7 +398,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}/insights
-  name: "Get post performance metrics"
+  name: "One Facebook post's reach, impressions and clicks"
   summary: Per-post metrics — impressions, reach, engaged users, clicks, negative feedback
   scope: own_account
   cost:
@@ -414,7 +414,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}/likes
-  name: "List post likes"
+  name: "Who liked a Facebook Page post"
   summary: Who liked a post (summary=true gives just the total)
   scope: own_account
   cost:
@@ -430,7 +430,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}/reactions
-  name: "List reactions on a post"
+  name: "Reactions on a Facebook Page post, by type"
   summary: Reactions on a post broken down by type (LIKE, LOVE, WOW, ANGRY…)
   scope: own_account
   cost:
@@ -446,7 +446,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /{post_id}/sharedposts
-  name: "List posts sharing a post"
+  name: "Posts that shared a Facebook Page post"
   summary: The posts that shared this post
   scope: own_account
   cost:

--- a/src/treg/catalog/facebook.yaml
+++ b/src/treg/catalog/facebook.yaml
@@ -30,7 +30,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /me/accounts
-    name: "List Pages you manage"
+    name: "Facebook Pages you manage, with their Page tokens"
     summary: "List the Facebook Pages you manage, with the page token each one needs"
     input:
       queryParams:
@@ -52,7 +52,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{page_id}/posts
-    name: "List posts on your Page"
+    name: "Posts on your Facebook Page with engagement counts"
     summary: "List the posts published on your Facebook Page with their engagement counts"
     input:
       pathParams:
@@ -78,7 +78,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{page_id}/insights
-    name: "Get Page performance metrics"
+    name: "Your Facebook Page reach and engagement metrics"
     summary: "Get reach, impressions and engagement metrics for your Facebook Page"
     input:
       pathParams:
@@ -104,7 +104,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /{page_id}/feed
-    name: "Publish a Page post"
+    name: "Publish a post to your Facebook Page"
     summary: "Publish a post to your Facebook Page"
     input:
       pathParams:
@@ -132,7 +132,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /{page_id}/photos
-    name: "Publish or stage a Page photo"
+    name: "Publish a photo to your Facebook Page, or stage one"
     summary: "Publish a photo to your Facebook Page, or stage one for a multi-photo post"
     input:
       pathParams:
@@ -155,7 +155,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /{page_id}/videos
-    name: "Publish a Page video"
+    name: "Publish a video or Reel to your Facebook Page"
     summary: "Publish a video or Reel to your Facebook Page"
     input:
       pathParams:

--- a/src/treg/catalog/fiber-ai.yaml
+++ b/src/treg/catalog/fiber-ai.yaml
@@ -46,7 +46,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/contact-details/single
-    name: "Find a person's work email (standard)"
+    name: "Find a person's work email by LinkedIn URL (standard)"
     summary: "Reveal contact details (standard)"
     input:
       bodyType: json
@@ -80,7 +80,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/contact-details/turbo/sync
-    name: "Find a person's work email (turbo)"
+    name: "Find a person's work email by LinkedIn URL (turbo)"
     summary: "Reveal contact details (turbo)"
     input:
       bodyType: json
@@ -112,7 +112,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/kitchen-sink/person
-    name: "Enrich a person from LinkedIn, email or name"
+    name: "Enrich a person by LinkedIn URL, email or name"
     summary: "Kitchen sink person lookup"
     input:
       bodyType: json
@@ -149,7 +149,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/kitchen-sink/company
-    name: "Enrich a company from domain or LinkedIn"
+    name: "Enrich a company by domain or LinkedIn URL — tech, funding"
     summary: "Kitchen sink company lookup"
     input:
       bodyType: json
@@ -215,7 +215,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/linkedin-live-fetch/company/single
-    name: "Live-fetch a LinkedIn company profile"
+    name: "Live-fetch a LinkedIn company profile — headcount history"
     summary: "Live fetch LinkedIn company"
     input:
       bodyType: json
@@ -246,7 +246,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/email-to-person/single
-    name: "Find a person from their email address"
+    name: "Reverse email lookup — LinkedIn URL, name, title"
     summary: "Find person by email (single)"
     input:
       bodyType: json
@@ -275,7 +275,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/company-search
-    name: "Search companies by industry, size or tech"
+    name: "Search companies with typed filters"
     summary: "Search for companies using filters"
     input:
       bodyType: json
@@ -311,7 +311,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/people-search
-    name: "Search people by role, company or location"
+    name: "Search people by seniority or current employer"
     summary: "Search for people using filters"
     input:
       bodyType: json
@@ -376,7 +376,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/github-to-linkedin/trigger
-    name: "Resolve a GitHub username to LinkedIn"
+    name: "Resolve GitHub usernames to LinkedIn profiles (async)"
     summary: "Start GitHub to LinkedIn lookup"
     input:
       bodyType: json
@@ -408,7 +408,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/github-to-linkedin/polling
-    name: "Poll a GitHub-to-LinkedIn lookup"
+    name: "Poll a GitHub-to-LinkedIn lookup job"
     summary: "Poll GitHub to LinkedIn lookup"
     input:
       bodyType: json

--- a/src/treg/catalog/findymail.yaml
+++ b/src/treg/catalog/findymail.yaml
@@ -71,7 +71,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /search/business-profile
-    name: "Find a work email from a business profile URL"
+    name: "Find a work email from a LinkedIn profile URL"
     summary: "Find someone's verified professional email from their public professional-network profile URL"
     input:
       body:
@@ -163,7 +163,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /search/company
-    name: "Enrich a company"
+    name: "Enrich a company by domain, name or LinkedIn URL — size"
     summary: "Firmographics for a company from its domain, name or professional-network URL — size, industry, description"
     input:
       body:
@@ -194,7 +194,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /search/phone
-    name: "Find a mobile phone number"
+    name: "Find a mobile phone number by LinkedIn URL"
     summary: "Find a person's direct phone number from their public professional profile URL"
     input:
       body:
@@ -223,7 +223,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /search/reverse-email
-    name: "Reverse-lookup a person from their email"
+    name: "Reverse email lookup — the person's LinkedIn profile"
     summary: "Resolve an email address back to the person's professional profile, optionally with the full profile"
     input:
       body:
@@ -253,7 +253,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /verify
-    name: "Verify an email address"
+    name: "Verify an email address is deliverable"
     summary: "Check whether an email address is deliverable, and which mail provider hosts it"
     input:
       body:
@@ -283,7 +283,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /technologies
-    name: "Detect a company's tech stack"
+    name: "Detect a company's tech stack by domain"
     summary: "The technologies detected on a company's domain, each with category and a last-detected timestamp"
     input:
       body:
@@ -334,7 +334,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /lookalike/search
-    name: "Find companies similar to a seed company"
+    name: "Find lookalike companies from a seed domain"
     summary: "Build a list of companies that look like a seed company, optionally constrained to the same country or size"
     input:
       body:
@@ -439,7 +439,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /signals
-    name: "Read detected buying signals"
+    name: "Buying signals from your monitors — hiring, job postings"
     summary: "Signals your monitors have detected — job posts, hiring and other intent events, with the company and contact attached"
     input:
       queryParams:

--- a/src/treg/catalog/finnhub.yaml
+++ b/src/treg/catalog/finnhub.yaml
@@ -16,7 +16,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /quote
-    name: "Real-time quote"
+    name: "Real-time stock quote by ticker — price, day change"
     summary: "Current price, day change, open/high/low and previous close for a US ticker"
     input:
       queryParams:
@@ -33,7 +33,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /stock/profile2
-    name: "Company profile"
+    name: "Company profile by stock ticker — industry, market cap"
     summary: "Company behind a ticker: name, industry, market cap, IPO date, logo and weburl"
     input:
       queryParams:
@@ -50,7 +50,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Search symbols"
+    name: "Search stock ticker symbols by company name"
     summary: "Resolve a company name or fragment to tradable symbols"
     input:
       queryParams:
@@ -67,7 +67,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /company-news
-    name: "Company news"
+    name: "Company news by stock ticker over a date range"
     summary: "News articles for one company over a date range"
     input:
       queryParams:
@@ -86,7 +86,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /stock/metric
-    name: "Fundamental metrics"
+    name: "Stock fundamentals by ticker — P/E, margins, 52-week range"
     summary: "Valuation, margin, growth and per-share metrics for a ticker (P/E, 52-week range, beta and more)"
     input:
       queryParams:

--- a/src/treg/catalog/google-ads.extended.yaml
+++ b/src/treg/catalog/google-ads.extended.yaml
@@ -33,7 +33,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get campaign details and performance'
+  name: "Google Ads campaign stats via GAQL"
   summary: GAQL FROM campaign — Campaigns — name, status, budget, bidding strategy, start/end dates and all campaign-level metrics
   scope: own_account
   cost:
@@ -61,7 +61,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get ad group details and performance'
+  name: "Google Ads ad group stats via GAQL"
   summary: GAQL FROM ad_group — Ad groups — name, status, type, CPC bid and ad-group-level metrics
   scope: own_account
   cost:
@@ -89,7 +89,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get individual ad details and performance'
+  name: "Google Ads individual ads via GAQL — headlines, URLs"
   summary: GAQL FROM ad_group_ad — The individual ads — headlines, descriptions, final URLs, approval status and per-ad metrics
   scope: own_account
   cost:
@@ -117,7 +117,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get ad group targeting and bids'
+  name: "Google Ads ad group targeting and bids via GAQL"
   summary: 'GAQL FROM ad_group_criterion — Everything targeted or excluded in an ad group: keywords, audiences, placements, with bids'
   scope: own_account
   cost:
@@ -145,7 +145,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get keyword performance metrics'
+  name: "Google Ads per-keyword performance via GAQL"
   summary: GAQL FROM keyword_view — Per-keyword performance — the metrics view over ad_group_criterion keywords
   scope: own_account
   cost:
@@ -173,7 +173,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get search terms that triggered ads'
+  name: "Google Ads search terms that triggered ads via GAQL"
   summary: GAQL FROM search_term_view — The actual queries people typed that triggered your ads, and what each cost
   scope: own_account
   cost:
@@ -201,7 +201,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get campaign budget details'
+  name: "Google Ads campaign budgets via GAQL"
   summary: GAQL FROM campaign_budget — Budgets — daily amount, delivery method, and which campaigns share them
   scope: own_account
   cost:
@@ -229,7 +229,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get campaign-level targeting and exclusions'
+  name: "Google Ads campaign targeting, exclusions via GAQL"
   summary: 'GAQL FROM campaign_criterion — Campaign-level targeting and exclusions: locations, languages, devices, negative keywords'
   scope: own_account
   cost:
@@ -257,7 +257,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get account details and metrics'
+  name: "Google Ads account details and metrics via GAQL"
   summary: GAQL FROM customer — The account itself — name, currency, timezone, auto-tagging, and account-level metrics
   scope: own_account
   cost:
@@ -285,7 +285,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'List accounts under a manager account'
+  name: "Accounts under a Google Ads manager (MCC) via GAQL"
   summary: GAQL FROM customer_client — Every account under a manager (MCC), including the hierarchy level and whether it is a manager
   scope: own_account
   cost:
@@ -313,7 +313,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get conversion action settings'
+  name: "Google Ads conversion action settings via GAQL"
   summary: GAQL FROM conversion_action — Conversion actions — what counts as a conversion, its category, value and counting rules
   scope: own_account
   cost:
@@ -341,7 +341,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get recent account change history'
+  name: "Google Ads change history, last 30 days via GAQL"
   summary: GAQL FROM change_event — Who changed what in the account in the last 30 days, old value and new value
   scope: own_account
   cost:
@@ -369,7 +369,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get resources changed since a timestamp'
+  name: "Google Ads resources changed since a timestamp via GAQL"
   summary: GAQL FROM change_status — Which resources changed since a timestamp — the cheap way to poll for edits
   scope: own_account
   cost:
@@ -397,7 +397,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get portfolio bidding strategy details'
+  name: "Google Ads portfolio bidding strategies via GAQL"
   summary: GAQL FROM bidding_strategy — Portfolio bidding strategies and their targets (target CPA, target ROAS, maximise conversions)
   scope: own_account
   cost:
@@ -425,7 +425,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get billing setup and payment accounts'
+  name: "Google Ads billing setups and payment accounts via GAQL"
   summary: GAQL FROM billing_setup — Billing setups and payment accounts attached to the customer
   scope: own_account
   cost:
@@ -453,7 +453,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get account-level budget limits'
+  name: "Google Ads account-level budget limits via GAQL"
   summary: GAQL FROM account_budget — Account-level budgets and their approved spending limits (invoiced accounts)
   scope: own_account
   cost:
@@ -481,7 +481,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: "List assets and where they're used"
+  name: "Google Ads assets and where they are used via GAQL"
   summary: GAQL FROM asset — Assets — images, videos, text, sitelinks, callouts — and where each is used
   scope: own_account
   cost:
@@ -509,7 +509,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get Performance Max asset group metrics'
+  name: "Performance Max asset group metrics via GAQL"
   summary: GAQL FROM asset_group — Asset groups (Performance Max) with their status and per-group metrics
   scope: own_account
   cost:
@@ -537,7 +537,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get assets attached to a campaign'
+  name: "Assets attached to Google Ads campaigns via GAQL"
   summary: GAQL FROM campaign_asset — Which assets are attached to which campaign, and in what field type
   scope: own_account
   cost:
@@ -565,7 +565,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get assets attached to the account'
+  name: "Google Ads account-level assets via GAQL"
   summary: GAQL FROM customer_asset — Assets attached at the account level
   scope: own_account
   cost:
@@ -593,7 +593,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get per-asset performance within an ad'
+  name: "Google Ads per-asset performance in an ad via GAQL"
   summary: GAQL FROM ad_group_ad_asset_view — Per-asset performance inside a specific ad — which headline actually pulled
   scope: own_account
   cost:
@@ -621,7 +621,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'List audiences and their segments'
+  name: "Google Ads audiences and their segments via GAQL"
   summary: GAQL FROM audience — Audiences defined in the account and their segments
   scope: own_account
   cost:
@@ -649,7 +649,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get remarketing and customer match lists'
+  name: "Google Ads remarketing, customer match lists via GAQL"
   summary: GAQL FROM user_list — Remarketing and customer-match lists, their size and eligibility per network
   scope: own_account
   cost:
@@ -677,7 +677,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'List interest and affinity categories'
+  name: "Affinity and in-market interest taxonomy via GAQL"
   summary: GAQL FROM user_interest — The affinity and in-market interest taxonomy available for targeting
   scope: own_account
   cost:
@@ -705,7 +705,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get audience performance by campaign'
+  name: "Google Ads audience performance by campaign via GAQL"
   summary: GAQL FROM campaign_audience_view — Audience performance at campaign level
   scope: own_account
   cost:
@@ -733,7 +733,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get audience performance by ad group'
+  name: "Google Ads audience performance by ad group via GAQL"
   summary: GAQL FROM ad_group_audience_view — Audience performance at ad-group level
   scope: own_account
   cost:
@@ -761,7 +761,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by age bracket'
+  name: "Google Ads performance by age bracket via GAQL"
   summary: GAQL FROM age_range_view — Performance split by the viewer's age bracket
   scope: own_account
   cost:
@@ -789,7 +789,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by gender'
+  name: "Google Ads performance by gender via GAQL"
   summary: GAQL FROM gender_view — Performance split by the viewer's gender
   scope: own_account
   cost:
@@ -817,7 +817,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by parental status'
+  name: "Google Ads performance by parental status via GAQL"
   summary: GAQL FROM parental_status_view — Performance split by parental status
   scope: own_account
   cost:
@@ -845,7 +845,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by household income'
+  name: "Google Ads performance by household income via GAQL"
   summary: GAQL FROM income_range_view — Performance split by household income bracket
   scope: own_account
   cost:
@@ -873,7 +873,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by triggering location'
+  name: "Google Ads performance by triggering location via GAQL"
   summary: GAQL FROM geographic_view — Performance by the location that triggered the ad (physical or interest)
   scope: own_account
   cost:
@@ -901,7 +901,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: "Get performance by user's actual location"
+  name: "Google Ads performance by user's real location via GAQL"
   summary: GAQL FROM user_location_view — Performance by where the user actually was, ignoring location-of-interest
   scope: own_account
   cost:
@@ -929,7 +929,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by targeted location'
+  name: "Google Ads performance by targeted location via GAQL"
   summary: GAQL FROM location_view — Performance per targeted location criterion
   scope: own_account
   cost:
@@ -957,7 +957,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by day and hour'
+  name: "Google Ads performance by day and hour via GAQL"
   summary: GAQL FROM ad_schedule_view — Performance by day of week and hour of day
   scope: own_account
   cost:
@@ -985,7 +985,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get exact URLs and apps ads ran on'
+  name: "Exact URLs and apps your ads ran on via GAQL"
   summary: GAQL FROM detail_placement_view — Exact URLs and apps your Display/Video ads ran on
   scope: own_account
   cost:
@@ -1013,7 +1013,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance of chosen placements'
+  name: "Google Ads managed placements performance via GAQL"
   summary: GAQL FROM managed_placement_view — Performance of placements you chose yourself
   scope: own_account
   cost:
@@ -1041,7 +1041,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get Display topic targeting performance'
+  name: "Google Ads Display topic performance via GAQL"
   summary: GAQL FROM topic_view — Performance of Display topic targeting
   scope: own_account
   cost:
@@ -1069,7 +1069,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get performance by landing page'
+  name: "Google Ads performance by landing page via GAQL"
   summary: GAQL FROM landing_page_view — Performance grouped by the unexpanded final URL
   scope: own_account
   cost:
@@ -1097,7 +1097,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get Shopping performance by product attribute'
+  name: "Shopping ads performance by product attribute via GAQL"
   summary: GAQL FROM shopping_performance_view — Shopping metrics broken down by product attributes (brand, category, item id)
   scope: own_account
   cost:
@@ -1125,7 +1125,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get optimization suggestions and impact'
+  name: "Google Ads optimisation suggestions and impact via GAQL"
   summary: GAQL FROM recommendation — Google's own optimisation suggestions for the account, with their estimated impact
   scope: own_account
   cost:
@@ -1153,7 +1153,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get paid and organic search terms combined'
+  name: "Paid and organic search terms side by side via GAQL"
   summary: GAQL FROM paid_organic_search_term_view — Paid and organic side by side per query — needs Search Console linked
   scope: own_account
   cost:
@@ -1181,7 +1181,7 @@ endpoints:
   platform: google-ads
   method: POST
   path: /v25/customers/{customer_id}/googleAds:searchStream
-  name: 'Get individual clicks with GCLID'
+  name: "Individual ad clicks with GCLID, last 90 days via GAQL"
   summary: GAQL FROM click_view — Individual clicks with GCLID and location, for the last 90 days
   scope: own_account
   cost:

--- a/src/treg/catalog/google-ads.yaml
+++ b/src/treg/catalog/google-ads.yaml
@@ -40,7 +40,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v25/customers:listAccessibleCustomers
-    name: "List accessible accounts"
+    name: "List the Google Ads accounts your login can reach"
     summary: "List the Google Ads accounts your login can reach"
     input:
       note: "no parameters. Returns {resourceNames: [\"customers/6186675831\", …]} — ids ONLY, no names, which is why treg runs a second GAQL lookup (SELECT customer.descriptive_name FROM customer) per row to label the picker. Still needs the developer-token header"
@@ -56,7 +56,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v25/customers/{customer_id}/googleAds:search
-    name: "Run a custom GAQL query"
+    name: "Run a GAQL query on your Google Ads account"
     summary: "Run a GAQL query against your Google Ads account (campaigns, spend, clicks, conversions)"
     input:
       pathParams:
@@ -82,7 +82,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v25/customers/{customer_id}:generateKeywordIdeas
-    name: "Generate keyword ideas from a seed"
+    name: "Keyword Planner ideas by seed — volume and competition"
     summary: "Related keyword ideas from Google's own Keyword Planner, with volume and competition"
     input:
       pathParams:
@@ -116,7 +116,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v25/customers/{customer_id}:generateKeywordHistoricalMetrics
-    name: "Get historical keyword search volume"
+    name: "Google search volume, competition, bids by keyword list"
     summary: "Get Google search volume, competition and bid range for a list of keywords"
     input:
       pathParams:
@@ -148,7 +148,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v25/customers/{customer_id}/campaignBudgets:mutate
-    name: "Update campaign budget"
+    name: "Change a campaign's daily budget in Google Ads"
     summary: "Change a campaign's daily budget in your Google Ads account"
     input:
       pathParams:

--- a/src/treg/catalog/google-analytics.extended.yaml
+++ b/src/treg/catalog/google-analytics.extended.yaml
@@ -32,7 +32,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/accountSummaries
-  name: "List account summaries"
+  name: "List your GA4 account and property summaries"
   summary: accountSummaries.list — Returns summaries of all accounts accessible by the caller.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -59,7 +59,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/accounts
-  name: "List accessible accounts"
+  name: "List your GA4 accounts"
   summary: 'accounts.list — Returns all accounts accessible by the caller. Note that these accounts might not currently have GA properties. Soft-deleted (ie: "trashed") accounts are excluded by default. Returns an empty list if no relevant accounts are found. Note: The easiest way to retrieve a list of all properties you have access to is by using `ListAccountSummaries`.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -86,7 +86,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/accounts/{accountsId}
-  name: "Soft-delete an account"
+  name: "Soft-delete a GA4 account by account id"
   summary: 'accounts.delete — Marks target Account as soft-deleted (ie: "trashed") and returns it. This API does not have a method to restore soft-deleted accounts. However, they can be restored using the Trash Can UI. If the accounts are not restored before the expiration time, the account and all child resources (eg: Properties, GoogleAdsLinks, Streams, AccessBindings) will be permanently purged. https://su'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -105,7 +105,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/accounts/{accountsId}
-  name: "Get an account"
+  name: "GA4 account details by account id"
   summary: accounts.get — Lookup for a single Account.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -124,7 +124,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/accounts/{accountsId}
-  name: "Update an account"
+  name: "Update a GA4 account's settings"
   summary: accounts.patch — Updates an account.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -153,7 +153,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/accounts/{accountsId}/dataSharingSettings
-  name: "Get account data sharing settings"
+  name: "GA4 account data sharing settings by account id"
   summary: accounts.getDataSharingSettings — Get data sharing settings on an account. Data sharing settings are singletons.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -171,7 +171,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/accounts/{accountsId}:runAccessReport
-  name: "Run account data access report"
+  name: "Run a GA4 data access report for your account"
   summary: accounts.runAccessReport — Returns a customized report of data access records. The report provides records of each time a user reads Google Analytics reporting data. Access records are retained for up to 2 years. Data Access Reports can be requested for a property. Reports may be requested for any property, but dimensions that aren't related to quota can only be requested on Google Analytics 360 p
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -194,7 +194,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/accounts/{accountsId}:searchChangeHistoryEvents
-  name: "Search account change history"
+  name: "Search your GA4 account's change history"
   summary: accounts.searchChangeHistoryEvents — Searches through all changes to an account or its children given the specified set of filters. Only returns the subset of changes supported by the API. The UI may return additional changes.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -219,7 +219,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/accounts:provisionAccountTicket
-  name: "Request an account creation ticket"
+  name: "Request a GA4 account creation ticket"
   summary: accounts.provisionAccountTicket — Requests a ticket for creating an account.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -237,7 +237,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties
-  name: "List properties under an account"
+  name: "List GA4 properties under your account"
   summary: 'properties.list — Returns child Properties under the specified parent Account. Properties will be excluded if the caller does not have access. Soft-deleted (ie: "trashed") properties are excluded by default. Returns an empty list if no relevant properties are found.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -268,7 +268,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties
-  name: "Create a property"
+  name: "Create a GA4 property"
   summary: properties.create — Creates a Google Analytics property with the specified location and attributes.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -288,7 +288,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}
-  name: "Soft-delete a property"
+  name: "Soft-delete a GA4 property by property id"
   summary: 'properties.delete — Marks target Property as soft-deleted (ie: "trashed") and returns it. This API does not have a method to restore soft-deleted properties. However, they can be restored using the Trash Can UI. If the properties are not restored before the expiration time, the Property and all child resources (eg: GoogleAdsLinks, Streams, AccessBindings) will be permanently purged. https://suppor'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -307,7 +307,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}
-  name: "Get a property"
+  name: "GA4 property details by property id"
   summary: properties.get — Lookup for a single GA Property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -326,7 +326,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}
-  name: "Update a property"
+  name: "Update a GA4 property's settings"
   summary: properties.patch — Updates a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -355,7 +355,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/audienceExports
-  name: "List audience exports for a property"
+  name: "List audience exports on your GA4 property"
   summary: audienceExports.list — Lists all audience exports for a property. This method can be used for you to find and reuse existing audience exports rather than creating unnecessary new audience exports. The same audience can have multiple audience exports that represent the export of users that were in an audience on different days. See [Creating an Audience Export](https://developers.google.com/analyti
   scope: own_account
   cost: *id001
@@ -382,7 +382,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/audienceExports
-  name: "Create an audience export"
+  name: "Create an audience export on your GA4 property"
   summary: audienceExports.create — Creates an audience export for later retrieval. This method quickly returns the audience export's resource name and initiates a long running asynchronous request to form an audience export. To export the users in an audience export, first create the audience export through this method and then send the audience resource name to the `QueryAudienceExport` method. See [Creati
   scope: own_account
   cost: *id001
@@ -404,7 +404,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/audienceExports/{audienceExportsId}
-  name: "Get audience export details"
+  name: "GA4 audience export metadata by export id"
   summary: audienceExports.get — Gets configuration metadata about a specific audience export. This method can be used to understand an audience export after it has been created. See [Creating an Audience Export](https://developers.google.com/analytics/devguides/reporting/data/v1/audience-list-basics) for an introduction to Audience Exports with examples. Audience Export APIs have some methods at alpha and o
   scope: own_account
   cost: *id001
@@ -421,7 +421,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/audienceExports/{audienceExportsId}:query
-  name: "Query users in an audience export"
+  name: "List users in a GA4 audience export"
   summary: audienceExports.query — Retrieves an audience export of users. After creating an audience, the users are not immediately available for exporting. First, a request to `CreateAudienceExport` is necessary to create an audience export of users, and then second, this method is used to retrieve the users in the audience export. See [Creating an Audience Export](https://developers.google.com/analytics/de
   scope: own_account
   cost: *id001
@@ -443,7 +443,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/conversionEvents
-  name: "List conversion events (deprecated)"
+  name: "List GA4 conversion events (deprecated)"
   summary: 'conversionEvents.list — Deprecated: Use `ListKeyEvents` instead. Returns a list of conversion events in the specified parent property. Returns an empty list if no conversion events are found.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -471,7 +471,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/conversionEvents
-  name: "Create a conversion event (deprecated)"
+  name: "Create a GA4 conversion event (deprecated)"
   summary: 'conversionEvents.create — Deprecated: Use `CreateKeyEvent` instead. Creates a conversion event with the specified attributes.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -496,7 +496,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/conversionEvents/{conversionEventsId}
-  name: "Delete a conversion event (deprecated)"
+  name: "Delete a GA4 conversion event (deprecated)"
   summary: 'conversionEvents.delete — Deprecated: Use `DeleteKeyEvent` instead. Deletes a conversion event in a property.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -515,7 +515,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/conversionEvents/{conversionEventsId}
-  name: "Get a conversion event (deprecated)"
+  name: "GA4 conversion event details (deprecated)"
   summary: 'conversionEvents.get — Deprecated: Use `GetKeyEvent` instead. Retrieve a single conversion event.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -534,7 +534,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/conversionEvents/{conversionEventsId}
-  name: "Update a conversion event (deprecated)"
+  name: "Update a GA4 conversion event (deprecated)"
   summary: 'conversionEvents.patch — Deprecated: Use `UpdateKeyEvent` instead. Updates a conversion event with the specified attributes.'
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -563,7 +563,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/customDimensions
-  name: "List custom dimensions"
+  name: "List custom dimensions on your GA4 property"
   summary: customDimensions.list — Lists CustomDimensions on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -591,7 +591,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/customDimensions
-  name: "Create a custom dimension"
+  name: "Create a custom dimension on your GA4 property"
   summary: customDimensions.create — Creates a CustomDimension.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -615,7 +615,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/customDimensions/{customDimensionsId}
-  name: "Get a custom dimension"
+  name: "GA4 custom dimension details by dimension id"
   summary: customDimensions.get — Lookup for a single CustomDimension.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -634,7 +634,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/customDimensions/{customDimensionsId}
-  name: "Update a custom dimension"
+  name: "Update a custom dimension on your GA4 property"
   summary: customDimensions.patch — Updates a CustomDimension on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -664,7 +664,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/customDimensions/{customDimensionsId}:archive
-  name: "Archive a custom dimension"
+  name: "Archive a custom dimension on your GA4 property"
   summary: customDimensions.archive — Archives a CustomDimension on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -688,7 +688,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/customMetrics
-  name: "List custom metrics"
+  name: "List custom metrics on your GA4 property"
   summary: customMetrics.list — Lists CustomMetrics on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -716,7 +716,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/customMetrics
-  name: "Create a custom metric"
+  name: "Create a custom metric on your GA4 property"
   summary: customMetrics.create — Creates a CustomMetric.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -740,7 +740,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/customMetrics/{customMetricsId}
-  name: "Get a custom metric"
+  name: "GA4 custom metric details by metric id"
   summary: customMetrics.get — Lookup for a single CustomMetric.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -759,7 +759,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/customMetrics/{customMetricsId}
-  name: "Update a custom metric"
+  name: "Update a custom metric on your GA4 property"
   summary: customMetrics.patch — Updates a CustomMetric on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -789,7 +789,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/customMetrics/{customMetricsId}:archive
-  name: "Archive a custom metric"
+  name: "Archive a custom metric on your GA4 property"
   summary: customMetrics.archive — Archives a CustomMetric on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -813,7 +813,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/dataRetentionSettings
-  name: "Get data retention settings"
+  name: "GA4 property data retention settings"
   summary: properties.getDataRetentionSettings — Returns the singleton data retention settings for this property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -832,7 +832,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/dataRetentionSettings
-  name: "Update data retention settings"
+  name: "Update your GA4 property's data retention settings"
   summary: properties.updateDataRetentionSettings — Updates the singleton data retention settings for this property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -861,7 +861,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/dataStreams
-  name: "List data streams"
+  name: "List data streams on your GA4 property"
   summary: dataStreams.list — Lists DataStreams on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -889,7 +889,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/dataStreams
-  name: "Create a data stream"
+  name: "Create a data stream on your GA4 property"
   summary: dataStreams.create — Creates a DataStream.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -914,7 +914,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}
-  name: "Delete a data stream"
+  name: "Delete a data stream from your GA4 property"
   summary: dataStreams.delete — Deletes a DataStream on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -933,7 +933,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}
-  name: "Get a data stream"
+  name: "GA4 data stream details by stream id"
   summary: dataStreams.get — Lookup for a single DataStream.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -952,7 +952,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}
-  name: "Update a data stream"
+  name: "Update a data stream on your GA4 property"
   summary: dataStreams.patch — Updates a DataStream on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -981,7 +981,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}/measurementProtocolSecrets
-  name: "List measurement protocol secrets"
+  name: "List Measurement Protocol secrets on a GA4 stream"
   summary: measurementProtocolSecrets.list — Returns child MeasurementProtocolSecrets under the specified parent Property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1009,7 +1009,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}/measurementProtocolSecrets
-  name: "Create a measurement protocol secret"
+  name: "Create a Measurement Protocol secret on a GA4 stream"
   summary: measurementProtocolSecrets.create — Creates a measurement protocol secret.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1034,7 +1034,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}/measurementProtocolSecrets/{measurementProtocolSecretsId}
-  name: "Delete a measurement protocol secret"
+  name: "Delete a Measurement Protocol secret from a GA4 stream"
   summary: measurementProtocolSecrets.delete — Deletes target MeasurementProtocolSecret.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1053,7 +1053,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}/measurementProtocolSecrets/{measurementProtocolSecretsId}
-  name: "Get a measurement protocol secret"
+  name: "GA4 Measurement Protocol secret by secret id"
   summary: measurementProtocolSecrets.get — Lookup for a single MeasurementProtocolSecret.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1072,7 +1072,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/dataStreams/{dataStreamsId}/measurementProtocolSecrets/{measurementProtocolSecretsId}
-  name: "Update a measurement protocol secret"
+  name: "Update a Measurement Protocol secret on a GA4 stream"
   summary: measurementProtocolSecrets.patch — Updates a measurement protocol secret.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1101,7 +1101,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/firebaseLinks
-  name: "List Firebase links for a property"
+  name: "List Firebase links on your GA4 property"
   summary: firebaseLinks.list — Lists FirebaseLinks on a property. Properties can have at most one FirebaseLink.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1129,7 +1129,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/firebaseLinks
-  name: "Create a Firebase link"
+  name: "Link Firebase to your GA4 property"
   summary: firebaseLinks.create — Creates a FirebaseLink. Properties can have at most one FirebaseLink.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1154,7 +1154,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/firebaseLinks/{firebaseLinksId}
-  name: "Delete a Firebase link"
+  name: "Delete a Firebase link from your GA4 property"
   summary: firebaseLinks.delete — Deletes a FirebaseLink on a property
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1173,7 +1173,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/googleAdsLinks
-  name: "List Google Ads links"
+  name: "List Google Ads links on your GA4 property"
   summary: googleAdsLinks.list — Lists GoogleAdsLinks on a property.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1201,7 +1201,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/googleAdsLinks
-  name: "Create a Google Ads link"
+  name: "Link Google Ads to your GA4 property"
   summary: googleAdsLinks.create — Creates a GoogleAdsLink.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1226,7 +1226,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/googleAdsLinks/{googleAdsLinksId}
-  name: "Delete a Google Ads link"
+  name: "Delete a Google Ads link from your GA4 property"
   summary: googleAdsLinks.delete — Deletes a GoogleAdsLink on a property
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1246,7 +1246,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/googleAdsLinks/{googleAdsLinksId}
-  name: "Update a Google Ads link"
+  name: "Update a Google Ads link on your GA4 property"
   summary: googleAdsLinks.patch — Updates a GoogleAdsLink on a property
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1275,7 +1275,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/keyEvents
-  name: "List key events"
+  name: "List key events on your GA4 property"
   summary: keyEvents.list — Returns a list of Key Events in the specified parent property. Returns an empty list if no Key Events are found.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1303,7 +1303,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}/keyEvents
-  name: "Create a key event"
+  name: "Create a key event on your GA4 property"
   summary: keyEvents.create — Creates a Key Event.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1328,7 +1328,7 @@ endpoints:
   platform: google-analytics
   method: DELETE
   path: /v1beta/properties/{propertiesId}/keyEvents/{keyEventsId}
-  name: "Delete a key event"
+  name: "Delete a key event from your GA4 property"
   summary: keyEvents.delete — Deletes a Key Event.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1347,7 +1347,7 @@ endpoints:
   platform: google-analytics
   method: GET
   path: /v1beta/properties/{propertiesId}/keyEvents/{keyEventsId}
-  name: "Get a key event"
+  name: "GA4 key event details by key event id"
   summary: keyEvents.get — Retrieve a single Key Event.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1366,7 +1366,7 @@ endpoints:
   platform: google-analytics
   method: PATCH
   path: /v1beta/properties/{propertiesId}/keyEvents/{keyEventsId}
-  name: "Update a key event"
+  name: "Update a key event on your GA4 property"
   summary: keyEvents.patch — Updates a Key Event.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1396,7 +1396,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:acknowledgeUserDataCollection
-  name: "Acknowledge user data collection terms"
+  name: "Acknowledge GA4 user data collection terms"
   summary: properties.acknowledgeUserDataCollection — Acknowledges the terms of user data collection for the specified property. This acknowledgement must be completed (either in the Google Analytics UI or through this API) before MeasurementProtocolSecret resources may be created.
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1420,7 +1420,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:batchRunPivotReports
-  name: "Run multiple pivot reports in a batch"
+  name: "Run several GA4 pivot reports in one batch"
   summary: properties.batchRunPivotReports — Returns multiple pivot reports in a batch. All reports must be for the same Google Analytics property.
   scope: own_account
   cost: *id001
@@ -1442,7 +1442,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:batchRunReports
-  name: "Run multiple reports in a batch"
+  name: "Run several GA4 reports in one batch"
   summary: properties.batchRunReports — Returns multiple reports in a batch. All reports must be for the same Google Analytics property.
   scope: own_account
   cost: *id001
@@ -1465,7 +1465,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:checkCompatibility
-  name: "Check dimension and metric compatibility"
+  name: "Check GA4 dimension and metric compatibility"
   summary: properties.checkCompatibility — This compatibility method lists dimensions and metrics that can be added to a report request and maintain compatibility. This method fails if the request's dimensions and metrics are incompatible. In Google Analytics, reports fail if they request incompatible dimensions and/or metrics; in that case, you will need to remove dimensions and/or metrics from the incompat
   scope: own_account
   cost: *id001
@@ -1487,7 +1487,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:runAccessReport
-  name: "Run property data access report"
+  name: "Run a GA4 data access report for your property"
   summary: properties.runAccessReport — Returns a customized report of data access records. The report provides records of each time a user reads Google Analytics reporting data. Access records are retained for up to 2 years. Data Access Reports can be requested for a property. Reports may be requested for any property, but dimensions that aren't related to quota can only be requested on Google Analytics 360
   scope: own_account
   host: analyticsadmin.googleapis.com
@@ -1510,7 +1510,7 @@ endpoints:
   platform: google-analytics
   method: POST
   path: /v1beta/properties/{propertiesId}:runPivotReport
-  name: "Run a pivot report"
+  name: "Run a GA4 pivot report by property id"
   summary: properties.runPivotReport — Returns a customized pivot report of your Google Analytics event data. Pivot reports are more advanced and expressive formats than regular reports. In a pivot report, dimensions are only visible if they are included in a pivot. Multiple pivots can be specified to further dissect your data.
   scope: own_account
   cost: *id001

--- a/src/treg/catalog/google-analytics.yaml
+++ b/src/treg/catalog/google-analytics.yaml
@@ -28,7 +28,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v1beta/properties/{property_id}:runReport
-    name: "Run a custom analytics report"
+    name: "Run a custom GA4 report by property id"
     summary: "Run a traffic or behaviour report on your own Google Analytics property"
     input:
       pathParams:
@@ -62,7 +62,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v1beta/properties/{property_id}:runRealtimeReport
-    name: "Get realtime active users on your site"
+    name: "GA4 realtime active users by page, source, country"
     summary: "See who is on your site right now (active users by page, source and country)"
     input:
       pathParams:
@@ -91,7 +91,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v1beta/properties/{property_id}/metadata
-    name: "List available dimensions and metrics"
+    name: "List your GA4 property's dimensions and metrics"
     summary: "List the dimensions and metrics your GA4 property supports, including custom ones"
     input:
       pathParams:

--- a/src/treg/catalog/google-business-profile.extended.yaml
+++ b/src/treg/catalog/google-business-profile.extended.yaml
@@ -42,7 +42,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/accounts
-  name: "Create a business account"
+  name: "Create a Business Profile account"
   summary: accounts.create — Creates an account with the specified name and type under the given parent. - Personal accounts and Organizations cannot be created. - User Groups cannot be created with a Personal account as primary owner. - Location Groups cannot be created with a primary owner of a Personal account if the Personal account is in an Organization. - Location Groups cannot own Location Groups.
   scope: own_account
   cost: &id001
@@ -64,7 +64,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/accounts/{accountsId}
-  name: "Get account details"
+  name: "Business Profile account details by account id"
   summary: accounts.get — Gets the specified account. Returns `NOT_FOUND` if the account does not exist or if the caller does not have access rights to it.
   scope: own_account
   cost: *id001
@@ -82,7 +82,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/accounts/{accountsId}
-  name: "Update account details"
+  name: "Update a Business Profile account"
   summary: accounts.patch — Updates the specified business account. Personal accounts cannot be updated using this method.
   scope: own_account
   cost: *id001
@@ -113,7 +113,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/accounts/{accountsId}/admins
-  name: "List account admins"
+  name: "List admins of your Business Profile account"
   summary: admins.list — Lists the admins for the specified account.
   scope: own_account
   cost: *id001
@@ -130,7 +130,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/accounts/{accountsId}/admins
-  name: "Invite an account admin"
+  name: "Invite an admin to your Business Profile account"
   summary: admins.create — Invites the specified user to become an administrator for the specified account. The invitee must accept the invitation in order to be granted access to the account. See AcceptInvitation to programmatically accept an invitation.
   scope: own_account
   cost: *id001
@@ -152,7 +152,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/accounts/{accountsId}/admins/{adminsId}
-  name: "Remove an account admin"
+  name: "Remove an admin from your Business Profile account"
   summary: admins.delete — Removes the specified admin from the specified account.
   scope: own_account
   cost: *id001
@@ -169,7 +169,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/accounts/{accountsId}/admins/{adminsId}
-  name: "Update an account admin's role"
+  name: "Change an admin's role on your Business Profile account"
   summary: admins.patch — Updates the Admin for the specified Account Admin.
   scope: own_account
   cost: *id001
@@ -196,7 +196,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/accounts/{accountsId}/invitations
-  name: "List pending account invitations"
+  name: "List pending invitations to your Business Profile"
   summary: invitations.list — Lists pending invitations for the specified account.
   scope: own_account
   cost: *id001
@@ -218,7 +218,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/accounts/{accountsId}/invitations/{invitationsId}:accept
-  name: "Accept an account invitation"
+  name: "Accept a Business Profile admin invitation"
   summary: invitations.accept — Accepts the specified invitation.
   scope: own_account
   cost: *id001
@@ -240,7 +240,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/accounts/{accountsId}/invitations/{invitationsId}:decline
-  name: "Decline an account invitation"
+  name: "Decline a Business Profile admin invitation"
   summary: invitations.decline — Declines the specified invitation.
   scope: own_account
   cost: *id001
@@ -262,7 +262,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/accounts/{accountsId}/locations
-  name: "Create a business location"
+  name: "Create a business listing on your Business Profile"
   summary: locations.create — Creates a new Location that will be owned by the logged in user.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -294,7 +294,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/accounts/{accountsId}/notificationSetting
-  name: "Get account notification settings"
+  name: "Your Business Profile pubsub notification settings"
   summary: accounts.getNotificationSetting — Returns the pubsub notification settings for the account.
   scope: own_account
   host: mybusinessnotifications.googleapis.com
@@ -312,7 +312,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/accounts/{accountsId}/notificationSetting
-  name: "Update account notification settings"
+  name: "Update your Business Profile pubsub notifications"
   summary: accounts.updateNotificationSetting — Sets the pubsub notification setting for the account informing Google which topic to send pubsub notifications for. Use the notification_types field within notification_setting to manipulate the events an account wants to subscribe to. An account will only have one notification setting resource, and only one pubsub topic can be set. To delete the setting, updat
   scope: own_account
   host: mybusinessnotifications.googleapis.com
@@ -340,7 +340,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/attributes
-  name: "List available attributes for a category"
+  name: "Available listing attributes by category and country"
   summary: attributes.list — Returns the list of attributes that would be available for a location with the given primary category and country.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -383,7 +383,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/categories
-  name: "Search business categories"
+  name: "Search Business Profile categories by name"
   summary: categories.list — Returns a list of business categories. Search will match the category name but not the category ID. Search only matches the front of a category name (that is, 'food' may return 'Food Court' but not 'Fast Food Restaurant').
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -426,7 +426,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/categories:batchGet
-  name: "Get business categories by ID (batch)"
+  name: "Business Profile categories by GConcept ids"
   summary: categories.batchGet — Returns a list of business categories for the provided language and GConcept ids.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -460,7 +460,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/chains/{chainsId}
-  name: "Get chain details"
+  name: "Business chain details by chain id"
   summary: chains.get — Gets the specified chain. Returns `NOT_FOUND` if the chain does not exist.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -478,7 +478,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/chains:search
-  name: "Search business chains"
+  name: "Search business chains by name"
   summary: chains.search — Searches the chain based on chain name.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -500,7 +500,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/googleLocations:search
-  name: "Search for matching Google locations"
+  name: "Match your business to Google location records"
   summary: googleLocations.search — Search all of the possible locations that are a match to the specified request.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -519,7 +519,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/locations/{locationsId}
-  name: "Delete a business location"
+  name: "Delete a listing from your Business Profile"
   summary: locations.delete — Deletes a location. If this location cannot be deleted using the API and it is marked so in the `google.mybusiness.businessinformation.v1.LocationState`, use the [Google Business Profile](https://business.google.com/manage/) website.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -536,7 +536,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}
-  name: "Get location details"
+  name: "Your business listing as last set by the merchant"
   summary: locations.get — Returns the specified location as last set by the merchant. It may not reflect updates from Google or user-generated content that are live on Google Maps.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -560,7 +560,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/locations/{locationsId}
-  name: "Update a business location"
+  name: "Update your business listing details"
   summary: locations.patch — Updates the specified location.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -591,7 +591,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/VoiceOfMerchantState
-  name: "Get voice of merchant verification state"
+  name: "Voice of Merchant state of your business listing"
   summary: locations.getVoiceOfMerchantState — Gets the VoiceOfMerchant state.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -610,7 +610,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/admins
-  name: "List location admins"
+  name: "List admins of your business listing"
   summary: admins.list — Lists all of the admins for the specified location.
   scope: own_account
   cost: *id001
@@ -627,7 +627,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}/admins
-  name: "Invite a location admin"
+  name: "Invite an admin to your business listing"
   summary: admins.create — Invites the specified user to become an administrator for the specified location. The invitee must accept the invitation in order to be granted access to the location. See AcceptInvitation to programmatically accept an invitation.
   scope: own_account
   cost: *id001
@@ -649,7 +649,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/locations/{locationsId}/admins/{adminsId}
-  name: "Remove a location admin"
+  name: "Remove an admin from your business listing"
   summary: admins.delete — Removes the specified admin as a manager of the specified location.
   scope: own_account
   cost: *id001
@@ -666,7 +666,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/locations/{locationsId}/admins/{adminsId}
-  name: "Update a location admin's role"
+  name: "Change an admin's role on your business listing"
   summary: admins.patch — Updates the Admin for the specified location. Only the AdminRole of the Admin can be updated.
   scope: own_account
   cost: *id001
@@ -692,7 +692,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/attributes
-  name: "Get location attributes"
+  name: "Attributes set on your business listing"
   summary: locations.getAttributes — Retrieves attributes for a location as last set by the merchant. It may not reflect updates from Google or user-generated content that are live on Google Maps.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -711,7 +711,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/locations/{locationsId}/attributes
-  name: "Update location attributes"
+  name: "Update attributes on your business listing"
   summary: locations.updateAttributes — Update attributes for a given location.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -738,7 +738,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/attributes:getGoogleUpdated
-  name: "Get Google-updated location attributes"
+  name: "Google-updated attributes of your business listing"
   summary: attributes.getGoogleUpdated — Retrieves attributes for a location as they appear live on Google Maps and Search. This consumer-facing view may have been updated by Google or user-generated content and may differ from the merchant's version.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -755,7 +755,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/placeActionLinks
-  name: "List place action links for a location"
+  name: "List place action links on your business listing"
   summary: placeActionLinks.list — Lists the place action links for the specified location.
   scope: own_account
   host: mybusinessplaceactions.googleapis.com
@@ -787,7 +787,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}/placeActionLinks
-  name: "Create a place action link"
+  name: "Create a place action link on your business listing"
   summary: placeActionLinks.create — Creates a place action link associated with the specified location, and returns it. The request is considered duplicate if the `parent`, `place_action_link.uri` and `place_action_link.place_action_type` are the same as a previous request.
   scope: own_account
   host: mybusinessplaceactions.googleapis.com
@@ -810,7 +810,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/locations/{locationsId}/placeActionLinks/{placeActionLinksId}
-  name: "Delete a place action link"
+  name: "Delete a place action link from your business listing"
   summary: placeActionLinks.delete — Deletes a place action link from the specified location.
   scope: own_account
   host: mybusinessplaceactions.googleapis.com
@@ -827,7 +827,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/placeActionLinks/{placeActionLinksId}
-  name: "Get a place action link"
+  name: "Place action link details by link id"
   summary: placeActionLinks.get — Gets the specified place action link.
   scope: own_account
   host: mybusinessplaceactions.googleapis.com
@@ -845,7 +845,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/locations/{locationsId}/placeActionLinks/{placeActionLinksId}
-  name: "Update a place action link"
+  name: "Update a place action link on your business listing"
   summary: placeActionLinks.patch — Updates the specified place action link and returns it.
   scope: own_account
   host: mybusinessplaceactions.googleapis.com
@@ -872,7 +872,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/questions
-  name: "List questions for a location"
+  name: "List customer questions on your business listing"
   summary: questions.list — Returns the paginated list of questions and some of its answers for a specified location. This operation is only valid if the specified location is verified.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -912,7 +912,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}/questions
-  name: "Post a question for a location"
+  name: "Post a question on a business listing"
   summary: questions.create — Adds a question for the specified location.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -935,7 +935,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/locations/{locationsId}/questions/{questionsId}
-  name: "Delete a question"
+  name: "Delete your question on a business listing"
   summary: questions.delete — Deletes a specific question written by the current user.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -953,7 +953,7 @@ endpoints:
   platform: google-business
   method: PATCH
   path: /v1/locations/{locationsId}/questions/{questionsId}
-  name: "Update a question"
+  name: "Edit your question on a business listing"
   summary: questions.patch — Updates a specific question written by the current user.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -980,7 +980,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/questions/{questionsId}/answers
-  name: "List answers to a question"
+  name: "List answers to a business listing question"
   summary: answers.list — Returns the paginated list of answers for a specified question.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -1011,7 +1011,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v1/locations/{locationsId}/questions/{questionsId}/answers:delete
-  name: "Delete an answer to a question"
+  name: "Delete your answer to a business listing question"
   summary: answers.delete — Deletes the answer written by the current user to a question.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -1029,7 +1029,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}/questions/{questionsId}/answers:upsert
-  name: "Create or update an answer"
+  name: "Post or update your answer to a listing question"
   summary: answers.upsert — Creates an answer or updates the existing answer written by the user for the specified question. A user can only create one answer per question.
   scope: own_account
   host: mybusinessqanda.googleapis.com
@@ -1052,7 +1052,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/searchkeywords/impressions/monthly
-  name: "Get monthly search keyword impressions"
+  name: "Monthly search keywords, impressions for your listing"
   summary: 'monthly.list — Returns the search keywords used to find a business in search or maps. Each search keyword is accompanied by impressions which are aggregated on a monthly basis. Example request: `GET https://businessprofileperformance.googleapis.com/v1/locations/12345/searchkeywords/impressions/monthly?monthly_range.start_month.year=2022&monthly_range.start_month.month=1&monthly_range.end_month.yea'
   scope: own_account
   host: businessprofileperformance.googleapis.com
@@ -1103,7 +1103,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}/verifications
-  name: "List location verifications"
+  name: "List verification attempts for your business listing"
   summary: verifications.list — List verifications of a location, ordered by create time.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -1130,7 +1130,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}/verifications/{verificationsId}:complete
-  name: "Complete a pending verification"
+  name: "Complete a pending business listing verification"
   summary: verifications.complete — Completes a `PENDING` verification. It is only necessary for non `AUTO` verification methods. `AUTO` verification request is instantly `VERIFIED` upon creation.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -1152,7 +1152,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}:fetchMultiDailyMetricsTimeSeries
-  name: "Get multiple daily metrics time series"
+  name: "Daily metrics time series for your business listing"
   summary: 'locations.fetchMultiDailyMetricsTimeSeries — Returns the values for each date from a given time range that are associated with the specific daily metrics. Note: Only daily data is available. Hourly metrics are not supported. Example request: `GET https://businessprofileperformance.googleapis.com/v1/locations/12345:fetchMultiDailyMetricsTimeSeries?dailyMetrics=WEBSITE_CLICKS&dailyMetrics=CALL_CLICK'
   scope: own_account
   host: businessprofileperformance.googleapis.com
@@ -1212,7 +1212,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}:fetchVerificationOptions
-  name: "Get eligible verification options"
+  name: "Eligible verification options for your listing"
   summary: locations.fetchVerificationOptions — Reports all eligible verification options for a location in a specific language.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -1234,7 +1234,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}:getDailyMetricsTimeSeries
-  name: "Get a daily performance metric time series"
+  name: "Daily time series of one metric for your listing"
   summary: 'locations.getDailyMetricsTimeSeries — Returns the values for each date from a given time range that are associated with the specific daily metric. Note: Only daily data is available. Hourly metrics are not supported. Example request: `GET https://businessprofileperformance.googleapis.com/v1/locations/12345:getDailyMetricsTimeSeries?dailyMetric=WEBSITE_CLICKS&daily_range.start_date.year=2022&daily_'
   scope: own_account
   host: businessprofileperformance.googleapis.com
@@ -1323,7 +1323,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v1/locations/{locationsId}:getGoogleUpdated
-  name: "Get the live Google-updated location"
+  name: "Your business listing as it appears live on Google"
   summary: locations.getGoogleUpdated — Returns the specified location as it appears live on Google Maps and Search. This consumer-facing view may have been updated by Google or user-generated content and may differ from the merchant's version. The returned GoogleUpdatedLocation contains masks that indicate which fields differ from the merchant's information.
   scope: own_account
   host: mybusinessbusinessinformation.googleapis.com
@@ -1347,7 +1347,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}:transfer
-  name: "Transfer a location to another account"
+  name: "Transfer a business listing to another account"
   summary: locations.transfer — Moves a location from an account that the user owns to another account that the same user administers. The user must be an owner of the account the location is currently associated with and must also be at least a manager of the destination account.
   scope: own_account
   cost: *id001
@@ -1369,7 +1369,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/locations/{locationsId}:verify
-  name: "Start location verification"
+  name: "Start verification of your business listing"
   summary: locations.verify — Starts the verification process for a location.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -1422,7 +1422,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v1/verificationTokens:generate
-  name: "Generate a location verification token"
+  name: "Generate a verification token for your listing"
   summary: verificationTokens.generate — Generate a token for the provided location data to verify the location.
   scope: own_account
   host: mybusinessverifications.googleapis.com
@@ -1439,7 +1439,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v4/accounts/{account_id}/locations/{location_id}/localPosts
-  name: "List local posts for a listing"
+  name: "List local posts on your business listing"
   summary: localPosts.list — List the local posts (offers, updates, events) on one of your listings
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1452,7 +1452,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v4/accounts/{account_id}/locations/{location_id}/localPosts
-  name: "Publish a local post"
+  name: "Publish a local post on your business listing"
   summary: localPosts.create — Publish a local post (offer, update or event) to one of your listings
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1464,7 +1464,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v4/accounts/{account_id}/locations/{location_id}/media
-  name: "List photos and videos for a listing"
+  name: "List photos and videos on your business listing"
   summary: media.list — List the photos and videos on one of your listings
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1477,7 +1477,7 @@ endpoints:
   platform: google-business
   method: POST
   path: /v4/accounts/{account_id}/locations/{location_id}/media
-  name: "Add a photo or video"
+  name: "Add a photo or video to your business listing"
   summary: media.create — Add a photo or video to one of your listings
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1489,7 +1489,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v4/accounts/{account_id}/locations/{location_id}/reviews/{review_id}
-  name: "Get a single review"
+  name: "Read one customer review by review id"
   summary: reviews.get — Read a single review left on one of your listings
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1502,7 +1502,7 @@ endpoints:
   platform: google-business
   method: DELETE
   path: /v4/accounts/{account_id}/locations/{location_id}/reviews/{review_id}/reply
-  name: "Delete a reply to a review"
+  name: "Delete your public reply to a customer review"
   summary: reviews.deleteReply — Delete the business's public reply to a review
   scope: own_account
   host: mybusiness.googleapis.com
@@ -1513,7 +1513,7 @@ endpoints:
   platform: google-business
   method: GET
   path: /v4/accounts/{account_id}/locations:batchGetReviews
-  name: "Get reviews across multiple listings"
+  name: "Customer reviews across several of your listings"
   summary: reviews.batchGetReviews — Read reviews across several of your listings in one call
   scope: own_account
   host: mybusiness.googleapis.com

--- a/src/treg/catalog/google-business-profile.yaml
+++ b/src/treg/catalog/google-business-profile.yaml
@@ -30,7 +30,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v1/accounts
-    name: "Accounts"
+    name: "List your Business Profile accounts"
     summary: "List the Google Business Profile accounts you manage"
     input:
       queryParams:
@@ -47,7 +47,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v1/accounts/{account_id}/locations
-    name: "List business locations"
+    name: "List your business listings — address, hours, category"
     summary: "List your business's listings with their addresses, hours and categories"
     input:
       pathParams:
@@ -67,7 +67,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v4/accounts/{account_id}/locations/{location_id}/reviews
-    name: "Get customer reviews for a location"
+    name: "List customer reviews on your business listing"
     summary: "Read the reviews customers left on your Google Business Profile listing"
     input:
       pathParams:
@@ -88,7 +88,7 @@ endpoints:
     scope: own_account
     method: PUT
     path: /v4/accounts/{account_id}/locations/{location_id}/reviews/{review_id}/reply
-    name: "Reply to a review"
+    name: "Reply to a customer review as the business"
     summary: "Reply publicly to a customer review as the business"
     input:
       pathParams:

--- a/src/treg/catalog/google-search-console.extended.yaml
+++ b/src/treg/catalog/google-search-console.extended.yaml
@@ -26,7 +26,7 @@ endpoints:
   platform: search-console
   method: POST
   path: /v1/urlTestingTools/mobileFriendlyTest:run
-  name: "Run mobile-friendly test"
+  name: "Run Google's mobile-friendly test on a URL"
   summary: mobileFriendlyTest.run — Runs Mobile-Friendly Test for a given URL.
   scope: any_account
   cost: &id001
@@ -48,7 +48,7 @@ endpoints:
   platform: search-console
   method: DELETE
   path: /webmasters/v3/sites/{siteUrl}
-  name: "Delete a site property"
+  name: "Remove a site from your Search Console"
   summary: sites.delete — Removes a site from the set of the user's Search Console sites.
   scope: own_account
   cost: *id001
@@ -64,7 +64,7 @@ endpoints:
   platform: search-console
   method: GET
   path: /webmasters/v3/sites/{siteUrl}
-  name: "Get site details"
+  name: "Your Search Console site details by site URL"
   summary: sites.get — Retrieves information about specific site.
   scope: own_account
   cost: *id001
@@ -81,7 +81,7 @@ endpoints:
   platform: search-console
   method: PUT
   path: /webmasters/v3/sites/{siteUrl}
-  name: "Add a site property"
+  name: "Add a site to your Search Console"
   summary: sites.add — Adds a site to the set of the user's sites in Search Console.
   scope: own_account
   cost: *id001
@@ -98,7 +98,7 @@ endpoints:
   platform: search-console
   method: DELETE
   path: /webmasters/v3/sites/{siteUrl}/sitemaps/{feedpath}
-  name: "Delete a sitemap"
+  name: "Remove a sitemap from your Search Console report"
   summary: sitemaps.delete — Deletes a sitemap from the Sitemaps report. Does not stop Google from crawling this sitemap or the URLs that were previously crawled in the deleted sitemap.
   scope: own_account
   cost: *id001
@@ -118,7 +118,7 @@ endpoints:
   platform: search-console
   method: GET
   path: /webmasters/v3/sites/{siteUrl}/sitemaps/{feedpath}
-  name: "Get sitemap details"
+  name: "Sitemap details by site URL and feed path"
   summary: sitemaps.get — Retrieves information about a specific sitemap.
   scope: own_account
   cost: *id001
@@ -139,7 +139,7 @@ endpoints:
   platform: search-console
   method: PUT
   path: /webmasters/v3/sites/{siteUrl}/sitemaps/{feedpath}
-  name: "Submit a sitemap"
+  name: "Submit a sitemap for your site to Google"
   summary: sitemaps.submit — Submits a sitemap for a site.
   scope: own_account
   cost: *id001

--- a/src/treg/catalog/google-search-console.yaml
+++ b/src/treg/catalog/google-search-console.yaml
@@ -29,7 +29,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /webmasters/v3/sites/{siteUrl}/searchAnalytics/query
-    name: "Get search performance metrics"
+    name: "Search performance of your site — clicks, impressions, CTR"
     summary: "Get your site's Google Search performance — clicks, impressions, CTR and top queries"
     input:
       pathParams:
@@ -59,7 +59,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /webmasters/v3/sites
-    name: "List sites"
+    name: "List your Search Console sites"
     summary: "List the sites and domains you have access to in Search Console"
     input:
       note: "no parameters. Returns {siteEntry: [{siteUrl, permissionLevel}]}; permissionLevel siteUnverifiedUser means the property is listed but not readable. This is also the connection's health probe and resource picker"
@@ -75,7 +75,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v1/urlInspection/index:inspect
-    name: "Inspect a URL's index status"
+    name: "Inspect a URL's Google index status"
     summary: "Check whether a page of your site is indexed by Google, and why it is or isn't"
     input:
       body:
@@ -97,7 +97,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /webmasters/v3/sites/{siteUrl}/sitemaps
-    name: "List submitted sitemaps"
+    name: "List submitted sitemaps for your site"
     summary: "List the sitemaps submitted for your site and how many URLs Google took from each"
     input:
       pathParams:

--- a/src/treg/catalog/hunter.extended.yaml
+++ b/src/treg/catalog/hunter.extended.yaml
@@ -13,7 +13,7 @@ endpoints:
   capability: companies.search
   method: POST
   path: /discover
-  name: Discover companies matching criteria
+  name: "Discover companies by criteria or plain-language query"
   summary: Identifies companies matching specified criteria; returns up to 100 companies per request
   input:
     body:
@@ -65,7 +65,7 @@ endpoints:
   capability: companies.search
   method: GET
   path: /discover/people
-  name: "Discover companies with email counts (people activity)"
+  name: "Discover companies with their email counts"
   summary: Returns companies matching Discover filters together with their personal/generic email counts
   input:
     queryParams:
@@ -187,7 +187,7 @@ endpoints:
   platform: companies
   method: GET
   path: /domain-finder
-  name: "Find company domain"
+  name: "Find a company's domain from its name"
   summary: Returns the most likely domain name(s) for a given company name
   input:
     queryParams:
@@ -224,7 +224,7 @@ endpoints:
   platform: people
   method: GET
   path: /email-count
-  name: Count known emails for a domain
+  name: "Count known emails for a domain, by department"
   summary: Returns the number of email addresses Hunter has for a domain or company, broken down by department and seniority
   input:
     queryParams:
@@ -328,7 +328,7 @@ endpoints:
   platform: people
   method: GET
   path: /combined/find
-  name: "Enrich person and company by email"
+  name: "Enrich a person and their company by email"
   summary: Retrieves person and company information from a single email address
   input:
     queryParams:

--- a/src/treg/catalog/hunter.yaml
+++ b/src/treg/catalog/hunter.yaml
@@ -45,7 +45,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /email-finder
-    name: "Find a person's work email"
+    name: "Find a person's work email by name and company domain"
     summary: "Find someone's work email address from their name and their company's domain"
     input:
       queryParams:
@@ -81,7 +81,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /email-verifier
-    name: "Verify an email address"
+    name: "Verify an email address is deliverable"
     summary: "Check an email is real, deliverable and not a catch-all or disposable inbox"
     input:
       queryParams:
@@ -111,7 +111,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /domain-search
-    name: "Find email addresses at a company"
+    name: "Find email addresses at a company domain, with roles"
     summary: "People and email addresses Hunter knows at a company, with roles and confidence"
     input:
       queryParams:
@@ -153,7 +153,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /people/find
-    name: "Enrich a person by email"
+    name: "Enrich a person by email — name, role, social profiles"
     summary: "Enrich a person from their email — name, role, seniority, location, social profiles"
     input:
       queryParams:
@@ -185,7 +185,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/find
-    name: "Enrich a company by domain"
+    name: "Enrich a company by domain — headcount, revenue, tech"
     summary: "Enrich a company from its domain — industry, headcount, revenue, location, tech stack"
     input:
       queryParams:

--- a/src/treg/catalog/icypeas.yaml
+++ b/src/treg/catalog/icypeas.yaml
@@ -56,7 +56,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /email-search
-    name: "Find a person's work email"
+    name: "Find a work email from a name and domain (async)"
     summary: "Find a single email address from a firstname, a lastname and a company domain name"
     input:
       body:
@@ -89,7 +89,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /email-verification
-    name: "Verify an email address"
+    name: "Verify an email address is deliverable (async)"
     summary: "Check whether a specific email address exists and is deliverable, including catch-all detection"
     input:
       body:
@@ -120,7 +120,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /domain-search
-    name: "Scan a domain for role-based emails"
+    name: "Find role-based emails at a domain — contact@, support@"
     summary: "Discover a company's role-based addresses — contact@, support@, info@, admin@ and the rest"
     input:
       body:
@@ -151,7 +151,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /bulk-single-searchs/read
-    name: "Read search results"
+    name: "Read any search's results by id (the poll route)"
     summary: "Collect the result of any single search, or the rows of a bulk search, by id"
     input:
       body:
@@ -177,7 +177,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /bulk-search
-    name: "Start a bulk email job"
+    name: "Start a bulk email job (up to 5,000 rows)"
     summary: "Queue up to 5,000 rows of email discovery, email verification or domain scanning in one call"
     input:
       body:
@@ -234,7 +234,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /reverse-email-lookup
-    name: "Find the profile behind an email"
+    name: "Reverse email lookup — the person's profile URL"
     summary: "Reverse a professional email address to the person's public professional profile URL"
     input:
       body:
@@ -264,7 +264,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /reverse-email-lookups
-    name: "Find the profiles behind many emails"
+    name: "Reverse up to 50 emails to profile URLs in one call"
     summary: "Reverse up to 50 professional email addresses to their profile URLs in one call"
     input:
       body:
@@ -294,7 +294,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /find-people
-    name: "Search the people database"
+    name: "Search people by title, company, skills or location"
     summary: "Find people by job title, company, seniority, skills, school, location or years of experience"
     input:
       body:
@@ -325,7 +325,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /find-people/count
-    name: "Count people matching a search"
+    name: "Count people matching a search (free)"
     summary: "How many people match a query, before you pay to read any of them"
     input:
       body:
@@ -345,7 +345,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /find-companies
-    name: "Search the company database"
+    name: "Search companies by industry, headcount growth or revenue"
     summary: "Find companies by industry, headcount, headcount growth, revenue, type, location or keyword"
     input:
       body:
@@ -376,7 +376,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /find-companies/count
-    name: "Count companies matching a search"
+    name: "Count companies matching a search (free)"
     summary: "How many companies match a query, before you pay to read any of them"
     input:
       body:
@@ -396,7 +396,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /url-search/profile
-    name: "Find a person's profile URL"
+    name: "Find a person's profile URL from name and company"
     summary: "Resolve a name plus a company or job title to that person's professional profile URL"
     input:
       body:
@@ -429,7 +429,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /url-search/company
-    name: "Find a company's profile URL"
+    name: "Find a company's profile URL from its name or domain"
     summary: "Resolve a company name or domain to its professional profile URL"
     input:
       body:
@@ -459,7 +459,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /url-search
-    name: "Find profile URLs in bulk"
+    name: "Find up to 50 profile URLs in one call"
     summary: "Resolve up to 50 people or 50 companies to their professional profile URLs in one call"
     input:
       body:
@@ -490,7 +490,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /scrape/profile
-    name: "Enrich a person from their profile URL"
+    name: "Enrich a person by profile URL — roles, education"
     summary: "Full professional profile — headline, description, current and past roles, education, languages, location"
     input:
       queryParams:
@@ -520,7 +520,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /scrape/company
-    name: "Enrich a company from its profile URL"
+    name: "Enrich a company by profile URL — headcount and growth"
     summary: "Full company profile — description, headcount and growth, industry, address, website, specialties"
     input:
       queryParams:
@@ -550,7 +550,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /scrape
-    name: "Enrich profiles or companies in bulk"
+    name: "Enrich up to 50 profiles or companies by URL in one call"
     summary: "Read up to 50 people profiles, or up to 50 company profiles, from their URLs in one call"
     input:
       body:

--- a/src/treg/catalog/instagram.extended.yaml
+++ b/src/treg/catalog/instagram.extended.yaml
@@ -36,7 +36,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /ig_hashtag_search
-  name: "Search for a hashtag ID by name"
+  name: "Resolve an Instagram hashtag name to its id"
   summary: Resolve a hashtag name to its id — the first call of any hashtag lookup
   scope: own_account
   cost:
@@ -52,7 +52,7 @@ endpoints:
   platform: instagram
   method: DELETE
   path: /{ig_comment_id}
-  name: "Delete a comment"
+  name: "Delete a comment on your Instagram media"
   summary: Delete a comment on the account's own media
   scope: own_account
   cost:
@@ -68,7 +68,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_comment_id}
-  name: "Get a comment's details"
+  name: "One Instagram comment — text, username, likes"
   summary: A single comment — text, username, timestamp and like count
   scope: own_account
   cost:
@@ -83,7 +83,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_comment_id}/replies
-  name: "List replies to a comment"
+  name: "Replies under an Instagram comment"
   summary: The replies under a comment
   scope: own_account
   cost:
@@ -99,7 +99,7 @@ endpoints:
   platform: instagram
   method: POST
   path: /{ig_comment_id}/replies
-  name: "Reply to a comment"
+  name: "Reply to a comment as your Instagram account"
   summary: Reply to a comment as the account
   scope: own_account
   cost:
@@ -116,7 +116,7 @@ endpoints:
   platform: instagram
   method: POST
   path: /{ig_comment_id}?hide=true
-  name: "Hide a comment"
+  name: "Hide a comment on your Instagram media"
   summary: Hide a comment on the account's own media
   scope: own_account
   cost:
@@ -132,7 +132,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_hashtag_id}
-  name: "Get a hashtag's ID and name"
+  name: "An Instagram hashtag's id and name"
   summary: A hashtag's id and name
   scope: own_account
   cost:
@@ -147,7 +147,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_hashtag_id}/recent_media
-  name: "List recent posts for a hashtag"
+  name: "Recent public Instagram posts for a hashtag id"
   summary: The most recent public posts carrying a hashtag
   scope: own_account
   cost:
@@ -162,7 +162,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_hashtag_id}/top_media
-  name: "List top posts for a hashtag"
+  name: "Top public Instagram posts for a hashtag id"
   summary: The most popular public posts carrying a hashtag
   scope: own_account
   cost:
@@ -177,7 +177,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_media_id}
-  name: "Get a post's details"
+  name: "One of your Instagram posts — caption, media URL, counts"
   summary: A single post — caption, media_type, media_url, permalink, timestamp, like and comment counts
   scope: own_account
   cost:
@@ -192,7 +192,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_media_id}/children
-  name: "List media in a carousel post"
+  name: "Images and videos inside an Instagram carousel post"
   summary: The individual images or videos inside a carousel post
   scope: own_account
   cost:
@@ -208,7 +208,7 @@ endpoints:
   platform: instagram
   method: POST
   path: /{ig_media_id}/comments
-  name: "Comment on a post"
+  name: "Comment on your own Instagram media"
   summary: Comment on the account's own media
   scope: own_account
   cost:
@@ -224,7 +224,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/catalog_product_search
-  name: "Search catalog products to tag"
+  name: "Search your commerce catalog for products to tag"
   summary: Search the linked commerce catalog for products to tag in a post
   scope: own_account
   cost:
@@ -241,7 +241,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/content_publishing_limit
-  name: "Get remaining daily posting quota"
+  name: "Your remaining Instagram daily posting quota"
   summary: How many of the 24-hour posting quota (50 posts) this account has already used
   scope: own_account
   cost:
@@ -256,7 +256,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/conversations
-  name: "List Direct message threads"
+  name: "Your Instagram Direct message threads"
   summary: Instagram Direct threads with the account
   scope: own_account
   cost:
@@ -272,7 +272,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/live_media
-  name: "List an account's live broadcasts"
+  name: "Your Instagram live broadcasts now running"
   summary: The account's currently running live broadcasts
   scope: own_account
   cost:
@@ -287,7 +287,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/mentioned_comment
-  name: "Get a comment mentioning this account"
+  name: "A comment that @-mentions your Instagram account"
   summary: A comment that @-mentions this account, with its thread
   scope: own_account
   cost:
@@ -302,7 +302,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/mentioned_media
-  name: "List posts mentioning this account"
+  name: "Posts whose caption @-mentions your Instagram account"
   summary: Media whose caption @-mentions this account
   scope: own_account
   cost:
@@ -317,7 +317,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/product_appeal
-  name: "Get shopping product appeal status"
+  name: "Status of appeals for rejected shopping products"
   summary: The status of appeals against rejected shopping products
   scope: own_account
   cost:
@@ -333,7 +333,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/recently_searched_hashtags
-  name: "List recently searched hashtags"
+  name: "Hashtags your Instagram account searched recently"
   summary: The hashtags this account has looked up recently (the 30-per-week search quota)
   scope: own_account
   cost:
@@ -348,7 +348,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/stories
-  name: "List an account's active stories"
+  name: "Your Instagram stories from the last 24 hours"
   summary: The account's stories from the last 24 hours
   scope: own_account
   cost:
@@ -363,7 +363,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}/tags
-  name: "List posts this account is tagged in"
+  name: "Posts where your Instagram account is tagged"
   summary: Media where another account tagged this one in the photo
   scope: own_account
   cost:
@@ -378,7 +378,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /{ig_user_id}?fields=business_discovery.username({username})
-  name: "Get another account's public profile stats"
+  name: "Another Instagram account's public stats by username"
   summary: Read ANOTHER public professional account's followers, media count and recent posts
   scope: own_account
   cost:

--- a/src/treg/catalog/instagram.yaml
+++ b/src/treg/catalog/instagram.yaml
@@ -32,7 +32,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_user_id}
-    name: "Get your account profile and followers"
+    name: "Your Instagram profile and follower counts"
     summary: "Get your Instagram professional account's profile and follower counts"
     input:
       pathParams:
@@ -54,7 +54,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_user_id}/media
-    name: "List your posts"
+    name: "Your Instagram posts — captions, likes, comments"
     summary: "List your Instagram posts with captions, permalinks and like/comment counts"
     input:
       pathParams:
@@ -79,7 +79,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_media_id}/comments
-    name: "List post comments"
+    name: "Comments on one of your Instagram posts"
     summary: "List the comments on one of your Instagram posts"
     input:
       pathParams:
@@ -102,7 +102,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_user_id}/insights
-    name: "Get account reach and audience metrics"
+    name: "Your Instagram account reach and audience metrics"
     summary: "Get reach, profile views and audience metrics for your Instagram account"
     input:
       pathParams:
@@ -128,7 +128,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_media_id}/insights
-    name: "Get engagement metrics for a post"
+    name: "Reach, saves and engagement for one Instagram post"
     summary: "Get reach, saves and engagement for a single one of your Instagram posts"
     input:
       pathParams:
@@ -167,7 +167,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /{ig_user_id}/media
-    name: "Create a post media container"
+    name: "Stage an Instagram post — create its media container"
     summary: "Stage an Instagram post by creating the media container it will be published from"
     input:
       pathParams:
@@ -194,7 +194,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ig_container_id}
-    name: "Check media container processing status"
+    name: "Check Instagram media container status"
     summary: "Check whether a staged Instagram container has finished processing"
     input:
       pathParams:
@@ -213,7 +213,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /{ig_user_id}/media_publish
-    name: "Publish a post"
+    name: "Publish a staged post to your Instagram account"
     summary: "Publish a post to your own Instagram business account"
     input:
       pathParams:

--- a/src/treg/catalog/justoneapi.extended.yaml
+++ b/src/treg/catalog/justoneapi.extended.yaml
@@ -26,7 +26,7 @@ endpoints:
   platform: '1688'
   method: GET
   path: /api/1688/get-item-detail/v1
-  name: "Get 1688 product detail"
+  name: "1688 product details by item id"
   summary: Retrieves the public product detail for a 1688 wholesale listing by item ID.
   docs_url: https://docs.justoneapi.com/en/api/1688/product-details-v1
   cost:
@@ -60,7 +60,7 @@ endpoints:
   platform: '1688'
   method: GET
   path: /api/1688/search-item-list/v1
-  name: "Search 1688 Products"
+  name: "Search 1688 wholesale products by keyword"
   summary: Searches 1688 wholesale product listings by keyword.
   docs_url: https://docs.justoneapi.com/en/api/1688/product-search-v1
   cost:
@@ -94,7 +94,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /api/amazon/get-best-sellers/v1
-  name: "List Amazon best sellers by category"
+  name: "Amazon Best Sellers by category and country"
   summary: Retrieves paginated Amazon Best Sellers for a category path in a selected country marketplace.
   docs_url: https://docs.justoneapi.com/en/api/amazon/best-sellers-v1
   cost:
@@ -164,7 +164,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /api/amazon/get-category-products/v1
-  name: "List Amazon products by category"
+  name: "Amazon products by category id and country"
   summary: Retrieves paginated Amazon products for a numeric category node in a selected country marketplace, with configurable result sorting.
   docs_url: https://docs.justoneapi.com/en/api/amazon/products-by-category-v1
   cost:
@@ -239,7 +239,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /api/amazon/get-product-detail/v1
-  name: "Get Amazon product detail"
+  name: "Amazon product details by ASIN"
   summary: Retrieves details for an Amazon product identified by ASIN in a selected country marketplace.
   docs_url: https://docs.justoneapi.com/en/api/amazon/product-details-v1
   cost:
@@ -303,7 +303,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /api/amazon/get-product-top-reviews/v1
-  name: "List top reviews for an Amazon product"
+  name: "Amazon product top reviews by ASIN"
   summary: Retrieves the top reviews for an Amazon product identified by ASIN in a selected country marketplace.
   docs_url: https://docs.justoneapi.com/en/api/amazon/product-top-reviews-v1
   cost:
@@ -364,7 +364,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /api/amazon/search-products/v1
-  name: "Search Amazon products"
+  name: "Search Amazon products by keyword or ASIN"
   summary: Searches Amazon marketplace products by keyword or ASIN with country, sort, condition, Prime-only, deals, and page controls.
   docs_url: https://docs.justoneapi.com/en/api/amazon/product-search-v1
   cost:
@@ -476,7 +476,7 @@ endpoints:
   method: GET
   path: /api/beike/community/list/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "List Beike residential communities"
+  name: "Beike residential communities by city id"
   summary: Retrieves Beike residential communities for a city with optional condition filters and offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/beike/community-list-v1-deprecated
   input:
@@ -507,7 +507,7 @@ endpoints:
   method: GET
   path: /api/beike/ershoufang/detail/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "Get Beike resale-housing listing detail"
+  name: "Beike resale housing listing by city id and house code"
   summary: Retrieves a Beike resale-housing listing by city ID and house code.
   docs_url: https://docs.justoneapi.com/en/api/beike/resale-housing-details-v1-deprecated
   input:
@@ -528,7 +528,7 @@ endpoints:
   method: GET
   path: /api/beike/get-ershoufang-list/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "List Beike resale-housing listings"
+  name: "Beike resale housing listings by city id"
   summary: Retrieves Beike resale-housing listings for a city with optional condition filters and offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/beike/resale-housing-list-v1-deprecated
   input:
@@ -559,7 +559,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-user-detail/v2
-  name: "Get Bilibili User Profile"
+  name: "Bilibili user profile by user id"
   summary: Retrieves a Bilibili user profile identified by UID.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/user-profile-v2
   cost:
@@ -593,7 +593,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-user-relation-stat/v1
-  name: "Get Bilibili user follower stats"
+  name: "Bilibili user follower stats by user id"
   summary: Retrieves relation statistics for a Bilibili user identified by WMID.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/user-relation-stats-v1
   cost:
@@ -627,7 +627,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-user-video-list/v2
-  name: "List videos from a Bilibili user"
+  name: "Bilibili user videos by user id"
   summary: Retrieves videos published by a Bilibili user identified by UID, with an optional continuation parameter from a prior response.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/user-published-videos-v2
   cost:
@@ -665,7 +665,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-video-caption/v2
-  name: "Get Bilibili video captions"
+  name: "Bilibili video captions by video id"
   summary: Retrieves caption data for a Bilibili video segment identified by BVID, AID, and CID.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/video-captions-v2
   cost:
@@ -709,7 +709,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-video-comment/v2
-  name: "List comments on a Bilibili video"
+  name: "Bilibili video comments by video id"
   summary: Retrieves comments for a Bilibili video identified by AID, with optional cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/video-comments-v2
   cost:
@@ -748,7 +748,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-video-danmu/v2
-  name: "Get Bilibili video danmaku comments"
+  name: "Bilibili video danmaku comments by video id"
   summary: Retrieves one page of danmaku comments for a Bilibili video segment identified by AID and CID.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/video-danmaku-v2
   cost:
@@ -792,7 +792,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/get-video-detail/v2
-  name: "Get Bilibili video detail"
+  name: "Bilibili video details by video id"
   summary: Retrieves details for a Bilibili video identified by its BVID.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/video-details-v2
   cost:
@@ -826,7 +826,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/search-video/v2
-  name: "Search Bilibili videos"
+  name: "Search Bilibili videos by keyword"
   summary: Searches Bilibili videos by keyword with page-based pagination and sorting by general ranking, play count, publish time, danmaku count, or favorites.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/video-search-v2
   cost:
@@ -877,7 +877,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/bilibili/share-url-transfer/v1
-  name: "Resolve a Bilibili short share link"
+  name: "Resolve a Bilibili short link to its video URL"
   summary: Resolve a supported Bilibili short share link that targets a video and return its public redirect URL.
   docs_url: https://docs.justoneapi.com/en/api/bilibili/share-link-resolution-v1
   cost:
@@ -907,7 +907,7 @@ endpoints:
   method: GET
   path: /api/dewu/search-item-list/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "Search Dewu (Poizon) products"
+  name: "Search Dewu (Poizon) products by keyword"
   summary: Searches Dewu (Poizon) products by keyword with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/dewu-poizon/product-search-v1-deprecated
   input:
@@ -932,7 +932,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-movie-comments/v1
-  name: "List short comments for a Douban title"
+  name: "Douban short comments by movie or TV subject id"
   summary: Retrieves paginated Douban short comments for a movie or TV subject, ordered by time or newest rating.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/comments-v1
   cost:
@@ -981,7 +981,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-movie-review-detail/v1
-  name: "Get Douban Review Detail"
+  name: "Douban long-form review by review id"
   summary: Retrieves a single Douban long-form review by its review ID.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/review-details-v1
   cost:
@@ -1015,7 +1015,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-movie-reviews/v1
-  name: "List long-form reviews for a Douban title"
+  name: "Douban long-form reviews by movie or TV subject id"
   summary: Retrieves paginated Douban long-form reviews for a movie or TV subject, ordered by time or popularity.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/movie-reviews-v1
   cost:
@@ -1064,7 +1064,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-recent-hot-movie/v1
-  name: "List recent hot Douban movies"
+  name: "Douban recent hot movies"
   summary: Retrieves a paginated list of movies currently featured in Douban's recent-hot collection.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/recent-hot-movie-v1
   cost:
@@ -1099,7 +1099,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-recent-hot-tv/v1
-  name: "List recent hot Douban TV shows"
+  name: "Douban recent hot TV shows"
   summary: Retrieves a paginated list of TV titles currently featured in Douban's recent-hot collection.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/recent-hot-tv-v1
   cost:
@@ -1134,7 +1134,7 @@ endpoints:
   platform: douban
   method: GET
   path: /api/douban/get-subject-detail/v1
-  name: "Get Douban movie or TV subject detail"
+  name: "Douban movie or TV details by subject id"
   summary: Retrieves the public detail page data for a Douban movie or TV subject by subject ID.
   docs_url: https://docs.justoneapi.com/en/api/douban-movie/subject-details-v1
   cost:
@@ -1168,7 +1168,7 @@ endpoints:
   method: GET
   path: /api/llm/doubao-answer/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "Get a Doubao answer"
+  name: "Doubao web answer by question or keyword"
   summary: Requests a Doubao web answer for a submitted keyword or question.
   docs_url: https://docs.justoneapi.com/en/api/llm/doubao-answer-v1-deprecated
   input:
@@ -1187,7 +1187,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-user-detail/v3
-  name: "Get Douyin User Profile"
+  name: "Douyin user profile by user id"
   summary: Retrieves a Douyin (TikTok China) user profile by secUid.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/user-profile-v3
   cost:
@@ -1217,7 +1217,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-user-video-list/v1
-  name: "List videos from a Douyin user"
+  name: "Douyin user videos by user id, newest or most popular"
   summary: Retrieves videos published by a Douyin (TikTok China) user, with cursor pagination and newest or most-popular sorting.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/user-published-videos-v1
   cost:
@@ -1266,7 +1266,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-user-video-list/v3
-  name: "List videos from a Douyin user (v3)"
+  name: "Douyin user videos by user id"
   summary: Retrieves videos published by a Douyin (TikTok China) user with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/user-published-videos-v3
   cost:
@@ -1306,7 +1306,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-video-comment/v1
-  name: "List comments on a Douyin video"
+  name: "Douyin video comments by video id"
   summary: Retrieves top-level comments for a Douyin (TikTok China) video by aweme ID with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/video-comments-v1
   cost:
@@ -1346,7 +1346,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-video-detail/v2
-  name: "Get Douyin video detail"
+  name: "Douyin video details by video id"
   summary: Retrieves details for a Douyin (TikTok China) video by video ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/video-details-v2
   cost:
@@ -1380,7 +1380,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/get-video-sub-comment/v1
-  name: "List replies to a Douyin video comment"
+  name: "Douyin comment replies by comment id"
   summary: Retrieves replies to a top-level Douyin (TikTok China) video comment with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/comment-replies-v1
   cost:
@@ -1420,7 +1420,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/hot-search/v1
-  name: "Search trending Douyin content"
+  name: "Douyin trending content search with engagement filters"
   summary: Searches Douyin (TikTok China) content with optional keyword, category, video-type, ranking, pagination, engagement, and creator-follower filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/hot-search-v1
   cost:
@@ -1563,7 +1563,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/search-user/v2
-  name: "Search Douyin users"
+  name: "Search Douyin users by keyword"
   summary: Searches Douyin (TikTok China) users by keyword with page-based pagination and optional account-type filtering.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/user-search-v2
   cost:
@@ -1611,7 +1611,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/search-video/v4
-  name: "Search Douyin videos"
+  name: "Search Douyin videos by keyword"
   summary: Searches Douyin (TikTok China) videos by keyword with sort, publish-time, duration, and page filters; later pages require the previous search ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/video-search-v4
   cost:
@@ -1687,7 +1687,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/douyin/share-url-transfer/v1
-  name: "Resolve a Douyin short share link"
+  name: "Resolve a Douyin short link to its video URL"
   summary: Resolve a supported Douyin (TikTok China) short share link that targets a video and return its public redirect URL.
   docs_url: https://docs.justoneapi.com/en/api/douyin-tiktok-china/share-link-resolution-v1
   cost:
@@ -1717,7 +1717,7 @@ endpoints:
   platform: douyin-shop
   method: GET
   path: /api/douyin-ec/get-item-comments/v1
-  name: "List comments for a Douyin shop product"
+  name: "Douyin Shop product comments by item id"
   summary: Retrieves paginated customer comments for a Douyin E-commerce product by item ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-e-commerce/item-comments-v1
   cost:
@@ -1756,7 +1756,7 @@ endpoints:
   platform: douyin-shop
   method: GET
   path: /api/douyin-ec/get-item-detail/v2
-  name: "Get Douyin Shop Product Detail"
+  name: "Douyin Shop product details by item id"
   summary: Retrieves Douyin E-commerce product details by item ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-e-commerce/item-details-v2
   cost:
@@ -1790,7 +1790,7 @@ endpoints:
   platform: douyin-shop
   method: GET
   path: /api/douyin-ec/get-item-sku-info/v1
-  name: "Get SKU info for a Douyin shop product"
+  name: "Douyin Shop product SKUs by item id"
   summary: Retrieves SKU information for a Douyin E-commerce product by item ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-e-commerce/product-sku-info-v1
   cost:
@@ -1824,7 +1824,7 @@ endpoints:
   platform: douyin-shop
   method: GET
   path: /api/douyin-ec/get-shop-item-list/v1
-  name: "List products in a Douyin shop"
+  name: "Douyin Shop products by shop id"
   summary: Retrieves a paginated product list for a Douyin E-commerce shop by shop ID.
   docs_url: https://docs.justoneapi.com/en/api/douyin-e-commerce/shop-product-list-v1
   cost:
@@ -1863,7 +1863,7 @@ endpoints:
   platform: douyin-shop
   method: GET
   path: /api/douyin-ec/search-item-list/v1
-  name: "Search Douyin shop products"
+  name: "Search Douyin Shop products by keyword"
   summary: Searches Douyin E-commerce products by keyword with page and search-ID pagination.
   docs_url: https://docs.justoneapi.com/en/api/douyin-e-commerce/product-search-v1
   cost:
@@ -1907,7 +1907,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_commerce_seed_base_info/v1
-  name: "Get Xingtu creator commerce-seeding baseline"
+  name: "Xingtu creator commerce seeding baseline by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) commerce-seeding baseline information for a creator over a selectable 30- or 90-day period.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/commerce-seeding-base-info-v1
   cost:
@@ -1950,7 +1950,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_commerce_spread_info/v1
-  name: "Get Xingtu creator commerce spread info"
+  name: "Xingtu creator commerce spread info by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) commerce spread information for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-commerce-spread-info-v1
   cost:
@@ -1984,7 +1984,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_contract_base_info
-  name: "Get Xingtu creator contract baseline"
+  name: "Xingtu creator contract baseline by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) contract-related baseline information for a creator over a selectable 30- or 90-day period.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-contract-base-info
   cost:
@@ -2027,7 +2027,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_homepage_videos/v1
-  name: "List Xingtu creator homepage videos"
+  name: "Xingtu creator homepage videos by creator id"
   summary: Lists a Douyin Creator Marketplace (Xingtu) creator's homepage videos with keyword, video-type, assignment, date, and page filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-homepage-videos-v1
   cost:
@@ -2098,7 +2098,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_live_statistics/v1
-  name: "Get Xingtu creator live-stream statistics"
+  name: "Xingtu creator live-stream stats by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) live-stream statistics for a creator, with live-room, period, marketplace-order, and flow filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/live-statistics-v1
   cost:
@@ -2167,7 +2167,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_live_watch_distribution/v1
-  name: "Get Xingtu creator live watch distribution"
+  name: "Xingtu creator live watch distribution by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) live audience or follower watch-distribution data for a creator and selected live-room type.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/live-watch-distribution-v1
   cost:
@@ -2221,7 +2221,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_order_experience/v1
-  name: "Get Xingtu creator order experience"
+  name: "Xingtu creator order experience by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) creator order-experience information for the last 30 or 90 days.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-order-experience-v1
   cost:
@@ -2264,7 +2264,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_side_base_info/v1
-  name: "Get Xingtu creator side-card baseline"
+  name: "Xingtu creator side-card baseline by creator id"
   summary: Returns the Douyin Creator Marketplace (Xingtu) side-card baseline information for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-side-base-info-v1
   cost:
@@ -2298,7 +2298,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/aggregator/get_author_tags/v1
-  name: "Get Xingtu creator tags"
+  name: "Xingtu creator tags by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) tags for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-tags-v1
   cost:
@@ -2332,7 +2332,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/author/get_author_base_info/v1
-  name: "Get Xingtu creator profile"
+  name: "Xingtu creator profile by creator id"
   summary: Returns the Douyin Creator Marketplace (Xingtu) profile for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-profile-v1
   cost:
@@ -2377,7 +2377,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/author/get_author_marketing_info/v1
-  name: "Get Xingtu creator marketing info"
+  name: "Xingtu creator marketing info by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) marketing information for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/marketing-metrics-v1
   cost:
@@ -2422,7 +2422,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/author/get_author_platform_channel_info_v2/v1
-  name: "Get Xingtu creator channel info"
+  name: "Xingtu creator channel info by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) channel information for a specified creator and content format.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-channel-metrics-v1
   cost:
@@ -2467,7 +2467,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/author/get_author_show_items_v2/v1
-  name: "List Xingtu creator showcase items"
+  name: "Xingtu creator showcase items by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) showcase items for a creator, with content-channel, assignment, and flow filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/showcase-items-v1
   cost:
@@ -2527,7 +2527,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data/get_author_hot_comment_tokens/v1
-  name: "Get Xingtu creator comment keyword analysis"
+  name: "Xingtu creator comment keyword analysis by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) comment keyword analysis for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/comment-keyword-analysis-v1
   cost:
@@ -2561,7 +2561,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_audience_distribution/v1
-  name: "Get Xingtu creator audience distribution"
+  name: "Xingtu creator audience distribution by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) audience-distribution data for a creator, content channel, and selected relationship stage.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/audience-distribution-v1
   cost:
@@ -2618,7 +2618,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_cp_info/v1
-  name: "Get Xingtu creator cost-performance info"
+  name: "Xingtu creator cost-performance by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) cost-performance information for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/cost-performance-analysis-v1
   cost:
@@ -2663,7 +2663,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_link_struct/v1
-  name: "Get Xingtu creator link structure data"
+  name: "Xingtu creator link structure by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) creator-link structure data for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-link-structure-v1
   cost:
@@ -2708,7 +2708,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_rec_videos_v2/v1
-  name: "List Xingtu creator recommended videos"
+  name: "Xingtu creator recommended videos by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) recommended videos for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/recommended-videos-v1
   cost:
@@ -2753,7 +2753,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_touch_distribution/v1
-  name: "Get Xingtu creator audience touchpoint distribution"
+  name: "Xingtu creator touchpoint distribution by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) audience-touchpoint distribution data for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/audience-touchpoint-distribution-v1
   cost:
@@ -2798,7 +2798,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/author_video_distribution/v1
-  name: "Get Xingtu creator video distribution data"
+  name: "Xingtu creator video distribution by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) video-distribution data for a specified creator and content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/video-distribution-v1
   cost:
@@ -2842,7 +2842,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/check_author_display/v1
-  name: "Check Xingtu creator display eligibility"
+  name: "Check Xingtu creator display eligibility by creator id"
   summary: Returns whether a specified creator can be displayed in Douyin Creator Marketplace (Xingtu) for the selected content channel.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-visibility-status-v1
   cost:
@@ -2887,7 +2887,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_convert_ability/v1
-  name: "Get Xingtu creator conversion analysis"
+  name: "Xingtu creator conversion analysis by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) conversion analysis for a creator, content channel, and 30- or 90-day period.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/conversion-analysis-v1
   cost:
@@ -2941,7 +2941,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_convert_videos_or_products/v1
-  name: "List Xingtu creator conversion videos or products"
+  name: "Xingtu creator conversion videos or products by creator id"
   summary: Lists Douyin Creator Marketplace (Xingtu) conversion-related videos or products for a creator, with industry, period, resource-type, and page filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/conversion-resources-v1
   cost:
@@ -3055,7 +3055,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_daily_fans/v1
-  name: "Get Xingtu creator daily follower trend"
+  name: "Xingtu creator daily follower trend by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) daily follower trend data for a specified creator and date range.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/follower-growth-trend-v1
   cost:
@@ -3099,7 +3099,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_fans_distribution/v1
-  name: "Get Xingtu creator follower distribution"
+  name: "Xingtu creator follower distribution by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) follower or loyal-follower distribution data for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/follower-distribution-v1
   cost:
@@ -3142,7 +3142,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_link_info/v1
-  name: "Get Xingtu creator link metrics"
+  name: "Xingtu creator link metrics by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) creator-link metrics for a specified creator, content channel, and industry category.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-link-metrics-v1
   cost:
@@ -3232,7 +3232,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/get_author_spread_info/v1
-  name: "Get Xingtu creator spread metrics"
+  name: "Xingtu creator spread metrics by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) spread metrics for a creator, with channel, period, video-type, assignment, and flow filters.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/spread-metrics-v1
   cost:
@@ -3310,7 +3310,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/item_report_detail/v1
-  name: "Get Xingtu video item report detail"
+  name: "Xingtu video report details by item id"
   summary: Returns Douyin Creator Marketplace (Xingtu) report details for a specified video item.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/video-details-v1
   cost:
@@ -3344,7 +3344,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/item_report_th_analysis/v1
-  name: "Get Xingtu video item report analysis"
+  name: "Xingtu video report analysis by item id"
   summary: Returns Douyin Creator Marketplace (Xingtu) report analysis for a specified video item.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/item-report-analysis-v1
   cost:
@@ -3378,7 +3378,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/data_sp/item_report_trend/v1
-  name: "Get Xingtu video item report trend"
+  name: "Xingtu video report trend by item id"
   summary: Returns Douyin Creator Marketplace (Xingtu) report trend data for a specified video item.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/item-report-trends-v1
   cost:
@@ -3412,7 +3412,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/gauthor/author_get_business_card_info/v1
-  name: "Get Xingtu creator business-card profile"
+  name: "Xingtu creator business card by creator id"
   summary: Returns the Douyin Creator Marketplace (Xingtu) business-card profile for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-business-card-v1
   cost:
@@ -3446,7 +3446,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/gauthor/get_author_content_hot_keywords/v1
-  name: "Get Xingtu creator content keyword analysis"
+  name: "Xingtu creator content keyword analysis by creator id"
   summary: Returns Douyin Creator Marketplace (Xingtu) content keyword analysis for a specified creator.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/content-keyword-analysis-v1
   cost:
@@ -3480,7 +3480,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/douyin-xingtu/gw/api/gsearch/search_for_author_square/v1
-  name: "Search Xingtu creators by filters"
+  name: "Search Xingtu creators by keyword, audience, and pricing"
   summary: Searches Douyin Creator Marketplace (Xingtu) creators by keyword and structured filters for audience, pricing, content, performance, and campaign fit.
   docs_url: https://docs.justoneapi.com/en/api/douyin-creator-marketplace-xingtu/creator-search-v1
   cost:
@@ -3692,7 +3692,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /api/facebook/get-post-comments/v1
-  name: "List comments on a Facebook post"
+  name: "Facebook post comments by post id"
   summary: Retrieves comments for a Facebook post ID with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/facebook/post-comments-v1
   cost:
@@ -3732,7 +3732,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /api/facebook/get-profile-id/v1
-  name: "Resolve a Facebook profile ID"
+  name: "Resolve a Facebook profile URL to its profile id"
   summary: Resolves the Facebook profile ID associated with a submitted profile-path value.
   docs_url: https://docs.justoneapi.com/en/api/facebook/get-profile-id-v1
   cost:
@@ -3768,7 +3768,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /api/facebook/get-profile-posts/v1
-  name: "List posts from a Facebook profile"
+  name: "Facebook profile posts by profile id"
   summary: Retrieves public posts for a Facebook profile ID with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/facebook/get-profile-posts-v1
   cost:
@@ -3808,7 +3808,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /api/facebook/search-post/v1
-  name: "Search public Facebook posts"
+  name: "Search public Facebook posts by keyword"
   summary: Searches public Facebook posts by keyword with optional inclusive date-range filters and cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/facebook/post-search-v1
   cost:
@@ -3856,7 +3856,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/news-by-category-query/v1
-  name: "List IMDb news by category"
+  name: "IMDb news by category (top, movie, TV, celebrity)"
   summary: Retrieves IMDb news for a selected top, movie, TV, or celebrity category using language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/news-by-category-v1
   cost:
@@ -3912,7 +3912,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/streaming-picks-query/v1
-  name: "List IMDb Prime Video streaming picks"
+  name: "IMDb streaming picks for Prime Video"
   summary: Retrieves IMDb streaming picks for Prime Video using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/streaming-picks-v1
   cost:
@@ -3958,7 +3958,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-awards-summary-query/v1
-  name: "Get IMDb title awards summary"
+  name: "IMDb title awards summary by title id"
   summary: Retrieves the IMDb awards summary for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/awards-summary-v1
   cost:
@@ -4009,7 +4009,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-base-query/v1
-  name: "Get IMDb title base info"
+  name: "IMDb title base info by title id"
   summary: Retrieves base IMDb information for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/base-info-v1
   cost:
@@ -4060,7 +4060,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-box-office-summary/v1
-  name: "Get IMDb title box-office summary"
+  name: "IMDb title box office summary by title id"
   summary: Retrieves the IMDb box-office summary for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/box-office-summary-v1
   cost:
@@ -4111,7 +4111,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-chart-rankings/v1
-  name: "Get IMDb Top 250 chart rankings"
+  name: "IMDb Top 250 movie or TV chart by ranking type"
   summary: Retrieves the IMDb Top 250 movie or TV chart selected by ranking type using language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/chart-rankings-v1
   cost:
@@ -4164,7 +4164,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-contribution-questions/v1
-  name: "Get IMDb title contribution questions"
+  name: "IMDb title contribution questions by title id"
   summary: Retrieves IMDb contribution questions associated with a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/contribution-questions-v1
   cost:
@@ -4214,7 +4214,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-countries-of-origin/v1
-  name: "Get IMDb title countries of origin"
+  name: "IMDb title countries of origin by title id"
   summary: Retrieves countries of origin associated with an IMDb title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/countries-of-origin-v1
   cost:
@@ -4265,7 +4265,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-critics-review-summary-query/v1
-  name: "Get IMDb title critics-review summary"
+  name: "IMDb title critics review summary by title id"
   summary: Retrieves the IMDb critics-review summary for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/critics-review-summary-v1
   cost:
@@ -4316,7 +4316,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-details-query/v1
-  name: "Get IMDb title details"
+  name: "IMDb title details by title id"
   summary: Retrieves IMDb title details for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/details-v1
   cost:
@@ -4367,7 +4367,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-did-you-know-query/v1
-  name: "Get IMDb title 'Did You Know' info"
+  name: "IMDb title Did You Know info by title id"
   summary: Retrieves IMDb 'Did You Know' information for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/did-you-know-insights-v1
   cost:
@@ -4418,7 +4418,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-extended-details-query/v1
-  name: "Get extended IMDb title details"
+  name: "IMDb title extended details by title id"
   summary: Retrieves extended IMDb details for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/extended-details-v1
   cost:
@@ -4469,7 +4469,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-more-like-this-query/v1
-  name: "List IMDb titles similar to a title"
+  name: "IMDb similar titles by title id"
   summary: Retrieves IMDb titles similar to a specified title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/recommendations-v1
   cost:
@@ -4520,7 +4520,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-plot-query/v1
-  name: "Get IMDb title plot"
+  name: "IMDb title plot by title id"
   summary: Retrieves IMDb plot information for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/plot-summary-v1
   cost:
@@ -4571,7 +4571,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-redux-overview-query/v1
-  name: "Get IMDb title Redux overview"
+  name: "IMDb title Redux overview by title id"
   summary: Retrieves the IMDb Redux overview for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/redux-overview-v1
   cost:
@@ -4622,7 +4622,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-release-expectation-query/v1
-  name: "Get IMDb title release-expectation info"
+  name: "IMDb title release expectation by title id"
   summary: Retrieves IMDb release-expectation information for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/release-expectation-v1
   cost:
@@ -4673,7 +4673,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-top-cast-and-crew/v1
-  name: "Get IMDb title top cast and crew"
+  name: "IMDb title top cast and crew by title id"
   summary: Retrieves IMDb top cast and crew information for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/top-cast-and-crew-v1
   cost:
@@ -4724,7 +4724,7 @@ endpoints:
   platform: imdb
   method: GET
   path: /api/imdb/title-user-reviews-summary-query/v1
-  name: "Get IMDb title user-reviews summary"
+  name: "IMDb title user reviews summary by title id"
   summary: Retrieves the IMDb user-reviews summary for a title ID using selected language and country preferences.
   docs_url: https://docs.justoneapi.com/en/api/imdb/user-reviews-summary-v1
   cost:
@@ -4775,7 +4775,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/get-comment-replies/v1
-  name: "List replies to an Instagram post comment"
+  name: "Instagram comment replies by media and comment id"
   summary: Retrieves replies to a specific Instagram post comment by media and comment IDs, with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/instagram/comment-reply-list-v1
   cost:
@@ -4819,7 +4819,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/get-post-comments/v1
-  name: "List comments on an Instagram post"
+  name: "Instagram post comments by shortcode"
   summary: Retrieves top-level comments for an Instagram post by shortcode, with cursor pagination and popular or newest sorting.
   docs_url: https://docs.justoneapi.com/en/api/instagram/post-comment-list-v1
   cost:
@@ -4867,7 +4867,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/get-post-detail/v1
-  name: "Get Instagram Post Detail"
+  name: "Instagram post details by shortcode"
   summary: Retrieves an Instagram post by its shortcode.
   docs_url: https://docs.justoneapi.com/en/api/instagram/post-details-v1
   cost:
@@ -4901,7 +4901,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/get-user-detail/v1
-  name: "Get Instagram User Detail (v1)"
+  name: "Instagram user profile by username"
   summary: Retrieves an Instagram user profile by username.
   docs_url: https://docs.justoneapi.com/en/api/instagram/user-profile-v1
   cost:
@@ -4935,7 +4935,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/search-hashtag-posts/v1
-  name: "Search Instagram Hashtag Posts"
+  name: "Search Instagram posts by hashtag"
   summary: Searches Instagram posts by hashtag with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/instagram/hashtag-posts-search-v1
   cost:
@@ -4975,7 +4975,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/instagram/search-reels/v1
-  name: "Search Instagram Reels"
+  name: "Search Instagram Reels by keyword or hashtag"
   summary: Searches Instagram Reels by keyword or hashtag with token-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/instagram/reels-search-v1
   cost:
@@ -5014,7 +5014,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-comments/v1
-  name: "List JD.com product comments"
+  name: "JD.com product comments by item id"
   summary: Retrieve paginated customer comments for a JD.com product identified by item ID.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-comments-v1
   cost:
@@ -5053,7 +5053,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-comments/v2
-  name: "List JD.com SKU comments"
+  name: "JD.com SKU-level product comments by item id"
   summary: Retrieve paginated JD.com product comments for a specific SKU.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-comments-v2
   cost:
@@ -5092,7 +5092,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-detail/v1
-  name: "Get JD Product Detail (v1)"
+  name: "JD.com product details by item id"
   summary: Retrieve JD.com product details for a known item ID.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-details-v1
   cost:
@@ -5126,7 +5126,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-detail/v2
-  name: "Get JD.com product detail (async task)"
+  name: "JD.com product details by item id (async task)"
   summary: Access the asynchronous JD.com product detail workflow from the Just One API dashboard Task Management page.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-details-v2
   input:
@@ -5148,7 +5148,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-detail/v3
-  name: "Get JD Product Detail (v3)"
+  name: "JD.com product details by item id"
   summary: Retrieves JD.com product details for a known item ID.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-details-v3
   cost:
@@ -5178,7 +5178,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-item-price/v1
-  name: "Get JD.com product price"
+  name: "JD.com current product price by item id"
   summary: Retrieve the current JD.com product price for a known item ID.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-price-v1
   cost:
@@ -5211,7 +5211,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/get-shop-item-list/v1
-  name: "List products from a JD.com shop"
+  name: "JD.com shop products by shop id"
   summary: Retrieve a page of products from a JD.com shop identified by shop ID.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/shop-product-list-v1
   cost:
@@ -5246,7 +5246,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/search-item-list/v1
-  name: "Search JD.com products"
+  name: "Search JD.com products by keyword"
   summary: Search JD.com products by keyword with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-search-v1
   cost:
@@ -5285,7 +5285,7 @@ endpoints:
   platform: jd
   method: GET
   path: /api/jd/search-item-list/v2
-  name: "Search JD.com products by sales volume"
+  name: "Search JD.com products by keyword, sorted by sales"
   summary: Search JD.com products by keyword with page-based pagination and sales-volume ordering.
   docs_url: https://docs.justoneapi.com/en/api/jdcom/product-search-v2
   cost:
@@ -5324,7 +5324,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/get-user-detail/v1
-  name: "Get Kuaishou user profile"
+  name: "Kuaishou user profile by user id"
   summary: Retrieve the public profile for a Kuaishou user identified by user ID.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/user-profile-v1
   cost:
@@ -5357,7 +5357,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/get-user-video-list/v2
-  name: "List videos from a Kuaishou user"
+  name: "Kuaishou user videos by user id"
   summary: Retrieve public videos published by a Kuaishou user, with optional cursor-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/user-published-videos-v2
   cost:
@@ -5390,7 +5390,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/get-video-comment/v1
-  name: "List comments on a Kuaishou video"
+  name: "Kuaishou video comments by video id"
   summary: Retrieve public comments for a Kuaishou video, with optional cursor-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/video-comments-v1
   cost:
@@ -5423,7 +5423,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/get-video-detail/v2
-  name: "Get Kuaishou video detail"
+  name: "Kuaishou video details by video id"
   summary: Retrieve public details for a Kuaishou video identified by its video ID.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/video-details-v2
   cost:
@@ -5453,7 +5453,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/search-user/v2
-  name: "Search Kuaishou users"
+  name: "Search Kuaishou users by keyword"
   summary: Search public Kuaishou user accounts by keyword with page-number pagination.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/user-search-v2
   cost:
@@ -5493,7 +5493,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/search-video/v1
-  name: "Search Kuaishou videos (cursor pagination)"
+  name: "Search Kuaishou videos by keyword, cursor paginated"
   summary: Search public Kuaishou videos by keyword with cursor-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/video-search-v1
   cost:
@@ -5532,7 +5532,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/search-video/v2
-  name: "Search Kuaishou videos (page pagination)"
+  name: "Search Kuaishou videos by keyword, page paginated"
   summary: Search public Kuaishou videos by keyword with page-number pagination.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/video-search-v2
   cost:
@@ -5572,7 +5572,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/kuaishou/share-url-transfer/v1
-  name: "Resolve a Kuaishou short share link"
+  name: "Resolve a Kuaishou short link to its public URL"
   summary: Resolve a supported Kuaishou short share link and return its public redirect URL.
   docs_url: https://docs.justoneapi.com/en/api/kuaishou/share-link-resolution-v1
   cost:
@@ -5602,7 +5602,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/get-company-employees/v1
-  name: "List employees of a LinkedIn company"
+  name: "LinkedIn company employees by company id"
   summary: Retrieves a page of LinkedIn people associated with a company ID.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/company-employees-v1
   cost:
@@ -5642,7 +5642,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/get-post-comments/v1
-  name: "List comments on a LinkedIn post"
+  name: "LinkedIn post comments by post id"
   summary: Retrieves a page of LinkedIn comments for a post with relevance or recent sorting and activity or UGC post types.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/post-comments-v1
   cost:
@@ -5700,7 +5700,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/get-post-reactions/v1
-  name: "List reactions on a LinkedIn post"
+  name: "LinkedIn post reactions by post id"
   summary: Retrieves LinkedIn reaction records for a post, optionally filtered by reaction type and page.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/post-reactions-v1
   cost:
@@ -5753,7 +5753,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/get-user-detail/v1
-  name: "Get LinkedIn profile detail"
+  name: "LinkedIn user profile by username — name, headline"
   summary: Retrieves a LinkedIn profile by username, including documented core profile fields such as name and headline.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/user-profile-v1
   cost:
@@ -5787,7 +5787,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/get-user-posts/v1
-  name: "List posts from a LinkedIn user"
+  name: "LinkedIn user posts by user URN"
   summary: Retrieves posts published by a LinkedIn user URN with page and pagination-token support.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/user-published-posts-v1
   cost:
@@ -5832,7 +5832,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/linkedin/search-user/v1
-  name: "Search LinkedIn people"
+  name: "Search LinkedIn people by name, title, or company"
   summary: Searches LinkedIn people by name, title, company, school, location, language, industry, or service category with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/linkedin/people-search-v1
   cost:
@@ -5921,7 +5921,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/finder_publisher/detail/v1
-  name: "Get QQ Huxuan Video Account creator detail"
+  name: "Huxuan Video Account creator details by app id"
   summary: Retrieves QQ Huxuan Video Account creator details for a known creator app ID.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/video-account-creator-details-v1
   cost:
@@ -5955,7 +5955,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/finder_publisher/get_finder_video_show/v1
-  name: "List QQ Huxuan Video Account creator videos"
+  name: "Huxuan Video Account creator videos by app id and dates"
   summary: Lists videos from a QQ Huxuan Video Account creator within a required date range, with a choice of all, Huxuan order, hot, or personal videos.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/video-account-recent-videos-v1
   cost:
@@ -6016,7 +6016,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/finder_publisher/search/v1
-  name: "Search QQ Huxuan Video Account creators"
+  name: "Search Huxuan Video Account creators by nickname"
   summary: Searches or browses QQ Huxuan Video Account creators by optional nickname keyword with page-number pagination.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/video-account-creator-search-v1
   cost:
@@ -6058,7 +6058,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/mp_publisher/detail/v1
-  name: "Get QQ Huxuan Official Account creator detail"
+  name: "Huxuan Official Account creator details by app id"
   summary: Retrieves QQ Huxuan Official Account creator details for a known creator app ID.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/official-account-creator-details-v1
   cost:
@@ -6092,7 +6092,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/mp_publisher/get_user_articles/v1
-  name: "List QQ Huxuan Official Account creator articles"
+  name: "Huxuan Official Account articles by app id and dates"
   summary: Lists articles from a QQ Huxuan Official Account creator within a required date range, with an optional title keyword and a choice between all articles and Huxuan order articles.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/official-account-article-list-v1
   cost:
@@ -6157,7 +6157,7 @@ endpoints:
   platform: qq-huxuan
   method: GET
   path: /api/qq-huxuan/cgi-bin/advertiser/mp_publisher/search/v1
-  name: "Search QQ Huxuan Official Account creators"
+  name: "Search Huxuan Official Account creators by nickname"
   summary: Searches or browses QQ Huxuan Official Account creators by optional nickname or account keyword with page-number pagination.
   docs_url: https://docs.justoneapi.com/en/api/qq-huxuan-creator-marketplace/official-account-creator-search-v1
   cost:
@@ -6199,7 +6199,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/reddit/get-post-comments/v1
-  name: "List comments on a Reddit post"
+  name: "Reddit post comments by post id"
   summary: Retrieves comments for a Reddit post with pagination-token support.
   docs_url: https://docs.justoneapi.com/en/api/reddit/post-comments-v1
   cost:
@@ -6240,7 +6240,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/reddit/get-post-detail/v1
-  name: "Get Reddit post detail"
+  name: "Reddit post details by post id"
   summary: Retrieves details for a Reddit post identified by its full post ID.
   docs_url: https://docs.justoneapi.com/en/api/reddit/post-details-v1
   cost:
@@ -6274,7 +6274,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/reddit/search/v1
-  name: "Search Reddit posts"
+  name: "Search Reddit posts by keyword"
   summary: Searches Reddit posts by keyword with an optional continuation token.
   docs_url: https://docs.justoneapi.com/en/api/reddit/keyword-search-v1
   cost:
@@ -6312,7 +6312,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-comment/v3
-  name: "List Taobao or Tmall product reviews"
+  name: "Taobao and Tmall product reviews by item id"
   summary: Retrieves Taobao and Tmall product reviews by item ID with page-based pagination, configurable sorting, and optional exclusion of default positive reviews.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-reviews-v3
   cost:
@@ -6370,7 +6370,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-detail/v1
-  name: "Get Taobao or Tmall product detail (v1)"
+  name: "Taobao and Tmall product details by item id"
   summary: Retrieves Taobao or Tmall product details by item ID through the V1 endpoint.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-details-v1
   cost:
@@ -6405,7 +6405,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-detail/v2
-  name: "Get Taobao or Tmall product detail (async task)"
+  name: "Taobao and Tmall product details by item id (async task)"
   summary: Access the asynchronous Taobao and Tmall product detail workflow from the Just One API dashboard Task Management page.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-details-v2
   cost:
@@ -6439,7 +6439,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-detail/v4
-  name: "Get Taobao or Tmall product detail (v4)"
+  name: "Taobao and Tmall product details by item id"
   summary: Retrieves Taobao or Tmall product details by item ID through the V4 endpoint.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-details-v4
   cost:
@@ -6473,7 +6473,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-detail/v5
-  name: "Get Taobao or Tmall product detail (v5)"
+  name: "Taobao and Tmall product details by item id"
   summary: Retrieves Taobao or Tmall product details by item ID through the V5 endpoint.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-details-v5
   cost:
@@ -6507,7 +6507,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-item-detail/v9
-  name: "Get Taobao or Tmall product detail (v9)"
+  name: "Taobao and Tmall product details by item id"
   summary: Retrieves Taobao or Tmall product details by item ID through the V9 endpoint.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-details-v9
   cost:
@@ -6541,7 +6541,7 @@ endpoints:
   method: GET
   path: /api/taobao/get-item-sale/v1
   cost: {type: per_success, value: null, currency: CNY, unit: call, source: inferred, checked: '2026-08-07', confidence: unknown, note: 'UNPRICED and unmeasurable from here. JustOneAPI publishes no rate-card API (the other rates came from a dashboard price export), exposes no balance endpoint, and returns no billing field in its responses — so a per-call price cannot be observed the way DataForSEO and Lusha were. The route is DEPRECATED upstream but still answers (400 for missing params, not 404), and it is the only endpoint in the catalog for this platform, so it is kept rather than dropped. To price it: re-export the JustOneAPI dashboard price list'}
-  name: "Get 30-day sales count for a Taobao product"
+  name: "Taobao product 30-day sales count by item id"
   summary: Retrieves the 30-day sales count for a Taobao or Tmall product by item ID.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-sales-v1-deprecated
   input:
@@ -6560,7 +6560,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-shop-item-list/v1
-  name: "List products from a Taobao or Tmall shop (v1)"
+  name: "Taobao and Tmall shop products by seller id"
   summary: Retrieves products from a Taobao or Tmall shop by seller or user ID, with page-based pagination and default or sales sorting.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/shop-product-list-v1
   cost:
@@ -6609,7 +6609,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-shop-item-list/v2
-  name: "List products from a Taobao or Tmall shop (v2)"
+  name: "Taobao and Tmall shop products by seller and shop id"
   summary: Retrieves products from a Taobao or Tmall shop using both seller or user ID and shop ID, with page-based pagination and configurable sorting.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/shop-product-list-v2
   cost:
@@ -6665,7 +6665,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-shop-item-list/v4
-  name: "List products from a Taobao or Tmall shop (v4)"
+  name: "Taobao and Tmall shop products by seller id"
   summary: Retrieves products from a Taobao or Tmall shop by seller ID with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/shop-product-list-v4
   cost:
@@ -6701,7 +6701,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/get-social-feed/v1
-  name: "Get social feed for a Taobao product"
+  name: "Taobao product social feed by item id"
   summary: Retrieves the Taobao or Tmall product social feed by item ID with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-questions-v1
   cost:
@@ -6741,7 +6741,7 @@ endpoints:
   platform: taobao
   method: GET
   path: /api/taobao/search-item-list/v1
-  name: "Search Taobao and Tmall products"
+  name: "Search Taobao and Tmall products by keyword"
   summary: Searches Taobao and Tmall products by keyword with page, sort, optional Tmall-only, and inclusive price-range filters.
   docs_url: https://docs.justoneapi.com/en/api/taobao-and-tmall/product-search-v1
   cost:
@@ -6806,7 +6806,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/tiktok/get-post-sub-comment/v1
-  name: "List replies to a TikTok post comment"
+  name: "TikTok comment replies by post and comment id"
   summary: Retrieves replies to a specific comment on a TikTok post with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/tiktok/comment-replies-v1
   cost:
@@ -6851,7 +6851,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/tiktok/search-user/v1
-  name: "Search TikTok users"
+  name: "Search TikTok users by keyword"
   summary: Searches TikTok users by keyword with cursor pagination and search-session continuity.
   docs_url: https://docs.justoneapi.com/en/api/tiktok/user-search-v1
   cost:
@@ -6896,7 +6896,7 @@ endpoints:
   platform: tiktok-shop
   method: GET
   path: /api/tiktok-shop/get-product-detail/v1
-  name: "Get TikTok Shop product detail"
+  name: "TikTok Shop product details by product id"
   summary: Retrieves the public TikTok Shop product detail for a product ID in a selected region.
   docs_url: https://docs.justoneapi.com/en/api/tiktok-shop/product-details-v1
   cost:
@@ -6946,7 +6946,7 @@ endpoints:
   platform: tiktok-shop
   method: GET
   path: /api/tiktok-shop/search-products/v1
-  name: "Search TikTok Shop products"
+  name: "Search TikTok Shop products by keyword"
   summary: Searches TikTok Shop products by keyword within a selected region, with offset and page-token pagination.
   docs_url: https://docs.justoneapi.com/en/api/tiktok-shop/product-search-v1
   cost:
@@ -7005,7 +7005,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/toutiao/get-article-detail/v1
-  name: "Get Toutiao article detail"
+  name: "Toutiao article details by article id"
   summary: Retrieves details for a Toutiao article identified by its article ID.
   docs_url: https://docs.justoneapi.com/en/api/toutiao/article-details-v1
   cost:
@@ -7031,7 +7031,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/toutiao/get-user-detail/v1
-  name: "Get Toutiao User Profile"
+  name: "Toutiao user profile by user id"
   summary: Retrieves a Toutiao user profile identified by user ID.
   docs_url: https://docs.justoneapi.com/en/api/toutiao/user-profile-v1
   cost:
@@ -7058,7 +7058,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/toutiao/get-user-id/v1
-  name: "Resolve Toutiao User ID"
+  name: "Resolve a Toutiao profile URL to its user id"
   summary: Resolves the user ID associated with a Toutiao profile URL.
   docs_url: https://docs.justoneapi.com/en/api/toutiao/user-id-v1
   cost:
@@ -7085,7 +7085,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/toutiao/search/v2
-  name: "Search Toutiao Articles"
+  name: "Search Toutiao articles by keyword"
   summary: Searches Toutiao web articles by keyword.
   docs_url: https://docs.justoneapi.com/en/api/toutiao/web-keyword-search-v2
   cost:
@@ -7118,7 +7118,7 @@ endpoints:
   platform: web
   method: GET
   path: /api/search/v1
-  name: "Search across news, Weibo, WeChat, and more"
+  name: "Search Chinese news, Weibo, WeChat, and more by keyword"
   summary: Searches recent content across news, Weibo, WeChat, Zhihu, Douyin, Xiaohongshu, Bilibili, and Kuaishou with source and time filters.
   docs_url: https://docs.justoneapi.com/en/api/social-media/cross-platform-search-v1
   cost:
@@ -7176,7 +7176,7 @@ endpoints:
   platform: wechat-channels
   method: GET
   path: /api/weixin-channels/convert-export-id/v1
-  name: "Convert a WeChat Channels export ID"
+  name: "Convert a WeChat Channels export id to a video id"
   summary: Converts an encrypted WeChat Channels export ID from search results into a usable video object identity.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/export-id-conversion-v1
   cost:
@@ -7210,7 +7210,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/get-account-videos/v1
-  name: "List videos from a WeChat Channels account"
+  name: "WeChat Channels account videos by account id"
   summary: Retrieves a paginated WeChat Channels account feed by v2Name with continuation-buffer support.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/account-videos-v1
   cost:
@@ -7250,7 +7250,7 @@ endpoints:
   platform: wechat-channels
   method: GET
   path: /api/weixin-channels/get-bound-channel/v1
-  name: "Find the WeChat Channels account bound to an account"
+  name: "WeChat Channels account bound to an Official Account"
   summary: Finds the WeChat Channels account bound to a WeChat Official Account using either its original ID or an article URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/get-bound-channel-v1
   cost:
@@ -7282,7 +7282,7 @@ endpoints:
   platform: wechat-channels
   method: GET
   path: /api/weixin-channels/get-video-basic-info/v1
-  name: "Get basic info for a WeChat Channels video"
+  name: "WeChat Channels video basic info by link or feed id"
   summary: Resolves a copied WeChat Channels video link, preview URL, or short feed ID to basic video information.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-basic-info-v1
   cost:
@@ -7309,7 +7309,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/get-video-comment/v1
-  name: "List comments on a WeChat Channels video"
+  name: "WeChat Channels video comments by object id"
   summary: Retrieves first-level comments for a WeChat Channels video by object ID with continuation-buffer pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-comments-v1
   cost:
@@ -7355,7 +7355,7 @@ endpoints:
   platform: wechat-channels
   method: GET
   path: /api/weixin-channels/get-video-download-url/v1
-  name: "Get a WeChat Channels video download URL"
+  name: "WeChat Channels video download URL by object id"
   summary: Retrieves a downloadable media URL for a WeChat Channels video by object ID and optional nonce ID.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-download-url-v1
   cost:
@@ -7394,7 +7394,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/get-video-metrics/v1
-  name: "Get interaction metrics for a WeChat Channels video"
+  name: "WeChat Channels video interaction metrics by object id"
   summary: Retrieves interaction metrics for a WeChat Channels video by object ID with optional continuation-buffer input.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-metrics-v1
   cost:
@@ -7440,7 +7440,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/get-video-sub-comment/v1
-  name: "List replies to a WeChat Channels video comment"
+  name: "WeChat Channels comment replies by video and comment id"
   summary: Retrieves replies under a first-level WeChat Channels video comment using the video and root-comment IDs.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-sub-comments-v1
   cost:
@@ -7487,7 +7487,7 @@ endpoints:
   platform: wechat-channels
   method: GET
   path: /api/weixin-channels/get-video-title/v1
-  name: "Get title info for a WeChat Channels video"
+  name: "WeChat Channels video title by object id"
   summary: Retrieves lightweight title information for a WeChat Channels video by object ID and optional nonce ID.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-title-v1
   cost:
@@ -7525,7 +7525,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/search-account/v1
-  name: "Search WeChat Channels accounts (v1)"
+  name: "Search WeChat Channels accounts by keyword"
   summary: Searches the WeChat Channels account category by keyword with page, offset, and continuation-state controls.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/account-search-v1
   cost:
@@ -7568,7 +7568,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/search-account/v2
-  name: "Search WeChat Channels accounts (v2)"
+  name: "Search WeChat Channels accounts by keyword"
   summary: Searches WeChat Channels account-related records by keyword using the direct Channels lookup.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/account-search-v2
   cost:
@@ -7603,7 +7603,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/search-account/v3
-  name: "Look up a WeChat Channels account identity"
+  name: "Look up a WeChat Channels account id by keyword"
   summary: Looks up a specific WeChat Channels account identity by keyword.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/account-search-v3
   cost:
@@ -7637,7 +7637,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/search-video/v1
-  name: "Search WeChat Channels videos (v1)"
+  name: "Search WeChat Channels videos by keyword"
   summary: Searches WeChat Channels videos by keyword with publish-time, sort, page, offset, and continuation-state controls.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-search-v1
   cost:
@@ -7710,7 +7710,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/weixin-channels/search-video/v2
-  name: "Search WeChat Channels videos (v2)"
+  name: "Search WeChat Channels videos by keyword"
   summary: Searches the WeChat Channels video category by keyword with page, offset, and continuation-state controls.
   docs_url: https://docs.justoneapi.com/en/api/wechat-channels/video-search-v2
   cost:
@@ -7754,7 +7754,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/convert-article-link/v1
-  name: "Expand a WeChat article link"
+  name: "Expand a WeChat article short link to its full URL"
   summary: Expands a WeChat Official Account article link to its resolved long-form destination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-link-conversion-v1
   cost:
@@ -7788,7 +7788,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-account-basic-info/v1
-  name: "Get basic info for a WeChat Official Account"
+  name: "WeChat Official Account profile by account name"
   summary: Retrieves basic profile information for a WeChat Official Account by account name.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-basic-info-v1
   cost:
@@ -7822,7 +7822,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/get-account-history-articles/v1
-  name: "List historical articles for a WeChat account (v1)"
+  name: "WeChat Official Account past articles by id, URL, or name"
   summary: Retrieves page-number-paginated historical articles for a WeChat Official Account identified by biz ID, article URL, account name, or wxid.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-historical-articles-v1
   cost:
@@ -7873,7 +7873,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/get-account-history-articles/v2
-  name: "List historical articles for a WeChat account (v2)"
+  name: "WeChat Official Account past articles by id or URL"
   summary: Retrieves historical articles for a WeChat Official Account identified by ghid or article URL, with an offset cursor from the previous page.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-historical-articles-v2
   cost:
@@ -7921,7 +7921,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-account-original-count/v1
-  name: "Get original-article count for a WeChat account"
+  name: "WeChat Official Account original article count by id or URL"
   summary: Retrieves the original-article count for a WeChat Official Account identified by ghid or article URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-original-article-count-v1
   cost:
@@ -7953,7 +7953,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-account-principal-info/v1
-  name: "Get principal info for a WeChat Official Account"
+  name: "WeChat Official Account principal info by id or URL"
   summary: Retrieves principal information for a WeChat Official Account identified by biz ID, article URL, or wxid.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-principal-info-v1
   cost:
@@ -7991,7 +7991,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-account-today-articles/v1
-  name: "List today's articles for a WeChat account"
+  name: "WeChat Official Account today's articles by id or name"
   summary: Retrieves articles published today by a WeChat Official Account identified by biz ID, article URL, account name, or wxid.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-today-articles-v1
   cost:
@@ -8036,7 +8036,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/get-article-comment/v1
-  name: "List comments on a WeChat article"
+  name: "WeChat article comments by article URL"
   summary: Retrieves top-level comments for a WeChat Official Account article by URL, with an optional buffer cursor for pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-comments-v1
   cost:
@@ -8077,7 +8077,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-detail/v1
-  name: "Get WeChat article detail (text or rich text)"
+  name: "WeChat article content by article URL — plain or rich text"
   summary: Retrieves a WeChat Official Account article by URL with selectable plain-text or rich-text content mode.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-details-v1
   cost:
@@ -8120,7 +8120,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-detail/v2
-  name: "Get structured WeChat article detail"
+  name: "WeChat article structured details by article URL"
   summary: Retrieves structured details for a WeChat Official Account article by URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-details-v2
   cost:
@@ -8154,7 +8154,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-detail/v3
-  name: "Get WeChat article detail with video content"
+  name: "WeChat article details with video content by article URL"
   summary: Retrieves details for a WeChat Official Account article that may include video content, with selectable plain-text or rich-text mode.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-details-v3
   cost:
@@ -8197,7 +8197,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-detail/v4
-  name: "Get WeChat article as HTML"
+  name: "WeChat article HTML by article URL"
   summary: Retrieves an HTML representation of a WeChat Official Account article by URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-details-v4
   cost:
@@ -8231,7 +8231,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-detail/v5
-  name: "Get lightweight WeChat article info"
+  name: "WeChat article lightweight info by article URL"
   summary: Retrieves lightweight information for a WeChat Official Account article by URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-details-v5
   cost:
@@ -8265,7 +8265,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-metrics/v1
-  name: "Get basic interaction metrics for a WeChat article"
+  name: "WeChat article basic interaction metrics by article URL"
   summary: 'Retrieves basic interaction metrics for a WeChat Official Account article URL that ends with #rd or #wechat_redirect.'
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-metrics-v1
   cost:
@@ -8299,7 +8299,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-metrics/v2
-  name: "Get extended interaction metrics for a WeChat article"
+  name: "WeChat article extended interaction metrics by article URL"
   summary: Retrieves extended interaction metrics for a WeChat Official Account article by URL.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-metrics-v2
   cost:
@@ -8334,7 +8334,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/get-article-sub-comment/v1
-  name: "List replies to a WeChat article comment"
+  name: "WeChat article comment replies by URL and comment id"
   summary: Retrieves replies under a top-level comment for a WeChat Official Account article, identified by article URL and contentId.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-comment-replies-v1
   cost:
@@ -8373,7 +8373,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/search-account/v1
-  name: "Search WeChat Official Accounts (v1)"
+  name: "Search WeChat Official Accounts by keyword"
   summary: Searches WeChat Official Accounts by keyword with page-number pagination and one result per page.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-search-v1
   cost:
@@ -8412,7 +8412,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/search-account/v2
-  name: "Search WeChat Official Accounts (v2)"
+  name: "Search WeChat Official Accounts by keyword"
   summary: Searches WeChat Official Accounts by keyword with page, offset, and continuation-state pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/account-search-v2
   cost:
@@ -8455,7 +8455,7 @@ endpoints:
   platform: wechat-mp
   method: GET
   path: /api/weixin/search-article-hot/v1
-  name: "Search hot WeChat articles by date range"
+  name: "Search hot WeChat articles by date range and keyword"
   summary: Searches hot WeChat Official Account articles within a required date range, with optional keyword plus publication-format, category, and page filters.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/hot-article-search-v1
   cost:
@@ -8557,7 +8557,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/search-article/v1
-  name: "Search WeChat articles (v1)"
+  name: "Search WeChat articles by keyword"
   summary: Searches WeChat Official Account articles by keyword with publish-time and sort filters plus page, offset, and continuation-state pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-search-v1
   cost:
@@ -8631,7 +8631,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/weixin/search-article/v2
-  name: "Search WeChat articles by category"
+  name: "Search WeChat articles by keyword and category"
   summary: Searches WeChat Official Account articles by keyword within a selected category such as followed accounts, latest, recently read, or hot, with continuation pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/article-search-v2
   cost:
@@ -8696,7 +8696,7 @@ endpoints:
   platform: wechat-search
   method: POST
   path: /api/weixin/search-miniprogram/v1
-  name: "Search WeChat Mini Programs"
+  name: "Search WeChat Mini Programs by keyword"
   summary: Searches WeChat Mini Programs by keyword with page, offset, and continuation-state pagination.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/mini-program-search-v1
   cost:
@@ -8749,7 +8749,7 @@ endpoints:
   platform: wechat-search
   method: GET
   path: /api/weixin/search-suggestions/v1
-  name: "Get WeChat search suggestions"
+  name: "WeChat search suggestions by keyword"
   summary: Retrieves WeChat search suggestions for a keyword, optionally scoped by a supported business type.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/search-suggestions-v1
   cost:
@@ -8803,7 +8803,7 @@ endpoints:
   platform: wechat-search
   method: GET
   path: /api/weixin/search-wechat-index/v1
-  name: "Get WeChat Index for Keyword"
+  name: "WeChat Index trend by keyword"
   summary: Queries WeChat Index for a keyword.
   docs_url: https://docs.justoneapi.com/en/api/wechat-official-accounts/wechat-index-search-v1
   cost:
@@ -8837,7 +8837,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-fans/v1
-  name: "List a Weibo user's fans"
+  name: "Weibo user followers by user id"
   summary: Retrieves a page of fan accounts that follow a Weibo user identified by UID.
   docs_url: https://docs.justoneapi.com/en/api/weibo/user-fans-v1
   cost:
@@ -8877,7 +8877,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-followers/v1
-  name: "List accounts a Weibo user follows"
+  name: "Weibo accounts a user follows by user id"
   summary: Retrieves a page of accounts followed by a Weibo user identified by UID.
   docs_url: https://docs.justoneapi.com/en/api/weibo/user-followers-v1
   cost:
@@ -8917,7 +8917,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-post-comments/v1
-  name: "List comments on a Weibo post"
+  name: "Weibo post comments by post id"
   summary: Retrieves comments for a Weibo post identified by MID, with optional maxId cursor pagination and time or hot sorting.
   docs_url: https://docs.justoneapi.com/en/api/weibo/post-comments-v1
   cost:
@@ -8964,7 +8964,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-user-post/v1
-  name: "List posts from a Weibo user"
+  name: "Weibo user posts by user id"
   summary: Retrieves posts published by a Weibo user identified by UID, using page numbers and a required sinceId cursor after the first page.
   docs_url: https://docs.justoneapi.com/en/api/weibo/user-published-posts-v1
   cost:
@@ -9008,7 +9008,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-user-video-list/v1
-  name: "List a Weibo user's video feed"
+  name: "Weibo user video feed by user id"
   summary: Retrieves a Weibo user's video waterfall feed by UID, with an optional cursor from a prior response.
   docs_url: https://docs.justoneapi.com/en/api/weibo/user-video-list-v1
   cost:
@@ -9047,7 +9047,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/get-weibo-detail/v1
-  name: "Get Weibo post detail"
+  name: "Weibo post details by post id"
   summary: Retrieves details for a Weibo post identified by its post ID.
   docs_url: https://docs.justoneapi.com/en/api/weibo/post-details-v1
   cost:
@@ -9081,7 +9081,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/hot-search/v1
-  name: "Get Weibo Hot Search Ranking"
+  name: "Weibo current hot search ranking"
   summary: Retrieves the current Weibo hot-search ranking.
   docs_url: https://docs.justoneapi.com/en/api/weibo/hot-search-v1
   cost:
@@ -9108,7 +9108,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/search-all/v2
-  name: "Search Weibo posts"
+  name: "Search Weibo posts by keyword and time range"
   summary: Searches Weibo posts by keyword within a required day-and-hour time range, with page-based pagination, hot or time sorting, and filters for pictures, video, music, or links.
   docs_url: https://docs.justoneapi.com/en/api/weibo/keyword-search-v2
   cost:
@@ -9186,7 +9186,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/search-profile/v1
-  name: "Search posts from a specific Weibo user"
+  name: "Search a Weibo user's posts by user id and keyword"
   summary: Searches posts published by a specific Weibo user, using a keyword, optional date range, and page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/weibo/search-user-published-posts-v1
   cost:
@@ -9240,7 +9240,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/weibo/tv-component/v1
-  name: "Get Weibo TV video detail"
+  name: "Weibo TV video details by object id"
   summary: Retrieves Weibo TV video details for a colon-delimited object ID (OID).
   docs_url: https://docs.justoneapi.com/en/api/weibo/tv-video-details-v1
   cost:
@@ -9270,7 +9270,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/twitter/get-post-comments/v1
-  name: "List comments on an X post"
+  name: "X (Twitter) post comments by tweet id"
   summary: Retrieves the latest comments for an X (Twitter) post identified by tweet ID, with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/twitter/post-comments-v1
   cost:
@@ -9310,7 +9310,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/twitter/get-user-detail/v1
-  name: "Get X (Twitter) user profile"
+  name: "X (Twitter) user profile by numeric user id"
   summary: Retrieves an X (Twitter) user profile identified by its numeric Rest ID.
   docs_url: https://docs.justoneapi.com/en/api/twitter/user-profile-v1
   cost:
@@ -9344,7 +9344,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/twitter/get-user-posts/v1
-  name: "List posts from an X (Twitter) user"
+  name: "X (Twitter) user posts by numeric user id"
   summary: Retrieves posts published by an X (Twitter) user identified by Rest ID, with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/twitter/user-published-posts-v1
   cost:
@@ -9384,7 +9384,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/twitter/search/v1
-  name: "Search X (Twitter)"
+  name: "Search X (Twitter) by keyword — top, latest, media, people"
   summary: Searches X (Twitter) by keyword across top, latest, media, people, or list result modes with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/twitter/search-timeline-v1
   cost:
@@ -9436,7 +9436,7 @@ endpoints:
   platform: xianyu
   method: GET
   path: /api/xianyu/get-item-detail/v1
-  name: "Get Xianyu listing detail"
+  name: "Xianyu second-hand listing details by item id"
   summary: Retrieves the public detail for a Xianyu (GooFish) second-hand listing by item ID.
   docs_url: https://docs.justoneapi.com/en/api/xianyu-goofish/product-details-v1
   cost:
@@ -9470,7 +9470,7 @@ endpoints:
   platform: xianyu
   method: GET
   path: /api/xianyu/search-item-list/v1
-  name: "Search Xianyu listings"
+  name: "Search Xianyu second-hand listings by keyword"
   summary: Searches Xianyu (GooFish) second-hand listings by keyword with page and sort controls.
   docs_url: https://docs.justoneapi.com/en/api/xianyu-goofish/product-search-v1
   cost:
@@ -9523,7 +9523,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/get-note-comment/v2
-  name: "List comments on a Xiaohongshu note"
+  name: "Xiaohongshu note comments by note id"
   summary: Retrieves comments for a Xiaohongshu (RedNote) note with cursor pagination and normal, latest, or like-count sorting.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/note-comments-v2
   cost:
@@ -9571,7 +9571,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/get-note-detail/v6
-  name: "Get Xiaohongshu video-note detail"
+  name: "Xiaohongshu video note details by note id"
   summary: Retrieves Xiaohongshu (RedNote) video-note details by note ID.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/note-details-v6
   cost:
@@ -9606,7 +9606,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/get-note-sub-comment/v2
-  name: "List replies to a Xiaohongshu note comment"
+  name: "Xiaohongshu comment replies by note and comment id"
   summary: Retrieves replies to a specific Xiaohongshu (RedNote) note comment with cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/comment-replies-v2
   cost:
@@ -9649,7 +9649,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/get-topic-note-list/v1
-  name: "List Xiaohongshu notes for a topic"
+  name: "Xiaohongshu topic notes by topic id"
   summary: Retrieves Xiaohongshu (RedNote) notes associated with a topic ID, with hot or latest sorting and cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/topic-note-list-v1
   cost:
@@ -9697,7 +9697,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/get-user/v3
-  name: "Get Xiaohongshu user profile"
+  name: "Xiaohongshu user profile by user id or URL"
   summary: Retrieves a Xiaohongshu (RedNote) user profile from a user ID or supported profile URL.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/user-profile-v3
   cost:
@@ -9731,7 +9731,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/hot-list/v1
-  name: "Get the current Xiaohongshu hot list"
+  name: "Xiaohongshu current hot list"
   summary: Retrieves the current Xiaohongshu (RedNote) hot list for platform trend monitoring and content research.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/hot-list-v1
   cost:
@@ -9758,7 +9758,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/hot-search/v1
-  name: "Search Xiaohongshu hot content"
+  name: "Search Xiaohongshu hot content by keyword"
   summary: Searches Xiaohongshu (RedNote) hot-content entries with optional keyword, pagination, ranking metric, and time-range controls.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/hot-search-v1
   cost:
@@ -9825,7 +9825,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/search-note/v2
-  name: "Search Xiaohongshu notes"
+  name: "Search Xiaohongshu notes by keyword"
   summary: Searches Xiaohongshu (RedNote) notes by keyword with pagination plus sort, note-type, and publish-time filters.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/note-search-v2
   cost:
@@ -9895,7 +9895,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/search-recommend/v1
-  name: "Get Xiaohongshu search keyword suggestions"
+  name: "Xiaohongshu keyword suggestions by seed term"
   summary: Returns Xiaohongshu (RedNote) search keyword suggestions for a submitted seed term.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/keyword-suggestions-v1
   cost:
@@ -9929,7 +9929,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/search-user/v2
-  name: "Search Xiaohongshu users"
+  name: "Search Xiaohongshu users by keyword"
   summary: Searches Xiaohongshu (RedNote) users by keyword with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/user-search-v2
   cost:
@@ -9969,7 +9969,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/xiaohongshu/share-url-transfer/v1
-  name: "Resolve a Xiaohongshu short share link"
+  name: "Resolve a Xiaohongshu short link to its public URL"
   summary: Resolve a supported Xiaohongshu (RedNote) short share link and return its public redirect URL.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-rednote/share-link-resolution-v1
   cost:
@@ -9999,7 +9999,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/pgy/content_square/search_note_v2/v1
-  name: "Search Xiaohongshu Pugongying Content Square notes"
+  name: "Search Pugongying Content Square notes by keyword"
   summary: Search Xiaohongshu Pugongying Content Square notes by keyword or browse all notes, with business-category, ranking, time-window, and page controls.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/content-square-notes-v1
   cost:
@@ -10081,7 +10081,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/pgy/kol/data/core_data/v1
-  name: "Get Xiaohongshu Pugongying creator core data"
+  name: "Pugongying creator core data by creator id"
   summary: Retrieves Xiaohongshu Pugongying core data for a creator with business, note-type, date-range, and advertisement filters.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-core-metrics-v1
   cost:
@@ -10152,7 +10152,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/cooperator/blogger/v2/v1
-  name: "Search Xiaohongshu Pugongying creators by filters"
+  name: "Search Pugongying creators by keyword, audience, and price"
   summary: Search Xiaohongshu Pugongying creators with keyword, audience, location, content, pricing, performance, cooperation, live, and similarity filters.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-search-v1
   cost:
@@ -10486,7 +10486,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/cooperator/user/blogger/userId/v1
-  name: "Get Xiaohongshu Pugongying creator profile and quote"
+  name: "Pugongying creator profile and quote by creator id"
   summary: Retrieve a Xiaohongshu Pugongying creator profile and cooperation quote information for a known user ID.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-profile-v1
   cost:
@@ -10520,7 +10520,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/data/userId/fans_overall_new_history/v1
-  name: "Get Xiaohongshu Pugongying creator follower history"
+  name: "Pugongying creator follower history by creator id"
   summary: Retrieve Xiaohongshu Pugongying follower history for a creator over the selected 30- or 90-day period.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/follower-growth-history-v1
   cost:
@@ -10572,7 +10572,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/data/userId/fans_profile/v1
-  name: "Get Xiaohongshu Pugongying creator follower profile"
+  name: "Pugongying creator follower profile by creator id"
   summary: Retrieves Xiaohongshu Pugongying follower profile data for a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/follower-distribution-v1
   cost:
@@ -10606,7 +10606,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV2/costEffective/v1
-  name: "Get Xiaohongshu Pugongying creator cost-effectiveness"
+  name: "Pugongying creator cost-effectiveness by creator id"
   summary: Retrieve the Xiaohongshu Pugongying cost-effectiveness analysis for a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/cost-effectiveness-analysis-v1
   cost:
@@ -10640,7 +10640,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV2/kolContentTags/v1
-  name: "Get Xiaohongshu Pugongying creator content tags"
+  name: "Pugongying creator content tags by creator id"
   summary: Retrieve Xiaohongshu Pugongying content category tags associated with a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-content-tags-v1
   cost:
@@ -10674,7 +10674,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV2/kolFeatureTags/v1
-  name: "Get Xiaohongshu Pugongying creator feature tags"
+  name: "Pugongying creator feature tags by creator id"
   summary: Retrieve Xiaohongshu Pugongying feature tags assigned to a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-feature-tags-v1
   cost:
@@ -10708,7 +10708,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV2/notesDetail/v1
-  name: "List Xiaohongshu Pugongying creator notes"
+  name: "Pugongying creator notes by creator id"
   summary: Retrieve a paginated Xiaohongshu Pugongying creator note list with advertisement, sort-order, note-type, and third-platform filters.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-note-list-v1
   cost:
@@ -10787,7 +10787,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV3/dataSummary/v1
-  name: "Get Xiaohongshu Pugongying creator data summary"
+  name: "Pugongying creator data summary by creator id"
   summary: Retrieve the Xiaohongshu Pugongying data summary for a creator's daily or cooperation notes.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/data-summary-v1
   cost:
@@ -10830,7 +10830,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV3/fansSummary/v1
-  name: "Get Xiaohongshu Pugongying creator follower summary"
+  name: "Pugongying creator follower summary by creator id"
   summary: Retrieve the Xiaohongshu Pugongying follower summary for a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/follower-summary-v1
   cost:
@@ -10864,7 +10864,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/dataV3/notesRate/v1
-  name: "Get Xiaohongshu Pugongying note performance metrics"
+  name: "Pugongying note performance metrics by creator id"
   summary: Retrieve Xiaohongshu Pugongying aggregate note performance metrics for a creator with business, note-type, date-range, and advertisement filters.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/note-performance-metrics-v1
   cost:
@@ -10935,7 +10935,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/kol/get_similar_kol/v1
-  name: "List similar Xiaohongshu Pugongying creators"
+  name: "Similar Pugongying creators by creator id"
   summary: Retrieve paginated Xiaohongshu Pugongying creators similar to a known creator.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/similar-creators-v1
   cost:
@@ -10975,7 +10975,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/api/solar/note/noteId/detail/v1
-  name: "Get Xiaohongshu Pugongying note detail"
+  name: "Pugongying note details by note id"
   summary: Retrieves Xiaohongshu Pugongying details for a known note ID.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/note-details-v1
   cost:
@@ -11009,7 +11009,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: GET
   path: /api/xiaohongshu-pgy/get-kol-note-list/v1
-  name: "List Xiaohongshu Pugongying creator notes (basic)"
+  name: "Pugongying creator notes by creator id"
   summary: Retrieve a paginated Xiaohongshu Pugongying creator note list with advertisement, sort-order, and note-type controls.
   docs_url: https://docs.justoneapi.com/en/api/xiaohongshu-creator-marketplace-pugongying/creator-note-list-pro-v1
   cost:
@@ -11077,7 +11077,7 @@ endpoints:
   platform: youku
   method: GET
   path: /api/youku/get-user-detail/v1
-  name: "Get Youku User Profile"
+  name: "Youku user profile by user id"
   summary: Retrieves a Youku user profile identified by UID.
   docs_url: https://docs.justoneapi.com/en/api/youku/user-profile-v1
   cost:
@@ -11111,7 +11111,7 @@ endpoints:
   platform: youku
   method: GET
   path: /api/youku/get-video-detail/v1
-  name: "Get Youku Video Detail"
+  name: "Youku video details by video id"
   summary: Retrieves details for a Youku video identified by video ID.
   docs_url: https://docs.justoneapi.com/en/api/youku/video-details-v1
   cost:
@@ -11145,7 +11145,7 @@ endpoints:
   platform: youku
   method: GET
   path: /api/youku/search-video/v1
-  name: "Search Youku Videos"
+  name: "Search Youku videos by keyword"
   summary: Searches Youku videos by keyword with page-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/youku/video-search-v1
   cost:
@@ -11186,7 +11186,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/youtube/get-channel-videos/v1
-  name: "List videos from a YouTube channel"
+  name: "YouTube channel videos by channel id"
   summary: Retrieve public videos from a YouTube channel, with optional cursor-based pagination.
   docs_url: https://docs.justoneapi.com/en/api/youtube/channel-videos-v1
   cost:
@@ -11224,7 +11224,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/youtube/get-video-captions/v1
-  name: "Get YouTube video captions"
+  name: "YouTube video captions by video id — SRT, XML, JSON3, text"
   summary: Retrieve available caption tracks for a YouTube video or request captions in SRT, XML, JSON3, or plain-text format.
   docs_url: https://docs.justoneapi.com/en/api/youtube/video-captions-v1
   cost:
@@ -11271,7 +11271,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/youtube/get-video-comment/v1
-  name: "List top-level comments on a YouTube video"
+  name: "YouTube video comments by video id"
   summary: Retrieve first-level comments for a YouTube video with sorting, locale options, and cursor pagination.
   docs_url: https://docs.justoneapi.com/en/api/youtube/video-comment-list-v1
   cost:
@@ -11333,7 +11333,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/youtube/get-video-sub-comment/v1
-  name: "List replies to a YouTube comment"
+  name: "YouTube comment replies by reply cursor"
   summary: Retrieve replies associated with a YouTube comment continuation cursor, with optional locale settings.
   docs_url: https://docs.justoneapi.com/en/api/youtube/video-sub-comment-list-v1
   cost:
@@ -11379,7 +11379,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/youtube/search/v1
-  name: "Search YouTube"
+  name: "Search YouTube by keyword"
   summary: Search YouTube by keyword with optional type, upload-date, duration, feature, and sort filters, or continue with a token.
   docs_url: https://docs.justoneapi.com/en/api/youtube/general-search-v1
   cost:
@@ -11469,7 +11469,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-answer-comments/v1
-  name: "List comments on a Zhihu answer"
+  name: "Zhihu answer comments by answer id"
   summary: Retrieve comments for a Zhihu answer with hottest or latest sorting and offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/answer-comments-v1
   cost:
@@ -11518,7 +11518,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-answer-list/v1
-  name: "List answers to a Zhihu question"
+  name: "Zhihu question answers by question id"
   summary: Retrieve answers for a Zhihu question with sorting and pagination controls.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/answer-list-v1
   cost:
@@ -11578,7 +11578,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-column-article-detail/v1
-  name: "Get Zhihu column article detail"
+  name: "Zhihu column article details by article id"
   summary: Retrieve details for a Zhihu column article identified by article ID.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/column-article-details-v1
   cost:
@@ -11612,7 +11612,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-column-article-list/v1
-  name: "List articles in a Zhihu column"
+  name: "Zhihu column articles by column id"
   summary: Retrieve articles from a Zhihu column with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/column-article-list-v1
   cost:
@@ -11652,7 +11652,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-comment-replies/v1
-  name: "List replies to a Zhihu comment"
+  name: "Zhihu comment replies by comment id"
   summary: Retrieve replies to a Zhihu comment with hottest or latest sorting and offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/comment-replies-v1
   cost:
@@ -11701,7 +11701,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-articles/v1
-  name: "List articles by a Zhihu user"
+  name: "Zhihu user articles by profile URL token"
   summary: Retrieve articles published by a Zhihu user with offset pagination and publish-time or upvote sorting.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-articles-v1
   cost:
@@ -11750,7 +11750,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-follow-collections/v1
-  name: "List collections a Zhihu user follows"
+  name: "Zhihu collections a user follows by profile URL token"
   summary: Retrieve Zhihu collections followed by a user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-follow-collections-v1
   cost:
@@ -11790,7 +11790,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-follow-columns/v1
-  name: "List columns a Zhihu user follows"
+  name: "Zhihu columns a user follows by profile URL token"
   summary: Retrieve Zhihu columns followed by a user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-follow-columns-v1
   cost:
@@ -11830,7 +11830,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-follow-questions/v1
-  name: "List questions a Zhihu user follows"
+  name: "Zhihu questions a user follows by profile URL token"
   summary: Retrieve Zhihu questions followed by a user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-follow-questions-v1
   cost:
@@ -11870,7 +11870,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-follow-topics/v1
-  name: "List topics a Zhihu user follows"
+  name: "Zhihu topics a user follows by profile URL token"
   summary: Retrieve Zhihu topics followed by a user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-follow-topics-v1
   cost:
@@ -11910,7 +11910,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-followees/v1
-  name: "List accounts a Zhihu user follows"
+  name: "Zhihu accounts a user follows by profile URL token"
   summary: Retrieve accounts followed by a Zhihu user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-followees-v1
   cost:
@@ -11950,7 +11950,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-followers/v1
-  name: "List a Zhihu user's followers"
+  name: "Zhihu user followers by profile URL token"
   summary: Retrieve accounts that follow a Zhihu user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-followers-v1
   cost:
@@ -11989,7 +11989,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-included-articles/v1
-  name: "List a Zhihu user's included articles"
+  name: "Zhihu user included articles by profile URL token"
   summary: Retrieve the included-article records exposed for a Zhihu user, with offset pagination.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-included-articles-v1
   cost:
@@ -12029,7 +12029,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/get-user-info/v1
-  name: "Get Zhihu user profile"
+  name: "Zhihu user profile by profile URL token"
   summary: Retrieve the public profile for a Zhihu user identified by URL token.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/user-info-v1
   cost:
@@ -12063,7 +12063,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/zhihu/search/v1
-  name: "Search Zhihu"
+  name: "Search Zhihu by keyword"
   summary: Search Zhihu by keyword with optional result-type, sort, time-interval, topic-display, and offset controls.
   docs_url: https://docs.justoneapi.com/en/api/zhihu/keyword-search-v1
   cost:

--- a/src/treg/catalog/justoneapi.yaml
+++ b/src/treg/catalog/justoneapi.yaml
@@ -16,7 +16,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/tiktok/get-user-detail/v1
-    name: "Get TikTok User Profile"
+    name: "TikTok user profile by username or user id"
     summary: "Public TikTok profile by username (uniqueId) or secUid"
     input:
       queryParams:
@@ -37,7 +37,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/tiktok/get-user-post/v1
-    name: "List posts from a TikTok user"
+    name: "TikTok user posts by user id"
     summary: "Posts published by a TikTok user, by secUid, cursor-paginated"
     input:
       queryParams:
@@ -58,7 +58,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/tiktok/get-post-detail/v1
-    name: "Get TikTok post details"
+    name: "TikTok post details by post id — metadata, stats"
     summary: "A single TikTok post's metadata and stats by post id"
     input:
       queryParams:
@@ -77,7 +77,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/tiktok/get-post-comment/v1
-    name: "List TikTok Post Comments"
+    name: "TikTok post comments by post id"
     summary: "Comments on a TikTok post, cursor-paginated"
     input:
       queryParams:
@@ -146,7 +146,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/xiaohongshu/get-note-detail/v1
-    name: "Get Xiaohongshu note details"
+    name: "Xiaohongshu note details by note id or URL"
     summary: "A single Xiaohongshu (RedNote) note by note id or explore URL"
     input:
       queryParams:
@@ -166,7 +166,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/xiaohongshu/get-user-note-list/v4
-    name: "List notes from a Xiaohongshu user"
+    name: "Xiaohongshu user notes by user id"
     summary: "Notes published by a Xiaohongshu (RedNote) user, cursor-paginated"
     input:
       queryParams:
@@ -186,7 +186,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/instagram/get-user-detail/v2
-    name: "Get Instagram User Profile"
+    name: "Instagram user profile by username"
     summary: "Public Instagram profile by username"
     input:
       queryParams:
@@ -205,7 +205,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/instagram/get-user-posts/v1
-    name: "List Instagram User Posts"
+    name: "Instagram user posts by username"
     summary: "Recent posts of an Instagram user, token-paginated"
     input:
       queryParams:
@@ -225,7 +225,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/youtube/get-video-detail/v1
-    name: "Get YouTube Video Detail"
+    name: "YouTube video metadata and stats by video id"
     summary: "Public metadata and stats for a YouTube video by video id"
     input:
       queryParams:
@@ -244,7 +244,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/weibo/get-user-detail/v3
-    name: "Get Weibo User Profile"
+    name: "Weibo user profile by user id"
     summary: "Public Weibo profile by numeric UID"
     input:
       queryParams:

--- a/src/treg/catalog/leadmagic.extended.yaml
+++ b/src/treg/catalog/leadmagic.extended.yaml
@@ -53,7 +53,7 @@ endpoints:
     platform: people
     method: POST
     path: /v1/people/b2b-profile
-    name: "Find profile URL from email"
+    name: "Reverse email lookup — the person's profile URL"
     summary: "Performs reverse email lookup to identify professional profile URLs associated with work or personal email addresses"
     input:
       bodyType: json
@@ -149,7 +149,7 @@ endpoints:
     platform: people
     method: POST
     path: /v1/people/role-finder
-    name: "Find one person by job title"
+    name: "Find one person at a company by job title"
     summary: "Locates a person at a company based on their job title, enabling targeted outreach for account-based marketing campaigns and other role-specific needs"
     input:
       bodyType: json
@@ -183,7 +183,7 @@ endpoints:
     platform: people
     method: POST
     path: /v1/people/employee-finder
-    name: "List employees at a company"
+    name: "List employees at a company by domain or name"
     summary: "Retrieves a list of employees from a company using either domain or company name"
     input:
       bodyType: json
@@ -216,7 +216,7 @@ endpoints:
     platform: people
     method: POST
     path: /v1/people/job-change-detector
-    name: "Detect if a person changed jobs"
+    name: "Detect a job change from a profile URL and last company"
     summary: "Detects whether a professional has changed jobs by comparing their current employment against a previously known company"
     input:
       bodyType: json
@@ -250,7 +250,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v1/companies/competitors-search
-    name: "Find a company's competitors"
+    name: "Find a company's competitors by domain or name"
     summary: "Retrieves a comprehensive list of competing companies based on a target company identifier — domains, employee counts, industries and descriptions"
     input:
       bodyType: json
@@ -282,7 +282,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v1/companies/company-funding
-    name: "Get a company's funding history"
+    name: "A company's funding history by domain or name — investors"
     summary: "Retrieves comprehensive funding information for a company, including funding history, investor details, and leadership data"
     input:
       bodyType: json
@@ -314,7 +314,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v1/companies/technographics
-    name: "Get a company's tech stack"
+    name: "Detect a company's tech stack by domain"
     summary: "Analyzes a company's website to identify their technology stack, including marketing tools, analytics platforms, hosting providers, CRM systems, and more"
     input:
       bodyType: json
@@ -345,7 +345,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v3/companies/search
-    name: "Search companies by firmographics, tech, funding"
+    name: "Search companies by firmographics, tech stack or funding"
     summary: "The canonical company discovery endpoint supporting both single-company lookups and broad criteria-based discovery — domain, website, name, profile URL, and extensive firmographic/technographic/funding filters with cursor pagination"
     input:
       bodyType: json
@@ -386,7 +386,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v3/jobs/search
-    name: "Search open job postings and hiring signals"
+    name: "Search job postings — titles, companies, hiring signals"
     summary: "Discovers open job postings with hiring signal data including titles, companies, locations, tags, and occupation taxonomy — resolves company domains, country codes, tags and occupation values into normalized filter IDs before executing a bounded query. Searches job postings, not people"
     input:
       bodyType: json
@@ -425,7 +425,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v1/jobs/jobs-finder
-    name: "Search job listings (basic)"
+    name: "Search job postings by company, location or date (basic)"
     summary: "Search for job listings filtered by company, job details, location, and posting date. Returns paginated results with company information and job descriptions"
     input:
       bodyType: json
@@ -464,7 +464,7 @@ endpoints:
     platform: google-ads
     method: POST
     path: /v1/ads/google-ads-search
-    name: "Search a company's Google Ads"
+    name: "A company's Google Ads by domain or name"
     summary: "Retrieves Google Ads data for a specified company, enabling competitive intelligence and ad strategy analysis"
     input:
       bodyType: json
@@ -494,7 +494,7 @@ endpoints:
     platform: meta-ads
     method: POST
     path: /v1/ads/meta-ads-search
-    name: "Search a company's Meta (Facebook/Instagram) ads"
+    name: "A company's Meta (Facebook/Instagram) ads by domain"
     summary: "Retrieves Meta (Facebook/Instagram) advertisements for a specified company using their domain or name"
     input:
       bodyType: json
@@ -525,7 +525,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v1/ads/b2b-ads-search
-    name: "Search a company's LinkedIn ads"
+    name: "A company's LinkedIn ads by domain or name — creatives"
     summary: "Retrieves B2B advertisements for a company, returning ad creatives with metadata including headlines, CTAs, landing pages, and performance metrics"
     input:
       bodyType: json

--- a/src/treg/catalog/leadmagic.yaml
+++ b/src/treg/catalog/leadmagic.yaml
@@ -39,7 +39,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/people/email-finder
-    name: "Find a person's work email"
+    name: "Find a person's work email by name and company"
     summary: "Find someone's work email address from their name and their company's domain or name"
     input:
       bodyType: json
@@ -74,7 +74,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/people/email-validation
-    name: "Verify an email address"
+    name: "Verify an email address is deliverable"
     summary: "Check an email is real and deliverable, and whether its domain is catch-all"
     input:
       bodyType: json
@@ -105,7 +105,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/people/profile-search
-    name: "Enrich a person from their profile URL"
+    name: "Enrich a person by profile URL — role, work history"
     summary: "Enrich a person from their profile URL — role, employer, location and work history"
     input:
       bodyType: json
@@ -136,7 +136,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/people/mobile-finder
-    name: "Find a person's mobile number"
+    name: "Find a person's mobile number by profile URL or email"
     summary: "Find someone's mobile number from their profile URL or email address"
     input:
       bodyType: json
@@ -169,7 +169,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/companies/company-search
-    name: "Enrich a company from domain or name"
+    name: "Enrich a company by domain or name — headcount, revenue"
     summary: "Enrich a company from domain, name or profile URL — industry, headcount, revenue"
     input:
       bodyType: json
@@ -202,7 +202,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/people/search
-    name: "Find people at a company by job title"
+    name: "Find people at a company by job title, with contact details"
     summary: "Find the people at a company by job title, optionally revealing their emails and mobiles"
     input:
       bodyType: json

--- a/src/treg/catalog/leadsforge.yaml
+++ b/src/treg/catalog/leadsforge.yaml
@@ -42,7 +42,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /search
-    name: "Search B2B leads"
+    name: "Search people by company, industry or tech — ids only"
     summary: "Search leads. Accepts the full person filter set."
     input:
       queryParams:
@@ -129,7 +129,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /enrichment/email
-    name: "Find a work email (synchronous)"
+    name: "Find a work email by LinkedIn URL or name + company"
     summary: "Enrich a single person's work email and return the result in the same response, no polling."
     input:
       body:
@@ -165,7 +165,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /enrichment/phone
-    name: "Find a mobile phone number (synchronous)"
+    name: "Find a mobile number by LinkedIn URL or name + company"
     summary: "Enrich a single person's phone number and return the result in the same response, no polling."
     input:
       body:
@@ -274,7 +274,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /enrichment/linkedin
-    name: "Start a bulk LinkedIn-profile job"
+    name: "Start a bulk job — name + company to LinkedIn URL"
     summary: "Request linkedin profile finding."
     input:
       headers:
@@ -407,7 +407,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /lookalikes/preview
-    name: "Preview lookalike companies (free)"
+    name: "Preview lookalike companies for seed domains (free)"
     summary: "Free, uncharged preview of companies similar to the provided domains."
     input:
       body:
@@ -440,7 +440,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /lookalikes/search
-    name: "Search lookalike companies"
+    name: "Find lookalike companies for seed domains"
     summary: "Search for companies similar to the provided domains."
     input:
       headers:
@@ -479,7 +479,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /company-followers/search
-    name: "Start a company-followers job"
+    name: "List a LinkedIn company page's followers (async job)"
     summary: "Starts an async company followers search for a LinkedIn company page"
     input:
       headers:

--- a/src/treg/catalog/linkedin.yaml
+++ b/src/treg/catalog/linkedin.yaml
@@ -32,7 +32,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v2/userinfo
-    name: "Get the connected member's profile"
+    name: "Your connected LinkedIn profile — name, email, member id"
     summary: "Get the connected LinkedIn member's identity (name, headline picture, email, member id)"
     input:
       note: "no parameters — the token identifies the member. Returns OpenID Connect claims: sub (the member id), name, given_name, family_name, picture, email, locale. The author URN every post needs is urn:li:person:{sub}"
@@ -46,7 +46,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /rest/posts
-    name: "Create a post"
+    name: "Publish a post to your own LinkedIn feed"
     summary: "Publish a text or link post to your own LinkedIn feed"
     input:
       body:
@@ -82,7 +82,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /rest/images?action=initializeUpload
-    name: "Start an image upload"
+    name: "Start an image upload for a LinkedIn post"
     summary: "Start an image upload for a LinkedIn post and get the URN to attach"
     input:
       body:
@@ -100,7 +100,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /rest/videos?action=initializeUpload
-    name: "Start a video upload"
+    name: "Start a video upload for a LinkedIn post"
     summary: "Start a video upload for a LinkedIn post and get its part-upload URLs"
     input:
       body:
@@ -118,7 +118,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /rest/videos?action=finalizeUpload
-    name: "Finish a video upload"
+    name: "Finish a LinkedIn video upload before attaching to a post"
     summary: "Finish a LinkedIn video upload so the video can be attached to a post"
     input:
       body:

--- a/src/treg/catalog/lusha.extended.yaml
+++ b/src/treg/catalog/lusha.extended.yaml
@@ -62,7 +62,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v3/companies/enrich
-    name: "Reveal companies' full details by company id"
+    name: "Enrich companies by Lusha id (up to 100)"
     summary: "Enrich companies you already found in a prospecting search, by ids (max 100), into full firmographic records"
     input:
       bodyType: json
@@ -82,7 +82,7 @@ endpoints:
     platform: people
     method: POST
     path: /v3/contacts/lookalike
-    name: "Find contacts similar to a seed list"
+    name: "Find lookalike contacts from 5-100 seed contacts"
     summary: "AI-powered recommendations for contacts who share similar roles, seniority and company profile to 5-100 seed contacts"
     input:
       bodyType: json
@@ -107,7 +107,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v3/companies/lookalike
-    name: "Find companies similar to a seed list"
+    name: "Find lookalike companies from 5-100 seed companies"
     summary: "AI-powered recommendations for companies of similar size, industry and profile to 5-100 seed companies"
     input:
       bodyType: json
@@ -131,7 +131,7 @@ endpoints:
     platform: people
     method: POST
     path: /v3/contacts/signals
-    name: "Get job-change signals for a list of contacts"
+    name: "Job-change and promotion signals for contact ids"
     summary: "Retrieve signal events for a list of contacts — job changes and promotions"
     input:
       bodyType: json
@@ -152,7 +152,7 @@ endpoints:
     platform: companies
     method: POST
     path: /v3/companies/signals
-    name: "Get activity signals for a list of companies"
+    name: "Hiring and headcount signals for company ids"
     summary: "Retrieve signal events for a list of companies — hiring activity, headcount changes, web traffic, IT spend and news"
     input:
       bodyType: json

--- a/src/treg/catalog/lusha.yaml
+++ b/src/treg/catalog/lusha.yaml
@@ -57,7 +57,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/contacts/search-and-enrich
-    name: "Find and enrich a person's contact info"
+    name: "Find a person's work email and phone by LinkedIn or name"
     summary: "Enrich a person — work email, direct dial and mobile — from email, LinkedIn or name"
     input:
       bodyType: json
@@ -96,7 +96,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/contacts/prospecting
-    name: "Search contacts by role and company"
+    name: "Search people by title, company or intent (free preview)"
     summary: "Search Lusha's contacts by title, seniority, company, location or intent (free preview)"
     input:
       bodyType: json
@@ -118,7 +118,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/contacts/enrich
-    name: "Reveal contacts' emails and phone numbers"
+    name: "Reveal emails and phone numbers for found contact ids"
     summary: "Reveal emails and phone numbers for contacts you already found in a prospecting search"
     input:
       bodyType: json
@@ -157,7 +157,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/companies/search-and-enrich
-    name: "Find and enrich a company's details"
+    name: "Enrich a company by domain or name — headcount, funding"
     summary: "Enrich a company from domain or name — industry, headcount, revenue, funding, tech"
     input:
       bodyType: json
@@ -193,7 +193,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/companies/prospecting
-    name: "Search companies by industry and size"
+    name: "Search companies by industry or tech (free preview)"
     summary: "Search Lusha's companies by industry, headcount, revenue or tech (free preview)"
     input:
       bodyType: json

--- a/src/treg/catalog/majestic.yaml
+++ b/src/treg/catalog/majestic.yaml
@@ -42,7 +42,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "Get Trust Flow and Citation Flow for URLs"
+    name: "Trust Flow and Citation Flow by domain or URL"
     summary: "Trust Flow, Citation Flow and link counts for up to 100 URLs or domains per call"
     input:
       queryParams:
@@ -73,7 +73,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "Get backlink summary for a domain"
+    name: "Backlinks summary by domain — referring domains, .edu/.gov"
     summary: "Aggregate backlink profile of a domain — external links, referring domains, .edu/.gov"
     input:
       queryParams:
@@ -106,7 +106,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "List backlinks to a URL"
+    name: "Backlinks by domain or URL — anchor texts, Trust Flow"
     summary: "Individual backlinks to a URL or domain, with anchor text and both ends' Trust Flow"
     input:
       queryParams:
@@ -145,7 +145,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "List referring domains linking to a target"
+    name: "Referring domains by domain — Trust Flow, country, IP"
     summary: "Referring domains linking to a target, with Trust Flow, country, IP and link count"
     input:
       queryParams:
@@ -178,7 +178,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "List anchor texts linking to a target"
+    name: "Anchor texts in backlinks by domain or URL"
     summary: "Anchor texts pointing at a target, with referring-domain and link counts per phrase"
     input:
       queryParams:
@@ -213,7 +213,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/json
-    name: "List a site's most-linked pages"
+    name: "Most-linked pages by domain — backlinks, Trust Flow"
     summary: "A site's most-linked pages, with Trust Flow, Citation Flow and backlink counts"
     input:
       queryParams:
@@ -244,7 +244,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /api/json
-    name: "Get account usage and index status"
+    name: "Account usage — remaining units and index status"
     summary: "Remaining Analysis, Retrieval and Index Item units, plan dates and current index build"
     input:
       queryParams:

--- a/src/treg/catalog/marketstack.yaml
+++ b/src/treg/catalog/marketstack.yaml
@@ -18,7 +18,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /eod
-    name: "End-of-day price history"
+    name: "End-of-day stock prices by ticker — OHLCV, date range"
     summary: "Daily open/high/low/close/volume for one or more tickers, with date range and adjusted values — 70+ exchanges worldwide"
     input:
       queryParams:
@@ -40,7 +40,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /eod/latest
-    name: "Latest end-of-day prices"
+    name: "Latest closing price by stock ticker — end-of-day bar"
     summary: "The most recent end-of-day bar for one or more tickers — the quick 'what did it close at'"
     input:
       queryParams:
@@ -57,7 +57,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /intraday
-    name: "Intraday prices"
+    name: "Intraday stock price bars by ticker — hourly to 1-minute"
     summary: "Intraday bars for a ticker (hourly by default). On the Basic plan this is DELAYED data, not real-time"
     input:
       queryParams:
@@ -78,7 +78,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /tickers
-    name: "Find tickers"
+    name: "Search stock tickers by company name or symbol"
     summary: "Search 300,000+ tickers by name or symbol and see which exchange each trades on — the symbol-resolver for the other endpoints"
     input:
       queryParams:
@@ -97,7 +97,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /exchanges
-    name: "Stock exchange directory"
+    name: "Stock exchange directory — MIC codes, countries"
     summary: "The exchanges marketstack covers, each with MIC code, country and timezone"
     input:
       queryParams:
@@ -116,7 +116,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /splits
-    name: "Stock split history"
+    name: "Stock split history by ticker — dates and ratios"
     summary: "Split events for a ticker with date and ratio"
     input:
       queryParams:
@@ -136,7 +136,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /dividends
-    name: "Dividend history"
+    name: "Dividend history by stock ticker — ex-dates, amounts"
     summary: "Dividend payments for a ticker with ex-date and amount"
     input:
       queryParams:

--- a/src/treg/catalog/meta-ad-library.yaml
+++ b/src/treg/catalog/meta-ad-library.yaml
@@ -63,7 +63,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /ads_archive
-    name: "Search Facebook and Instagram ads by keyword"
+    name: "Search the Meta ad library by keyword"
     summary: "Search publicly running Facebook and Instagram ads by keyword"
     input:
       queryArrayEncoding: json
@@ -92,7 +92,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /ads_archive
-    name: "List ads by advertiser (Page)"
+    name: "Ads a Facebook Page runs, by Page id — Meta ad library"
     summary: "List every ad a specific Facebook Page is currently running"
     input:
       queryArrayEncoding: json
@@ -114,7 +114,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /ads_archive
-    name: "Search political and issue ads by spender"
+    name: "Political and issue ads with spend — Meta ad library"
     summary: "Search political and issue ads and see who paid for them and roughly how much"
     input:
       queryArrayEncoding: json
@@ -137,7 +137,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /ads_archive
-    name: "Get EU ad reach and audience breakdown"
+    name: "EU ad reach and audience breakdown — Meta ad library"
     summary: "Get the EU reach, audience breakdown and payer of ads delivered in Europe"
     input:
       queryArrayEncoding: json

--- a/src/treg/catalog/meta-ads.extended.yaml
+++ b/src/treg/catalog/meta-ads.extended.yaml
@@ -35,7 +35,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /me/businesses
-  name: "List Business Manager accounts"
+  name: "Business Manager accounts for your Meta login"
   summary: The Business Manager accounts this login belongs to
   scope: own_account
   cost:
@@ -50,7 +50,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}
-  name: "Get ad account details"
+  name: "Your Meta ad account — currency, spend cap, status"
   summary: The ad account itself — name, currency, timezone, spend cap, amount_spent, account_status
   scope: own_account
   cost:
@@ -65,7 +65,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/activities
-  name: "Get ad account change log"
+  name: "Change history of your Meta ad account"
   summary: 'The change log: who changed what on the account and when'
   scope: own_account
   cost:
@@ -80,7 +80,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adcreatives
-  name: "List ad creatives"
+  name: "Ad creatives in your Meta ad account"
   summary: The creatives — body, title, image/video, link and call-to-action
   scope: own_account
   cost:
@@ -96,7 +96,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{ad_account_id}/adcreatives
-  name: "Create ad creative"
+  name: "Create an ad creative in your Meta ad account"
   summary: Create an ad creative
   scope: own_account
   cost:
@@ -112,7 +112,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adimages
-  name: "List uploaded ad images"
+  name: "Images uploaded to your Meta ad account"
   summary: Images uploaded to the ad account, with hash, dimensions and permalink
   scope: own_account
   cost:
@@ -127,7 +127,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adlabels
-  name: "List ad labels"
+  name: "Ad labels in your Meta ad account"
   summary: Labels used to group campaigns, ad sets and ads
   scope: own_account
   cost:
@@ -142,7 +142,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adrules_library
-  name: "List automated rules"
+  name: "Automated rules on your Meta ad account"
   summary: Automated rules on the account — their conditions and actions
   scope: own_account
   cost:
@@ -157,7 +157,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/ads
-  name: "List ads in account"
+  name: "Every ad in your Meta ad account, with status"
   summary: Every ad in the account with its creative, status and effective review status
   scope: own_account
   cost:
@@ -173,7 +173,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{ad_account_id}/ads
-  name: "Create ad"
+  name: "Create an ad in a Meta ad set from a creative"
   summary: Create an ad from a creative inside an ad set
   scope: own_account
   cost:
@@ -189,7 +189,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adsets
-  name: "List ad sets in account"
+  name: "Ad sets in your Meta ad account — budget, targeting"
   summary: Every ad set in the account with budget, schedule, optimisation goal and targeting
   scope: own_account
   cost:
@@ -205,7 +205,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{ad_account_id}/adsets
-  name: "Create an ad set"
+  name: "Create a Meta ad set — targeting, budget, schedule"
   summary: Create an ad set (targeting, budget, schedule, optimisation goal)
   scope: own_account
   cost:
@@ -221,7 +221,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/adspixels
-  name: "List ad pixels"
+  name: "Meta pixels on your ad account, with last fired time"
   summary: Meta pixels on the account and when each last fired
   scope: own_account
   cost:
@@ -236,7 +236,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/advideos
-  name: "List ad videos"
+  name: "Videos uploaded to your Meta ad account"
   summary: Videos uploaded to the ad account
   scope: own_account
   cost:
@@ -252,7 +252,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{ad_account_id}/campaigns
-  name: "Create campaign"
+  name: "Create a Meta ad campaign — objective, status"
   summary: Create a campaign (objective, status, special ad categories)
   scope: own_account
   cost:
@@ -268,7 +268,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/customaudiences
-  name: "List custom and lookalike audiences"
+  name: "Custom and lookalike audiences in your Meta ad account"
   summary: Custom and lookalike audiences with approximate size and delivery status
   scope: own_account
   cost:
@@ -283,7 +283,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/customconversions
-  name: "List custom conversions"
+  name: "Custom conversions on your Meta ad account"
   summary: Custom conversions defined on the account and their rules
   scope: own_account
   cost:
@@ -299,7 +299,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/delivery_estimate
-  name: "Estimate delivery reach and bid"
+  name: "Estimate reach and bid for a Meta targeting spec"
   summary: Estimated daily reach and bid range for a targeting spec, before you spend anything
   scope: own_account
   cost:
@@ -315,7 +315,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/reachestimate
-  name: "Estimate audience reach"
+  name: "Estimate audience size for a Meta targeting spec"
   summary: Estimated audience size for a targeting spec
   scope: own_account
   cost:
@@ -331,7 +331,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/targetingbrowse
-  name: "Browse targeting taxonomy"
+  name: "Browse Meta's ad targeting taxonomy as a tree"
   summary: Browse the targeting taxonomy as a tree
   scope: own_account
   cost:
@@ -347,7 +347,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/targetingsearch
-  name: "Search targeting options by keyword"
+  name: "Search Meta ad targeting options by keyword"
   summary: Search Meta's targeting taxonomy (interests, behaviours, demographics) by keyword
   scope: own_account
   cost:
@@ -363,7 +363,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_account_id}/targetingsuggestions
-  name: "Suggest related targeting interests"
+  name: "Meta targeting interests related to ones you target"
   summary: Interests related to ones you already target
   scope: own_account
   cost:
@@ -378,7 +378,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_id}
-  name: "Get ad details"
+  name: "One Meta ad — creative, status, review status"
   summary: A single ad — its creative, status, tracking specs and review status
   scope: own_account
   cost:
@@ -394,7 +394,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{ad_id}
-  name: "Update ad"
+  name: "Update a Meta ad — pause it or swap its creative"
   summary: Update an ad — pause it or swap its creative
   scope: own_account
   cost:
@@ -410,7 +410,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_id}/leads
-  name: "List leads from a lead ad"
+  name: "Leads collected by one of your Meta lead ads"
   summary: The leads a lead ad has collected
   scope: own_account
   cost:
@@ -427,7 +427,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{ad_id}/previews
-  name: "Preview an ad in a placement"
+  name: "Preview a Meta ad rendered in a placement"
   summary: A rendered preview of an ad in a given placement, as an iframe
   scope: own_account
   cost:
@@ -442,7 +442,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{adset_id}
-  name: "Get ad set details"
+  name: "One Meta ad set — targeting, budget, schedule"
   summary: A single ad set — targeting, schedule, budget, optimisation goal and billing event
   scope: own_account
   cost:
@@ -458,7 +458,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{adset_id}
-  name: "Update an ad set"
+  name: "Update a Meta ad set — pause, budget, targeting"
   summary: Update an ad set — pause it, change budget, schedule or targeting
   scope: own_account
   cost:
@@ -474,7 +474,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{adset_id}/ads
-  name: "List ads in an ad set"
+  name: "Ads inside one Meta ad set"
   summary: The ads inside one ad set
   scope: own_account
   cost:
@@ -489,7 +489,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{business_id}/owned_ad_accounts
-  name: "List ad accounts owned by a business"
+  name: "Ad accounts owned by a Business Manager"
   summary: The ad accounts a Business Manager owns
   scope: own_account
   cost:
@@ -504,7 +504,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{campaign_id}
-  name: "Get campaign details"
+  name: "One Meta campaign — objective, budget, status"
   summary: A single campaign — objective, status, budget, bid strategy and spend cap
   scope: own_account
   cost:
@@ -520,7 +520,7 @@ endpoints:
   platform: meta-ads
   method: POST
   path: /{campaign_id}
-  name: "Update campaign"
+  name: "Update a Meta campaign — pause, rename, budget"
   summary: Update a campaign — pause it, rename it, change its budget
   scope: own_account
   cost:
@@ -536,7 +536,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{campaign_id}/ads
-  name: "List ads in a campaign"
+  name: "Ads inside one Meta campaign"
   summary: The ads inside one campaign
   scope: own_account
   cost:
@@ -551,7 +551,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /{campaign_id}/adsets
-  name: "List ad sets in a campaign"
+  name: "Ad sets inside one Meta campaign"
   summary: The ad sets inside one campaign
   scope: own_account
   cost:

--- a/src/treg/catalog/meta-ads.yaml
+++ b/src/treg/catalog/meta-ads.yaml
@@ -28,7 +28,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /me/adaccounts
-    name: "List ad accounts you can access"
+    name: "Meta ad accounts you can access"
     summary: "List the Meta ad accounts you can access, with their names and currencies"
     input:
       queryParams:
@@ -48,7 +48,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{ad_account_id}/campaigns
-    name: "List campaigns in an ad account"
+    name: "Campaigns in your Meta ad account — status, budget"
     summary: "List the campaigns in your Meta ad account with status, objective and budget"
     input:
       pathParams:
@@ -73,7 +73,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /{object_id}/insights
-    name: "Get spend and performance metrics"
+    name: "Your Meta ads' spend, impressions, clicks, conversions"
     summary: "Get spend, impressions, clicks and conversions for your Meta ads"
     input:
       pathParams:

--- a/src/treg/catalog/microsoft-ads.yaml
+++ b/src/treg/catalog/microsoft-ads.yaml
@@ -36,7 +36,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /Campaigns/QueryByAccountId
-    name: "List campaigns in an account"
+    name: "List your Microsoft Ads campaigns — status, budget"
     summary: "Campaigns in your Microsoft Advertising account, with status, budget and bid strategy"
     input:
       body:
@@ -54,7 +54,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /AdGroups/QueryByCampaignId
-    name: "List ad groups in a campaign"
+    name: "List ad groups in a Microsoft Ads campaign — bids, status"
     summary: "List the ad groups in a Microsoft Advertising campaign with their bids and status"
     input:
       body:
@@ -71,7 +71,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /Ads/QueryByAdGroupId
-    name: "List ads in an ad group"
+    name: "List ads in a Microsoft Ads ad group — headlines, URLs"
     summary: "List the ads in a Microsoft Advertising ad group with their headlines and final URLs"
     input:
       body:
@@ -89,7 +89,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /Keywords/QueryByAdGroupId
-    name: "List keywords in an ad group"
+    name: "List keywords in a Microsoft Ads ad group — match types"
     summary: "List the keywords in a Microsoft Advertising ad group with match types and bids"
     input:
       body:

--- a/src/treg/catalog/moz.yaml
+++ b/src/treg/catalog/moz.yaml
@@ -51,7 +51,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /url_metrics
-    name: "Get URL authority and link metrics"
+    name: "Domain Authority, Page Authority and Spam Score by URL"
     summary: "Domain Authority, Page Authority, Spam Score and link counts for up to 50 URLs"
     input:
       bodyType: json
@@ -86,7 +86,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /url_metrics
-    name: "Get backlink summary with distribution histograms"
+    name: "Backlinks summary by domain — authority, spam histograms"
     summary: "Aggregate backlink profile plus histograms by DA, spam score and root domains"
     input:
       bodyType: json
@@ -117,7 +117,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /links
-    name: "List inbound links with source and target metrics"
+    name: "Backlinks by domain or URL — source and target metrics"
     summary: "Individual inbound links, with full URL metrics for both source and target"
     input:
       bodyType: json
@@ -156,7 +156,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /linking_root_domains
-    name: "List root domains linking to a target"
+    name: "Referring domains by domain or URL — authority, spam"
     summary: "Root domains linking to a target, with each source's DA, spam score and link counts"
     input:
       bodyType: json
@@ -193,7 +193,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /anchor_text
-    name: "Get anchor text distribution of inbound links"
+    name: "Anchor texts in backlinks by domain or URL"
     summary: "Anchor-text distribution of inbound links, with domain and page counts per phrase"
     input:
       bodyType: json
@@ -226,7 +226,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /top_pages
-    name: "List a domain's highest-authority pages"
+    name: "Highest-authority pages by domain, with URL metrics"
     summary: "Highest-authority pages of a domain, with full URL metrics per page"
     input:
       bodyType: json
@@ -264,7 +264,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /link_status
-    name: "Check if specific sources link to a target"
+    name: "Check whether specific sources link to a target domain"
     summary: "Check whether specific sources link to a target — returns one boolean per source"
     input:
       bodyType: json
@@ -297,7 +297,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /link_intersect
-    name: "Find link-gap prospects from competitor backlinks"
+    name: "Sources linking to competitors but not you — link gap"
     summary: "Sources that link to the given competitors but not to you — link-gap prospecting"
     input:
       bodyType: json
@@ -335,7 +335,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /index_metadata
-    name: "Get current Moz link index version"
+    name: "Current Moz link index version"
     summary: "Which Moz link index is serving results — tells you if metrics moved on a refresh"
     input:
       bodyType: json
@@ -364,7 +364,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /usage_data
-    name: "Get API quota usage for this period"
+    name: "Account usage — quota rows consumed this period"
     summary: "Rows consumed this period — Moz's quota meter, covering both V1 and V2 usage"
     input:
       bodyType: json
@@ -391,7 +391,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /global_top_pages
-    name: "List most-linked pages on the web"
+    name: "Most-linked pages on the web — index-wide, no target"
     summary: "Most-linked pages on the web, with full URL metrics (index-wide, takes no target)"
     input:
       bodyType: json
@@ -423,7 +423,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /global_top_root_domains
-    name: "List most-linked root domains on the web"
+    name: "Most-linked domains on the web — Domain Authority, spam"
     summary: "Most-linked root domains on the web, with DA and spam score (index-wide, no target)"
     input:
       bodyType: json

--- a/src/treg/catalog/oceanio.yaml
+++ b/src/treg/catalog/oceanio.yaml
@@ -66,7 +66,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/enrich/company
-    name: "Enrich a company"
+    name: "Enrich a company — web traffic, tech stack, headcount"
     summary: "Match a company with our database and enrich it with additional information"
     input:
       body:
@@ -98,7 +98,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/lookup/companies
-    name: "Look up companies by domain (bulk)"
+    name: "Enrich up to 1,000 companies by domain in one call"
     summary: "Lookup and enrich multiple companies by domain (max 1000). This endpoint provides simple, per-result pricing"
     input:
       body:
@@ -161,7 +161,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/warmup/companies
-    name: "Warm up company coverage"
+    name: "Check which domains are covered before enriching (free)"
     summary: "Check available companies in Ocean's database and trigger process of data gathering for the missing ones"
     input:
       body:
@@ -182,7 +182,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/enrich/person
-    name: "Enrich a person"
+    name: "Enrich a person — role, work history, skills, LinkedIn"
     summary: "Match a person with our database and enrich it with additional information"
     input:
       body:
@@ -215,7 +215,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/lookup/people
-    name: "Look up people by LinkedIn handle (bulk)"
+    name: "Enrich up to 1,000 people by LinkedIn handle in one call"
     summary: "Lookup and enrich multiple people by LinkedIn handle or Ocean ID (max 1000). This endpoint provides simple, per-result pricing"
     input:
       body:
@@ -278,7 +278,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/search/companies
-    name: "Search companies (with lookalike)"
+    name: "Search companies by industry, technology or region"
     summary: "Search companies using filters"
     input:
       body:
@@ -315,7 +315,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/search/companies
-    name: "Find lookalike companies"
+    name: "Find lookalike companies from seed domains"
     summary: "Search companies using filters — seeded with lookalikeDomains, this returns companies similar to your seeds"
     input:
       body:
@@ -351,7 +351,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v3/search/people
-    name: "Search people"
+    name: "Search people by job title, skills or company filters"
     summary: "Search people using filters and/or people Ids"
     input:
       body:
@@ -391,7 +391,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/reveal/emails
-    name: "Reveal verified emails (async, webhook)"
+    name: "Reveal verified work emails for person ids (async)"
     summary: "Get emails and email statuses for people"
     input:
       body:
@@ -422,7 +422,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/reveal/phones
-    name: "Reveal direct phone numbers (async, webhook)"
+    name: "Reveal direct phone numbers for person ids (async)"
     summary: "Get phones and phone statuses for people"
     input:
       body:
@@ -454,7 +454,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/segmentation
-    name: "Start an ICP segmentation"
+    name: "Start an ICP segmentation from a list of domains"
     summary: "Create a new segmentation from a list of company domains"
     input:
       body:
@@ -522,7 +522,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v2/segmentation/{segmentation_id}/attribute-domains
-    name: "Attribute companies to a segment"
+    name: "Assign domains to the closest segment, with match score"
     summary: "Assign each input domain to the closest segment in a segmentation, with a 0-1 match score"
     input:
       pathParams:

--- a/src/treg/catalog/pdl.extended.yaml
+++ b/src/treg/catalog/pdl.extended.yaml
@@ -29,7 +29,7 @@ endpoints:
     platform: people
     method: GET
     path: /person/enrich/preview
-    name: "Preview person enrich"
+    name: "Preview a person enrichment by email, name or phone"
     summary: "Enrich a person record on a variety of fields and receive a preview record in return"
     input:
       queryParams:
@@ -68,7 +68,7 @@ endpoints:
     platform: people
     method: GET
     path: /person/identify
-    name: "Recover all related profiles for an identity"
+    name: "Recover all profiles for one identity by email or name"
     summary: "Recover all related profiles for an identity"
     input:
       queryParams:
@@ -109,7 +109,7 @@ endpoints:
     platform: people
     method: GET
     path: /person/retrieve/{person_id}
-    name: "Retrieve a person by PDL ID"
+    name: "A person record by PDL id"
     summary: "Retrieves a person based on a PDL ID."
     input:
       pathParams:
@@ -129,7 +129,7 @@ endpoints:
     platform: people
     method: POST
     path: /person/retrieve/bulk
-    name: "Retrieve up to 100 people by PDL ID"
+    name: "Up to 100 person records by PDL id in one call"
     summary: "Retrieves up to 100 person records based on a PDL ID."
     input:
       queryParams:
@@ -222,7 +222,7 @@ endpoints:
     platform: web
     method: GET
     path: /ip/enrich
-    name: "Enrich an IP address"
+    name: "Enrich an IP address — location, company behind it"
     summary: "Enrich data on an IP by performing a one-to-one match of this IP with the nearly 2 Billion IPs hosted in our dataset, returning location, company, and metadata"
     input:
       queryParams:

--- a/src/treg/catalog/pdl.yaml
+++ b/src/treg/catalog/pdl.yaml
@@ -41,7 +41,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /person/enrich
-    name: "Enrich a person from email or name"
+    name: "Enrich a person by email, LinkedIn or name + company"
     summary: "Enrich a person from email, LinkedIn or name + company — job history, skills, contact"
     input:
       queryParams:
@@ -89,7 +89,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /person/search
-    name: "Search people by title, company, skills"
+    name: "Search people by title, company, skills or location"
     summary: "Search PDL people by title, company, seniority, skills or location — pays per record"
     input:
       queryParams:
@@ -125,7 +125,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /company/enrich
-    name: "Enrich a company from website or name"
+    name: "Enrich a company by website, name or ticker"
     summary: "Enrich a company from website, name or ticker — industry, size, founded, location"
     input:
       queryParams:
@@ -166,7 +166,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /company/search
-    name: "Search companies by industry, size, location"
+    name: "Search companies by industry, headcount or location"
     summary: "Search PDL companies by industry, headcount, location or tags — pays per record"
     input:
       queryParams:
@@ -201,7 +201,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /autocomplete
-    name: "Get autocomplete suggestions for filter fields"
+    name: "Autocomplete filter values (free key check)"
     summary: "Check the key works and get suggested values for a filter field (free — 0 credits)"
     input:
       queryParams:

--- a/src/treg/catalog/pinterest-ads.yaml
+++ b/src/treg/catalog/pinterest-ads.yaml
@@ -31,7 +31,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts
-    name: "List accessible ad accounts"
+    name: "List your Pinterest ad accounts"
     summary: "List the Pinterest ad accounts you can access"
     input:
       queryParams:
@@ -48,7 +48,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts/{ad_account_id}/analytics
-    name: "Ad account analytics"
+    name: "Your Pinterest ad account performance — spend, conversions"
     summary: "Get spend, impressions, clicks and conversions for your Pinterest ad account"
     input:
       pathParams:
@@ -72,7 +72,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts/{ad_account_id}/campaigns
-    name: "List campaigns in an ad account"
+    name: "List your Pinterest ad campaigns — objective, budget"
     summary: "List the campaigns in your Pinterest ad account with objective, status and budget"
     input:
       pathParams:
@@ -93,7 +93,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts/{ad_account_id}/campaigns/analytics
-    name: "Campaign analytics"
+    name: "Per-campaign Pinterest ad performance — spend, conversions"
     summary: "Get spend and performance per campaign in your Pinterest ad account"
     input:
       pathParams:
@@ -116,7 +116,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts/{ad_account_id}/ad_groups
-    name: "List ad groups in an ad account"
+    name: "List your Pinterest ad groups — budget, bid, targeting"
     summary: "List the ad groups in your Pinterest ad account with budget, bid and targeting"
     input:
       pathParams:
@@ -137,7 +137,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad_accounts/{ad_account_id}/ads
-    name: "List ads in an ad account"
+    name: "List your Pinterest ads — promoted Pins, destinations"
     summary: "List the ads in your Pinterest ad account with their promoted Pins and destinations"
     input:
       pathParams:

--- a/src/treg/catalog/polygon.yaml
+++ b/src/treg/catalog/polygon.yaml
@@ -19,7 +19,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v2/aggs/ticker/{ticker}/prev
-    name: "Previous close for a ticker"
+    name: "Previous close by stock ticker — prior day OHLCV bar"
     summary: "The prior trading day's open/high/low/close/volume bar for one ticker"
     input:
       queryParams:
@@ -37,7 +37,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v2/aggs/ticker/{ticker}/range/{multiplier}/{timespan}/{from}/{to}
-    name: "Aggregate bars over a date range"
+    name: "Stock OHLCV bars by ticker and date range, any interval"
     summary: "OHLCV bars for a ticker at any granularity (minute to year) over a date range — Polygon's workhorse endpoint"
     input:
       queryParams:
@@ -61,7 +61,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/open-close/{ticker}/{date}
-    name: "Open and close on a specific date"
+    name: "Daily open and close by stock ticker on one date"
     summary: "One ticker's open, close, high, low, volume and after-hours prices on one date"
     input:
       queryParams:
@@ -80,7 +80,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v3/reference/tickers
-    name: "Search tickers"
+    name: "Search stock and crypto tickers by symbol or name"
     summary: "Search Polygon's reference directory of tickers by symbol or name, filtered by market and type"
     input:
       queryParams:
@@ -101,7 +101,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v3/reference/tickers/{ticker}
-    name: "Ticker details"
+    name: "Company details by stock ticker — market cap, listing date"
     summary: "Company details behind a ticker: name, market cap, listing date, SIC classification, homepage"
     input:
       queryParams:
@@ -118,7 +118,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/marketstatus/now
-    name: "Market status right now"
+    name: "US stock market open or closed right now"
     summary: "Whether US markets and each exchange are open, closed or in extended hours at this moment"
     input:
       note: "no parameters"

--- a/src/treg/catalog/predictleads.yaml
+++ b/src/treg/catalog/predictleads.yaml
@@ -104,7 +104,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/similar_companies
-    name: "Find similar companies"
+    name: "Lookalike companies for a domain, with reasons"
     summary: "Returns a list of a company's Similar Companies and, for the top 20, provides a reason why they are considered similar."
     input:
       pathParams:
@@ -128,7 +128,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/job_openings
-    name: "A company's job openings"
+    name: "A company's job postings by domain — hiring signal"
     summary: "Returns a list of company's Job Openings."
     input:
       pathParams:
@@ -162,7 +162,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /job_openings/{id}
-    name: "Get a job opening by ID"
+    name: "Get a job posting by id"
     summary: "Returns a single Job Opening."
     input:
       pathParams:
@@ -181,7 +181,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /discover/job_openings
-    name: "Search job openings across all companies"
+    name: "Search job postings by occupation code and location"
     summary: "Returns a list of Job Openings filtered by a given profession using O*NET occupation codes and/or location of the company."
     input:
       queryParams:
@@ -208,7 +208,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/technology_detections
-    name: "A company's technology stack"
+    name: "A company's tech stack by domain, with evidence"
     summary: "Returns Technologies used by a specific Company as a list of Technology Detections."
     input:
       pathParams:
@@ -236,7 +236,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /discover/technologies/{technology_id_or_fuzzy_name}/technology_detections
-    name: "Companies using a given technology"
+    name: "Companies using a given technology — reverse tech lookup"
     summary: "Returns Companies using a specific Technology as a list of Technology Detections, ordered by first_seen_at descending."
     input:
       pathParams:
@@ -264,7 +264,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /technologies
-    name: "Browse tracked technologies"
+    name: "Browse the ~54,000 tracked technologies"
     summary: "Returns a list of all tracked Technologies."
     input:
       queryParams:
@@ -325,7 +325,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/news_events
-    name: "A company's news events"
+    name: "A company's classified news events by domain"
     summary: "Returns a list of company's News Events."
     input:
       pathParams:
@@ -396,7 +396,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/financing_events
-    name: "A company's funding rounds"
+    name: "A company's funding rounds by domain"
     summary: "Returns a list of company's Financing Events."
     input:
       pathParams:
@@ -422,7 +422,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /discover/financing_events
-    name: "Browse funding rounds across all companies"
+    name: "Browse funding rounds — the who-just-raised feed"
     summary: "Returns a list of Financing Events, optionally filtered by normalized financing type and company's location, ordered by updated date."
     input:
       queryParams:
@@ -445,7 +445,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/sec_filings
-    name: "A company's SEC filings"
+    name: "A company's SEC filings by domain, with full text"
     summary: "Returns a list of company's SEC Filings, ordered by filed_at descending."
     input:
       pathParams:
@@ -491,7 +491,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/connections
-    name: "A company's partners, customers and investors"
+    name: "A company's partners, customers and investors by domain"
     summary: "Returns a list of company's Connections."
     input:
       pathParams:
@@ -569,7 +569,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/github_repositories
-    name: "A company's public GitHub repositories"
+    name: "A company's public GitHub repositories by domain"
     summary: "Returns a list of company's Github Repositories."
     input:
       pathParams:
@@ -595,7 +595,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{company_id_or_domain}/products
-    name: "A company's products and services"
+    name: "A company's products and services by domain"
     summary: "Returns a list of company's Products."
     input:
       pathParams:
@@ -665,7 +665,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /discover/startup_platform_posts
-    name: "Latest startup-platform launch posts"
+    name: "Latest startup launch posts, resolved to company domains"
     summary: "Returns a list of latest posts on popular startup platforms by companies that are hiring or launching new products."
     input:
       queryParams:

--- a/src/treg/catalog/scrapecreators.extended.yaml
+++ b/src/treg/catalog/scrapecreators.extended.yaml
@@ -102,7 +102,7 @@ endpoints:
   platform: amazon
   method: GET
   path: /v1/amazon/shop
-  name: Get Amazon Shop page
+  name: "Amazon Shop storefront by URL — profile, products"
   summary: Scrapes a creator's Amazon Shop page by URL, returning their storefront profile and product collections.
   cost:
     type: per_call
@@ -133,7 +133,7 @@ endpoints:
   platform: apple-music
   method: GET
   path: /v1/apple-music/album
-  name: Get Apple Music Album
+  name: "Apple Music album by id or URL — tracks, release info"
   summary: Retrieves public Apple Music album details, including title, artist, artwork, release info, tracks, and more by the artist.
   cost:
     type: per_call
@@ -167,7 +167,7 @@ endpoints:
   platform: apple-music
   method: GET
   path: /v1/apple-music/artist
-  name: Get Apple Music Artist
+  name: "Apple Music artist by id or URL — top songs, albums"
   summary: Retrieves public Apple Music artist details, including artwork, editorial notes, top songs, albums, music videos, playlists, and related sections.
   cost:
     type: per_call
@@ -201,7 +201,7 @@ endpoints:
   platform: apple-music
   method: GET
   path: /v1/apple-music/search
-  name: "Search Apple Music"
+  name: "Search Apple Music by keyword — songs, artists, albums"
   summary: Searches Apple Music and returns public result sections for artists, albums, songs, playlists, stations, and music videos.
   cost:
     type: per_call
@@ -235,7 +235,7 @@ endpoints:
   platform: apple-music
   method: GET
   path: /v1/apple-music/track
-  name: Get Apple Music Track
+  name: "Apple Music track by id or URL — song details"
   summary: Retrieves public Apple Music song details by id or URL.
   cost:
     type: per_call
@@ -269,7 +269,7 @@ endpoints:
   platform: bluesky
   method: GET
   path: /v1/bluesky/post
-  name: Get Bluesky Post
+  name: "Bluesky post by URL — text, author, engagement counts"
   summary: Fetches a single Bluesky post by URL, returning the post's record text, author info, embed content, replyCount, repostCount, likeCount, and quoteCount.
   cost:
     type: per_call
@@ -299,7 +299,7 @@ endpoints:
   platform: bluesky
   method: GET
   path: /v1/bluesky/profile
-  name: Get Bluesky Profile
+  name: "Bluesky profile by username — bio, follower counts"
   summary: Retrieves a Bluesky user's public profile including handle, displayName, avatar, description, followersCount, followsCount, postsCount, createdAt, and verification status.
   cost:
     type: per_call
@@ -329,7 +329,7 @@ endpoints:
   platform: bluesky
   method: GET
   path: /v1/bluesky/user/posts
-  name: List Bluesky Posts
+  name: "Bluesky user posts by username — text, engagement"
   summary: Fetches a paginated feed of posts from a Bluesky user, returning each post's uri, record text, author info, embed content, replyCount, repostCount, likeCount, quoteCount, and indexedAt.
   cost:
     type: per_call
@@ -365,7 +365,7 @@ endpoints:
   platform: web
   method: GET
   path: /v1/detect-age-gender
-  name: Get image Age and Gender
+  name: "Estimate age and gender from a profile photo URL"
   summary: Uses AI to analyze a creator's profile photo and estimate their age and gender.
   cost:
     type: per_call
@@ -394,7 +394,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /v1/facebook/adLibrary/ad
-  name: "Get Facebook Ad Details"
+  name: "Facebook ad library ad details by id or URL"
   summary: Retrieves detailed information about a specific Facebook ad by its ID or URL.
   cost:
     type: per_call
@@ -438,7 +438,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /v1/facebook/adLibrary/ad/transcript
-  name: "Get Facebook Ad Transcript"
+  name: "Facebook ad library video ad transcript by id or URL"
   summary: Retrieves a transcript for a single Facebook Ad Library video ad by ID or URL.
   cost:
     type: per_call
@@ -478,7 +478,7 @@ endpoints:
   capability: meta-ads.library.advertiser
   method: GET
   path: /v1/facebook/adLibrary/company/ads
-  name: "List Facebook Company Ads"
+  name: "Facebook ad library company ads by page id or name"
   summary: Fetches all ads currently running for a specific company from the Meta Ad Library.
   cost:
     type: per_call
@@ -558,7 +558,7 @@ endpoints:
   capability: meta-ads.library.search
   method: GET
   path: /v1/facebook/adLibrary/search/ads
-  name: "Search Facebook Ads"
+  name: "Search Facebook ad library ads by keyword"
   summary: Searches the Meta Ad Library by keyword and returns matching ads.
   cost:
     type: per_call
@@ -637,7 +637,7 @@ endpoints:
   platform: meta-ads
   method: GET
   path: /v1/facebook/adLibrary/search/companies
-  name: "Search Facebook Ad Library Companies"
+  name: "Search Facebook ad library companies by name — page ids"
   summary: Searches for companies by name in the Meta Ad Library and returns their page IDs for use with other ad library endpoints.
   cost:
     type: per_call
@@ -666,7 +666,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/event/details
-  name: Get Facebook events Event Details
+  name: "Facebook event details by id or URL"
   summary: Get a specific event by its URL or id.
   cost:
     type: per_call
@@ -703,7 +703,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/events
-  name: "List Facebook Events by City"
+  name: "Facebook events for a city by URL"
   summary: Get the events of a city.
   cost:
     type: per_call
@@ -744,7 +744,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/events/search
-  name: Search Facebook events by name
+  name: "Search Facebook events by name"
   summary: Search for events by name.
   cost:
     type: per_call
@@ -781,7 +781,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/group
-  name: Get Facebook Group Info
+  name: "Facebook group profile by URL or id — members, admins"
   summary: Fetches the public information shown on a Facebook group's About page, including its description, privacy and visibility, member and activity counts, categories, administrators and moderators when Facebook exposes them, group history, and rules.
   cost:
     type: per_call
@@ -818,7 +818,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/group/posts
-  name: List Facebook Group Posts
+  name: "Facebook group posts by URL or group id"
   summary: Fetches posts from a public Facebook group, limited to 3 posts per page due to API limitations.
   cost:
     type: per_call
@@ -865,7 +865,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/marketplace/item
-  name: Get Facebook Marketplace item detail
+  name: "Facebook Marketplace item by id or URL — price, seller"
   summary: Fetches details for a Facebook Marketplace item by item id or Marketplace item URL, including title, description, price, location, condition, photos, seller, and availability flags.
   cost:
     type: per_call
@@ -902,7 +902,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/marketplace/location/search
-  name: Search Facebook Marketplace locations
+  name: "Search Facebook Marketplace locations by city — lat/lng"
   summary: Searches Facebook Marketplace locations/cities and returns coordinates you can use with the Marketplace Search endpoint.
   cost:
     type: per_call
@@ -934,7 +934,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/marketplace/search
-  name: Search Facebook Marketplace listings
+  name: "Search Facebook Marketplace listings by keyword and lat/lng"
   summary: Searches Facebook Marketplace listings by keyword and lat/lng.
   cost:
     type: per_call
@@ -1028,7 +1028,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/post
-  name: Get Facebook Post
+  name: "Facebook post or reel by URL"
   summary: Retrieves a single public Facebook post or reel by URL.
   cost:
     type: per_call
@@ -1065,7 +1065,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/post/comment/replies
-  name: List Facebook Comment Replies
+  name: "Facebook comment replies by feedback id"
   summary: Get the replies to a comment.
   cost:
     type: per_call
@@ -1107,7 +1107,7 @@ endpoints:
   capability: facebook.post.comments
   method: GET
   path: /v1/facebook/post/comments
-  name: List Facebook Comments
+  name: "Facebook post or reel comments by URL"
   summary: Fetches comments from a Facebook post or reel with cursor-based pagination.
   cost:
     type: per_call
@@ -1148,7 +1148,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/post/transcript
-  name: Get Facebook Transcript
+  name: "Facebook video post transcript by URL"
   summary: Extracts the transcript text from a Facebook video post or reel.
   cost:
     type: per_call
@@ -1182,7 +1182,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/profile
-  name: Get Facebook Profile
+  name: "Facebook page profile by URL — contact info, followers"
   summary: Retrieves public Facebook page details including category, address, email, phone, website, services, priceRange, rating, likeCount, and followerCount.
   cost:
     type: per_call
@@ -1229,7 +1229,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/profile/events
-  name: List Facebook Profile Events
+  name: "Facebook page events by URL"
   summary: Get the events of a public Facebook page.
   cost:
     type: per_call
@@ -1266,7 +1266,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/profile/photos
-  name: List Facebook Profile Photos
+  name: "Facebook page photos by URL"
   summary: Fetches photos from a public Facebook page with pagination support.
   cost:
     type: per_call
@@ -1309,7 +1309,7 @@ endpoints:
   capability: facebook.user.posts
   method: GET
   path: /v1/facebook/profile/posts
-  name: List Facebook Profile Posts
+  name: "Facebook page posts by URL or page id"
   summary: Returns publicly visible Facebook profile posts, limited to 3 posts per page due to API limitations.
   cost:
     type: per_call
@@ -1350,7 +1350,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /v1/facebook/profile/reels
-  name: List Facebook Profile Reels
+  name: "Facebook page reels by URL"
   summary: Fetches up to 10 reels per request from a public Facebook page.
   cost:
     type: per_call
@@ -1392,7 +1392,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/repository
-  name: Get GitHub Repository
+  name: "GitHub repository by URL — stars, forks, topics"
   summary: Retrieves public metadata for one GitHub repository, including owner, description, language, stars, forks, topics, license, visibility, default branch, open issues, and timestamps.
   cost:
     type: per_call
@@ -1422,7 +1422,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/trending/developers
-  name: List GitHub Trending Developers
+  name: "GitHub trending developers — filter by language"
   summary: Scrapes GitHub's public Trending developers page.
   cost:
     type: per_call
@@ -1457,7 +1457,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/trending/repositories
-  name: List GitHub Trending Repositories
+  name: "GitHub trending repositories — filter by language"
   summary: Scrapes GitHub's public Trending repositories page.
   cost:
     type: per_call
@@ -1497,7 +1497,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user
-  name: Get GitHub User
+  name: "GitHub user profile by username — bio, followers"
   summary: Retrieves public GitHub user details including name, bio, avatar, company, location, blog, follower counts, public repo counts, and account timestamps.
   cost:
     type: per_call
@@ -1532,7 +1532,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/activity
-  name: Get GitHub Activity
+  name: "GitHub user activity timeline by username"
   summary: Retrieves GitHub profile contribution activity for a user from the public profile activity timeline.
   cost:
     type: per_call
@@ -1577,7 +1577,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/contributions
-  name: List GitHub Contributions
+  name: "GitHub contribution graph by username and year"
   summary: Retrieves the public GitHub contribution graph for a user and year, including total contributions and daily contribution counts/intensity.
   cost:
     type: per_call
@@ -1617,7 +1617,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/followers
-  name: List GitHub Followers
+  name: "GitHub user followers by username"
   summary: Retrieves public GitHub followers for a user.
   cost:
     type: per_call
@@ -1657,7 +1657,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/following
-  name: List GitHub Following
+  name: "GitHub user following list by username"
   summary: Retrieves public accounts followed by a GitHub user.
   cost:
     type: per_call
@@ -1697,7 +1697,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/pull-requests
-  name: List GitHub Pull Requests
+  name: "GitHub user pull requests by username"
   summary: Searches public GitHub pull requests authored by a user using GitHub's public search index.
   cost:
     type: per_call
@@ -1742,7 +1742,7 @@ endpoints:
   platform: github
   method: GET
   path: /v1/github/user/repositories
-  name: List GitHub Repositories
+  name: "GitHub user repositories by username — stars, language"
   summary: Retrieves a user's public repositories with repo metadata like description, language, stars, forks, topics, license, visibility, default branch, and timestamps.
   cost:
     type: per_call
@@ -1797,7 +1797,7 @@ endpoints:
   platform: google-ads
   method: GET
   path: /v1/google/ad
-  name: "Get Google Ad Details"
+  name: "Google ad library ad details by URL — impressions"
   summary: Retrieves detailed information about a specific Google ad including advertiserId, creativeId, format, firstShown, lastShown, and overallImpressions.
   cost:
     type: per_call
@@ -1833,7 +1833,7 @@ endpoints:
   platform: google-ads
   method: GET
   path: /v1/google/adLibrary/advertisers/search
-  name: "Search Google Advertisers"
+  name: "Search Google ad library advertisers by name"
   summary: Searches the Google Ad Transparency Library for advertisers by name.
   cost:
     type: per_call
@@ -1869,7 +1869,7 @@ endpoints:
   platform: google-ads
   method: GET
   path: /v1/google/company/ads
-  name: "List Google Company Ads"
+  name: "Google ad library company ads by domain or advertiser id"
   summary: Fetches public ads for a company from the Google Ad Transparency Library by domain or advertiser_id.
   cost:
     type: per_call
@@ -1946,7 +1946,7 @@ endpoints:
   capability: google.serp.organic
   method: GET
   path: /v1/google/search
-  name: "Search Google"
+  name: "Search Google by keyword — organic results"
   summary: Performs a Google search and returns organic results with url, title, and description for each result.
   cost:
     type: per_call
@@ -1993,7 +1993,7 @@ endpoints:
   capability: instagram.music.posts
   method: GET
   path: /v1/instagram/audio/reels
-  name: List Instagram Reels By Audio Id
+  name: "Instagram reels using an audio, by audio id"
   summary: Fetches the reels Instagram exposes for an audio page like instagram.com/reels/audio/{audio_id}/.
   cost:
     type: per_call
@@ -2030,7 +2030,7 @@ endpoints:
   capability: instagram.user.profile
   method: GET
   path: /v1/instagram/basic-profile
-  name: Get Instagram Basic Profile
+  name: "Instagram basic profile by user id — bio, followers"
   summary: Fetches a lightweight Instagram profile summary by user ID, returning username, full name, biography, profile picture URL, verification status, follower count, following count, media count, and account privacy and type.
   cost:
     type: per_call
@@ -2067,7 +2067,7 @@ endpoints:
   capability: instagram.post.detail
   method: GET
   path: /v1/instagram/post
-  name: Get Instagram Post/Reel Info
+  name: "Instagram post or reel by URL or shortcode"
   summary: Fetches detailed metadata for a single Instagram post or reel by shortcode or URL.
   cost:
     type: per_call
@@ -2114,7 +2114,7 @@ endpoints:
   capability: instagram.reels.recommended
   method: GET
   path: /v1/instagram/reels/trending
-  name: List Instagram Trending Reels
+  name: "Instagram trending reels feed"
   summary: Fetches trending reels from Instagram's public instagram.com/reels page.
   cost:
     type: per_call
@@ -2138,7 +2138,7 @@ endpoints:
   capability: instagram.hashtag.posts
   method: GET
   path: /v1/instagram/search/hashtag
-  name: Search Instagram Hashtag Posts
+  name: "Search Instagram posts by hashtag — caption, engagement"
   summary: Finds public Instagram posts for a hashtag using Google Search, then returns post details such as caption, play count when available, like count, comment count, owner, and post time.
   cost:
     type: per_call
@@ -2185,7 +2185,7 @@ endpoints:
   capability: instagram.search.users
   method: GET
   path: /v1/instagram/search/profiles
-  name: Search Instagram Profiles
+  name: "Search Instagram profiles by keyword"
   summary: Searches Google for public Instagram results matching a keyword or phrase, then returns matching public profiles.
   cost:
     type: per_call
@@ -2221,7 +2221,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /v1/instagram/user/embed
-  name: Get Instagram Embed HTML
+  name: "Instagram profile embed HTML by username"
   summary: Returns the raw HTML embed snippet for an Instagram user's profile widget.
   cost:
     type: per_call
@@ -2253,7 +2253,7 @@ endpoints:
   capability: instagram.highlight.items
   method: GET
   path: /v1/instagram/user/highlight/detail
-  name: List Instagram Highlights Details
+  name: "Instagram story highlight contents by highlight id"
   summary: Fetches the full contents of a specific Instagram story highlight album by its ID.
   cost:
     type: per_call
@@ -2285,7 +2285,7 @@ endpoints:
   capability: instagram.user.highlights
   method: GET
   path: /v1/instagram/user/highlights
-  name: List Instagram Story Highlights
+  name: "Instagram story highlights by username or user id"
   summary: Lists all story highlight albums for an Instagram user.
   cost:
     type: per_call
@@ -2322,7 +2322,7 @@ endpoints:
   capability: instagram.user.reels
   method: GET
   path: /v1/instagram/user/reels
-  name: List Instagram Reels
+  name: "Instagram user reels by username — short videos"
   summary: Returns a paginated list of a user's public Instagram reels (short-form videos).
   cost:
     type: per_call
@@ -2368,7 +2368,7 @@ endpoints:
   platform: kick
   method: GET
   path: /v1/kick/clip
-  name: Get Kick Clip
+  name: "Kick clip by URL — video, channel info"
   summary: Fetches detailed data for a Kick clip by URL, including video, metadata, and channel info.
   cost:
     type: per_call
@@ -2397,7 +2397,7 @@ endpoints:
   platform: linkinbio
   method: GET
   path: /v1/komi
-  name: Get Komi page
+  name: "Komi link-in-bio page by URL — profile, social links"
   summary: Scrapes a Komi page by URL, extracting the creator's profile, social links, and featured content.
   cost:
     type: per_call
@@ -2432,7 +2432,7 @@ endpoints:
   capability: kuaishou.video.detail
   method: GET
   path: /v1/kwai/post
-  name: Get Kwai Post
+  name: "Kwai post by URL — caption, media, counts"
   summary: Fetches public Kwai post details including caption, media URLs, cover images, counts, author info, and music metadata.
   cost:
     type: per_call
@@ -2464,7 +2464,7 @@ endpoints:
   capability: kuaishou.user.profile
   method: GET
   path: /v1/kwai/profile
-  name: Get Kwai Profile
+  name: "Kwai profile by username or URL — bio, counts"
   summary: Fetches public Kwai profile data including username, bio, avatar, verification status, gender, and public counts.
   cost:
     type: per_call
@@ -2500,7 +2500,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /v1/kwai/user/posts
-  name: List Kwai User Posts
+  name: "Kwai user posts by username or URL"
   summary: Fetches a paginated list of public Kwai posts for a user, including captions, media URLs, covers, counts, author info, and the next cursor when more results are available.
   cost:
     type: per_call
@@ -2546,7 +2546,7 @@ endpoints:
   platform: linkinbio
   method: GET
   path: /v1/linkbio
-  name: Get Linkbio page
+  name: "Linkbio (lnk.bio) link-in-bio page by URL"
   summary: Scrapes a Linkbio (lnk.bio) page by URL, extracting the creator's profile and all their links.
   cost:
     type: per_call
@@ -2581,7 +2581,7 @@ endpoints:
   capability: linkedin.ad.detail
   method: GET
   path: /v1/linkedin/ad
-  name: "Get LinkedIn Ad Details"
+  name: "LinkedIn ad details by URL"
   summary: Retrieves detailed information about a specific LinkedIn ad by URL.
   cost:
     type: per_call
@@ -2613,7 +2613,7 @@ endpoints:
   capability: linkedin.search.ads
   method: GET
   path: /v1/linkedin/ads/search
-  name: "Search LinkedIn Ads"
+  name: "Search LinkedIn ad library by company or keyword"
   summary: Searches the LinkedIn Ad Library by company name, keyword, or companyId with optional country and date filters.
   cost:
     type: per_call
@@ -2675,7 +2675,7 @@ endpoints:
   capability: linkedin.company.profile
   method: GET
   path: /v1/linkedin/company
-  name: Get LinkedIn Company Page
+  name: "LinkedIn company profile by URL — headcount, industry"
   summary: Fetches a LinkedIn company page with details including name, description, logo, cover image, slogan, location, headquarters, employee count (headcount/staff size), website, industry, company type, founded year, specialties, funding rounds with investors, featured employees, recent posts, and simi...
   cost:
     type: per_call
@@ -2707,7 +2707,7 @@ endpoints:
   capability: linkedin.company.posts
   method: GET
   path: /v1/linkedin/company/posts
-  name: List LinkedIn Company Posts
+  name: "LinkedIn company posts by URL — full text, dates"
   summary: Retrieves paginated posts from a LinkedIn company page, including each post's URL, ID, publication date, and full text content.
   cost:
     type: per_call
@@ -2744,7 +2744,7 @@ endpoints:
   capability: linkedin.post.detail
   method: GET
   path: /v1/linkedin/post
-  name: Get LinkedIn Post
+  name: "LinkedIn post or article by URL — likes, comments"
   summary: Fetches a single LinkedIn post or article, returning the title, headline, full description text, author info with follower count, publication date, like count (reactions), comment count, and individual comments.
   cost:
     type: per_call
@@ -2775,7 +2775,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /v1/linkedin/post/transcript
-  name: Get LinkedIn Post Transcript
+  name: "LinkedIn post video transcript by URL"
   summary: Fetches the transcript from a LinkedIn post video when LinkedIn exposes one publicly.
   cost:
     type: per_call
@@ -2807,7 +2807,7 @@ endpoints:
   capability: linkedin.search.posts
   method: GET
   path: /v1/linkedin/search/posts
-  name: Search LinkedIn Posts
+  name: "Search LinkedIn posts by keyword"
   summary: Finds public LinkedIn posts, feed updates, and Pulse articles by keyword using Google Search, then returns post details such as description, author, media, images, like count, comment count, and published date when LinkedIn exposes them publicly.
   cost:
     type: per_call
@@ -2848,7 +2848,7 @@ endpoints:
   platform: linkinbio
   method: GET
   path: /v1/linkme
-  name: Get Linkme Profile
+  name: "Linkme link-in-bio profile by URL — links, contacts"
   summary: Retrieves a Linkme profile by URL, including identity, social links, and contact details.
   cost:
     type: per_call
@@ -2882,7 +2882,7 @@ endpoints:
   platform: linkinbio
   method: GET
   path: /v1/linktree
-  name: Get Linktree page
+  name: "Linktree link-in-bio page by URL — profile, links"
   summary: Scrapes a Linktree page by URL, extracting the creator's profile and all their links.
   cost:
     type: per_call
@@ -2916,7 +2916,7 @@ endpoints:
   platform: linkinbio
   method: GET
   path: /v1/pillar
-  name: Get Pillar page
+  name: "Pillar link-in-bio page by URL — links, products"
   summary: Scrapes a Pillar page by URL, extracting the creator's profile, social links, and products.
   cost:
     type: per_call
@@ -2950,7 +2950,7 @@ endpoints:
   platform: pinterest
   method: GET
   path: /v1/pinterest/board
-  name: Get Pinterest Board
+  name: "Pinterest board pins by board URL"
   summary: Fetches a paginated list of pins from a Pinterest board by URL, returning each pin's id, description, title, images, board info, pin_join annotations, and aggregated_pin_data.
   cost:
     type: per_call
@@ -2990,7 +2990,7 @@ endpoints:
   platform: pinterest
   method: GET
   path: /v1/pinterest/pin
-  name: Get Pinterest Pin
+  name: "Pinterest pin by URL — title, images, annotations"
   summary: Fetches detailed information about a single Pinterest pin by URL, returning title, description, link, dominantColor, originPinner, pinner, images at multiple resolutions (imageSpec_236x through imageSpec_orig), and pinJoin with visual annotations.
   cost:
     type: per_call
@@ -3030,7 +3030,7 @@ endpoints:
   platform: pinterest
   method: GET
   path: /v1/pinterest/search
-  name: "Search Pinterest"
+  name: "Search Pinterest pins by keyword"
   summary: Searches Pinterest for pins matching a query, returning results with id, url, title, description, images, link, domain, board info, and pinner details.
   cost:
     type: per_call
@@ -3070,7 +3070,7 @@ endpoints:
   platform: pinterest
   method: GET
   path: /v1/pinterest/user/boards
-  name: List Pinterest User Boards
+  name: "Pinterest user boards by username — pin counts"
   summary: Fetches a paginated list of boards for a Pinterest user, returning each board's name, url, description, pin_count, follower_count, owner info, cover_images, and created_at.
   cost:
     type: per_call
@@ -3106,7 +3106,7 @@ endpoints:
   capability: reddit.post.comments
   method: GET
   path: /v1/reddit/post/comments
-  name: List Reddit Post Comments
+  name: "Reddit post comments by URL"
   summary: Retrieves comments and post details from a Reddit post by URL.
   cost:
     type: per_call
@@ -3145,7 +3145,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /v1/reddit/post/transcript
-  name: Get Reddit Post Transcript
+  name: "Reddit video post transcript by URL — captions"
   summary: Gets the transcript from a Reddit video post or direct v.redd.it URL when Reddit exposes a VTT caption file.
   cost:
     type: per_call
@@ -3185,7 +3185,7 @@ endpoints:
   capability: reddit.subreddit.info
   method: GET
   path: /v1/reddit/subreddit/details
-  name: Get Reddit Subreddit Details
+  name: "Subreddit details by name or URL"
   summary: Retrieves metadata about a subreddit by name or URL.
   cost:
     type: per_call
@@ -3224,7 +3224,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /v1/reddit/subreddit/search
-  name: "Search Within Subreddit"
+  name: "Search within a subreddit by keyword — posts, comments"
   summary: Searches within a specific subreddit for posts, comments, and media matching a query.
   cost:
     type: per_call
@@ -3270,7 +3270,7 @@ endpoints:
   platform: rumble
   method: GET
   path: /v1/rumble/channel/videos
-  name: List Rumble Channel Videos
+  name: "Rumble channel videos by username or URL"
   summary: Gets videos from a Rumble channel by handle or URL.
   cost:
     type: per_call
@@ -3310,7 +3310,7 @@ endpoints:
   platform: rumble
   method: GET
   path: /v1/rumble/search
-  name: "Search Rumble"
+  name: "Search Rumble videos by keyword"
   summary: Searches Rumble videos by keyword.
   cost:
     type: per_call
@@ -3345,7 +3345,7 @@ endpoints:
   platform: rumble
   method: GET
   path: /v1/rumble/video
-  name: Get Rumble Video
+  name: "Rumble video details by URL"
   summary: Gets Rumble video details by URL.
   cost:
     type: per_call
@@ -3375,7 +3375,7 @@ endpoints:
   platform: rumble
   method: GET
   path: /v1/rumble/video/comments
-  name: List Rumble Comments
+  name: "Rumble video comments by URL — top level"
   summary: Gets all top level comments for a Rumble video by URL.
   cost:
     type: per_call
@@ -3405,7 +3405,7 @@ endpoints:
   platform: rumble
   method: GET
   path: /v1/rumble/video/transcript
-  name: Get Rumble Transcript
+  name: "Rumble video transcript by URL — captions"
   summary: Gets a Rumble video's transcript when captions are available.
   cost:
     type: per_call
@@ -3435,7 +3435,7 @@ endpoints:
   platform: snapchat
   method: GET
   path: /v1/snapchat/profile
-  name: Get Snapchat User Profile
+  name: "Snapchat profile by username — stories, spotlight"
   summary: Retrieves a Snapchat user's public profile by handle, including identity, stories, and spotlight content.
   cost:
     type: per_call
@@ -3464,7 +3464,7 @@ endpoints:
   platform: snapchat
   method: GET
   path: /v1/snapchat/spotlight
-  name: Get Snapchat Spotlight by Link
+  name: "Snapchat Spotlight video by URL"
   summary: Fetches public data for a Snapchat Spotlight video by URL.
   cost:
     type: per_call
@@ -3493,7 +3493,7 @@ endpoints:
   platform: snapchat
   method: GET
   path: /v1/snapchat/spotlight/comments
-  name: List Snapchat Spotlight Comments by Link
+  name: "Snapchat Spotlight comments by URL"
   summary: Fetches public comments from Snapchat's Spotlight comments API by URL.
   cost:
     type: per_call
@@ -3527,7 +3527,7 @@ endpoints:
   platform: soundcloud
   method: GET
   path: /v1/soundcloud/artist
-  name: Get SoundCloud Artist
+  name: "SoundCloud artist profile by username or URL"
   summary: Fetches detailed information about a SoundCloud artist by its handle or URL.
   cost:
     type: per_call
@@ -3561,7 +3561,7 @@ endpoints:
   platform: soundcloud
   method: GET
   path: /v1/soundcloud/artist/tracks
-  name: List SoundCloud Artist Tracks
+  name: "SoundCloud artist tracks by username or URL"
   summary: Fetches tracks/songs for a SoundCloud artist by handle or URL.
   cost:
     type: per_call
@@ -3600,7 +3600,7 @@ endpoints:
   platform: soundcloud
   method: GET
   path: /v1/soundcloud/track
-  name: Get SoundCloud Track
+  name: "SoundCloud track by URL — song details"
   summary: Fetches detailed information about a SoundCloud track/song by URL.
   cost:
     type: per_call
@@ -3629,7 +3629,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/album
-  name: Get Spotify Album
+  name: "Spotify album by id or URL — tracks, release info"
   summary: Retrieves detailed information about a Spotify album by its id or URL, including album metadata, artists, release date, cover art, copyright info, tracks, and sharing details.
   cost:
     type: per_call
@@ -3664,7 +3664,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/artist
-  name: Get Spotify Artist
+  name: "Spotify artist by id or URL — followers, genres"
   summary: Retrieves detailed information about a Spotify artist by their handle, including name, followers count, genres, and related artists.
   cost:
     type: per_call
@@ -3699,7 +3699,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/podcast
-  name: Get Spotify Podcast
+  name: "Spotify podcast details by id or URL"
   summary: Retrieves detailed information about a Spotify podcast by its id or URL.
   cost:
     type: per_call
@@ -3734,7 +3734,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/podcast/episodes
-  name: List Spotify Podcast Episodes
+  name: "Spotify podcast episodes by id or URL"
   summary: Returns episodes for a Spotify podcast.
   cost:
     type: per_call
@@ -3774,7 +3774,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/search
-  name: "Search Spotify"
+  name: "Search Spotify by keyword — tracks, artists, albums"
   summary: Search Spotify for tracks, artists, albums, episodes, podcasts, and audiobooks.
   cost:
     type: per_call
@@ -3804,7 +3804,7 @@ endpoints:
   platform: spotify
   method: GET
   path: /v1/spotify/track
-  name: Get Spotify Track
+  name: "Spotify track by id or URL — album, duration"
   summary: Retrieves detailed information about a Spotify track by its id or URL, including track metadata, artists, album info, duration, playability, and sharing details.
   cost:
     type: per_call
@@ -3840,7 +3840,7 @@ endpoints:
   capability: threads.post.detail
   method: GET
   path: /v1/threads/post
-  name: Get Threads Post
+  name: "Threads post by URL — likes, views, replies"
   summary: Fetches a single Threads post by URL, returning the post's caption, like_count, view_counts, reshare_count, direct_reply_count, image_versions2, and taken_at.
   cost:
     type: per_call
@@ -3880,7 +3880,7 @@ endpoints:
   capability: threads.user.profile
   method: GET
   path: /v1/threads/profile
-  name: Get Threads Profile
+  name: "Threads profile by username — bio, followers"
   summary: Retrieves a Threads user's public profile including username, full_name, biography, profile_pic_url, follower_count, is_verified, bio_links, and hd_profile_pic_versions.
   cost:
     type: per_call
@@ -3915,7 +3915,7 @@ endpoints:
   capability: threads.search.posts
   method: GET
   path: /v1/threads/search
-  name: Search Threads by Keyword
+  name: "Search Threads posts by keyword"
   summary: Searches Threads for posts matching a keyword, returning up to 10 results with caption text, like_count, reshare_count, direct_reply_count, user info, and image_versions2.
   cost:
     type: per_call
@@ -3960,7 +3960,7 @@ endpoints:
   capability: threads.search.profiles
   method: GET
   path: /v1/threads/search/users
-  name: Search Threads Users
+  name: "Search Threads users by name"
   summary: Searches for Threads users by username, returning matching profiles with username, full_name, profile_pic_url, is_verified, and pk.
   cost:
     type: per_call
@@ -3990,7 +3990,7 @@ endpoints:
   capability: threads.user.posts
   method: GET
   path: /v1/threads/user/posts
-  name: List Threads Posts
+  name: "Threads user posts by username — likes, reshares"
   summary: Fetches the most recent posts from a Threads user, returning id, caption text, code, like_count, reshare_count, direct_reply_count, repost_count, image_versions2, video_versions, and taken_at.
   cost:
     type: per_call
@@ -4025,7 +4025,7 @@ endpoints:
   capability: tiktok-ads.library.ad.detail
   method: GET
   path: /v1/tiktok/ad-library/ad
-  name: "Get TikTok Ad Library Ad"
+  name: "TikTok ad library ad details by ad id"
   summary: Fetches one TikTok ad by ID or URL.
   cost:
     type: per_call
@@ -4055,7 +4055,7 @@ endpoints:
   capability: tiktok-ads.library.search
   method: GET
   path: /v1/tiktok/ad-library/search
-  name: "Search TikTok Ad Library"
+  name: "Search TikTok ad library by keyword or advertiser"
   summary: Searches TikTok's public Ads Library by advertiser name or keyword.
   cost:
     type: per_call
@@ -4089,7 +4089,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /v1/tiktok/creators/popular
-  name: Get TikTok popular creators
+  name: "TikTok popular creators — filter by followers, country"
   summary: Discovers trending and popular TikTok creators, filterable by follower count range, creator country, and audience country.
   cost:
     type: per_call
@@ -4139,7 +4139,7 @@ endpoints:
   capability: tiktok.feed.home
   method: GET
   path: /v1/tiktok/get-trending-feed
-  name: List TikTok Trending Feed
+  name: "TikTok trending feed by region — viral videos"
   summary: Fetches TikTok's trending/For You feed for a given region — useful for discovering viral content and what's currently popular.
   cost:
     type: per_call
@@ -4174,7 +4174,7 @@ endpoints:
   capability: tiktok.live.detail
   method: GET
   path: /v1/tiktok/live
-  name: Get TikTok Live Info
+  name: "TikTok live room info by room id or user id"
   summary: Gets curated room-level info for a TikTok live using TokAPI's live info endpoint.
   cost:
     type: per_call
@@ -4210,7 +4210,7 @@ endpoints:
   capability: tiktok-shop.product.detail
   method: GET
   path: /v1/tiktok/product
-  name: Get TikTok Shop Product Details
+  name: "TikTok Shop product by URL — stock, affiliate videos"
   summary: Fetches full details for a specific US TikTok Shop product by its URL, including stock levels and affiliate videos.
   cost:
     type: per_call
@@ -4245,7 +4245,7 @@ endpoints:
   capability: tiktok.user.country
   method: GET
   path: /v1/tiktok/profile/region
-  name: Get TikTok Profile Region
+  name: "TikTok profile region code by username"
   summary: Returns the TikTok region code for a public profile, like `US` for United States or `MX` for Mexico.
   cost:
     type: per_call
@@ -4275,7 +4275,7 @@ endpoints:
   capability: tiktok.search.hashtags
   method: GET
   path: /v1/tiktok/search/hashtag
-  name: Search TikTok by Hashtag
+  name: "Search TikTok videos by hashtag"
   summary: Searches for TikTok videos under a specific hashtag — useful for finding content by topic or trend.
   cost:
     type: per_call
@@ -4318,7 +4318,7 @@ endpoints:
   capability: tiktok.search.suggestions
   method: GET
   path: /v1/tiktok/search/suggestions
-  name: Search TikTok Suggestions
+  name: "TikTok search autocomplete suggestions by keyword"
   summary: Gets the autocomplete suggestions TikTok shows while someone is typing in search.
   cost:
     type: per_call
@@ -4353,7 +4353,7 @@ endpoints:
   capability: tiktok.search.general
   method: GET
   path: /v1/tiktok/search/top
-  name: "Search TikTok Top Results"
+  name: "Search TikTok top results by keyword — videos, photos"
   summary: Searches TikTok's 'Top' results by query — returns both videos and photo carousels, unlike keyword search which only returns videos.
   cost:
     type: per_call
@@ -4401,7 +4401,7 @@ endpoints:
   capability: tiktok.search.users
   method: GET
   path: /v1/tiktok/search/users
-  name: Search TikTok Users
+  name: "Search TikTok users by name or keyword"
   summary: Searches for TikTok users by keyword or name — useful for finding creators or accounts matching a query.
   cost:
     type: per_call
@@ -4439,7 +4439,7 @@ endpoints:
   capability: tiktok-shop.product.reviews
   method: GET
   path: /v1/tiktok/shop/product/reviews
-  name: Get TikTok Shop Product Reviews
+  name: "TikTok Shop product reviews by URL or product id"
   summary: Fetches customer reviews for a TikTok Shop product by URL or product_id.
   cost:
     type: per_call
@@ -4484,7 +4484,7 @@ endpoints:
   capability: tiktok-shop.shop.products
   method: GET
   path: /v1/tiktok/shop/products
-  name: "List TikTok Shop Products"
+  name: "TikTok Shop store products by store URL"
   summary: Lists all products from a specific TikTok Shop store by its URL.
   cost:
     type: per_call
@@ -4528,7 +4528,7 @@ endpoints:
   capability: tiktok-shop.search.products
   method: GET
   path: /v1/tiktok/shop/search
-  name: Search TikTok Shop products
+  name: "Search TikTok Shop products by keyword"
   summary: Searches TikTok Shop for products matching a keyword query.
   cost:
     type: per_call
@@ -4568,7 +4568,7 @@ endpoints:
   capability: tiktok.music.detail
   method: GET
   path: /v1/tiktok/song
-  name: Get TikTok Song Details
+  name: "TikTok sound or song details by clip id"
   summary: Fetches detailed metadata for a specific TikTok sound or song by its clipId.
   cost:
     type: per_call
@@ -4598,7 +4598,7 @@ endpoints:
   capability: tiktok.music.videos
   method: GET
   path: /v1/tiktok/song/videos
-  name: "List TikTok Song Videos"
+  name: "TikTok videos using a sound, by clip id"
   summary: Fetches TikTok videos that use a specific sound or song, identified by its clipId.
   cost:
     type: per_call
@@ -4632,7 +4632,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /v1/tiktok/user/audience
-  name: Get TikTok User's Audience Demographics
+  name: "TikTok audience demographics by username — countries"
   summary: Retrieves audience demographic data for a TikTok user, showing where their followers are located by country.
   cost:
     type: per_call
@@ -4662,7 +4662,7 @@ endpoints:
   capability: tiktok.user.followers
   method: GET
   path: /v1/tiktok/user/followers
-  name: List TikTok Followers
+  name: "TikTok user followers by username or id"
   summary: Retrieves the follower list of a TikTok account by handle or user_id — useful for seeing who follows a creator or getting subscriber data.
   cost:
     type: per_call
@@ -4706,7 +4706,7 @@ endpoints:
   capability: tiktok.user.following
   method: GET
   path: /v1/tiktok/user/following
-  name: List TikTok Following
+  name: "TikTok user following list by username"
   summary: Retrieves the following list — accounts that a TikTok user follows — by their handle.
   cost:
     type: per_call
@@ -4745,7 +4745,7 @@ endpoints:
   capability: tiktok.live.status
   method: GET
   path: /v1/tiktok/user/live
-  name: Get TikTok Live
+  name: "TikTok live status by username — room details"
   summary: Checks if a TikTok user is currently live streaming and retrieves their live room details.
   cost:
     type: per_call
@@ -4774,7 +4774,7 @@ endpoints:
   platform: tiktok-shop
   method: GET
   path: /v1/tiktok/user/showcase
-  name: Get TikTok Shop User Showcase
+  name: "TikTok Shop creator showcase products by username"
   summary: Fetches products featured in a TikTok user's public showcase — the products a creator promotes on their profile.
   cost:
     type: per_call
@@ -4814,7 +4814,7 @@ endpoints:
   capability: tiktok.comment.replies
   method: GET
   path: /v1/tiktok/video/comment/replies
-  name: List TikTok Comment Replies
+  name: "TikTok comment replies by comment id"
   summary: Fetches replies to a specific TikTok comment by its ID.
   cost:
     type: per_call
@@ -4854,7 +4854,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /v1/tiktok/video/transcript
-  name: Get TikTok Transcript
+  name: "TikTok video transcript by URL — captions, subtitles"
   summary: Extracts the transcript, captions, or subtitles from a TikTok video by URL.
   cost:
     type: per_call
@@ -4893,7 +4893,7 @@ endpoints:
   platform: truthsocial
   method: GET
   path: /v1/truthsocial/post
-  name: Get Truth Social Post
+  name: "Truth Social post by URL — text, engagement counts"
   summary: Fetches a single Truth Social post by URL, returning text, id, created_at, url, content, account details, media_attachments, card link previews, replies_count, reblogs_count, and favourites_count.
   cost:
     type: per_call
@@ -4922,7 +4922,7 @@ endpoints:
   platform: truthsocial
   method: GET
   path: /v1/truthsocial/profile
-  name: Get Truth Social Profile
+  name: "Truth Social profile by username — bio, followers"
   summary: Retrieves a Truth Social user's public profile including display_name, username, avatar, header, followers_count, following_count, statuses_count, verified status, website, and created_at.
   cost:
     type: per_call
@@ -4951,7 +4951,7 @@ endpoints:
   platform: truthsocial
   method: GET
   path: /v1/truthsocial/user/posts
-  name: List Truth Social User Posts
+  name: "Truth Social user posts by username"
   summary: Fetches a paginated list of posts from a Truth Social user, returning text, id, created_at, url, content, account info, media_attachments, card link previews, replies_count, reblogs_count, and favourites_count.
   cost:
     type: per_call
@@ -4995,7 +4995,7 @@ endpoints:
   platform: twitch
   method: GET
   path: /v1/twitch/clip
-  name: Get Twitch Clip
+  name: "Twitch clip by URL — video URLs, metadata"
   summary: Fetches detailed data for a Twitch clip by URL, including metadata and direct video URLs.
   docs_url: https://docs.scrapecreators.com/twitch/clip
   input:
@@ -5022,7 +5022,7 @@ endpoints:
   platform: twitch
   method: GET
   path: /v1/twitch/profile
-  name: Get Twitch Profile
+  name: "Twitch profile by username — identity, links"
   summary: Retrieves a Twitch user's public profile by handle, including identity, social links, and content.
   cost:
     type: per_call
@@ -5057,7 +5057,7 @@ endpoints:
   platform: twitch
   method: GET
   path: /v1/twitch/user/schedule
-  name: Get Twitch User Schedule
+  name: "Twitch stream schedule by username"
   summary: Fetches a user's schedule by handle, returning a list of scheduled events with start time, end time, title, description, and thumbnail URL.
   cost:
     type: per_call
@@ -5087,7 +5087,7 @@ endpoints:
   platform: twitch
   method: GET
   path: /v1/twitch/user/videos
-  name: List Twitch User Videos
+  name: "Twitch user videos by username — views, game info"
   summary: Fetches a list of videos (100 max) for a Twitch user, returning each video's id, slug, url, embedURL, title, viewCount, language, durationSeconds, game info, broadcaster details with follower count, thumbnailURL, and videoQualities at multiple resolutions with a signed videoURL for playback.
   cost:
     type: per_call
@@ -5125,7 +5125,7 @@ endpoints:
   platform: x
   method: GET
   path: /v1/twitter/community
-  name: Get Twitter Community
+  name: "X (Twitter) community details by URL"
   summary: Retrieves details about a Twitter/X Community by URL.
   cost:
     type: per_call
@@ -5155,7 +5155,7 @@ endpoints:
   platform: x
   method: GET
   path: /v1/twitter/community/tweets
-  name: List Twitter Community Tweets
+  name: "X (Twitter) community tweets by URL"
   summary: Fetches tweets posted within a Twitter/X Community by URL.
   cost:
     type: per_call
@@ -5186,7 +5186,7 @@ endpoints:
   capability: x.post.detail
   method: GET
   path: /v1/twitter/tweet
-  name: Get Twitter Tweet Details
+  name: "X (Twitter) tweet by URL — author, engagement"
   summary: Retrieves detailed information about a specific tweet by URL, including the author's profile and engagement metrics.
   cost:
     type: per_call
@@ -5224,7 +5224,7 @@ endpoints:
   platform: x
   method: GET
   path: /v1/twitter/tweet/transcript
-  name: Get Twitter Transcript
+  name: "X (Twitter) video tweet transcript by URL"
   summary: Extracts the transcript from a Twitter video tweet using AI-powered transcription.
   cost:
     type: per_call
@@ -5260,7 +5260,7 @@ endpoints:
   capability: youtube.channel.videos
   method: GET
   path: /v1/youtube/channel-videos
-  name: List YouTube Channel Videos
+  name: "YouTube channel videos by id or username — views, dates"
   summary: Fetches a paginated list of videos uploaded by a YouTube channel, including each video's title, URL, thumbnail, view count (views), publish date, duration, and description.
   cost:
     type: per_call
@@ -5315,7 +5315,7 @@ endpoints:
   capability: youtube.channel.posts
   method: GET
   path: /v1/youtube/channel/community-posts
-  name: List YouTube Channel Community Posts
+  name: "YouTube channel community posts by id or username"
   summary: Fetches community posts from a YouTube channel's Posts tab, including post ID, URL, content, images, attached video, like count, publish time, channel info, and a continuationToken when YouTube has more results.
   cost:
     type: per_call
@@ -5354,7 +5354,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /v1/youtube/channel/lives
-  name: Get YouTube Channel Lives
+  name: "YouTube channel live streams by id or username"
   summary: Fetches live streams and past streams from a YouTube channel's Live tab, including title, URL, thumbnail, view count, publish time, duration, and a continuationToken when YouTube has more results.
   cost:
     type: per_call
@@ -5393,7 +5393,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /v1/youtube/channel/playlists
-  name: List YouTube Channel Playlists
+  name: "YouTube channel playlists by id or username"
   summary: Fetches playlists from a YouTube channel's Playlists tab, including playlist ID, title, thumbnail, video count, channel info, playlist URL, and a continuationToken when YouTube has more results.
   cost:
     type: per_call
@@ -5433,7 +5433,7 @@ endpoints:
   capability: youtube.channel.shorts
   method: GET
   path: /v1/youtube/channel/shorts
-  name: List YouTube Channel Shorts
+  name: "YouTube channel Shorts by id or username — views, likes"
   summary: Retrieves a paginated list of short-form videos (Shorts) from a YouTube channel, including each short's title, URL, view count (views), likes, comments, and description.
   cost:
     type: per_call
@@ -5478,7 +5478,7 @@ endpoints:
   capability: youtube.post.detail
   method: GET
   path: /v1/youtube/community-post
-  name: Get YouTube Community Post Details
+  name: "YouTube community post by URL — text, images, likes"
   summary: Retrieves the full details of a YouTube community post, including its text content, attached images, like count, publish date, and associated channel info.
   cost:
     type: per_call
@@ -5507,7 +5507,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /v1/youtube/playlist
-  name: Get YouTube Playlist
+  name: "YouTube playlist videos by playlist id"
   summary: Retrieves all videos in a YouTube playlist, including the playlist title, owner info, total video count, and each video's title, URL, thumbnail, duration, and channel.
   cost:
     type: per_call
@@ -5537,7 +5537,7 @@ endpoints:
   capability: youtube.search.videos
   method: GET
   path: /v1/youtube/search
-  name: "Search YouTube"
+  name: "Search YouTube by keyword — videos, channels, playlists"
   summary: Searches YouTube by keyword query and returns matching videos, channels, playlists, shorts, shelves, and live streams.
   cost:
     type: per_call
@@ -5599,7 +5599,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /v1/youtube/search/hashtag
-  name: Search YouTube by Hashtag
+  name: "Search YouTube videos by hashtag"
   summary: Searches YouTube for content matching a specific hashtag and returns matching videos with title, URL, thumbnail, view count (views), publish date, duration, and channel info.
   cost:
     type: per_call
@@ -5639,7 +5639,7 @@ endpoints:
   capability: youtube.trending.videos
   method: GET
   path: /v1/youtube/shorts/trending
-  name: List YouTube Trending Shorts
+  name: "YouTube trending Shorts — views, likes, channels"
   summary: Fetches approximately 48 currently trending YouTube Shorts (viral/popular short-form videos) per call, returning each short's title, URL, thumbnail, view count (views), like count (likes), comment count, publish date, channel info, keywords, and duration.
   cost:
     type: per_call
@@ -5661,7 +5661,7 @@ endpoints:
   capability: youtube.comment.replies
   method: GET
   path: /v1/youtube/video/comment/replies
-  name: List YouTube Comment Replies
+  name: "YouTube comment replies by continuation token"
   summary: Fetches replies to a specific comment on a YouTube video, including each reply's text content, author details (name, channel ID, avatar, verified/creator status), like count, and publish date.
   cost:
     type: per_call
@@ -5690,7 +5690,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /v1/youtube/video/sponsors
-  name: Get YouTube Video Sponsors
+  name: "YouTube video sponsors by URL (experimental)"
   summary: Experimental endpoint.
   cost:
     type: per_call
@@ -5725,7 +5725,7 @@ endpoints:
   capability: youtube.video.captions
   method: GET
   path: /v1/youtube/video/transcript
-  name: Get YouTube Transcript
+  name: "YouTube video transcript by URL — captions, subtitles"
   summary: Retrieves the captions, subtitles, or transcript of a YouTube video or short.
   cost:
     type: per_call
@@ -5764,7 +5764,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /v2/instagram/media/transcript
-  name: Get Instagram Transcript
+  name: "Instagram video or reel transcript by URL"
   summary: Generates an AI-powered speech-to-text transcription for an Instagram video post or reel.
   cost:
     type: per_call
@@ -5798,7 +5798,7 @@ endpoints:
   capability: instagram.search.reels
   method: GET
   path: /v2/instagram/reels/search
-  name: Search Instagram Reels
+  name: "Search Instagram reels by keyword"
   summary: Searches for Instagram reels matching a keyword or phrase via Google Search, bypassing Instagram's login-gated search.
   cost:
     type: per_call
@@ -5840,7 +5840,7 @@ endpoints:
   capability: tiktok.user.videos
   method: GET
   path: /v3/tiktok/profile/videos
-  name: List TikTok Profile Videos
+  name: "TikTok user videos by username or id"
   summary: Fetches videos posted by a TikTok user, sortable by latest or most popular — use this to get a creator's video feed or TikToks.
   cost:
     type: per_call

--- a/src/treg/catalog/scrapecreators.yaml
+++ b/src/treg/catalog/scrapecreators.yaml
@@ -15,7 +15,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/account/credit-balance
-    name: "Get account credit balance"
+    name: "Check credit balance"
     summary: "Returns the number of API credits remaining on your Scrape Creators account."
     input:
       queryParams: {}
@@ -33,7 +33,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/tiktok/profile
-    name: "Get TikTok profile"
+    name: "TikTok user profile by username or id — bio, stats"
     summary: "Fetches public profile data for a TikTok user by their handle or user_id — useful for looking up a creator's identity, bio, and account stats."
     input:
       queryParams:
@@ -53,7 +53,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v2/tiktok/video
-    name: "Get TikTok video info"
+    name: "TikTok video by URL — engagement stats, transcript"
     summary: "Fetches detailed data for a single TikTok video by URL, including its metadata, engagement stats, and optionally its transcript/captions."
     input:
       queryParams:
@@ -72,7 +72,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/tiktok/video/comments
-    name: "List TikTok comments"
+    name: "TikTok video comments by URL — replies, engagement"
     summary: "Fetches comments on a TikTok video by URL — useful for reading audience reactions, replies, and engagement."
     input:
       queryParams:
@@ -91,7 +91,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/tiktok/search/keyword
-    name: "Search TikTok by keyword"
+    name: "Search TikTok videos by keyword"
     summary: "Searches for TikTok videos by keyword or phrase — the general video search across all of TikTok."
     input:
       queryParams:
@@ -111,7 +111,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/instagram/profile
-    name: "Get Instagram profile"
+    name: "Instagram profile by username — bio, followers, links"
     summary: "Retrieves comprehensive public Instagram profile information including biography, bio links, follower and following counts, verification status, and profile picture URLs."
     input:
       queryParams:
@@ -129,7 +129,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v2/instagram/user/posts
-    name: "List Instagram posts"
+    name: "Instagram user posts by username — reels, photos, videos"
     summary: "Returns a paginated feed of a user's public Instagram posts, including reels, photos, videos, and carousels."
     input:
       queryParams:
@@ -148,7 +148,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v2/instagram/post/comments
-    name: "List Instagram comments"
+    name: "Instagram post or reel comments by URL"
     summary: "Retrieves comments on a public Instagram post or reel."
     input:
       queryParams:
@@ -168,7 +168,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/youtube/channel
-    name: "Get YouTube channel details"
+    name: "YouTube channel profile by id or username — subscribers"
     summary: "Retrieves comprehensive YouTube channel profile data including name, avatar images, subscriber count, total video and view counts, join date, tags, and linked social accounts."
     input:
       queryParams:
@@ -189,7 +189,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/youtube/video
-    name: "Get YouTube video/short details"
+    name: "YouTube video or short by URL — views, chapters, captions"
     summary: "Fetches full details for a YouTube video or short, including title, description, thumbnail, view/like/comment counts, publish date, duration, chapters and caption tracks."
     input:
       queryParams:
@@ -207,7 +207,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/youtube/video/comments
-    name: "List YouTube comments"
+    name: "YouTube video comments by URL — replies, likes, authors"
     summary: "Fetches comments and replies from a YouTube video, including each comment's text, author details, like count, reply count, and publish date."
     input:
       queryParams:
@@ -227,7 +227,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/twitter/profile
-    name: "Get Twitter profile"
+    name: "X (Twitter) profile by username — account stats"
     summary: "Retrieves a Twitter user's profile by handle, including account metadata and statistics."
     input:
       queryParams:
@@ -245,7 +245,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/twitter/user-tweets
-    name: "List Twitter user tweets"
+    name: "X (Twitter) user tweets by username"
     summary: "Fetches tweets from a Twitter user's profile by handle."
     input:
       queryParams:
@@ -264,7 +264,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/linkedin/profile
-    name: "Get LinkedIn person's profile"
+    name: "LinkedIn person profile by URL — experience, education"
     summary: "Retrieves a person's public LinkedIn profile data, including their name, photo, location, follower count, about/bio summary, recent posts, work experience and education."
     input:
       queryParams:
@@ -283,7 +283,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/reddit/subreddit
-    name: "List subreddit posts"
+    name: "Subreddit posts by name — sorted feed"
     summary: "Fetches posts from a subreddit with sorting and filtering options."
     input:
       queryParams:
@@ -302,7 +302,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/reddit/search
-    name: "Search Reddit"
+    name: "Search Reddit posts by keyword"
     summary: "Searches across all of Reddit for posts matching a query."
     input:
       queryParams:

--- a/src/treg/catalog/semrush.yaml
+++ b/src/treg/catalog/semrush.yaml
@@ -60,7 +60,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "List Google keywords a domain ranks for"
+    name: "Google keywords a domain ranks for — search volume, traffic"
     summary: "Google keywords a domain ranks for in the top 100, with position, volume and traffic"
     input:
       queryParams:
@@ -96,7 +96,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "List Google Ads keywords a domain bids on"
+    name: "Google Ads keywords a domain bids on — CPC, ad copy"
     summary: "List the Google Ads keywords a domain bids on, with ad position, CPC and the live ad copy"
     input:
       queryParams:
@@ -131,7 +131,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "List Google organic competitors for a domain"
+    name: "Google organic competitors by domain — shared keywords"
     summary: "Domains competing with a target in Google organic, ranked by shared keywords"
     input:
       queryParams:
@@ -162,7 +162,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "Get search volume for a keyword"
+    name: "Google search volume, CPC and competition by keyword"
     summary: "Get Google search volume, CPC, competition and result count for a single keyword"
     input:
       queryParams:
@@ -195,7 +195,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "List related keyword ideas"
+    name: "Related keyword ideas by seed keyword — search volume, CPC"
     summary: "Get keywords semantically related to a seed keyword, each with volume, CPC and competition"
     input:
       queryParams:
@@ -231,7 +231,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /
-    name: "List Google organic search results for a keyword"
+    name: "Google organic results by keyword — top 100 domains, URLs"
     summary: "List the domains and URLs ranking in Google's top 100 organic results for a keyword"
     input:
       queryParams:
@@ -271,7 +271,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /analytics/v1/
-    name: "Get backlink profile summary"
+    name: "Backlinks summary by domain or URL — Authority Score"
     summary: "Aggregate backlink profile — Authority Score, links, referring domains, follow split"
     input:
       queryParams:
@@ -300,7 +300,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /analytics/v1/
-    name: "List backlinks to a domain or URL"
+    name: "Backlinks by domain or URL — source page, anchor texts"
     summary: "Individual backlinks to a domain or URL, with source page, anchor and follow status"
     input:
       queryParams:
@@ -333,7 +333,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /analytics/v1/
-    name: "List referring domains linking to a target"
+    name: "Referring domains by domain or URL — Authority Score"
     summary: "Referring domains linking to a target, with Authority Score, country and link count"
     input:
       queryParams:
@@ -366,7 +366,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /analytics/v1/
-    name: "List anchor texts in a backlink profile"
+    name: "Anchor texts in backlinks by domain or URL"
     summary: "Anchor texts across a target's backlink profile, with domain and link counts"
     input:
       queryParams:
@@ -399,7 +399,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /analytics/v1/
-    name: "List backlink competitors for a domain"
+    name: "Backlink competitors by domain — shared referring domains"
     summary: "Domains whose backlink profile overlaps a target's, by shared referring domains"
     input:
       queryParams:

--- a/src/treg/catalog/seranking.yaml
+++ b/src/treg/catalog/seranking.yaml
@@ -69,7 +69,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v1/account/subscription
-    name: "Check account plan and credit balance"
+    name: "Account usage — plan status and credits remaining"
     summary: "Check the calling account's plan status, credit allowance and credits remaining"
     input:
       queryParams:
@@ -93,7 +93,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /v1/keywords/export
-    name: "Get Google keyword volume and metrics in bulk"
+    name: "Bulk Google search volume, CPC and difficulty by keyword"
     summary: "Google volume, CPC, difficulty, competition and intent for up to 5,000 keywords"
     input:
       bodyType: json
@@ -130,7 +130,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/keywords/related
-    name: "List related keyword ideas for a seed"
+    name: "Related keyword ideas by seed keyword — search volume, CPC"
     summary: "Keywords related to a seed, each with volume, CPC, difficulty and relevance"
     input:
       queryParams:
@@ -172,7 +172,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/domain/overview/db
-    name: "Get a domain's Google search overview"
+    name: "Google overview by domain — keywords, traffic cost"
     summary: "A domain's Google presence in one country — keyword counts, traffic and traffic cost"
     input:
       queryParams:
@@ -204,7 +204,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/domain/keywords
-    name: "List keywords a domain ranks for"
+    name: "Google keywords a domain ranks for — search volume, traffic"
     summary: "Google keywords a domain ranks for, with position, volume, traffic and ranking URL"
     input:
       queryParams:
@@ -244,7 +244,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/domain/competitors
-    name: "List a domain's Google search competitors"
+    name: "Google search competitors by domain — shared keywords"
     summary: "Find the domains competing with a target in Google search, ranked by shared keywords"
     input:
       queryParams:
@@ -279,7 +279,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/backlinks/summary
-    name: "Get a domain's backlink profile summary"
+    name: "Backlinks summary by domain or URL — referring domains"
     summary: "Aggregate backlink profile — backlinks, referring domains, IPs, subnets, follow split"
     input:
       queryParams:
@@ -309,7 +309,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/backlinks/all
-    name: "List individual backlinks to a target"
+    name: "Backlinks by domain or URL — source page, anchor texts"
     summary: "Individual backlinks to a domain or URL, with source page, anchor and follow status"
     input:
       queryParams:
@@ -341,7 +341,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/backlinks/refdomains
-    name: "List domains linking to a target"
+    name: "Referring domains by domain or URL — authority, link counts"
     summary: "Referring domains linking to a target, with each source's link count and authority"
     input:
       queryParams:
@@ -373,7 +373,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/backlinks/anchors
-    name: "List anchor texts in a target's backlinks"
+    name: "Anchor texts in backlinks by domain or URL"
     summary: "Anchor texts across a target's backlink profile, with link and domain counts"
     input:
       queryParams:
@@ -405,7 +405,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/backlinks/authority
-    name: "Get page and domain authority scores"
+    name: "Page and domain authority scores by domain or URL"
     summary: "Get SE Ranking's page and domain authority scores for a URL or domain"
     input:
       queryParams:

--- a/src/treg/catalog/serpapi.extended.yaml
+++ b/src/treg/catalog/serpapi.extended.yaml
@@ -10,7 +10,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Maps places
+  name: "Google Maps place results for a query — rating, address"
   summary: Live Google Maps place results for a keyword and location — position, place_id, rating, address, phone, website
   input:
     queryParams:
@@ -65,7 +65,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Shopping products
+  name: "Google Shopping results for a query — price, seller"
   summary: Live Google Shopping results for a keyword — price, seller, rating, delivery
   input:
     queryParams:
@@ -115,7 +115,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Scholar articles
+  name: "Google Scholar results for a query — citation counts"
   summary: Live Google Scholar results for a keyword — title, link, snippet, citation count
   input:
     queryParams:
@@ -151,7 +151,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Get Google Trends interest data
+  name: "Google Trends interest over time for search terms"
   summary: Interest-over-time, regional breakdown, related topics or related queries for up to 5 comma-separated terms
   input:
     queryParams:
@@ -205,7 +205,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google News articles
+  name: "Google News results for a query or topic"
   summary: Live Google News results for a keyword, topic token or story token
   input:
     queryParams:
@@ -256,7 +256,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Images
+  name: "Google Images results for a query"
   summary: Live Google Images results for a keyword — thumbnail, original URL, source, size
   input:
     queryParams:
@@ -292,7 +292,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Jobs listings
+  name: "Google Jobs postings for a query and location"
   summary: Live Google Jobs results for a keyword and location
   input:
     queryParams:
@@ -346,7 +346,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Get Google Finance quote and history
+  name: "Google Finance quote, chart and news by ticker"
   summary: Live Google Finance data for a ticker — price, chart series, key statistics, related news
   input:
     queryParams:
@@ -393,7 +393,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Patents
+  name: "Google Patents results for a query — inventor, assignee"
   summary: Live Google Patents results for a keyword — patent id, dates, inventor, assignee
   input:
     queryParams:
@@ -448,7 +448,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Flights itineraries
+  name: "Google Flights itineraries by route and date — prices"
   summary: Live Google Flights results — best/other flights, price insights, for a route and date
   input:
     queryParams:
@@ -511,7 +511,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Hotels properties
+  name: "Google Hotels results for a query and stay dates"
   summary: Live Google Hotels results for a query, check-in/out dates and party size
   input:
     queryParams:
@@ -564,7 +564,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google local business results
+  name: "Google local pack results for a query and location"
   summary: The Google 'local pack' — nearby businesses for a keyword and location
   input:
     queryParams:
@@ -613,7 +613,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Reverse image search with Google Lens
+  name: "Google Lens reverse image search by image URL"
   summary: Visual matches, exact matches or 'about this image' data for an image URL
   input:
     queryParams:
@@ -655,7 +655,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Videos
+  name: "Google Videos results for a query"
   summary: Live Google Videos vertical results for a keyword
   input:
     queryParams:
@@ -691,7 +691,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Search Google Events listings
+  name: "Google Events results for a query and location"
   summary: Live Google Events vertical results for a keyword and location
   input:
     queryParams:
@@ -735,7 +735,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Get paid ads shown on a Google SERP
+  name: "Paid ads on a Google results page for a query"
   summary: The shopping/text ad units Google shows on its own results page for a keyword (distinct from the Ads Transparency Center)
   input:
     queryParams:
@@ -786,7 +786,7 @@ endpoints:
   method: GET
   path: /search
   capability: google.serp.organic
-  name: Search Google (lightweight organic)
+  name: "Google organic results for a query — fast, trimmed"
   summary: A faster, trimmed-down variant of the main Google organic engine — same query grammar, smaller payload
   input:
     queryParams:
@@ -830,7 +830,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Get Google AI Mode response
+  name: "Google AI Mode answer for a query"
   summary: Google's conversational AI Mode answer for a query
   input:
     queryParams:
@@ -865,7 +865,7 @@ endpoints:
   platform: google
   method: GET
   path: /search
-  name: Get a Google AI Overview panel
+  name: "Google AI Overview panel by page token"
   summary: The AI Overview panel Google attaches to a SERP, fetched via the page_token a prior engine=google call returned
   input:
     queryParams:
@@ -895,7 +895,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Search Bing organic results
+  name: "Bing organic search results for a query"
   summary: Live Bing organic results for a keyword
   input:
     queryParams:
@@ -942,7 +942,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Search Bing News
+  name: "Bing News results for a query"
   summary: Live Bing News vertical results for a keyword
   input:
     queryParams:
@@ -979,7 +979,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Search Bing Images
+  name: "Bing Images results for a query"
   summary: Live Bing Images vertical results for a keyword
   input:
     queryParams:
@@ -1016,7 +1016,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Search Bing Videos
+  name: "Bing Videos results for a query"
   summary: Live Bing Videos vertical results for a keyword
   input:
     queryParams:
@@ -1053,7 +1053,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Search Bing Shopping
+  name: "Bing Shopping results for a query"
   summary: Live Bing Shopping vertical results for a keyword
   input:
     queryParams:
@@ -1090,7 +1090,7 @@ endpoints:
   platform: bing
   method: GET
   path: /search
-  name: Get a Bing Copilot answer
+  name: "Bing Copilot answer for a prompt"
   summary: Bing's conversational Copilot answer for a prompt
   input:
     queryParams:
@@ -1125,7 +1125,7 @@ endpoints:
   platform: baidu
   method: GET
   path: /search
-  name: Search Baidu organic results
+  name: "Baidu organic search results for a query"
   summary: Live Baidu organic results for a keyword
   input:
     queryParams:
@@ -1166,7 +1166,7 @@ endpoints:
   platform: baidu
   method: GET
   path: /search
-  name: Search Baidu News
+  name: "Baidu News results for a query"
   summary: Live Baidu News vertical results for a keyword
   input:
     queryParams:
@@ -1203,7 +1203,7 @@ endpoints:
   platform: duckduckgo
   method: GET
   path: /search
-  name: Search DuckDuckGo organic results
+  name: "DuckDuckGo organic search results for a query"
   summary: Live DuckDuckGo organic results for a keyword
   input:
     queryParams:
@@ -1247,7 +1247,7 @@ endpoints:
   platform: duckduckgo
   method: GET
   path: /search
-  name: Search DuckDuckGo News
+  name: "DuckDuckGo News results for a query"
   summary: Live DuckDuckGo News vertical results for a keyword
   input:
     queryParams:
@@ -1284,7 +1284,7 @@ endpoints:
   platform: duckduckgo
   method: GET
   path: /search
-  name: Search DuckDuckGo (lightweight)
+  name: "DuckDuckGo organic results for a query — fast, trimmed"
   summary: A faster, trimmed-down variant of DuckDuckGo organic search
   input:
     queryParams:
@@ -1321,7 +1321,7 @@ endpoints:
   platform: duckduckgo
   method: GET
   path: /search
-  name: Search DuckDuckGo Maps
+  name: "DuckDuckGo Maps results for a query and location"
   summary: Live DuckDuckGo Maps vertical results for a keyword and location
   input:
     queryParams:
@@ -1356,7 +1356,7 @@ endpoints:
   platform: yahoo
   method: GET
   path: /search
-  name: Search Yahoo organic results
+  name: "Yahoo organic search results for a query"
   summary: Live Yahoo organic results for a keyword
   input:
     queryParams:
@@ -1400,7 +1400,7 @@ endpoints:
   platform: yahoo
   method: GET
   path: /search
-  name: Search Yahoo Images
+  name: "Yahoo Images results for a query"
   summary: Live Yahoo Images vertical results for a keyword
   input:
     queryParams:
@@ -1437,7 +1437,7 @@ endpoints:
   platform: yahoo
   method: GET
   path: /search
-  name: Search Yahoo Videos
+  name: "Yahoo Videos results for a query"
   summary: Live Yahoo Videos vertical results for a keyword
   input:
     queryParams:
@@ -1474,7 +1474,7 @@ endpoints:
   platform: yandex
   method: GET
   path: /search
-  name: Search Yandex organic results
+  name: "Yandex organic search results for a query"
   summary: Live Yandex organic results for a keyword
   input:
     queryParams:
@@ -1517,7 +1517,7 @@ endpoints:
   platform: yandex
   method: GET
   path: /search
-  name: Search Yandex Images
+  name: "Yandex Images results for a query"
   summary: Live Yandex Images vertical results for a keyword
   input:
     queryParams:
@@ -1554,7 +1554,7 @@ endpoints:
   platform: yandex
   method: GET
   path: /search
-  name: Search Yandex Videos
+  name: "Yandex Videos results for a query"
   summary: Live Yandex Videos vertical results for a keyword
   input:
     queryParams:
@@ -1591,7 +1591,7 @@ endpoints:
   platform: naver
   method: GET
   path: /search
-  name: Search Naver organic results
+  name: "Naver organic search results for a query"
   summary: Live Naver organic results for a keyword
   input:
     queryParams:
@@ -1633,7 +1633,7 @@ endpoints:
   platform: naver
   method: GET
   path: /search
-  name: Get a Naver AI overview panel
+  name: "Naver AI overview panel for a query"
   summary: Naver's AI-generated overview panel for a query
   input:
     queryParams:
@@ -1669,7 +1669,7 @@ endpoints:
   method: GET
   path: /search
   capability: amazon.search.products
-  name: Search Amazon products
+  name: "Amazon product search by keyword — ASIN, price, rating"
   summary: Live Amazon search results for a keyword — ASIN, title, price, rating, reviews
   input:
     queryParams:
@@ -1713,7 +1713,7 @@ endpoints:
   method: GET
   path: /search
   capability: amazon.product.detail
-  name: Get an Amazon product's detail page
+  name: "Amazon product page by ASIN — price, specs, reviews"
   summary: Full Amazon product page data for a given ASIN — price, specs, reviews, related products
   input:
     queryParams:
@@ -1755,7 +1755,7 @@ endpoints:
   platform: ebay
   method: GET
   path: /search
-  name: Search eBay listings
+  name: "eBay listing search by keyword or category"
   summary: Live eBay search results for a keyword or category
   input:
     queryParams:
@@ -1797,7 +1797,7 @@ endpoints:
   platform: ebay
   method: GET
   path: /search
-  name: Get an eBay listing's detail page
+  name: "eBay listing page by product id — price, seller, shipping"
   summary: Full eBay item page data for a given product id — price, seller, shipping, specifications
   input:
     queryParams:
@@ -1838,7 +1838,7 @@ endpoints:
   platform: walmart
   method: GET
   path: /search
-  name: Search Walmart products
+  name: "Walmart product search by keyword"
   summary: Live Walmart search results for a keyword
   input:
     queryParams:
@@ -1880,7 +1880,7 @@ endpoints:
   platform: walmart
   method: GET
   path: /search
-  name: Get a Walmart product's detail page
+  name: "Walmart product page by product id — price, stock, reviews"
   summary: Full Walmart product page data for a given product id — price, stock, shipping, reviews
   input:
     queryParams:
@@ -1917,7 +1917,7 @@ endpoints:
   platform: web
   method: GET
   path: /search
-  name: Search Home Depot products
+  name: "Home Depot product search by keyword"
   summary: Live Home Depot search results for a keyword
   input:
     queryParams:
@@ -1957,7 +1957,7 @@ endpoints:
   platform: yelp
   method: GET
   path: /search
-  name: Search Yelp businesses
+  name: "Yelp business search by description and location"
   summary: Live Yelp business listings for a description and location
   input:
     queryParams:
@@ -2001,7 +2001,7 @@ endpoints:
   platform: tripadvisor
   method: GET
   path: /search
-  name: Search Tripadvisor listings
+  name: "Tripadvisor search for a destination — hotels, restaurants"
   summary: Live Tripadvisor results for a destination or query — hotels, restaurants, things to do
   input:
     queryParams:
@@ -2044,7 +2044,7 @@ endpoints:
   platform: facebook
   method: GET
   path: /search
-  name: Get a public Facebook profile or Page
+  name: "Public Facebook profile or Page by username or id"
   summary: Public Facebook profile/Page data for a username or numeric id — followers, likes, about, photos
   input:
     queryParams:
@@ -2083,7 +2083,7 @@ endpoints:
   method: GET
   path: /search
   capability: instagram.user.profile
-  name: Get a public Instagram profile
+  name: "Public Instagram profile by username — bio, followers"
   summary: Public Instagram profile data for a username — bio, followers, recent posts
   input:
     queryParams:
@@ -2124,7 +2124,7 @@ endpoints:
   platform: ai-search
   method: GET
   path: /search
-  name: Get a Brave AI Mode answer
+  name: "Brave AI Mode answer for a query"
   summary: Brave Search's conversational AI answer for a query
   input:
     queryParams:

--- a/src/treg/catalog/serpapi.yaml
+++ b/src/treg/catalog/serpapi.yaml
@@ -55,7 +55,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Get Google organic search results"
+    name: "Google organic search results for a query"
     summary: "Live Google organic results for a keyword — position, title, URL, snippet, by location"
     input:
       queryParams:
@@ -107,7 +107,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "List a Google advertiser's running ads"
+    name: "Google advertiser's running ads — Ads Transparency Center"
     summary: "Ads a Google advertiser is running now, from the Ads Transparency Center"
     input:
       queryParams:
@@ -146,7 +146,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Search YouTube videos by keyword"
+    name: "YouTube video search for a query — views, channels"
     summary: "Search YouTube videos by keyword and get titles, channels, view counts and links"
     input:
       queryParams:
@@ -179,7 +179,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Search App Store apps by keyword"
+    name: "Apple App Store app search by keyword — ratings, prices"
     summary: "Search App Store apps by keyword — titles, developers, ratings and prices"
     input:
       queryParams:
@@ -220,7 +220,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Search Google Play apps or charts"
+    name: "Google Play app search by keyword, or store charts"
     summary: "Search apps on Google Play by keyword, or pull a store chart without a keyword"
     input:
       queryParams:
@@ -264,7 +264,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /search
-    name: "Get Google autocomplete keyword ideas"
+    name: "Google Autocomplete keyword suggestions for a seed term"
     summary: "Get the keyword suggestions Google autocompletes for a seed term, with relevance scores"
     input:
       queryParams:
@@ -306,7 +306,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /account.json
-    name: "Get account plan and search usage"
+    name: "SerpApi plan and monthly search usage"
     summary: "Check the calling account's plan, searches used this month and searches remaining"
     input:
       note: |

--- a/src/treg/catalog/serpstat.yaml
+++ b/src/treg/catalog/serpstat.yaml
@@ -61,7 +61,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "Get Google domain visibility overview"
+    name: "Google overview for up to 10 domains — visibility, traffic"
     summary: "Google summary for up to 10 domains at once — visibility, keywords, traffic, ad keywords"
     input:
       bodyType: json
@@ -92,7 +92,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List keywords a domain ranks for"
+    name: "Google keywords a domain ranks for — search volume, CPC"
     summary: "Google keywords a domain ranks for, with position, volume, CPC and difficulty"
     input:
       bodyType: json
@@ -131,7 +131,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List Google organic competitors"
+    name: "Google organic competitors by domain — keyword overlap"
     summary: "Domains competing with a target in Google organic, ranked by keyword overlap"
     input:
       bodyType: json
@@ -164,7 +164,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "Get search volume for keywords"
+    name: "Bulk Google search volume, CPC and difficulty by keyword"
     summary: "Google volume, CPC, competition and difficulty for up to 1,000 keywords per call"
     input:
       bodyType: json
@@ -197,7 +197,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List related keyword ideas"
+    name: "Related keyword ideas by seed keyword — search volume, CPC"
     summary: "Keywords semantically related to a seed, with volume, CPC, difficulty and weight"
     input:
       bodyType: json
@@ -235,7 +235,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List organic search results for a keyword"
+    name: "Google organic results by keyword — ranking URLs, titles"
     summary: "URLs ranking in Google's top results for a keyword, with position, title and snippet"
     input:
       bodyType: json
@@ -276,7 +276,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "Get backlink profile summary"
+    name: "Backlinks summary by domain — referring domains, authority"
     summary: "Aggregate backlink profile — external links, referring domains, IPs, domain authority"
     input:
       bodyType: json
@@ -306,7 +306,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List active backlinks"
+    name: "Active backlinks by domain or URL — anchor texts"
     summary: "Currently active backlinks to a domain or URL, with source page, anchor and link type"
     input:
       bodyType: json
@@ -345,7 +345,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List referring domains to a target"
+    name: "Referring domains by domain — authority, link counts"
     summary: "Referring domains linking to a target, with each source's link count and authority"
     input:
       bodyType: json
@@ -380,7 +380,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List anchor texts linking to a target"
+    name: "Anchor texts in backlinks by domain or URL"
     summary: "Anchor texts pointing at a target, with referring-domain and link counts per phrase"
     input:
       bodyType: json
@@ -417,7 +417,7 @@ endpoints:
     scope: any_account
     method: POST
     path: /
-    name: "List a site's top linked pages"
+    name: "Most-linked pages by domain — backlinks, referring domains"
     summary: "List a site's most-linked-to pages, ranked by backlinks and referring domains"
     input:
       bodyType: json
@@ -454,7 +454,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /
-    name: "Get API credit balance"
+    name: "Account usage — credit limits and credits remaining"
     summary: "Check the calling account's API credit limits and how many credits are left"
     input:
       bodyType: json

--- a/src/treg/catalog/slack.yaml
+++ b/src/treg/catalog/slack.yaml
@@ -38,7 +38,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /conversations.list
-    name: "List workspace channels"
+    name: "List your Slack workspace channels, public and private"
     summary: "List the channels in your Slack workspace, public and private"
     input:
       queryParams:
@@ -59,7 +59,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /chat.postMessage
-    name: "Post message"
+    name: "Send a Slack message to a channel or thread"
     summary: "Post a message to a Slack channel, or reply in a thread"
     input:
       body:
@@ -82,7 +82,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /conversations.history
-    name: "Read channel history"
+    name: "Read recent messages from a Slack channel"
     summary: "Read recent messages from a Slack channel"
     input:
       queryParams:
@@ -103,7 +103,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /conversations.replies
-    name: "Read thread replies"
+    name: "Read the replies in a Slack message thread"
     summary: "Read the replies in a Slack message thread"
     input:
       queryParams:
@@ -125,7 +125,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /conversations.info
-    name: "Get channel details"
+    name: "Slack channel details by id — topic, member count"
     summary: "Get a Slack channel's details — topic, purpose, member count and archived state"
     input:
       queryParams:
@@ -143,7 +143,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /users.list
-    name: "List workspace members"
+    name: "List the members of your Slack workspace"
     summary: "List the members of your Slack workspace"
     input:
       queryParams:
@@ -162,7 +162,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /users.info
-    name: "Get user profile"
+    name: "Slack member profile by user id"
     summary: "Get a Slack workspace member's profile by user ID"
     input:
       queryParams:
@@ -180,7 +180,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /reactions.add
-    name: "Add emoji reaction"
+    name: "Add an emoji reaction to a Slack message"
     summary: "Add an emoji reaction to a Slack message"
     input:
       body:
@@ -200,7 +200,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /auth.test
-    name: "Get connected workspace and bot identity"
+    name: "Check the connected Slack workspace and bot identity"
     summary: "Check which Slack workspace and bot identity the token belongs to"
     input:
       note: "takes no parameters. Returns team, team_id, user, user_id and url — this is what treg's connection label is built from, and the cheapest way to tell a live token from a revoked one"

--- a/src/treg/catalog/snapchat-ads.yaml
+++ b/src/treg/catalog/snapchat-ads.yaml
@@ -29,7 +29,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /me/organizations
-    name: "Organizations"
+    name: "List your Snapchat business organizations"
     summary: "List the Snapchat business organizations you belong to"
     input:
       queryParams:
@@ -44,7 +44,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /organizations/{organization_id}/adaccounts
-    name: "Accounts"
+    name: "List Snapchat ad accounts in your organization"
     summary: "List the Snapchat ad accounts in a business organization"
     input:
       pathParams:
@@ -62,7 +62,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /adaccounts/{ad_account_id}/stats
-    name: "Get ad account performance stats"
+    name: "Your Snapchat ad account performance — spend, swipes"
     summary: "Get spend, impressions and swipes for your whole Snapchat ad account"
     input:
       pathParams:
@@ -85,7 +85,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /adaccounts/{ad_account_id}/campaigns
-    name: "List campaigns"
+    name: "List your Snapchat ad campaigns — objective, budget"
     summary: "List the campaigns in your Snapchat ad account with status, objective and budget"
     input:
       pathParams:
@@ -104,7 +104,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /campaigns/{campaign_id}/stats
-    name: "Campaign stats"
+    name: "One Snapchat campaign's performance — spend, swipes"
     summary: "Get spend, impressions and swipes for one Snapchat campaign"
     input:
       pathParams:
@@ -126,7 +126,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /adaccounts/{ad_account_id}/ads
-    name: "List ads"
+    name: "List your Snapchat ads — creatives and ad types"
     summary: "List the ads in your Snapchat ad account with their creatives and types"
     input:
       pathParams:

--- a/src/treg/catalog/spyfu.yaml
+++ b/src/treg/catalog/spyfu.yaml
@@ -47,7 +47,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/domain_stats_api/v2/getLatestDomainStats
-    name: "Get domain's Google performance overview"
+    name: "Google overview by domain — keywords, clicks, ad budget"
     summary: "A domain's recent Google performance — keyword counts, clicks and monthly ad budget"
     input:
       queryParams:
@@ -79,7 +79,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/keyword_api/v2/ppc/getMostSuccessful
-    name: "List a domain's top paid keywords"
+    name: "Top Google Ads keywords by domain — search volume, CPC"
     summary: "A domain's best-performing Google Ads keywords, with volume, CPC and monthly cost"
     input:
       queryParams:
@@ -115,7 +115,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/cloud_ad_history_api/v2/domain/getDomainAdHistory
-    name: "Get a domain's Google Ads history"
+    name: "Google Ads history by domain — ad copy and keywords"
     summary: "Google Ads a domain has run over time, with ad copy and the keywords it ran against"
     input:
       queryParams:
@@ -151,7 +151,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/serp_api/v2/seo/getMostValuableKeywords
-    name: "List a domain's top organic keywords"
+    name: "Google keywords a domain ranks for — clicks, search volume"
     summary: "Google organic keywords driving the most clicks to a domain, with rank and volume"
     input:
       queryParams:
@@ -195,7 +195,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/competitors_api/v2/seo/getTopCompetitors
-    name: "List a domain's organic search competitors"
+    name: "Google organic competitors by domain — shared keywords"
     summary: "Domains competing with a target in Google organic, ranked by shared keywords"
     input:
       queryParams:
@@ -225,7 +225,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /apis/competitors_api/v2/ppc/getTopCompetitors
-    name: "List a domain's PPC ad competitors"
+    name: "Google Ads competitors by domain — shared paid keywords"
     summary: "Find the domains bidding against a target on the same Google Ads keywords"
     input:
       queryParams:

--- a/src/treg/catalog/thecompaniesapi.yaml
+++ b/src/treg/catalog/thecompaniesapi.yaml
@@ -32,7 +32,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{domain}
-    name: "Enrich a company by domain"
+    name: "Enrich a company by domain — 80+ datapoints"
     summary: "Enrich a company from its domain — 80+ datapoints: industry, size, revenue, socials"
     input:
       pathParams:
@@ -61,7 +61,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies
-    name: "Search companies by attributes"
+    name: "Search companies by industry, size, location or tech"
     summary: "Search companies by industry, size, location, technology or any other attribute filter"
     input:
       queryParams:
@@ -98,7 +98,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/by-email
-    name: "Enrich company by email"
+    name: "Enrich the company behind an email address"
     summary: "Identify and enrich the company behind an email address"
     input:
       queryParams:
@@ -125,7 +125,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /companies/{domain}/email-patterns
-    name: "Get company email address patterns"
+    name: "A company's email address patterns by domain"
     summary: "Find which email-address formats a company uses, and how common each one is"
     input:
       pathParams:

--- a/src/treg/catalog/tiingo.yaml
+++ b/src/treg/catalog/tiingo.yaml
@@ -15,7 +15,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /tiingo/daily/{ticker}
-    name: "Ticker metadata"
+    name: "Ticker metadata by symbol — name, exchange, date range"
     summary: "Name, description, exchange and the date range Tiingo has data for — 30+ years for many tickers"
     input:
       queryParams:
@@ -32,7 +32,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /tiingo/daily/{ticker}/prices
-    name: "End-of-day price history"
+    name: "End-of-day stock prices by ticker — adjusted, 30+ years"
     summary: "Daily OHLCV with split/dividend-adjusted values, back 30+ years"
     input:
       queryParams:
@@ -52,7 +52,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /iex/{ticker}
-    name: "Latest IEX quote"
+    name: "Latest stock quote by ticker from the IEX feed"
     summary: "The latest top-of-book quote from the IEX feed for a ticker"
     input:
       queryParams:
@@ -69,7 +69,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /tiingo/crypto/prices
-    name: "Crypto price bars"
+    name: "Crypto OHLCV bars by currency pair — 1min to daily"
     summary: "OHLCV bars for crypto pairs (btcusd, ethusd …) at any resample frequency"
     input:
       queryParams:

--- a/src/treg/catalog/tikhub.extended.yaml
+++ b/src/treg/catalog/tikhub.extended.yaml
@@ -34,7 +34,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_bangumi_tab
-  name: Fetch bangumi tab
+  name: "Bilibili anime bangumi tab feed"
   summary: 'Bilibili: fetch bangumi tab (app)'
   cost:
     type: per_success
@@ -55,7 +55,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_cinema_tab
-  name: Fetch cinema tab
+  name: "Bilibili cinema tab feed"
   summary: 'Bilibili: fetch cinema tab (app)'
   cost:
     type: per_success
@@ -76,7 +76,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_home_feed
-  name: Fetch home feed
+  name: "Bilibili home feed recommendations"
   summary: 'Bilibili: fetch home feed (app)'
   cost:
     type: per_success
@@ -114,7 +114,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_one_video
-  name: Fetch one video
+  name: "Bilibili video details by AV or BV id"
   summary: 'Bilibili: fetch one video (app)'
   cost:
     type: per_success
@@ -150,7 +150,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_popular_feed
-  name: Fetch popular feed
+  name: "Bilibili popular videos feed"
   summary: 'Bilibili: fetch popular feed (app)'
   cost:
     type: per_success
@@ -183,7 +183,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_reply_detail
-  name: Fetch reply detail
+  name: "Bilibili comment replies by comment id"
   summary: 'Bilibili: fetch reply detail (app)'
   cost:
     type: per_success
@@ -235,7 +235,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_search_all
-  name: Fetch search all
+  name: "Bilibili search across all content by keyword"
   summary: 'Bilibili: fetch search all (app)'
   cost:
     type: per_success
@@ -280,7 +280,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_search_by_type
-  name: Fetch search by type
+  name: "Bilibili search by keyword and content type"
   summary: 'Bilibili: fetch search by type (app)'
   cost:
     type: per_success
@@ -330,7 +330,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_user_info
-  name: Fetch user info
+  name: "Bilibili user profile by user id"
   summary: 'Bilibili: fetch user info (app)'
   cost:
     type: per_success
@@ -360,7 +360,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_user_videos
-  name: Fetch user videos
+  name: "Bilibili user's videos by user id"
   summary: 'Bilibili: fetch user videos (app)'
   cost:
     type: per_success
@@ -405,7 +405,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/app/fetch_video_comments
-  name: Fetch video comments
+  name: "Bilibili video comments by AV or BV id"
   summary: 'Bilibili: fetch video comments (app)'
   cost:
     type: per_success
@@ -451,7 +451,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/bv_to_aid
-  name: Bv to aid
+  name: "Convert Bilibili BV id to AV id"
   summary: 'Bilibili: bv to aid (web)'
   cost:
     type: per_success
@@ -480,7 +480,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_all_live_areas
-  name: Fetch all live areas
+  name: "Bilibili live area category list"
   summary: 'Bilibili: fetch all live areas (web)'
   cost:
     type: per_success
@@ -502,7 +502,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_collect_folders
-  name: Fetch collect folders
+  name: "Bilibili user's favorite folders by user id"
   summary: 'Bilibili: fetch collect folders (web)'
   cost:
     type: per_success
@@ -532,7 +532,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_com_popular
-  name: Fetch com popular
+  name: "Bilibili popular videos ranking"
   summary: 'Bilibili: fetch com popular (web)'
   cost:
     type: per_success
@@ -561,7 +561,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_comment_reply
-  name: Fetch comment reply
+  name: "Bilibili comment replies by video and comment id"
   summary: 'Bilibili: fetch comment reply (web)'
   cost:
     type: per_success
@@ -602,7 +602,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_dynamic_detail
-  name: Fetch dynamic detail
+  name: "Bilibili dynamic post details by dynamic id"
   summary: 'Bilibili: fetch dynamic detail (web)'
   cost:
     type: per_success
@@ -632,7 +632,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_dynamic_detail_v2
-  name: Fetch dynamic detail v2
+  name: "Bilibili dynamic post details by dynamic id"
   summary: 'Bilibili: fetch dynamic detail v2 (web)'
   cost:
     type: per_success
@@ -662,7 +662,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_general_search
-  name: Fetch general search
+  name: "Bilibili keyword search with sort and date filters"
   summary: 'Bilibili: fetch general search (web)'
   cost:
     type: per_success
@@ -725,7 +725,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_get_user_id
-  name: Fetch get user id
+  name: "Bilibili user id from share link"
   summary: 'Bilibili: fetch get user id (web)'
   cost:
     type: per_success
@@ -754,7 +754,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_hot_search
-  name: Fetch hot search
+  name: "Bilibili trending search terms"
   summary: 'Bilibili: fetch hot search (web)'
   cost:
     type: per_success
@@ -784,7 +784,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_live_room_detail
-  name: Fetch live room detail
+  name: "Bilibili live room details by room id"
   summary: 'Bilibili: fetch live room detail (web)'
   cost:
     type: per_success
@@ -814,7 +814,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_live_streamers
-  name: Fetch live streamers
+  name: "Bilibili live streamers by area id"
   summary: 'Bilibili: fetch live streamers (web)'
   cost:
     type: per_success
@@ -847,7 +847,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_live_videos
-  name: Fetch live videos
+  name: "Bilibili live room stream by room id"
   summary: 'Bilibili: fetch live videos (web)'
   cost:
     type: per_success
@@ -877,7 +877,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_one_video
-  name: Fetch one video
+  name: "Bilibili video details by BV id"
   summary: 'Bilibili: fetch one video (web)'
   cost:
     type: per_success
@@ -907,7 +907,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_one_video_v2
-  name: Fetch one video v2
+  name: "Bilibili video details by AV id and cid"
   summary: 'Bilibili: fetch one video v2 (web)'
   cost:
     type: per_success
@@ -943,7 +943,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_one_video_v3
-  name: Fetch one video v3
+  name: "Bilibili video details by video URL"
   summary: 'Bilibili: fetch one video v3 (web)'
   cost:
     type: per_success
@@ -973,7 +973,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_collection_videos
-  name: Fetch user collection videos
+  name: "Bilibili favorite folder videos by folder id"
   summary: 'Bilibili: fetch user collection videos (web)'
   cost:
     type: per_success
@@ -1008,7 +1008,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_dynamic
-  name: Fetch user dynamic
+  name: "Bilibili user's dynamic posts by user id"
   summary: 'Bilibili: fetch user dynamic (web)'
   cost:
     type: per_success
@@ -1044,7 +1044,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_post_videos
-  name: Fetch user post videos
+  name: "Bilibili user's posted videos by user id"
   summary: 'Bilibili: fetch user post videos (web)'
   cost:
     type: per_success
@@ -1084,7 +1084,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_profile
-  name: Fetch user profile
+  name: "Bilibili user profile by user id"
   summary: 'Bilibili: fetch user profile (web)'
   cost:
     type: per_success
@@ -1114,7 +1114,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_relation_stat
-  name: Fetch user relation stat
+  name: "Bilibili user follower counts by user id"
   summary: 'Bilibili: fetch user relation stat (web)'
   cost:
     type: per_success
@@ -1144,7 +1144,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_user_up_stat
-  name: Fetch user up stat
+  name: "Bilibili uploader stats by user id"
   summary: 'Bilibili: fetch user up stat (web)'
   cost:
     type: per_success
@@ -1174,7 +1174,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_comments
-  name: Fetch video comments
+  name: "Bilibili video comments by BV id"
   summary: 'Bilibili: fetch video comments (web)'
   cost:
     type: per_success
@@ -1209,7 +1209,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_danmaku
-  name: Fetch video danmaku
+  name: "Bilibili video danmaku bullet comments by cid"
   summary: 'Bilibili: fetch video danmaku (web)'
   cost:
     type: per_success
@@ -1239,7 +1239,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_detail
-  name: Fetch video detail
+  name: "Bilibili video details by AV id"
   summary: 'Bilibili: fetch video detail (web)'
   cost:
     type: per_success
@@ -1269,7 +1269,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_parts
-  name: Fetch video parts
+  name: "Bilibili video parts list by BV id"
   summary: 'Bilibili: fetch video parts (web)'
   cost:
     type: per_success
@@ -1297,7 +1297,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_play_info
-  name: Fetch video play info
+  name: "Bilibili video play info by video URL"
   summary: 'Bilibili: fetch video play info (web)'
   cost:
     type: per_success
@@ -1327,7 +1327,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_playurl
-  name: Fetch video playurl
+  name: "Bilibili video stream URL by BV id and cid"
   summary: 'Bilibili: fetch video playurl (web)'
   cost:
     type: per_success
@@ -1363,7 +1363,7 @@ endpoints:
   platform: bilibili
   method: GET
   path: /api/v1/bilibili/web/fetch_video_subtitle
-  name: Fetch video subtitle
+  name: "Bilibili video subtitles by AV id and cid"
   summary: 'Bilibili: fetch video subtitle (web)'
   cost:
     type: per_success
@@ -1399,7 +1399,7 @@ endpoints:
   platform: bilibili
   method: POST
   path: /api/v1/bilibili/web/fetch_vip_video_playurl
-  name: Fetch vip video playurl
+  name: "Bilibili VIP video stream URL"
   summary: 'Bilibili: fetch vip video playurl (web)'
   cost:
     type: per_success
@@ -1436,7 +1436,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/add_video_play_count
-  name: Increase video play count
+  name: "Increase a Douyin video's play count by video id"
   summary: Increase the number of plays of the work according to the video ID
   cost:
     type: per_success
@@ -1475,6 +1475,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_brand_hot_search_list
   summary: Get Douyin brand hot search list data
+  name: "Douyin brand trending ranking"
   cost:
     type: per_success
     value: 0.001
@@ -1496,6 +1497,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_brand_hot_search_list_detail
   summary: Get Douyin brand hot search list detail data
+  name: "Douyin brand trending ranking by category id"
   cost:
     type: per_success
     value: 0.001
@@ -1525,6 +1527,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_hashtag_detail
   summary: Get details of specified hashtag
+  name: "Douyin hashtag details by hashtag id"
   cost:
     type: per_success
     value: 0.001
@@ -1554,6 +1557,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_hashtag_video_list
   summary: Get video list of specified hashtag
+  name: "Douyin hashtag videos by hashtag id"
   cost:
     type: per_success
     value: 0.001
@@ -1599,6 +1603,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_hot_search_list
   summary: Get Douyin hot search list data
+  name: "Douyin trending searches by board type"
   cost:
     type: per_success
     value: 0.001
@@ -1631,6 +1636,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_live_hot_search_list
   summary: Get Douyin live hot search list data
+  name: "Douyin live trending searches"
   cost:
     type: per_success
     value: 0.001
@@ -1650,6 +1656,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/app/v3/fetch_multi_video
   summary: Batch Get Video Information V1
+  name: "Douyin video details in bulk"
   cost:
     type: per_success
     value: 0.01
@@ -1677,6 +1684,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/app/v3/fetch_multi_video_high_quality_play_url
   summary: Batch get the highest quality play URL of videos
+  name: "Douyin best-quality play URLs in bulk"
   cost:
     type: per_success
     value: 0.25
@@ -1711,7 +1719,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/fetch_multi_video_statistics
-  name: Get stats for multiple videos
+  name: "Douyin video statistics in bulk by video ids — likes, plays"
   summary: Get the statistical data of the Post according to the video ID (like count, download count, play count, share count)
   cost:
     type: per_success
@@ -1742,6 +1750,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/app/v3/fetch_multi_video_v2
   summary: Batch Get Video Information V2
+  name: "Douyin video details in bulk"
   cost:
     type: per_success
     value: 0.05
@@ -1769,6 +1778,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_music_detail
   summary: Get details of specified music
+  name: "Douyin music details by music id"
   cost:
     type: per_success
     value: 0.001
@@ -1798,6 +1808,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_music_hot_search_list
   summary: Get Douyin music hot search list data
+  name: "Douyin music trending chart"
   cost:
     type: per_success
     value: 0.001
@@ -1833,6 +1844,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_music_video_list
   summary: Get video list of specified music
+  name: "Douyin videos using a music track by music id"
   cost:
     type: per_success
     value: 0.001
@@ -1873,6 +1885,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_one_video
   summary: Get single video data
+  name: "Douyin video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -1902,6 +1915,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_one_video_by_share_url
   summary: Get single video data by sharing link
+  name: "Douyin video details by share link"
   cost:
     type: per_success
     value: 0.001
@@ -1931,6 +1945,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_one_video_v2
   summary: Get single video data V2
+  name: "Douyin video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -1960,6 +1975,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_one_video_v3
   summary: Get single video data V3 (No copyright restrictions)
+  name: "Douyin video details by video or article id"
   cost:
     type: per_success
     value: 0.001
@@ -1989,6 +2005,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_series_detail
   summary: Get series detail
+  name: "Douyin series details by series id"
   cost:
     type: per_success
     value: 0.001
@@ -2018,6 +2035,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_series_video_list
   summary: Get series video list
+  name: "Douyin series episodes by series id"
   cost:
     type: per_success
     value: 0.001
@@ -2052,6 +2070,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_share_info_by_share_code
   summary: Get share info by share code
+  name: "Douyin share info by share code"
   cost:
     type: per_success
     value: 0.001
@@ -2080,6 +2099,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_user_fans_list
   summary: Get user fans list
+  name: "Douyin user's followers by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -2117,6 +2137,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_user_like_videos
   summary: Get user like video data
+  name: "Douyin user's liked videos by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -2156,6 +2177,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_user_post_videos
   summary: Get user homepage video data
+  name: "Douyin user's videos by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -2201,6 +2223,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_user_series_list
   summary: Get user series list
+  name: "Douyin user's series by user id or secUid"
   cost:
     type: per_success
     value: 0.001
@@ -2241,6 +2264,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_comment_replies
   summary: Get comment replies data of specified video
+  name: "Douyin comment replies by video and comment id"
   cost:
     type: per_success
     value: 0.001
@@ -2287,6 +2311,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_comments
   summary: Get single video comments data
+  name: "Douyin video comments by video id"
   cost:
     type: per_success
     value: 0.001
@@ -2327,6 +2352,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_high_quality_play_url
   summary: Get the highest quality play URL of the video
+  name: "Douyin best-quality play URL by video id or link"
   cost:
     type: per_success
     value: 0.005
@@ -2368,6 +2394,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_mix_detail
   summary: Get Douyin video mix detail data
+  name: "Douyin mix collection details by mix id"
   cost:
     type: per_success
     value: 0.001
@@ -2397,6 +2424,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_mix_post_list
   summary: Get Douyin video mix post list data
+  name: "Douyin mix collection videos by mix id"
   cost:
     type: per_success
     value: 0.001
@@ -2436,7 +2464,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/fetch_video_statistics
-  name: Get video statistics
+  name: "Douyin video statistics by video ids — likes, plays"
   summary: Get the statistical data of the Post according to the video ID (like count, download count, play count, share count)
   cost:
     type: per_success
@@ -2468,6 +2496,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/generate_douyin_short_url
   summary: Generate Douyin short link
+  name: "Douyin short link from URL"
   cost:
     type: per_success
     value: 0.001
@@ -2497,6 +2526,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/generate_douyin_video_share_qrcode
   summary: Generate Douyin video share QR code
+  name: "Douyin video share QR code by video id"
   cost:
     type: per_success
     value: 0.001
@@ -2525,6 +2555,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/handler_user_profile
   summary: Get information of specified user
+  name: "Douyin user profile by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -2553,7 +2584,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/open_douyin_app_to_keyword_search
-  name: Open app to keyword search
+  name: "Douyin app deep link to keyword search"
   summary: Generate Douyin share link, call Douyin APP, and jump to the specified keyword search result
   cost:
     type: per_success
@@ -2583,7 +2614,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/open_douyin_app_to_send_private_message
-  name: Open app to send private message
+  name: "Douyin app deep link to send a private message"
   summary: Generate Douyin share link, call Douyin APP, and send private messages to specified users
   cost:
     type: per_success
@@ -2618,7 +2649,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/open_douyin_app_to_user_profile
-  name: Open app to user profile
+  name: "Douyin app deep link to a user profile"
   summary: Generate Douyin share link, call Douyin APP, and jump to the specified user profile
   cost:
     type: per_success
@@ -2653,7 +2684,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/app/v3/open_douyin_app_to_video_detail
-  name: Open app to video detail
+  name: "Douyin app deep link to a video by video id"
   summary: Generate Douyin share link, call Douyin APP, and jump to the specified video details page
   cost:
     type: per_success
@@ -2683,6 +2714,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/app/v3/register_device
   summary: Douyin APP register device
+  name: "Register a Douyin app device"
   cost:
     type: per_success
     value: 0.001
@@ -2708,7 +2740,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_city_list
-  name: Fetch city list (billboard)
+  name: "Douyin billboard city list"
   summary: 'Douyin: fetch city list (billboard)'
   cost:
     type: per_success
@@ -2728,7 +2760,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_content_tag
-  name: Fetch content tag (billboard)
+  name: "Douyin billboard content tags"
   summary: 'Douyin: fetch content tag (billboard)'
   cost:
     type: per_success
@@ -2748,7 +2780,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_fans_interest_account_list
-  name: List hot accounts by fan interest
+  name: "Douyin hot account fans' interest accounts by secUid"
   summary: 'Douyin: fetch hot account fans interest account list (billboard)'
   cost:
     type: per_success
@@ -2776,7 +2808,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_fans_interest_search_list
-  name: List trending searches by fan interest
+  name: "Douyin hot account fans' interest searches by secUid"
   summary: 'Douyin: fetch hot account fans interest search list (billboard)'
   cost:
     type: per_success
@@ -2806,7 +2838,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_fans_interest_topic_list
-  name: List trending topics by fan interest
+  name: "Douyin hot account fans' interest topics by secUid"
   summary: 'Douyin: fetch hot account fans interest topic list (billboard)'
   cost:
     type: per_success
@@ -2836,7 +2868,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_fans_portrait_list
-  name: Fetch hot account fans portrait list (billboard)
+  name: "Douyin hot account fans demographics by secUid"
   summary: 'Douyin: fetch hot account fans portrait list (billboard)'
   cost:
     type: per_success
@@ -2872,7 +2904,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_item_analysis_list
-  name: Fetch hot account item analysis list (billboard)
+  name: "Douyin hot account video analysis by secUid"
   summary: 'Douyin: fetch hot account item analysis list (billboard)'
   cost:
     type: per_success
@@ -2902,7 +2934,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_account_list
-  name: Fetch hot account list (billboard)
+  name: "Douyin hot accounts ranking"
   summary: 'Douyin: fetch hot account list (billboard)'
   cost:
     type: per_success
@@ -2946,7 +2978,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_search_list
-  name: Fetch hot account search list (billboard)
+  name: "Search Douyin hot accounts by name"
   summary: 'Douyin: fetch hot account search list (billboard)'
   cost:
     type: per_success
@@ -2982,7 +3014,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_account_trends_list
-  name: Fetch hot account trends list (billboard)
+  name: "Douyin hot account growth trends by secUid"
   summary: 'Douyin: fetch hot account trends list (billboard)'
   cost:
     type: per_success
@@ -3023,7 +3055,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_calendar_detail
-  name: Fetch hot calendar detail (billboard)
+  name: "Douyin hot calendar event details by event id"
   summary: 'Douyin: fetch hot calendar detail (billboard)'
   cost:
     type: per_success
@@ -3053,7 +3085,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_calendar_list
-  name: Fetch hot calendar list (billboard)
+  name: "Douyin hot events calendar"
   summary: 'Douyin: fetch hot calendar list (billboard)'
   cost:
     type: per_success
@@ -3095,7 +3127,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_category_list
-  name: Fetch hot category list (billboard)
+  name: "Douyin trending categories by board type"
   summary: 'Douyin: fetch hot category list (billboard)'
   cost:
     type: per_success
@@ -3142,7 +3174,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_challenge_list
-  name: Fetch hot challenge list (billboard)
+  name: "Douyin trending challenges ranking"
   summary: 'Douyin: fetch hot challenge list (billboard)'
   cost:
     type: per_success
@@ -3182,7 +3214,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_city_list
-  name: Fetch hot city list (billboard)
+  name: "Douyin trending topics by city"
   summary: 'Douyin: fetch hot city list (billboard)'
   cost:
     type: per_success
@@ -3228,7 +3260,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_comment_word_list
-  name: Fetch hot comment word list (billboard)
+  name: "Douyin video hot comment words by video id"
   summary: 'Douyin: fetch hot comment word list (billboard)'
   cost:
     type: per_success
@@ -3258,7 +3290,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_item_trends_list
-  name: Fetch hot item trends list (billboard)
+  name: "Douyin video engagement trends by video id"
   summary: 'Douyin: fetch hot item trends list (billboard)'
   cost:
     type: per_success
@@ -3296,7 +3328,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_rise_list
-  name: Fetch hot rise list (billboard)
+  name: "Douyin rising trending topics"
   summary: 'Douyin: fetch hot rise list (billboard)'
   cost:
     type: per_success
@@ -3346,7 +3378,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_high_fan_list
-  name: Fetch hot total high fan list (billboard)
+  name: "Douyin trending topics from high-follower accounts"
   summary: 'Douyin: fetch hot total high fan list (billboard)'
   cost:
     type: per_success
@@ -3394,7 +3426,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_high_like_list
-  name: Fetch hot total high like list (billboard)
+  name: "Douyin trending topics with high likes"
   summary: 'Douyin: fetch hot total high like list (billboard)'
   cost:
     type: per_success
@@ -3442,7 +3474,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_high_play_list
-  name: Fetch hot total high play list (billboard)
+  name: "Douyin trending topics with high plays"
   summary: 'Douyin: fetch hot total high play list (billboard)'
   cost:
     type: per_success
@@ -3490,7 +3522,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_high_search_list
-  name: Fetch hot total high search list (billboard)
+  name: "Douyin trending topics with high searches"
   summary: 'Douyin: fetch hot total high search list (billboard)'
   cost:
     type: per_success
@@ -3534,7 +3566,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_high_topic_list
-  name: Fetch hot total high topic list (billboard)
+  name: "Douyin trending topics with high topic index"
   summary: 'Douyin: fetch hot total high topic list (billboard)'
   cost:
     type: per_success
@@ -3582,7 +3614,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_total_hot_word_detail_list
-  name: Fetch hot total hot word detail list (billboard)
+  name: "Douyin hot word details by word id and date"
   summary: 'Douyin: fetch hot total hot word detail list (billboard)'
   cost:
     type: per_success
@@ -3615,7 +3647,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_hot_word_list
-  name: Fetch hot total hot word list (billboard)
+  name: "Douyin hot words ranking"
   summary: 'Douyin: fetch hot total hot word list (billboard)'
   cost:
     type: per_success
@@ -3659,7 +3691,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_total_list
-  name: Fetch hot total list (billboard)
+  name: "Douyin overall trending ranking by time range"
   summary: 'Douyin: fetch hot total list (billboard)'
   cost:
     type: per_success
@@ -3714,7 +3746,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_low_fan_list
-  name: Fetch hot total low fan list (billboard)
+  name: "Douyin trending topics from low-follower accounts"
   summary: 'Douyin: fetch hot total low fan list (billboard)'
   cost:
     type: per_success
@@ -3762,7 +3794,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_search_list
-  name: Fetch hot total search list (billboard)
+  name: "Douyin trending searches ranking"
   summary: 'Douyin: fetch hot total search list (billboard)'
   cost:
     type: per_success
@@ -3806,7 +3838,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_topic_list
-  name: Fetch hot total topic list (billboard)
+  name: "Douyin trending topics ranking"
   summary: 'Douyin: fetch hot total topic list (billboard)'
   cost:
     type: per_success
@@ -3854,7 +3886,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/billboard/fetch_hot_total_video_list
-  name: Fetch hot total video list (billboard)
+  name: "Douyin trending videos ranking"
   summary: 'Douyin: fetch hot total video list (billboard)'
   cost:
     type: per_success
@@ -3906,7 +3938,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/billboard/fetch_hot_user_portrait_list
-  name: Fetch hot user portrait list (billboard)
+  name: "Douyin video audience demographics by video id"
   summary: 'Douyin: fetch hot user portrait list (billboard)'
   cost:
     type: per_success
@@ -3942,6 +3974,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_activity_detail
   summary: Get creator activity detail
+  name: "Douyin creator activity details by activity id"
   cost:
     type: per_success
     value: 0.001
@@ -3971,6 +4004,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_activity_list
   summary: Get creator activity list
+  name: "Douyin creator activities by date range"
   cost:
     type: per_success
     value: 0.001
@@ -4006,6 +4040,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_content_category
   summary: Get creator content creation category
+  name: "Douyin creator course categories"
   cost:
     type: per_success
     value: 0.001
@@ -4026,6 +4061,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_content_course
   summary: Get creator content creation course
+  name: "Douyin creator courses by category id"
   cost:
     type: per_success
     value: 0.001
@@ -4073,6 +4109,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_challenge_billboard
   summary: Get creator hot challenge billboard
+  name: "Douyin creator hot challenges billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4094,6 +4131,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_course
   summary: Get creator hot course
+  name: "Douyin creator popular courses"
   cost:
     type: per_success
     value: 0.001
@@ -4139,6 +4177,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_music_billboard
   summary: Get creator hot music billboard
+  name: "Douyin creator hot music billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4180,6 +4219,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_props_billboard
   summary: Get creator hot props billboard
+  name: "Douyin creator hot props billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4218,6 +4258,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_spot_billboard
   summary: Get creator hot spot billboard
+  name: "Douyin creator hot spots billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4255,6 +4296,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_hot_topic_billboard
   summary: Get creator hot topic billboard
+  name: "Douyin creator hot topics billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4293,6 +4335,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_material_center_billboard
   summary: Get creator material center billboard
+  name: "Douyin creator material center billboard"
   cost:
     type: per_success
     value: 0.001
@@ -4331,6 +4374,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_material_center_config
   summary: Get creator material center config
+  name: "Douyin creator material center configuration"
   cost:
     type: per_success
     value: 0.001
@@ -4351,6 +4395,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_creator_material_center_related
   summary: Get topic or hot spot related videos
+  name: "Douyin videos related to a topic or hot spot by id"
   cost:
     type: per_success
     value: 0.001
@@ -4398,6 +4443,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_industry_category_config
   summary: Get industry category config
+  name: "Douyin industry category configuration"
   cost:
     type: per_success
     value: 0.001
@@ -4418,6 +4464,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_mission_task_list
   summary: Get mission task list
+  name: "Douyin creator mission tasks by filters"
   cost:
     type: per_success
     value: 0.001
@@ -4508,7 +4555,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/creator/fetch_user_search
-  name: Search users
+  name: "Search Douyin users by name or Douyin id"
   summary: 'Douyin: Search users'
   cost:
     type: per_success
@@ -4539,6 +4586,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/creator/fetch_video_danmaku_list
   summary: Get video danmaku list
+  name: "Douyin video danmaku bullet comments by video id"
   cost:
     type: per_success
     value: 0.001
@@ -4591,7 +4639,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_author_diagnosis
-  name: Fetch author diagnosis
+  name: "Douyin creator account diagnosis"
   summary: 'Douyin: fetch author diagnosis (creator_v2)'
   cost:
     type: per_success
@@ -4621,6 +4669,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_analysis_involved_vertical
   summary: Fetch item analysis involved vertical
+  name: "Douyin video analysis — involved verticals"
   cost:
     type: per_success
     value: 0.001
@@ -4657,6 +4706,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_analysis_item_performance
   summary: Fetch item analysis item performance
+  name: "Douyin video analysis — performance"
   cost:
     type: per_success
     value: 0.001
@@ -4703,6 +4753,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_analysis_overview
   summary: Fetch item analysis overview
+  name: "Douyin video analysis overview"
   cost:
     type: per_success
     value: 0.001
@@ -4746,6 +4797,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_audience_others
   summary: Fetch item audience others analysis
+  name: "Douyin video audience extra analysis"
   cost:
     type: per_success
     value: 0.001
@@ -4778,6 +4830,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_audience_portrait
   summary: Fetch item audience portrait
+  name: "Douyin video audience demographics"
   cost:
     type: per_success
     value: 0.001
@@ -4810,6 +4863,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_danmaku_analysis
   summary: Fetch item bullet analysis
+  name: "Douyin video danmaku analysis"
   cost:
     type: per_success
     value: 0.001
@@ -4841,7 +4895,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_list
-  name: Fetch item list
+  name: "Douyin creator video list"
   summary: 'Douyin: fetch item list (creator_v2)'
   cost:
     type: per_success
@@ -4896,7 +4950,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_list_download
-  name: Fetch item list download
+  name: "Douyin creator video list export"
   summary: 'Douyin: fetch item list download (creator_v2)'
   cost:
     type: per_success
@@ -4940,6 +4994,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_overview_data
   summary: Fetch item overview data
+  name: "Douyin video overview metrics"
   cost:
     type: per_success
     value: 0.001
@@ -4975,6 +5030,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_play_source
   summary: Fetch item play source statistics
+  name: "Douyin video play source statistics"
   cost:
     type: per_success
     value: 0.001
@@ -5007,6 +5063,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_search_keyword
   summary: Fetch item search keywords statistics
+  name: "Douyin video search keywords statistics"
   cost:
     type: per_success
     value: 0.001
@@ -5039,6 +5096,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_item_watch_trend
   summary: Fetch item watch trend analysis
+  name: "Douyin video watch trend analysis"
   cost:
     type: per_success
     value: 0.001
@@ -5073,7 +5131,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/creator_v2/fetch_live_room_history_list
-  name: Fetch live room history list
+  name: "Douyin live room history list"
   summary: 'Douyin: fetch live room history list (creator_v2)'
   cost:
     type: per_success
@@ -5120,7 +5178,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/calculate_cost
-  name: Calculate cost (douplus)
+  name: "Douyin DOU+ promotion cost calculator"
   summary: 'Douyin: calculate cost (douplus)'
   cost:
     type: per_success
@@ -5160,7 +5218,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_analyse_detail
-  name: Fetch analyse detail (douplus)
+  name: "Douyin DOU+ promotion analysis detail"
   summary: 'Douyin: fetch analyse detail (douplus)'
   cost:
     type: per_success
@@ -5193,7 +5251,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_analyse_graph
-  name: Fetch analyse graph (douplus)
+  name: "Douyin DOU+ promotion analysis graph"
   summary: 'Douyin: fetch analyse graph (douplus)'
   cost:
     type: per_success
@@ -5226,7 +5284,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_analyse_overview
-  name: Fetch analyse overview (douplus)
+  name: "Douyin DOU+ promotion analysis overview"
   summary: 'Douyin: fetch analyse overview (douplus)'
   cost:
     type: per_success
@@ -5259,7 +5317,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_promotable_item_list
-  name: Fetch promotable item list (douplus)
+  name: "Douyin DOU+ promotable videos list"
   summary: 'Douyin: fetch promotable item list (douplus)'
   cost:
     type: per_success
@@ -5304,7 +5362,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_promoted_accounts
-  name: Fetch promoted accounts (douplus)
+  name: "Douyin DOU+ promoted accounts list"
   summary: 'Douyin: fetch promoted accounts (douplus)'
   cost:
     type: per_success
@@ -5339,7 +5397,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_sec_token
-  name: Fetch sec token (douplus)
+  name: "Douyin DOU+ security token"
   summary: 'Douyin: fetch sec token (douplus)'
   cost:
     type: per_success
@@ -5368,7 +5426,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_talent_categories
-  name: Fetch talent categories (douplus)
+  name: "Douyin DOU+ talent categories list"
   summary: 'Douyin: fetch talent categories (douplus)'
   cost:
     type: per_success
@@ -5400,7 +5458,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_talents_by_category
-  name: Fetch talents by category (douplus)
+  name: "Douyin DOU+ talents by category"
   summary: 'Douyin: fetch talents by category (douplus)'
   cost:
     type: per_success
@@ -5444,7 +5502,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_user_posts
-  name: Fetch user posts (douplus)
+  name: "Douyin DOU+ user's posts"
   summary: 'Douyin: fetch user posts (douplus)'
   cost:
     type: per_success
@@ -5489,7 +5547,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_video_detail
-  name: Fetch video detail (douplus)
+  name: "Douyin DOU+ video details"
   summary: 'Douyin: fetch video detail (douplus)'
   cost:
     type: per_success
@@ -5526,7 +5584,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/fetch_video_ranking
-  name: Fetch video ranking (douplus)
+  name: "Douyin DOU+ video ranking"
   summary: 'Douyin: fetch video ranking (douplus)'
   cost:
     type: per_success
@@ -5571,7 +5629,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/search_live_room
-  name: Search live room (douplus)
+  name: "Search Douyin DOU+ live rooms"
   summary: 'Douyin: search live room (douplus)'
   cost:
     type: per_success
@@ -5616,7 +5674,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/search_user
-  name: Search user (douplus)
+  name: "Search Douyin DOU+ users"
   summary: 'Douyin: search user (douplus)'
   cost:
     type: per_success
@@ -5658,7 +5716,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/search_user_v2
-  name: Search user v2 (douplus)
+  name: "Search Douyin DOU+ users"
   summary: 'Douyin: search user v2 (douplus)'
   cost:
     type: per_success
@@ -5707,7 +5765,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/douplus/search_video
-  name: Search video (douplus)
+  name: "Search Douyin DOU+ videos"
   summary: 'Douyin: search video (douplus)'
   cost:
     type: per_success
@@ -5752,7 +5810,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_all_area
-  name: Fetch all area (index)
+  name: "Douyin Index region list"
   summary: 'Douyin: fetch all area (index)'
   cost:
     type: per_success
@@ -5773,7 +5831,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_all_valid_date
-  name: Fetch all valid date (index)
+  name: "Douyin Index valid dates"
   summary: 'Douyin: fetch all valid date (index)'
   cost:
     type: per_success
@@ -5794,7 +5852,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_cycles
-  name: Fetch brand cycles (index)
+  name: "Douyin brand index cycles by brand name and dates"
   summary: 'Douyin: fetch brand cycles (index)'
   cost:
     type: per_success
@@ -5834,7 +5892,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_hot_videos_time_scope
-  name: Fetch brand hot videos time scope (index)
+  name: "Douyin brand hot videos time scope"
   summary: 'Douyin: fetch brand hot videos time scope (index)'
   cost:
     type: per_success
@@ -5856,7 +5914,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_initiative_rank_weekly
-  name: Fetch brand initiative rank weekly (index)
+  name: "Douyin weekly brand ranking by brand name and dates"
   summary: 'Douyin: fetch brand initiative rank weekly (index)'
   cost:
     type: per_success
@@ -5896,7 +5954,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_lines
-  name: Fetch brand lines (index)
+  name: "Douyin brand index trend lines by brand name"
   summary: 'Douyin: fetch brand lines (index)'
   cost:
     type: per_success
@@ -5936,7 +5994,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_radar_chart
-  name: Fetch brand radar chart (index)
+  name: "Douyin brand index radar chart by brand name"
   summary: 'Douyin: fetch brand radar chart (index)'
   cost:
     type: per_success
@@ -5976,7 +6034,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_suggest
-  name: Fetch brand suggest (index)
+  name: "Douyin brand suggestions by keyword"
   summary: 'Douyin: fetch brand suggest (index)'
   cost:
     type: per_success
@@ -6000,7 +6058,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_brand_valid_info
-  name: Fetch brand valid info (index)
+  name: "Douyin brand validity check by brand names"
   summary: 'Douyin: fetch brand valid info (index)'
   cost:
     type: per_success
@@ -6024,7 +6082,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_author_portrait
-  name: Fetch content author portrait (index)
+  name: "Douyin content creator demographics by category id"
   summary: 'Douyin: fetch content author portrait (index)'
   cost:
     type: per_success
@@ -6060,7 +6118,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_consume_trend
-  name: Fetch content consume trend (index)
+  name: "Douyin content consumption trend by category id"
   summary: 'Douyin: fetch content consume trend (index)'
   cost:
     type: per_success
@@ -6092,7 +6150,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_consumer_portrait
-  name: Fetch content consumer portrait (index)
+  name: "Douyin content audience demographics by category id"
   summary: 'Douyin: fetch content consumer portrait (index)'
   cost:
     type: per_success
@@ -6128,7 +6186,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_creative_duration
-  name: Fetch content creative duration (index)
+  name: "Douyin content duration analysis by category id"
   summary: 'Douyin: fetch content creative duration (index)'
   cost:
     type: per_success
@@ -6164,7 +6222,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_creative_keyword_items
-  name: Fetch content creative keyword items (index)
+  name: "Douyin videos for a creative keyword by category id"
   summary: 'Douyin: fetch content creative keyword items (index)'
   cost:
     type: per_success
@@ -6205,7 +6263,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_creative_keywords
-  name: Fetch content creative keywords (index)
+  name: "Douyin creative keywords by category id"
   summary: 'Douyin: fetch content creative keywords (index)'
   cost:
     type: per_success
@@ -6242,7 +6300,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_creative_topic
-  name: Fetch content creative topic (index)
+  name: "Douyin creative topics by category id"
   summary: 'Douyin: fetch content creative topic (index)'
   cost:
     type: per_success
@@ -6287,7 +6345,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_content_interact_trend
-  name: Fetch content interact trend (index)
+  name: "Douyin content interaction trend by category id"
   summary: 'Douyin: fetch content interact trend (index)'
   cost:
     type: per_success
@@ -6319,7 +6377,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_content_publish_trend
-  name: Fetch content publish trend (index)
+  name: "Douyin content publishing trend by category id"
   summary: 'Douyin: fetch content publish trend (index)'
   cost:
     type: per_success
@@ -6351,7 +6409,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_content_valid_date
-  name: Fetch content valid date (index)
+  name: "Douyin Index content valid dates"
   summary: 'Douyin: fetch content valid date (index)'
   cost:
     type: per_success
@@ -6372,7 +6430,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_current_hot_topic
-  name: Fetch current hot topic (index)
+  name: "Douyin current hot topics"
   summary: 'Douyin: fetch current hot topic (index)'
   cost:
     type: per_success
@@ -6394,7 +6452,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_compare_users_stable
-  name: Fetch daren compare users stable (index)
+  name: "Compare Douyin influencers by uid list"
   summary: 'Douyin: fetch daren compare users stable (index)'
   cost:
     type: per_success
@@ -6426,7 +6484,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_great_item_mile_info
-  name: Fetch daren great item mile info (index)
+  name: "Douyin influencer video milestones by uid"
   summary: 'Douyin: fetch daren great item mile info (index)'
   cost:
     type: per_success
@@ -6450,7 +6508,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_great_user_fans_info
-  name: Fetch daren great user fans info (index)
+  name: "Douyin influencer follower info by uid"
   summary: 'Douyin: fetch daren great user fans info (index)'
   cost:
     type: per_success
@@ -6474,7 +6532,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_great_user_top_video
-  name: Fetch daren great user top video (index)
+  name: "Douyin influencer top videos by uid and dates"
   summary: 'Douyin: fetch daren great user top video (index)'
   cost:
     type: per_success
@@ -6506,7 +6564,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_similar_users
-  name: Fetch daren similar users (index)
+  name: "Douyin similar influencers by uid"
   summary: 'Douyin: fetch daren similar users (index)'
   cost:
     type: per_success
@@ -6530,7 +6588,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_daren_sug_great_user_list
-  name: Fetch daren sug great user list (index)
+  name: "Douyin influencer suggestions by keyword"
   summary: 'Douyin: fetch daren sug great user list (index)'
   cost:
     type: per_success
@@ -6560,7 +6618,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_encrypt_user_id
-  name: Fetch encrypt user id (index)
+  name: "Douyin encrypted user id from uid"
   summary: 'Douyin: fetch encrypt user id (index)'
   cost:
     type: per_success
@@ -6584,7 +6642,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_get_user_sub_word
-  name: Fetch get user sub word (index)
+  name: "Douyin Index user subscribed words"
   summary: 'Douyin: fetch get user sub word (index)'
   cost:
     type: per_success
@@ -6605,7 +6663,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_hot_detail
-  name: Fetch hot detail (index)
+  name: "Douyin hot topic details by topic name"
   summary: 'Douyin: fetch hot detail (index)'
   cost:
     type: per_success
@@ -6629,7 +6687,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_hot_trend_word
-  name: Fetch hot trend word (index)
+  name: "Douyin trending words by platform"
   summary: 'Douyin: fetch hot trend word (index)'
   cost:
     type: per_success
@@ -6666,7 +6724,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_hot_words
-  name: Fetch hot words (index)
+  name: "Douyin hot words by platform"
   summary: 'Douyin: fetch hot words (index)'
   cost:
     type: per_success
@@ -6698,7 +6756,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_insight_get_rec
-  name: Fetch insight get rec (index)
+  name: "Douyin insight recommendations by report id"
   summary: 'Douyin: fetch insight get rec (index)'
   cost:
     type: per_success
@@ -6722,7 +6780,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_insight_recommend
-  name: Fetch insight recommend (index)
+  name: "Douyin insight recommendations"
   summary: 'Douyin: fetch insight recommend (index)'
   cost:
     type: per_success
@@ -6743,7 +6801,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_analysis
-  name: Fetch item analysis (index)
+  name: "Douyin video index analysis by video id and dates"
   summary: 'Douyin: fetch item analysis (index)'
   cost:
     type: per_success
@@ -6775,7 +6833,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_base
-  name: Fetch item base (index)
+  name: "Douyin video base info by video id"
   summary: 'Douyin: fetch item base (index)'
   cost:
     type: per_success
@@ -6799,7 +6857,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_item_filter_options
-  name: Fetch item filter options (index)
+  name: "Douyin Index video filter options"
   summary: 'Douyin: fetch item filter options (index)'
   cost:
     type: per_success
@@ -6820,7 +6878,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_index
-  name: Fetch item index (index)
+  name: "Douyin video index metrics by video id and dates"
   summary: 'Douyin: fetch item index (index)'
   cost:
     type: per_success
@@ -6852,7 +6910,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_index_interpret
-  name: Fetch item index interpret (index)
+  name: "Douyin video index interpretation by video id"
   summary: 'Douyin: fetch item index interpret (index)'
   cost:
     type: per_success
@@ -6884,7 +6942,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_query
-  name: Fetch item query (index)
+  name: "Search Douyin Index videos by keyword"
   summary: 'Douyin: fetch item query (index)'
   cost:
     type: per_success
@@ -6928,7 +6986,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_sug
-  name: Fetch item sug (index)
+  name: "Douyin Index video suggestions by keyword"
   summary: 'Douyin: fetch item sug (index)'
   cost:
     type: per_success
@@ -6952,7 +7010,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_item_user_profile
-  name: Fetch item user profile (index)
+  name: "Douyin video viewer demographics by video id"
   summary: 'Douyin: fetch item user profile (index)'
   cost:
     type: per_success
@@ -6984,7 +7042,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_keyword_valid_date
-  name: Fetch keyword valid date (index)
+  name: "Douyin keyword valid dates by keywords"
   summary: 'Douyin: fetch keyword valid date (index)'
   cost:
     type: per_success
@@ -7008,7 +7066,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_multi_keyword_hot_trend
-  name: Fetch multi keyword hot trend (index)
+  name: "Douyin keyword popularity trend by keywords and dates"
   summary: 'Douyin: fetch multi keyword hot trend (index)'
   cost:
     type: per_success
@@ -7052,7 +7110,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_multi_keyword_interpretation
-  name: Fetch multi keyword interpretation (index)
+  name: "Douyin keyword trend interpretation by keywords"
   summary: 'Douyin: fetch multi keyword interpretation (index)'
   cost:
     type: per_success
@@ -7096,7 +7154,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_portrait
-  name: Fetch portrait (index)
+  name: "Douyin keyword audience demographics by keyword"
   summary: 'Douyin: fetch portrait (index)'
   cost:
     type: per_success
@@ -7136,7 +7194,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_relation_word
-  name: Fetch relation word (index)
+  name: "Douyin related words by keyword and week"
   summary: 'Douyin: fetch relation word (index)'
   cost:
     type: per_success
@@ -7176,7 +7234,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_report_detail
-  name: Fetch report detail (index)
+  name: "Douyin Index report details by report id"
   summary: 'Douyin: fetch report detail (index)'
   cost:
     type: per_success
@@ -7200,7 +7258,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_report_search
-  name: Fetch report search (index)
+  name: "Search Douyin Index reports by keyword and type"
   summary: 'Douyin: fetch report search (index)'
   cost:
     type: per_success
@@ -7261,7 +7319,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_topic_query
-  name: Fetch topic query (index)
+  name: "Douyin topic index by keyword and dates"
   summary: 'Douyin: fetch topic query (index)'
   cost:
     type: per_success
@@ -7301,7 +7359,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/index/fetch_topic_suggest
-  name: Fetch topic suggest (index)
+  name: "Douyin topic suggestions by keyword"
   summary: 'Douyin: fetch topic suggest (index)'
   cost:
     type: per_success
@@ -7333,7 +7391,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/index/fetch_valid_date_for_relation
-  name: Fetch valid date for relation (index)
+  name: "Douyin related-word valid dates"
   summary: 'Douyin: fetch valid date for relation (index)'
   cost:
     type: per_success
@@ -7354,7 +7412,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_challenge_search_v1
-  name: Fetch challenge search v1 (search)
+  name: "Search Douyin challenges"
   summary: 'Douyin: fetch challenge search v1 (search)'
   cost:
     type: per_success
@@ -7412,7 +7470,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_challenge_search_v2
-  name: Fetch challenge search v2 (search)
+  name: "Search Douyin challenges"
   summary: 'Douyin: fetch challenge search v2 (search)'
   cost:
     type: per_success
@@ -7470,7 +7528,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_challenge_suggest
-  name: Fetch challenge suggest (search)
+  name: "Douyin challenge suggestions"
   summary: 'Douyin: fetch challenge suggest (search)'
   cost:
     type: per_success
@@ -7502,7 +7560,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_discuss_search
-  name: Fetch discuss search (search)
+  name: "Search Douyin discussions"
   summary: 'Douyin: fetch discuss search (search)'
   cost:
     type: per_success
@@ -7560,7 +7618,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_experience_search
-  name: Fetch experience search (search)
+  name: "Search Douyin experience posts"
   summary: 'Douyin: fetch experience search (search)'
   cost:
     type: per_success
@@ -7618,7 +7676,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_general_search_v1
-  name: Fetch general search v1 (search)
+  name: "Search Douyin across all content"
   summary: 'Douyin: fetch general search v1 (search)'
   cost:
     type: per_success
@@ -7676,7 +7734,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_general_search_v2
-  name: Fetch general search v2 (search)
+  name: "Search Douyin across all content"
   summary: 'Douyin: fetch general search v2 (search)'
   cost:
     type: per_success
@@ -7734,7 +7792,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_image_search
-  name: Fetch image search (search)
+  name: "Search Douyin images"
   summary: 'Douyin: fetch image search (search)'
   cost:
     type: per_success
@@ -7792,7 +7850,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_image_search_v3
-  name: Fetch image search v3 (search)
+  name: "Search Douyin images"
   summary: 'Douyin: fetch image search v3 (search)'
   cost:
     type: per_success
@@ -7826,7 +7884,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_live_search_v1
-  name: Fetch live search v1 (search)
+  name: "Search Douyin live streams"
   summary: 'Douyin: fetch live search v1 (search)'
   cost:
     type: per_success
@@ -7884,7 +7942,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_multi_search
-  name: Fetch multi search (search)
+  name: "Search Douyin across multiple types"
   summary: 'Douyin: fetch multi search (search)'
   cost:
     type: per_success
@@ -7942,7 +8000,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_music_search
-  name: Fetch music search (search)
+  name: "Search Douyin music"
   summary: 'Douyin: fetch music search (search)'
   cost:
     type: per_success
@@ -8000,7 +8058,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_school_search
-  name: Fetch school search (search)
+  name: "Search Douyin schools"
   summary: 'Douyin: fetch school search (search)'
   cost:
     type: per_success
@@ -8031,7 +8089,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_search_suggest
-  name: Fetch search suggest (search)
+  name: "Douyin search suggestions"
   summary: 'Douyin: fetch search suggest (search)'
   cost:
     type: per_success
@@ -8063,7 +8121,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_user_search
-  name: Fetch user search (search)
+  name: "Search Douyin users"
   summary: 'Douyin: fetch user search (search)'
   cost:
     type: per_success
@@ -8108,7 +8166,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_user_search_v2
-  name: Fetch user search v2 (search)
+  name: "Search Douyin users"
   summary: 'Douyin: fetch user search v2 (search)'
   cost:
     type: per_success
@@ -8142,7 +8200,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_video_search_v1
-  name: Fetch video search v1 (search)
+  name: "Search Douyin videos"
   summary: 'Douyin: fetch video search v1 (search)'
   cost:
     type: per_success
@@ -8200,7 +8258,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/search/fetch_video_search_v2
-  name: Fetch video search v2 (search)
+  name: "Search Douyin videos"
   summary: 'Douyin: fetch video search v2 (search)'
   cost:
     type: per_success
@@ -8310,6 +8368,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/douyin_live_room
   summary: Extract live room danmaku
+  name: "Douyin live room danmaku stream by live room URL"
   cost:
     type: free
     value: 0
@@ -8341,6 +8400,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/encrypt_uid_to_sec_user_id
   summary: Encrypt user uid to sec_user_id
+  name: "Douyin secUid from uid"
   cost:
     type: per_success
     value: 0.001
@@ -8369,6 +8429,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_batch_user_profile_v1
   summary: Get batch user profile (up to 10)
+  name: "Douyin user profiles in bulk by secUids (up to 10)"
   cost:
     type: per_success
     value: 0.03
@@ -8398,6 +8459,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_batch_user_profile_v2
   summary: Get batch user profile (up to 50)
+  name: "Douyin user profiles in bulk by secUids (up to 50)"
   cost:
     type: per_success
     value: 0.15
@@ -8426,7 +8488,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_cartoon_aweme
-  name: Anime Video
+  name: "Douyin anime channel videos"
   summary: 'Douyin: Anime Video'
   cost:
     type: per_success
@@ -8465,7 +8527,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/web/fetch_challenge_posts
-  name: Challenge Posts
+  name: "Douyin challenge posts"
   summary: 'Douyin: Challenge Posts'
   cost:
     type: per_success
@@ -8511,6 +8573,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_douyin_web_guest_cookie
   summary: Get the guest Cookie of Douyin Web
+  name: "Douyin web guest cookie by user agent"
   cost:
     type: per_success
     value: 0.001
@@ -8538,7 +8601,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_food_aweme
-  name: Food Video
+  name: "Douyin food channel videos"
   summary: 'Douyin: Food Video'
   cost:
     type: per_success
@@ -8577,7 +8640,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_game_aweme
-  name: Game Video
+  name: "Douyin game channel videos"
   summary: 'Douyin: Game Video'
   cost:
     type: per_success
@@ -8617,6 +8680,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_home_feed
   summary: Get home feed data
+  name: "Douyin home feed recommendations"
   cost:
     type: per_success
     value: 0.001
@@ -8655,6 +8719,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_hot_search_result
   summary: Get Douyin hot search results
+  name: "Douyin trending searches ranking"
   cost:
     type: per_success
     value: 0.001
@@ -8675,7 +8740,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_knowledge_aweme
-  name: Knowledge Video
+  name: "Douyin knowledge channel videos"
   summary: 'Douyin: Knowledge Video'
   cost:
     type: per_success
@@ -8715,6 +8780,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_live_gift_ranking
   summary: Get live room gift user ranking
+  name: "Douyin live room gift ranking by room id"
   cost:
     type: per_success
     value: 0.001
@@ -8749,6 +8815,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_live_im_fetch
   summary: Douyin live room danmaku parameters
+  name: "Douyin live room chat danmaku by room id"
   cost:
     type: per_success
     value: 0.001
@@ -8783,6 +8850,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_live_room_product_result
   summary: Douyin live room product information
+  name: "Douyin live room products by room and author id"
   cost:
     type: per_success
     value: 0.001
@@ -8829,6 +8897,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_multi_video
   summary: Batch Get Video Information
+  name: "Douyin video details in bulk"
   cost:
     type: per_success
     value: 0.05
@@ -8856,6 +8925,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_multi_video_high_quality_play_url
   summary: Batch get the highest quality play URL of videos
+  name: "Douyin best-quality play URLs in bulk"
   cost:
     type: per_success
     value: 0.25
@@ -8890,7 +8960,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_music_aweme
-  name: Music Video
+  name: "Douyin music channel videos"
   summary: 'Douyin: Music Video'
   cost:
     type: per_success
@@ -8930,6 +9000,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_one_video
   summary: Get single video data
+  name: "Douyin video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -8965,6 +9036,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_one_video_by_share_url
   summary: Get single video data by sharing link
+  name: "Douyin video details by share link"
   cost:
     type: per_success
     value: 0.001
@@ -8994,6 +9066,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_one_video_danmaku
   summary: Get single video danmaku data
+  name: "Douyin video danmaku by video id and time range"
   cost:
     type: per_success
     value: 0.001
@@ -9041,6 +9114,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_one_video_v2
   summary: Get single video data V2
+  name: "Douyin video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -9070,6 +9144,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_query_user
   summary: Query Douyin user basic information
+  name: "Douyin user basic info query"
   cost:
     type: per_success
     value: 0.001
@@ -9097,6 +9172,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_related_posts
   summary: Get related posts recommendation data
+  name: "Douyin related videos by video id"
   cost:
     type: per_success
     value: 0.001
@@ -9136,7 +9212,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_series_aweme
-  name: Series Video
+  name: "Douyin series channel videos by subtype"
   summary: 'Douyin: Series Video'
   cost:
     type: per_success
@@ -9183,6 +9259,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_user_collection_videos
   summary: Get user collection video data
+  name: "Douyin user's collected videos"
   cost:
     type: per_success
     value: 0.001
@@ -9216,6 +9293,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_user_collects
   summary: Get user collection
+  name: "Douyin user's collection folders"
   cost:
     type: per_success
     value: 0.001
@@ -9249,6 +9327,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_collects_videos
   summary: Get user collection data
+  name: "Douyin collection folder videos by folder id"
   cost:
     type: per_success
     value: 0.001
@@ -9282,6 +9361,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_fans_list
   summary: Get user fans list
+  name: "Douyin user's followers by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -9326,6 +9406,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_following_list
   summary: Get user following list
+  name: "Douyin accounts a user follows by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -9370,6 +9451,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/fetch_user_like_videos
   summary: Get user like video data
+  name: "Douyin user's liked videos"
   cost:
     type: per_success
     value: 0.001
@@ -9406,6 +9488,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_live_info_by_uid
   summary: Get user live information by UID
+  name: "Douyin user live stream info by uid"
   cost:
     type: per_success
     value: 0.001
@@ -9435,6 +9518,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_live_videos
   summary: Get user live video data
+  name: "Douyin live stream by webcast id"
   cost:
     type: per_success
     value: 0.001
@@ -9463,7 +9547,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/fetch_user_live_videos_by_room_id_v2
-  name: Get user live videos by room ID
+  name: "Douyin live stream by room id"
   summary: Gets the live stream data of the specified user by room_id V2
   cost:
     type: per_success
@@ -9494,6 +9578,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_live_videos_by_sec_uid
   summary: Get live video data of specified user by sec_uid
+  name: "Douyin live stream by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -9523,6 +9608,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_mix_videos
   summary: Get user mix video data
+  name: "Douyin mix collection videos by mix id"
   cost:
     type: per_success
     value: 0.001
@@ -9562,6 +9648,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_post_videos
   summary: Get user homepage video data
+  name: "Douyin user's videos by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -9611,6 +9698,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_profile_by_short_id
   summary: Get user information by Short ID
+  name: "Douyin user profile by short id"
   cost:
     type: per_success
     value: 0.001
@@ -9640,6 +9728,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_user_profile_by_uid
   summary: Get user information by UID
+  name: "Douyin user profile by uid"
   cost:
     type: per_success
     value: 0.001
@@ -9669,6 +9758,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_video_channel_result
   summary: Douyin video channel data
+  name: "Douyin channel videos by tag id"
   cost:
     type: per_success
     value: 0.001
@@ -9709,6 +9799,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_video_comment_replies
   summary: Get comment replies data of specified video
+  name: "Douyin comment replies by video and comment id"
   cost:
     type: per_success
     value: 0.001
@@ -9755,6 +9846,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_video_comments
   summary: Get single video comments data
+  name: "Douyin video comments by video id"
   cost:
     type: per_success
     value: 0.001
@@ -9795,6 +9887,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/fetch_video_high_quality_play_url
   summary: Get the highest quality play URL of the video
+  name: "Douyin best-quality play URL by video id or link"
   cost:
     type: per_success
     value: 0.005
@@ -9837,6 +9930,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/generate_a_bogus
   summary: Generate A-Bogus parameter using API URL
+  name: "Generate a Douyin A-Bogus signature"
   cost:
     type: per_success
     value: 0.001
@@ -9882,6 +9976,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/generate_real_msToken
   summary: Generate real msToken
+  name: "Generate a Douyin msToken"
   cost:
     type: per_success
     value: 0.001
@@ -9903,6 +9998,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/generate_s_v_web_id
   summary: Generate s_v_web_id
+  name: "Generate a Douyin s_v_web_id"
   cost:
     type: per_success
     value: 0.001
@@ -9923,7 +10019,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/generate_ttwid
-  name: Generate ttwid
+  name: "Generate a Douyin ttwid token"
   summary: 'Douyin: Generate ttwid'
   cost:
     type: per_success
@@ -9952,6 +10048,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/generate_verify_fp
   summary: Generate verify_fp
+  name: "Generate a Douyin verify_fp"
   cost:
     type: per_success
     value: 0.001
@@ -9973,6 +10070,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/generate_wss_xb_signature
   summary: Generate barrage xb signature
+  name: "Generate a Douyin WSS X-Bogus signature"
   cost:
     type: per_success
     value: 0.001
@@ -10014,6 +10112,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/generate_x_bogus
   summary: Generate X-Bogus parameter using API URL
+  name: "Generate a Douyin X-Bogus signature"
   cost:
     type: per_success
     value: 0.001
@@ -10050,6 +10149,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/get_all_aweme_id
   summary: Extract list video id
+  name: "Douyin video ids from URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -10077,6 +10177,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/get_all_sec_user_id
   summary: Extract list user id
+  name: "Douyin secUids from profile URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -10104,6 +10205,7 @@ endpoints:
   method: POST
   path: /api/v1/douyin/web/get_all_webcast_id
   summary: Extract list webcast id
+  name: "Douyin webcast ids from URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -10131,6 +10233,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/get_aweme_id
   summary: Extract single video id
+  name: "Douyin video id from video URL"
   cost:
     type: per_success
     value: 0.001
@@ -10158,6 +10261,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/get_sec_user_id
   summary: Extract single user id
+  name: "Douyin secUid from profile URL"
   cost:
     type: per_success
     value: 0.001
@@ -10185,6 +10289,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/get_webcast_id
   summary: Extract webcast id
+  name: "Douyin webcast id from live URL"
   cost:
     type: per_success
     value: 0.001
@@ -10211,7 +10316,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/handler_shorten_url
-  name: Handler shorten url
+  name: "Douyin short URL from target URL"
   summary: 'Douyin: handler shorten url (web)'
   cost:
     type: per_success
@@ -10241,6 +10346,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/handler_user_profile
   summary: Get information of specified user by sec_user_id
+  name: "Douyin user profile by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -10270,6 +10376,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/handler_user_profile_v2
   summary: Get information of specified user by unique_id
+  name: "Douyin user profile by username"
   cost:
     type: per_success
     value: 0.001
@@ -10299,6 +10406,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/handler_user_profile_v3
   summary: Get information of specified user by uid
+  name: "Douyin user profile by uid"
   cost:
     type: per_success
     value: 0.001
@@ -10327,7 +10435,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/web/handler_user_profile_v4
-  name: Handler user profile v4
+  name: "Douyin user profile by secUid"
   summary: 'Douyin: handler user profile v4 (web)'
   cost:
     type: per_success
@@ -10358,6 +10466,7 @@ endpoints:
   method: GET
   path: /api/v1/douyin/web/webcast_id_2_room_id
   summary: Webcast id to room id
+  name: "Douyin room id from webcast id"
   cost:
     type: per_success
     value: 0.001
@@ -10385,7 +10494,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/author_content_hot_comment_keywords_v1
-  name: Author content hot comment keywords v1 (xingtu)
+  name: "Douyin Xingtu creator comment keywords by kol id"
   summary: 'Douyin: author content hot comment keywords v1 (xingtu)'
   cost:
     type: per_success
@@ -10413,7 +10522,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/author_hot_comment_tokens_v1
-  name: Author hot comment tokens v1 (xingtu)
+  name: "Douyin Xingtu creator hot comment tokens by kol id"
   summary: 'Douyin: author hot comment tokens v1 (xingtu)'
   cost:
     type: per_success
@@ -10441,7 +10550,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/get_sign_image
-  name: Get sign image (xingtu)
+  name: "Douyin Xingtu signed image URL by image URI"
   summary: 'Douyin: get sign image (xingtu)'
   cost:
     type: per_success
@@ -10482,7 +10591,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/get_xingtu_kolid_by_sec_user_id
-  name: Get xingtu kolid by sec user id (xingtu)
+  name: "Douyin Xingtu kol id from secUid"
   summary: 'Douyin: get xingtu kolid by sec user id (xingtu)'
   cost:
     type: per_success
@@ -10511,7 +10620,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/get_xingtu_kolid_by_uid
-  name: Get xingtu kolid by uid (xingtu)
+  name: "Douyin Xingtu kol id from uid"
   summary: 'Douyin: get xingtu kolid by uid (xingtu)'
   cost:
     type: per_success
@@ -10540,7 +10649,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/get_xingtu_kolid_by_unique_id
-  name: Get xingtu kolid by unique id (xingtu)
+  name: "Douyin Xingtu kol id from username"
   summary: 'Douyin: get xingtu kolid by unique id (xingtu)'
   cost:
     type: per_success
@@ -10569,7 +10678,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_audience_portrait_v1
-  name: Kol audience portrait v1 (xingtu)
+  name: "Douyin Xingtu creator audience demographics by kol id"
   summary: 'Douyin: kol audience portrait v1 (xingtu)'
   cost:
     type: per_success
@@ -10597,7 +10706,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_base_info_v1
-  name: Kol base info v1 (xingtu)
+  name: "Douyin Xingtu creator base info by kol id"
   summary: 'Douyin: kol base info v1 (xingtu)'
   cost:
     type: per_success
@@ -10631,7 +10740,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_conversion_ability_analysis_v1
-  name: Kol conversion ability analysis v1 (xingtu)
+  name: "Douyin Xingtu creator conversion analysis by kol id"
   summary: 'Douyin: kol conversion ability analysis v1 (xingtu)'
   cost:
     type: per_success
@@ -10665,7 +10774,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_convert_video_display_v1
-  name: Kol convert video display v1 (xingtu)
+  name: "Douyin Xingtu creator conversion videos by kol id"
   summary: 'Douyin: kol convert video display v1 (xingtu)'
   cost:
     type: per_success
@@ -10705,7 +10814,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_cp_info_v1
-  name: Kol cp info v1 (xingtu)
+  name: "Douyin Xingtu creator CP info by kol id"
   summary: 'Douyin: kol cp info v1 (xingtu)'
   cost:
     type: per_success
@@ -10733,7 +10842,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_daily_fans_v1
-  name: Kol daily fans v1 (xingtu)
+  name: "Douyin Xingtu creator daily followers by kol id"
   summary: 'Douyin: kol daily fans v1 (xingtu)'
   cost:
     type: per_success
@@ -10773,7 +10882,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_data_overview_v1
-  name: Kol data overview v1 (xingtu)
+  name: "Douyin Xingtu creator metrics overview by kol id"
   summary: 'Douyin: kol data overview v1 (xingtu)'
   cost:
     type: per_success
@@ -10823,7 +10932,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_fans_portrait_v1
-  name: Kol fans portrait v1 (xingtu)
+  name: "Douyin Xingtu creator follower demographics by kol id"
   summary: 'Douyin: kol fans portrait v1 (xingtu)'
   cost:
     type: per_success
@@ -10857,7 +10966,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_link_struct_v1
-  name: Kol link struct v1 (xingtu)
+  name: "Douyin Xingtu creator link structure by kol id"
   summary: 'Douyin: kol link struct v1 (xingtu)'
   cost:
     type: per_success
@@ -10885,7 +10994,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_rec_videos_v1
-  name: Kol rec videos v1 (xingtu)
+  name: "Douyin Xingtu creator recommended videos by kol id"
   summary: 'Douyin: kol rec videos v1 (xingtu)'
   cost:
     type: per_success
@@ -10913,7 +11022,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_service_price_v1
-  name: Kol service price v1 (xingtu)
+  name: "Douyin Xingtu creator service pricing by kol id"
   summary: 'Douyin: kol service price v1 (xingtu)'
   cost:
     type: per_success
@@ -10947,7 +11056,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_touch_distribution_v1
-  name: Kol touch distribution v1 (xingtu)
+  name: "Douyin Xingtu creator reach distribution by kol id"
   summary: 'Douyin: kol touch distribution v1 (xingtu)'
   cost:
     type: per_success
@@ -10975,7 +11084,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_video_performance_v1
-  name: Kol video performance v1 (xingtu)
+  name: "Douyin Xingtu creator video performance by kol id"
   summary: 'Douyin: kol video performance v1 (xingtu)'
   cost:
     type: per_success
@@ -11009,7 +11118,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/kol_xingtu_index_v1
-  name: Kol xingtu index v1 (xingtu)
+  name: "Douyin Xingtu creator index score by kol id"
   summary: 'Douyin: kol xingtu index v1 (xingtu)'
   cost:
     type: per_success
@@ -11037,7 +11146,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/search_kol_v1
-  name: Search kol v1 (xingtu)
+  name: "Search Douyin Xingtu creators by keyword"
   summary: 'Douyin: search kol v1 (xingtu)'
   cost:
     type: per_success
@@ -11077,7 +11186,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu/search_kol_v2
-  name: Search kol v2 (xingtu)
+  name: "Search Douyin Xingtu creators by keyword and filters"
   summary: 'Douyin: search kol v2 (xingtu)'
   cost:
     type: per_success
@@ -11117,7 +11226,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_audience_distribution
-  name: Get author audience distribution
+  name: "Douyin Xingtu creator audience distribution by creator id"
   summary: 'Douyin: get author audience distribution (xingtu_v2)'
   cost:
     type: per_success
@@ -11161,7 +11270,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_base_info
-  name: Get author base info
+  name: "Douyin Xingtu creator base info by creator id"
   summary: 'Douyin: get author base info (xingtu_v2)'
   cost:
     type: per_success
@@ -11219,7 +11328,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_business_card_info
-  name: Get author business card info
+  name: "Douyin Xingtu creator business card by creator id"
   summary: 'Douyin: get author business card info (xingtu_v2)'
   cost:
     type: per_success
@@ -11247,7 +11356,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_convert_ability
-  name: Get author convert ability
+  name: "Douyin Xingtu creator conversion ability by creator id"
   summary: 'Douyin: get author convert ability (xingtu_v2)'
   cost:
     type: per_success
@@ -11299,7 +11408,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_convert_videos_or_products
-  name: Get author convert videos or products
+  name: "Douyin Xingtu creator conversion videos or products"
   summary: 'Douyin: get author convert videos or products (xingtu_v2)'
   cost:
     type: per_success
@@ -11363,7 +11472,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_daily_fans
-  name: Get author daily fans
+  name: "Douyin Xingtu creator daily followers by creator id"
   summary: 'Douyin: get author daily fans (xingtu_v2)'
   cost:
     type: per_success
@@ -11409,7 +11518,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_fans_distribution
-  name: Get author fans distribution
+  name: "Douyin Xingtu creator follower distribution by creator id"
   summary: 'Douyin: get author fans distribution (xingtu_v2)'
   cost:
     type: per_success
@@ -11449,7 +11558,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_homepage_videos
-  name: Get author homepage videos
+  name: "Douyin Xingtu creator homepage videos by creator id"
   summary: 'Douyin: get author homepage videos (xingtu_v2)'
   cost:
     type: per_success
@@ -11495,7 +11604,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_spread_info
-  name: Get author spread info
+  name: "Douyin Xingtu creator spread info by creator id"
   summary: 'Douyin: get author spread info (xingtu_v2)'
   cost:
     type: per_success
@@ -11559,7 +11668,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_touch_distribution
-  name: Get author touch distribution
+  name: "Douyin Xingtu creator reach distribution by creator id"
   summary: 'Douyin: get author touch distribution (xingtu_v2)'
   cost:
     type: per_success
@@ -11599,7 +11708,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_demander_mcn_list
-  name: Get demander mcn list
+  name: "Douyin Xingtu MCN agencies by name"
   summary: 'Douyin: get demander mcn list (xingtu_v2)'
   cost:
     type: per_success
@@ -11637,7 +11746,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_excellent_case_category_list
-  name: Get excellent case category list
+  name: "Douyin Xingtu case categories list"
   summary: 'Douyin: get excellent case category list (xingtu_v2)'
   cost:
     type: per_success
@@ -11665,7 +11774,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/xingtu_v2/get_ip_activity_list
-  name: Get ip activity list
+  name: "Douyin Xingtu IP activities list"
   summary: 'Douyin: get ip activity list (xingtu_v2)'
   cost:
     type: per_success
@@ -11706,7 +11815,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/xingtu_v2/get_recommend_for_star_authors
-  name: Get recommend for star authors
+  name: "Douyin Xingtu recommended star creators"
   summary: 'Douyin: get recommend for star authors (xingtu_v2)'
   cost:
     type: per_success
@@ -11740,7 +11849,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_resource_list
-  name: Get resource list
+  name: "Douyin Xingtu resources by resource id"
   summary: 'Douyin: get resource list (xingtu_v2)'
   cost:
     type: per_success
@@ -11769,7 +11878,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_user_profile_qrcode
-  name: Get user profile qrcode
+  name: "Douyin profile QR code by user id or secUid"
   summary: 'Douyin: get user profile qrcode (xingtu_v2)'
   cost:
     type: per_success
@@ -11802,7 +11911,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_xingtu_kolid_by_sec_user_id
-  name: Get xingtu kolid by sec user id
+  name: "Douyin Xingtu kol id from secUid"
   summary: 'Douyin: get xingtu kolid by sec user id (xingtu_v2)'
   cost:
     type: per_success
@@ -11831,7 +11940,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_xingtu_kolid_by_uid
-  name: Get xingtu kolid by uid
+  name: "Douyin Xingtu kol id from uid"
   summary: 'Douyin: get xingtu kolid by uid (xingtu_v2)'
   cost:
     type: per_success
@@ -11860,7 +11969,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_xingtu_kolid_by_unique_id
-  name: Get xingtu kolid by unique id
+  name: "Douyin Xingtu kol id from username"
   summary: 'Douyin: get xingtu kolid by unique id (xingtu_v2)'
   cost:
     type: per_success
@@ -11889,7 +11998,7 @@ endpoints:
   platform: douyin
   method: POST
   path: /api/v1/douyin/xingtu_v2/multi_get_author_info
-  name: Multi get author info
+  name: "Douyin Xingtu creator info in bulk"
   summary: 'Douyin: multi get author info (xingtu_v2)'
   cost:
     type: per_success
@@ -11923,7 +12032,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/search_anchor
-  name: Search anchor
+  name: "Search Douyin Xingtu live anchors by keyword, filters"
   summary: 'Douyin: search anchor (xingtu_v2)'
   cost:
     type: per_success
@@ -12115,7 +12224,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/search_creator
-  name: Search creator
+  name: "Search Douyin Xingtu creators by keyword and filters"
   summary: 'Douyin: search creator (xingtu_v2)'
   cost:
     type: per_success
@@ -12309,7 +12418,7 @@ endpoints:
   platform: douyin
   method: GET
   path: /api/v1/douyin/xingtu_v2/search_toutiao_creator
-  name: Search toutiao creator
+  name: "Search Toutiao creators via Xingtu by keyword"
   summary: 'Douyin: search toutiao creator (xingtu_v2)'
   cost:
     type: per_success
@@ -12501,7 +12610,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_content_hot_keywords
-  name: Get author content hot keywords
+  name: "Douyin Xingtu creator content keywords by creator id"
   summary: 'Douyin: get author content hot keywords (xingtu_v2)'
   cost:
     type: per_success
@@ -12537,7 +12646,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_cp_info
-  name: Get author cp info
+  name: "Douyin Xingtu creator CP info by creator id"
   summary: 'Douyin: get author cp info (xingtu_v2)'
   cost:
     type: per_success
@@ -12579,7 +12688,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_hot_comment_tokens
-  name: Get author hot comment tokens
+  name: "Douyin Xingtu creator hot comment tokens by creator id"
   summary: 'Douyin: get author hot comment tokens (xingtu_v2)'
   cost:
     type: per_success
@@ -12621,7 +12730,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_link_info
-  name: Get author link info
+  name: "Douyin Xingtu creator link info by creator id"
   summary: 'Douyin: get author link info (xingtu_v2)'
   cost:
     type: per_success
@@ -12669,7 +12778,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_local_info
-  name: Get author local info
+  name: "Douyin Xingtu creator local info by creator id"
   summary: 'Douyin: get author local info (xingtu_v2)'
   cost:
     type: per_success
@@ -12717,7 +12826,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_market_fields
-  name: Get author market fields
+  name: "Douyin Xingtu creator market fields list"
   summary: 'Douyin: get author market fields (xingtu_v2)'
   cost:
     type: per_success
@@ -12747,7 +12856,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_author_show_items
-  name: Get author show items
+  name: "Douyin Xingtu creator showcase videos by creator id"
   summary: 'Douyin: get author show items (xingtu_v2)'
   cost:
     type: per_success
@@ -12801,7 +12910,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_content_trend_guide
-  name: Get content trend guide
+  name: "Douyin Xingtu content trend guide"
   summary: 'Douyin: get content trend guide (xingtu_v2)'
   cost:
     type: per_success
@@ -12823,7 +12932,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_ip_activity_detail
-  name: Get ip activity detail
+  name: "Douyin Xingtu IP activity details by activity id"
   summary: 'Douyin: get ip activity detail (xingtu_v2)'
   cost:
     type: per_success
@@ -12853,7 +12962,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_ip_activity_industry_list
-  name: Get ip activity industry list
+  name: "Douyin Xingtu IP activity industries list"
   summary: 'Douyin: get ip activity industry list (xingtu_v2)'
   cost:
     type: per_success
@@ -12875,7 +12984,7 @@ endpoints:
   platform: douyin-xingtu
   method: POST
   path: /api/v1/douyin/xingtu_v2/get_playlet_actor_rank_catalog
-  name: Get playlet actor rank catalog
+  name: "Douyin short drama actor ranking catalog"
   summary: 'Douyin: get playlet actor rank catalog (xingtu_v2)'
   cost:
     type: per_success
@@ -12897,7 +13006,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_playlet_actor_rank_list
-  name: Get playlet actor rank list
+  name: "Douyin short drama actor rankings by period"
   summary: 'Douyin: get playlet actor rank list (xingtu_v2)'
   cost:
     type: per_success
@@ -12949,7 +13058,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_ranking_list_catalog
-  name: Get ranking list catalog
+  name: "Douyin Xingtu creator ranking catalog"
   summary: 'Douyin: get ranking list catalog (xingtu_v2)'
   cost:
     type: per_success
@@ -12983,7 +13092,7 @@ endpoints:
   platform: douyin-xingtu
   method: GET
   path: /api/v1/douyin/xingtu_v2/get_ranking_list_data
-  name: Get ranking list data
+  name: "Douyin Xingtu creator rankings by type and period"
   summary: 'Douyin: get ranking list data (xingtu_v2)'
   cost:
     type: per_success
@@ -13037,7 +13146,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_cities
-  name: Fetch cities
+  name: "Instagram cities list by country code"
   summary: 'Instagram: fetch cities (v1)'
   cost:
     type: per_success
@@ -13071,7 +13180,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_comment_replies
-  name: Fetch comment replies
+  name: "Instagram comment replies by media and comment id"
   summary: 'Instagram: fetch comment replies (v1)'
   cost:
     type: per_success
@@ -13109,7 +13218,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_explore_sections
-  name: Fetch explore sections
+  name: "Instagram explore page sections"
   summary: 'Instagram: fetch explore sections (v1)'
   cost:
     type: per_success
@@ -13131,7 +13240,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_hashtag_posts
-  name: Fetch hashtag posts
+  name: "Instagram hashtag posts by hashtag name"
   summary: 'Instagram: fetch hashtag posts (v1)'
   cost:
     type: per_success
@@ -13165,7 +13274,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_location_info
-  name: Fetch location info
+  name: "Instagram location details by location id"
   summary: 'Instagram: fetch location info (v1)'
   cost:
     type: per_success
@@ -13195,7 +13304,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_location_posts
-  name: Fetch location posts
+  name: "Instagram location posts by location id"
   summary: 'Instagram: fetch location posts (v1)'
   cost:
     type: per_success
@@ -13234,7 +13343,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_locations
-  name: Fetch locations
+  name: "Instagram locations list by city id"
   summary: 'Instagram: fetch locations (v1)'
   cost:
     type: per_success
@@ -13269,7 +13378,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_music_posts
-  name: Fetch music posts
+  name: "Instagram music posts by music id or URL"
   summary: 'Instagram: fetch music posts (v1)'
   cost:
     type: per_success
@@ -13309,7 +13418,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_post_by_id
-  name: Fetch post by id
+  name: "Instagram post details by post id"
   summary: 'Instagram: fetch post by id (v1)'
   cost:
     type: per_success
@@ -13339,7 +13448,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_post_by_url
-  name: Fetch post by url
+  name: "Instagram post details by post URL"
   summary: 'Instagram: fetch post by url (v1)'
   cost:
     type: per_success
@@ -13369,7 +13478,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_post_by_url_v2
-  name: Fetch post by url v2
+  name: "Instagram post details by post URL"
   summary: 'Instagram: fetch post by url v2 (v1)'
   cost:
     type: per_success
@@ -13399,7 +13508,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_post_comments_v2
-  name: Fetch post comments v2
+  name: "Instagram post comments by media id"
   summary: 'Instagram: fetch post comments v2 (v1)'
   cost:
     type: per_success
@@ -13437,7 +13546,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_related_profiles
-  name: Fetch related profiles
+  name: "Instagram related profiles by user id"
   summary: 'Instagram: fetch related profiles (v1)'
   cost:
     type: per_success
@@ -13467,7 +13576,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_search
-  name: Fetch search
+  name: "Search Instagram users, hashtags, places by keyword"
   summary: 'Instagram: fetch search (v1)'
   cost:
     type: per_success
@@ -13501,7 +13610,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_section_posts
-  name: Fetch section posts
+  name: "Instagram explore section posts by section id"
   summary: 'Instagram: fetch section posts (v1)'
   cost:
     type: per_success
@@ -13541,7 +13650,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_about_info
-  name: Fetch user about info
+  name: "Instagram account about info by user id"
   summary: 'Instagram: fetch user about info (v1)'
   cost:
     type: per_success
@@ -13569,7 +13678,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_info_by_id
-  name: Fetch user info by id
+  name: "Instagram profile by user id"
   summary: 'Instagram: fetch user info by id (v1)'
   cost:
     type: per_success
@@ -13599,7 +13708,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_info_by_id_v2
-  name: Fetch user info by id v2
+  name: "Instagram profile by user id"
   summary: 'Instagram: fetch user info by id v2 (v1)'
   cost:
     type: per_success
@@ -13629,7 +13738,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_info_by_username_v2
-  name: Fetch user info by username v2
+  name: "Instagram profile by username"
   summary: 'Instagram: fetch user info by username v2 (v1)'
   cost:
     type: per_success
@@ -13659,7 +13768,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_info_by_username_v3
-  name: Fetch user info by username v3
+  name: "Instagram profile by username"
   summary: 'Instagram: fetch user info by username v3 (v1)'
   cost:
     type: per_success
@@ -13689,7 +13798,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_posts_v2
-  name: Fetch user posts v2
+  name: "Instagram user's posts by user id"
   summary: 'Instagram: fetch user posts v2 (v1)'
   cost:
     type: per_success
@@ -13729,7 +13838,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_reels
-  name: Fetch user reels
+  name: "Instagram user's reels by user id"
   summary: 'Instagram: fetch user reels (v1)'
   cost:
     type: per_success
@@ -13769,7 +13878,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_reposts
-  name: Fetch user reposts
+  name: "Instagram user's reposts by user id"
   summary: 'Instagram: fetch user reposts (v1)'
   cost:
     type: per_success
@@ -13803,7 +13912,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/fetch_user_tagged_posts
-  name: Fetch user tagged posts
+  name: "Instagram user's tagged posts by user id"
   summary: 'Instagram: fetch user tagged posts (v1)'
   cost:
     type: per_success
@@ -13843,7 +13952,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/media_id_to_shortcode
-  name: Media id to shortcode
+  name: "Convert Instagram media id to shortcode"
   summary: 'Instagram: media id to shortcode (v1)'
   cost:
     type: per_success
@@ -13872,7 +13981,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/shortcode_to_media_id
-  name: Shortcode to media id
+  name: "Convert Instagram shortcode to media id"
   summary: 'Instagram: shortcode to media id (v1)'
   cost:
     type: per_success
@@ -13901,7 +14010,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v1/user_id_to_username
-  name: User id to username
+  name: "Instagram username from user id"
   summary: 'Instagram: user id to username (v1)'
   cost:
     type: per_success
@@ -13930,7 +14039,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_comment_replies
-  name: Fetch comment replies
+  name: "Instagram comment replies by shortcode or URL"
   summary: 'Instagram: fetch comment replies (v2)'
   cost:
     type: per_success
@@ -13970,7 +14079,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_hashtag_posts
-  name: Fetch hashtag posts
+  name: "Instagram hashtag posts by hashtag name"
   summary: 'Instagram: fetch hashtag posts (v2)'
   cost:
     type: per_success
@@ -14009,7 +14118,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_highlight_stories
-  name: Fetch highlight stories
+  name: "Instagram highlight stories by highlight id"
   summary: 'Instagram: fetch highlight stories (v2)'
   cost:
     type: per_success
@@ -14039,7 +14148,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_location_posts
-  name: Fetch location posts
+  name: "Instagram location posts by location id"
   summary: 'Instagram: fetch location posts (v2)'
   cost:
     type: per_success
@@ -14071,7 +14180,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_music_posts
-  name: Fetch music posts
+  name: "Instagram music posts by audio id"
   summary: 'Instagram: fetch music posts (v2)'
   cost:
     type: per_success
@@ -14105,7 +14214,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_post_comments
-  name: Fetch post comments
+  name: "Instagram post comments by shortcode or URL"
   summary: 'Instagram: fetch post comments (v2)'
   cost:
     type: per_success
@@ -14145,7 +14254,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_post_info
-  name: Fetch post info
+  name: "Instagram post details by shortcode or URL"
   summary: 'Instagram: fetch post info (v2)'
   cost:
     type: per_success
@@ -14175,7 +14284,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_post_likes
-  name: Fetch post likes
+  name: "Instagram post likes by shortcode or URL"
   summary: 'Instagram: fetch post likes (v2)'
   cost:
     type: per_success
@@ -14209,7 +14318,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_similar_users
-  name: Fetch similar users
+  name: "Instagram similar accounts by username or user id"
   summary: 'Instagram: fetch similar users (v2)'
   cost:
     type: per_success
@@ -14245,7 +14354,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_followers
-  name: Fetch user followers
+  name: "Instagram user's followers by username or user id"
   summary: 'Instagram: fetch user followers (v2)'
   cost:
     type: per_success
@@ -14285,7 +14394,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_following
-  name: Fetch user following
+  name: "Instagram accounts a user follows by username or id"
   summary: 'Instagram: fetch user following (v2)'
   cost:
     type: per_success
@@ -14325,7 +14434,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_highlights
-  name: Fetch user highlights
+  name: "Instagram user's highlights by username or user id"
   summary: 'Instagram: fetch user highlights (v2)'
   cost:
     type: per_success
@@ -14361,7 +14470,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_info
-  name: Fetch user info
+  name: "Instagram profile by username or user id"
   summary: 'Instagram: fetch user info (v2)'
   cost:
     type: per_success
@@ -14397,7 +14506,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_posts
-  name: Fetch user posts
+  name: "Instagram user's posts by username or user id"
   summary: 'Instagram: fetch user posts (v2)'
   cost:
     type: per_success
@@ -14437,7 +14546,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_reels
-  name: Fetch user reels
+  name: "Instagram user's reels by username or user id"
   summary: 'Instagram: fetch user reels (v2)'
   cost:
     type: per_success
@@ -14477,7 +14586,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_stories
-  name: Fetch user stories
+  name: "Instagram user's stories by username or user id"
   summary: 'Instagram: fetch user stories (v2)'
   cost:
     type: per_success
@@ -14513,7 +14622,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/fetch_user_tagged_posts
-  name: Fetch user tagged posts
+  name: "Instagram user's tagged posts by username or id"
   summary: 'Instagram: fetch user tagged posts (v2)'
   cost:
     type: per_success
@@ -14553,7 +14662,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/general_search
-  name: General search
+  name: "Search Instagram across all content by keyword"
   summary: 'Instagram: general search (v2)'
   cost:
     type: per_success
@@ -14587,7 +14696,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/media_id_to_shortcode
-  name: Media id to shortcode
+  name: "Convert Instagram media id to shortcode"
   summary: 'Instagram: media id to shortcode (v2)'
   cost:
     type: per_success
@@ -14616,7 +14725,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_by_coordinates
-  name: Search by coordinates
+  name: "Instagram places by GPS coordinates"
   summary: 'Instagram: search by coordinates (v2)'
   cost:
     type: per_success
@@ -14652,7 +14761,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_hashtags
-  name: Search hashtags
+  name: "Search Instagram hashtags by keyword"
   summary: 'Instagram: search hashtags (v2)'
   cost:
     type: per_success
@@ -14682,7 +14791,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_locations
-  name: Search locations
+  name: "Search Instagram locations by keyword"
   summary: 'Instagram: search locations (v2)'
   cost:
     type: per_success
@@ -14712,7 +14821,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_music
-  name: Search music
+  name: "Search Instagram music by keyword"
   summary: 'Instagram: search music (v2)'
   cost:
     type: per_success
@@ -14742,7 +14851,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_reels
-  name: Search reels
+  name: "Search Instagram reels by keyword"
   summary: 'Instagram: search reels (v2)'
   cost:
     type: per_success
@@ -14776,7 +14885,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/search_users
-  name: Search users
+  name: "Search Instagram users by keyword"
   summary: 'Instagram: search users (v2)'
   cost:
     type: per_success
@@ -14806,7 +14915,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/shortcode_to_media_id
-  name: Shortcode to media id
+  name: "Convert Instagram shortcode to media id"
   summary: 'Instagram: shortcode to media id (v2)'
   cost:
     type: per_success
@@ -14835,7 +14944,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v2/user_id_to_username
-  name: User id to username
+  name: "Instagram username from user id"
   summary: 'Instagram: user id to username (v2)'
   cost:
     type: per_success
@@ -14864,7 +14973,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/bulk_translate_comments
-  name: Bulk translate comments
+  name: "Translate Instagram comments in bulk by comment ids"
   summary: 'Instagram: bulk translate comments (v3)'
   cost:
     type: per_success
@@ -14894,7 +15003,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/extract_shortcode
-  name: Extract shortcode
+  name: "Instagram shortcode from post URL"
   summary: 'Instagram: extract shortcode (v3)'
   cost:
     type: per_success
@@ -14923,7 +15032,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/general_search
-  name: General search
+  name: "Search Instagram across all content by keyword"
   summary: 'Instagram: general search (v3)'
   cost:
     type: per_success
@@ -14966,7 +15075,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_comment_replies
-  name: Get comment replies
+  name: "Instagram comment replies by media and comment id"
   summary: 'Instagram: get comment replies (v3)'
   cost:
     type: per_success
@@ -15006,7 +15115,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_explore
-  name: Get explore
+  name: "Instagram explore feed"
   summary: 'Instagram: get explore (v3)'
   cost:
     type: per_success
@@ -15034,7 +15143,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_hashtag_posts
-  name: Get hashtag posts
+  name: "Instagram hashtag posts by hashtag name"
   summary: 'Instagram: get hashtag posts (v3)'
   cost:
     type: per_success
@@ -15066,7 +15175,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_highlight_stories
-  name: Get highlight stories
+  name: "Instagram highlight stories by highlight id"
   summary: 'Instagram: get highlight stories (v3)'
   cost:
     type: per_success
@@ -15108,7 +15217,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_location_info
-  name: Get location info
+  name: "Instagram location details by location id"
   summary: 'Instagram: get location info (v3)'
   cost:
     type: per_success
@@ -15143,7 +15252,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_location_nearby
-  name: Get location nearby
+  name: "Instagram nearby places by location id"
   summary: 'Instagram: get location nearby (v3)'
   cost:
     type: per_success
@@ -15171,7 +15280,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_location_posts
-  name: Get location posts
+  name: "Instagram location posts by location id"
   summary: 'Instagram: get location posts (v3)'
   cost:
     type: per_success
@@ -15223,7 +15332,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_music_posts
-  name: Get music posts
+  name: "Instagram music posts by audio id"
   summary: 'Instagram: get music posts (v3)'
   cost:
     type: per_success
@@ -15255,7 +15364,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_post_comments
-  name: Get post comments
+  name: "Instagram post comments by shortcode"
   summary: 'Instagram: get post comments (v3)'
   cost:
     type: per_success
@@ -15297,7 +15406,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_post_info
-  name: Get post info
+  name: "Instagram post details by media id or URL"
   summary: 'Instagram: get post info (v3)'
   cost:
     type: per_success
@@ -15333,7 +15442,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_post_info_by_code
-  name: Get post info by code
+  name: "Instagram post details by shortcode"
   summary: 'Instagram: get post info by code (v3)'
   cost:
     type: per_success
@@ -15363,7 +15472,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_post_likes
-  name: Get post likes
+  name: "Instagram post likes by shortcode"
   summary: 'Instagram: get post likes (v3)'
   cost:
     type: per_success
@@ -15393,7 +15502,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_post_oembed
-  name: Get post oembed
+  name: "Instagram post oEmbed by post URL"
   summary: 'Instagram: get post oembed (v3)'
   cost:
     type: per_success
@@ -15431,7 +15540,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_recommended_reels
-  name: Get recommended reels
+  name: "Instagram recommended reels feed"
   summary: 'Instagram: get recommended reels (v3)'
   cost:
     type: per_success
@@ -15464,7 +15573,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_similar_users
-  name: Get similar users
+  name: "Instagram similar accounts by user id"
   summary: 'Instagram: get similar users (v3)'
   cost:
     type: per_success
@@ -15494,7 +15603,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_about
-  name: Get user about
+  name: "Instagram account about info by username"
   summary: 'Instagram: get user about (v3)'
   cost:
     type: per_success
@@ -15524,7 +15633,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_brief
-  name: Get user brief
+  name: "Instagram profile brief by username and user id"
   summary: 'Instagram: get user brief (v3)'
   cost:
     type: per_success
@@ -15560,7 +15669,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_followers
-  name: Get user followers
+  name: "Instagram user's followers by username"
   summary: 'Instagram: get user followers (v3)'
   cost:
     type: per_success
@@ -15600,7 +15709,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_following
-  name: Get user following
+  name: "Instagram accounts a user follows by username"
   summary: 'Instagram: get user following (v3)'
   cost:
     type: per_success
@@ -15640,7 +15749,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_former_usernames
-  name: Get user former usernames
+  name: "Instagram former usernames by username"
   summary: 'Instagram: get user former usernames (v3)'
   cost:
     type: per_success
@@ -15670,7 +15779,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_highlights
-  name: Get user highlights
+  name: "Instagram user's highlights by username"
   summary: 'Instagram: get user highlights (v3)'
   cost:
     type: per_success
@@ -15717,7 +15826,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_id_by_username
-  name: Get user id by username
+  name: "Instagram user id from username"
   summary: 'Instagram: get user id by username (v3)'
   cost:
     type: per_success
@@ -15746,7 +15855,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_posts
-  name: Get user posts
+  name: "Instagram user's posts by username"
   summary: 'Instagram: get user posts (v3)'
   cost:
     type: per_success
@@ -15799,7 +15908,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_profile
-  name: Get user profile
+  name: "Instagram profile by username"
   summary: 'Instagram: get user profile (v3)'
   cost:
     type: per_success
@@ -15829,7 +15938,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_reels
-  name: Get user reels
+  name: "Instagram user's reels by username"
   summary: 'Instagram: get user reels (v3)'
   cost:
     type: per_success
@@ -15882,7 +15991,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_stories
-  name: Get user stories
+  name: "Instagram user's stories by username"
   summary: 'Instagram: get user stories (v3)'
   cost:
     type: per_success
@@ -15912,7 +16021,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/get_user_tagged_posts
-  name: Get user tagged posts
+  name: "Instagram user's tagged posts by username"
   summary: 'Instagram: get user tagged posts (v3)'
   cost:
     type: per_success
@@ -15965,7 +16074,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/media_id_to_shortcode
-  name: Media id to shortcode
+  name: "Convert Instagram media id to shortcode"
   summary: 'Instagram: media id to shortcode (v3)'
   cost:
     type: per_success
@@ -15994,7 +16103,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/search_by_coordinates
-  name: Search by coordinates
+  name: "Instagram places by GPS coordinates"
   summary: 'Instagram: search by coordinates (v3)'
   cost:
     type: per_success
@@ -16030,7 +16139,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/search_hashtags
-  name: Search hashtags
+  name: "Search Instagram hashtags by keyword"
   summary: 'Instagram: search hashtags (v3)'
   cost:
     type: per_success
@@ -16064,7 +16173,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/search_users
-  name: Search users
+  name: "Search Instagram users by keyword"
   summary: 'Instagram: search users (v3)'
   cost:
     type: per_success
@@ -16098,7 +16207,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/shortcode_to_media_id
-  name: Shortcode to media id
+  name: "Convert Instagram shortcode to media id"
   summary: 'Instagram: shortcode to media id (v3)'
   cost:
     type: per_success
@@ -16127,7 +16236,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/translate_comment
-  name: Translate comment
+  name: "Translate an Instagram comment by comment id"
   summary: 'Instagram: translate comment (v3)'
   cost:
     type: per_success
@@ -16155,7 +16264,7 @@ endpoints:
   platform: instagram
   method: GET
   path: /api/v1/instagram/v3/user_id_to_username
-  name: User id to username
+  name: "Instagram username from user id"
   summary: 'Instagram: user id to username (v3)'
   cost:
     type: per_success
@@ -16184,7 +16293,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_brand_top_list
-  name: Fetch brand top list
+  name: "Kuaishou brand ranking list"
   summary: 'Kuaishou: fetch brand top list (app)'
   cost:
     type: per_success
@@ -16215,7 +16324,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_hot_board_categories
-  name: Fetch hot board categories
+  name: "Kuaishou trending board categories"
   summary: 'Kuaishou: fetch hot board categories (app)'
   cost:
     type: per_success
@@ -16237,7 +16346,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_hot_board_detail
-  name: Fetch hot board detail
+  name: "Kuaishou trending board entries by board id"
   summary: 'Kuaishou: fetch hot board detail (app)'
   cost:
     type: per_success
@@ -16269,7 +16378,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_hot_search_person
-  name: Fetch hot search person
+  name: "Kuaishou trending people list"
   summary: 'Kuaishou: fetch hot search person (app)'
   cost:
     type: per_success
@@ -16291,7 +16400,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_live_top_list
-  name: Fetch live top list
+  name: "Kuaishou live streams ranking list"
   summary: 'Kuaishou: fetch live top list (app)'
   cost:
     type: per_success
@@ -16322,7 +16431,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_music_ranking
-  name: Fetch music ranking
+  name: "Kuaishou music ranking by chart tab"
   summary: 'Kuaishou: fetch music ranking (app)'
   cost:
     type: per_success
@@ -16361,7 +16470,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_one_user_v2
-  name: Fetch one user v2
+  name: "Kuaishou user profile by user id"
   summary: 'Kuaishou: fetch one user v2 (app)'
   cost:
     type: per_success
@@ -16390,7 +16499,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_one_video
-  name: Fetch one video
+  name: "Kuaishou video details by video id"
   summary: 'Kuaishou: fetch one video (app)'
   cost:
     type: per_success
@@ -16419,7 +16528,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_one_video_by_url
-  name: Fetch one video by url
+  name: "Kuaishou video details by share link"
   summary: 'Kuaishou: fetch one video by url (app)'
   cost:
     type: per_success
@@ -16448,7 +16557,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_selection_feed
-  name: Fetch selection feed
+  name: "Kuaishou selection feed"
   summary: 'Kuaishou: fetch selection feed (app)'
   cost:
     type: per_success
@@ -16470,7 +16579,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_shopping_top_list
-  name: Fetch shopping top list
+  name: "Kuaishou shopping ranking list"
   summary: 'Kuaishou: fetch shopping top list (app)'
   cost:
     type: per_success
@@ -16501,7 +16610,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_tag_feed
-  name: Fetch tag feed
+  name: "Kuaishou hashtag feed by tag id or name"
   summary: 'Kuaishou: fetch tag feed (app)'
   cost:
     type: per_success
@@ -16563,7 +16672,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_user_hot_post
-  name: Fetch user hot post
+  name: "Kuaishou user's popular posts by user id"
   summary: 'Kuaishou: fetch user hot post (app)'
   cost:
     type: per_success
@@ -16595,7 +16704,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_user_live_info
-  name: Fetch user live info
+  name: "Kuaishou user live stream info by user id"
   summary: 'Kuaishou: fetch user live info (app)'
   cost:
     type: per_success
@@ -16624,7 +16733,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_user_post_v2
-  name: Fetch user post v2
+  name: "Kuaishou user's posts by user id"
   summary: 'Kuaishou: fetch user post v2 (app)'
   cost:
     type: per_success
@@ -16663,7 +16772,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_video_comment
-  name: Fetch video comment
+  name: "Kuaishou video comments by video id"
   summary: 'Kuaishou: fetch video comment (app)'
   cost:
     type: per_success
@@ -16695,7 +16804,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_video_sub_comments
-  name: Fetch video sub comments
+  name: "Kuaishou comment replies by video and comment id"
   summary: 'Kuaishou: fetch video sub comments (app)'
   cost:
     type: per_success
@@ -16739,7 +16848,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/fetch_videos_batch
-  name: Fetch videos batch
+  name: "Kuaishou video details in bulk by video ids"
   summary: 'Kuaishou: fetch videos batch (app)'
   cost:
     type: per_success
@@ -16770,7 +16879,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/generate_kuaishou_share_link
-  name: Generate kuaishou share link
+  name: "Kuaishou share link from object id"
   summary: 'Kuaishou: generate kuaishou share link (app)'
   cost:
     type: per_success
@@ -16798,7 +16907,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_comprehensive
-  name: Search comprehensive
+  name: "Search Kuaishou across all content by keyword"
   summary: 'Kuaishou: search comprehensive (app)'
   cost:
     type: per_success
@@ -16859,7 +16968,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_image
-  name: Search image
+  name: "Search Kuaishou images by keyword"
   summary: 'Kuaishou: search image (app)'
   cost:
     type: per_success
@@ -16892,7 +17001,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_live
-  name: Search live
+  name: "Search Kuaishou live streams by keyword"
   summary: 'Kuaishou: search live (app)'
   cost:
     type: per_success
@@ -16925,7 +17034,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_music
-  name: Search music
+  name: "Search Kuaishou music by keyword"
   summary: 'Kuaishou: search music (app)'
   cost:
     type: per_success
@@ -16958,7 +17067,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_tag
-  name: Search tag
+  name: "Search Kuaishou hashtags by keyword"
   summary: 'Kuaishou: search tag (app)'
   cost:
     type: per_success
@@ -16991,7 +17100,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_user_v2
-  name: Search user v2
+  name: "Search Kuaishou users by keyword and filters"
   summary: 'Kuaishou: search user v2 (app)'
   cost:
     type: per_success
@@ -17053,7 +17162,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/app/search_video_v2
-  name: Search video v2
+  name: "Search Kuaishou videos by keyword"
   summary: 'Kuaishou: search video v2 (app)'
   cost:
     type: per_success
@@ -17086,7 +17195,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_get_user_id
-  name: Fetch get user id
+  name: "Kuaishou user id from share link"
   summary: 'Kuaishou: fetch get user id (web)'
   cost:
     type: per_success
@@ -17114,7 +17223,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_kuaishou_hot_list_v1
-  name: Fetch kuaishou hot list v1
+  name: "Kuaishou trending list"
   summary: 'Kuaishou: fetch kuaishou hot list v1 (web)'
   cost:
     type: per_success
@@ -17136,7 +17245,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_kuaishou_hot_list_v2
-  name: Fetch kuaishou hot list v2
+  name: "Kuaishou trending list by board type"
   summary: 'Kuaishou: fetch kuaishou hot list v2 (web)'
   cost:
     type: per_success
@@ -17165,7 +17274,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_one_video
-  name: Fetch one video
+  name: "Kuaishou video details by share link"
   summary: 'Kuaishou: fetch one video (web)'
   cost:
     type: per_success
@@ -17194,7 +17303,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_one_video_by_url
-  name: Fetch one video by url
+  name: "Kuaishou video details by video URL"
   summary: 'Kuaishou: fetch one video by url (web)'
   cost:
     type: per_success
@@ -17223,7 +17332,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_one_video_comment
-  name: Fetch one video comment
+  name: "Kuaishou video comments by video id"
   summary: 'Kuaishou: fetch one video comment (web)'
   cost:
     type: per_success
@@ -17255,7 +17364,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_one_video_sub_comment
-  name: Fetch one video sub comment
+  name: "Kuaishou comment replies by video and comment id"
   summary: 'Kuaishou: fetch one video sub comment (web)'
   cost:
     type: per_success
@@ -17294,7 +17403,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_one_video_v2
-  name: Fetch one video v2
+  name: "Kuaishou video details by video id"
   summary: 'Kuaishou: fetch one video v2 (web)'
   cost:
     type: per_success
@@ -17323,7 +17432,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_user_collect
-  name: Fetch user collect
+  name: "Kuaishou user's collected posts by user id"
   summary: 'Kuaishou: fetch user collect (web)'
   cost:
     type: per_success
@@ -17355,7 +17464,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_user_info
-  name: Fetch user info
+  name: "Kuaishou user profile by user id"
   summary: 'Kuaishou: fetch user info (web)'
   cost:
     type: per_success
@@ -17384,7 +17493,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/fetch_user_live_replay
-  name: Fetch user live replay
+  name: "Kuaishou user's live replays by user id"
   summary: 'Kuaishou: fetch user live replay (web)'
   cost:
     type: per_success
@@ -17417,7 +17526,7 @@ endpoints:
   platform: kuaishou
   method: GET
   path: /api/v1/kuaishou/web/generate_share_short_url
-  name: Generate share short url
+  name: "Kuaishou short share URL from video id"
   summary: 'Kuaishou: generate share short url (web)'
   cost:
     type: per_success
@@ -17445,7 +17554,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_discover_banners
-  name: Fetch discover banners
+  name: "Lemon8 discover tab banners"
   summary: 'Lemon8: fetch discover banners (app)'
   cost:
     type: per_success
@@ -17466,7 +17575,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_discover_tab
-  name: Fetch discover tab
+  name: "Lemon8 discover tab feed"
   summary: 'Lemon8: fetch discover tab (app)'
   cost:
     type: per_success
@@ -17488,7 +17597,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_discover_tab_information_tabs
-  name: Fetch discover tab information tabs
+  name: "Lemon8 discover tab category list"
   summary: 'Lemon8: fetch discover tab information tabs (app)'
   cost:
     type: per_success
@@ -17509,7 +17618,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_hot_search_keywords
-  name: Fetch hot search keywords
+  name: "Lemon8 trending search terms"
   summary: 'Lemon8: fetch hot search keywords (app)'
   cost:
     type: per_success
@@ -17531,7 +17640,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_post_comment_list
-  name: Fetch post comment list
+  name: "Lemon8 post comments by post id"
   summary: 'Lemon8: fetch post comment list (app)'
   cost:
     type: per_success
@@ -17579,7 +17688,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_post_detail
-  name: Fetch post detail
+  name: "Lemon8 post details by post id"
   summary: 'Lemon8: fetch post detail (app)'
   cost:
     type: per_success
@@ -17609,7 +17718,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_search
-  name: Fetch search
+  name: "Lemon8 keyword search with type and sort filters"
   summary: 'Lemon8: fetch search (app)'
   cost:
     type: per_success
@@ -17657,7 +17766,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_topic_info
-  name: Fetch topic info
+  name: "Lemon8 topic details by topic id"
   summary: 'Lemon8: fetch topic info (app)'
   cost:
     type: per_success
@@ -17687,7 +17796,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_topic_post_list
-  name: Fetch topic post list
+  name: "Lemon8 hashtag topic posts by hashtag name"
   summary: 'Lemon8: fetch topic post list (app)'
   cost:
     type: per_success
@@ -17738,7 +17847,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_user_follower_list
-  name: Fetch user follower list
+  name: "Lemon8 user's followers by user id"
   summary: 'Lemon8: fetch user follower list (app)'
   cost:
     type: per_success
@@ -17772,7 +17881,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_user_following_list
-  name: Fetch user following list
+  name: "Lemon8 accounts a user follows by user id"
   summary: 'Lemon8: fetch user following list (app)'
   cost:
     type: per_success
@@ -17806,7 +17915,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/fetch_user_profile
-  name: Fetch user profile
+  name: "Lemon8 user profile by user id"
   summary: 'Lemon8: fetch user profile (app)'
   cost:
     type: per_success
@@ -17836,7 +17945,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/get_item_id
-  name: Get item id
+  name: "Lemon8 post id from share link"
   summary: 'Lemon8: get item id (app)'
   cost:
     type: per_success
@@ -17865,7 +17974,7 @@ endpoints:
   platform: lemon8
   method: POST
   path: /api/v1/lemon8/app/get_item_ids
-  name: Get item ids
+  name: "Lemon8 post ids from share links"
   summary: 'Lemon8: get item ids (app)'
   cost:
     type: per_success
@@ -17893,7 +18002,7 @@ endpoints:
   platform: lemon8
   method: GET
   path: /api/v1/lemon8/app/get_user_id
-  name: Get user id
+  name: "Lemon8 user id from share link"
   summary: 'Lemon8: get user id (app)'
   cost:
     type: per_success
@@ -17922,7 +18031,7 @@ endpoints:
   platform: lemon8
   method: POST
   path: /api/v1/lemon8/app/get_user_ids
-  name: Get user ids
+  name: "Lemon8 user ids from share links"
   summary: 'Lemon8: get user ids (app)'
   cost:
     type: per_success
@@ -19739,7 +19848,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_company_posts
-  name: Get company posts
+  name: "LinkedIn company posts by URL or slug"
   summary: 'Linkedin: get company posts (web_v2)'
   cost:
     type: per_success
@@ -19775,7 +19884,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_company_profile
-  name: Get company profile
+  name: "LinkedIn company profile by URL or slug"
   summary: 'Linkedin: get company profile (web_v2)'
   cost:
     type: per_success
@@ -19805,7 +19914,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_job_detail
-  name: Get job detail
+  name: "LinkedIn job posting details by URL or job id"
   summary: 'Linkedin: get job detail (web_v2)'
   cost:
     type: per_success
@@ -19835,7 +19944,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_post_detail
-  name: Get post detail
+  name: "LinkedIn post details by post URL"
   summary: 'Linkedin: get post detail (web_v2)'
   cost:
     type: per_success
@@ -19866,7 +19975,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_post_comments
-  name: Get post comments
+  name: "LinkedIn post comments by activity URN"
   summary: Fetch comments of a LinkedIn post by its activity URN.
   input:
     queryParams:
@@ -19904,7 +20013,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_user_posts
-  name: Get user posts
+  name: "LinkedIn person's posts by profile URL or slug"
   summary: 'Linkedin: get user posts (web_v2)'
   cost:
     type: per_success
@@ -19940,7 +20049,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/get_user_profile
-  name: Get user profile
+  name: "LinkedIn person profile by URL or slug"
   summary: 'Linkedin: get user profile (web_v2)'
   cost:
     type: per_success
@@ -19971,7 +20080,7 @@ endpoints:
   platform: linkedin
   method: GET
   path: /api/v1/linkedin/web_v2/search_jobs
-  name: Search jobs
+  name: "Search LinkedIn job postings by location and keyword"
   summary: 'Linkedin: search jobs (web_v2)'
   cost:
     type: per_success
@@ -20100,7 +20209,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_hashtag_detail
-  name: Fetch hashtag detail
+  name: "Pipixia hashtag details by hashtag id"
   summary: 'Pipixia: fetch hashtag detail (app)'
   cost:
     type: per_success
@@ -20130,7 +20239,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_hashtag_post_list
-  name: Fetch hashtag post list
+  name: "Pipixia hashtag posts by hashtag id"
   summary: 'Pipixia: fetch hashtag post list (app)'
   cost:
     type: per_success
@@ -20184,7 +20293,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_home_feed
-  name: Fetch home feed
+  name: "Pipixia home feed recommendations"
   summary: 'Pipixia: fetch home feed (app)'
   cost:
     type: per_success
@@ -20214,7 +20323,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_home_short_drama_feed
-  name: Fetch home short drama feed
+  name: "Pipixia short drama home feed"
   summary: 'Pipixia: fetch home short drama feed (app)'
   cost:
     type: per_success
@@ -20244,7 +20353,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_hot_search_board_detail
-  name: Fetch hot search board detail
+  name: "Pipixia trending board entries by board type"
   summary: 'Pipixia: fetch hot search board detail (app)'
   cost:
     type: per_success
@@ -20274,7 +20383,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_hot_search_board_list
-  name: Fetch hot search board list
+  name: "Pipixia trending board list"
   summary: 'Pipixia: fetch hot search board list (app)'
   cost:
     type: per_success
@@ -20296,7 +20405,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_hot_search_words
-  name: Fetch hot search words
+  name: "Pipixia trending search terms"
   summary: 'Pipixia: fetch hot search words (app)'
   cost:
     type: per_success
@@ -20318,7 +20427,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_increase_post_view_count
-  name: Fetch increase post view count
+  name: "Increase a Pipixia post's view count by video id"
   summary: 'Pipixia: fetch increase post view count (app)'
   cost:
     type: per_success
@@ -20353,7 +20462,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_post_comment_list
-  name: Fetch post comment list
+  name: "Pipixia post comments by video id"
   summary: 'Pipixia: fetch post comment list (app)'
   cost:
     type: per_success
@@ -20395,7 +20504,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_post_detail
-  name: Fetch post detail
+  name: "Pipixia post details by video id"
   summary: 'Pipixia: fetch post detail (app)'
   cost:
     type: per_success
@@ -20431,7 +20540,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_post_statistics
-  name: Fetch post statistics
+  name: "Pipixia post statistics by video id"
   summary: 'Pipixia: fetch post statistics (app)'
   cost:
     type: per_success
@@ -20461,7 +20570,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_search
-  name: Fetch search
+  name: "Pipixia search by keyword and type"
   summary: 'Pipixia: fetch search (app)'
   cost:
     type: per_success
@@ -20503,7 +20612,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_short_url
-  name: Fetch short url
+  name: "Pipixia short URL from original URL"
   summary: 'Pipixia: fetch short url (app)'
   cost:
     type: per_success
@@ -20532,7 +20641,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_user_follower_list
-  name: Fetch user follower list
+  name: "Pipixia user's followers by user id"
   summary: 'Pipixia: fetch user follower list (app)'
   cost:
     type: per_success
@@ -20568,7 +20677,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_user_following_list
-  name: Fetch user following list
+  name: "Pipixia accounts a user follows by user id"
   summary: 'Pipixia: fetch user following list (app)'
   cost:
     type: per_success
@@ -20604,7 +20713,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_user_info
-  name: Fetch user info
+  name: "Pipixia user profile by user id"
   summary: 'Pipixia: fetch user info (app)'
   cost:
     type: per_success
@@ -20634,7 +20743,7 @@ endpoints:
   platform: pipixia
   method: GET
   path: /api/v1/pipixia/app/fetch_user_post_list
-  name: Fetch user post list
+  name: "Pipixia user's posts by user id"
   summary: 'Pipixia: fetch user post list (app)'
   cost:
     type: per_success
@@ -20676,7 +20785,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/check_subreddit_muted
-  name: Check subreddit muted
+  name: "Check subreddit muted status by t5 fullname"
   summary: 'Reddit: check subreddit muted (app)'
   cost:
     type: per_success
@@ -20711,7 +20820,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_comment_replies
-  name: Fetch comment replies
+  name: "Reddit comment replies by post fullname and cursor"
   summary: 'Reddit: fetch comment replies (app)'
   cost:
     type: per_success
@@ -20759,7 +20868,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_community_highlights
-  name: Fetch community highlights
+  name: "Reddit subreddit highlights by t5 fullname"
   summary: 'Reddit: fetch community highlights (app)'
   cost:
     type: per_success
@@ -20794,7 +20903,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_dynamic_search
-  name: Fetch dynamic search
+  name: "Search Reddit posts, communities, comments by keyword"
   summary: 'Reddit: fetch dynamic search (app)'
   cost:
     type: per_success
@@ -20864,7 +20973,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_games_feed
-  name: Fetch games feed
+  name: "Reddit games feed"
   summary: 'Reddit: fetch games feed (app)'
   cost:
     type: per_success
@@ -20910,7 +21019,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_home_feed
-  name: Fetch home feed
+  name: "Reddit home feed"
   summary: 'Reddit: fetch home feed (app)'
   cost:
     type: per_success
@@ -20963,7 +21072,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_news_feed
-  name: Fetch news feed
+  name: "Reddit news feed"
   summary: 'Reddit: fetch news feed (app)'
   cost:
     type: per_success
@@ -21005,7 +21114,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_popular_feed
-  name: Fetch popular feed
+  name: "Reddit popular feed"
   summary: 'Reddit: fetch popular feed (app)'
   cost:
     type: per_success
@@ -21055,7 +21164,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_post_comments
-  name: Fetch post comments
+  name: "Reddit post comments by post fullname"
   summary: 'Reddit: fetch post comments (app)'
   cost:
     type: per_success
@@ -21104,7 +21213,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_post_details
-  name: Fetch post details
+  name: "Reddit post details by post fullname"
   summary: 'Reddit: fetch post details (app)'
   cost:
     type: per_success
@@ -21150,7 +21259,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_post_details_batch
-  name: Fetch post details batch
+  name: "Reddit post details in bulk by post fullnames"
   summary: 'Reddit: fetch post details batch (app)'
   cost:
     type: per_success
@@ -21196,7 +21305,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_post_details_batch_large
-  name: Fetch post details batch large
+  name: "Reddit post details in large bulk by post fullnames"
   summary: 'Reddit: fetch post details batch large (app)'
   cost:
     type: per_success
@@ -21242,7 +21351,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_search_typeahead
-  name: Fetch search typeahead
+  name: "Reddit search suggestions by partial keyword"
   summary: 'Reddit: fetch search typeahead (app)'
   cost:
     type: per_success
@@ -21290,7 +21399,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_subreddit_feed
-  name: Fetch subreddit feed
+  name: "Reddit subreddit posts by subreddit name"
   summary: 'Reddit: fetch subreddit feed (app)'
   cost:
     type: per_success
@@ -21340,7 +21449,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_subreddit_info
-  name: Fetch subreddit info
+  name: "Reddit subreddit details by subreddit name"
   summary: 'Reddit: fetch subreddit info (app)'
   cost:
     type: per_success
@@ -21376,7 +21485,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_subreddit_post_channels
-  name: Fetch subreddit post channels
+  name: "Reddit subreddit post channels by subreddit name"
   summary: 'Reddit: fetch subreddit post channels (app)'
   cost:
     type: per_success
@@ -21423,7 +21532,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_subreddit_settings
-  name: Fetch subreddit settings
+  name: "Reddit subreddit settings by t5 fullname"
   summary: 'Reddit: fetch subreddit settings (app)'
   cost:
     type: per_success
@@ -21458,7 +21567,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_subreddit_style
-  name: Fetch subreddit style
+  name: "Reddit subreddit style by subreddit name"
   summary: 'Reddit: fetch subreddit style (app)'
   cost:
     type: per_success
@@ -21493,7 +21602,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_trending_searches
-  name: Fetch trending searches
+  name: "Reddit trending search terms"
   summary: 'Reddit: fetch trending searches (app)'
   cost:
     type: per_success
@@ -21523,7 +21632,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_user_active_subreddits
-  name: Fetch user active subreddits
+  name: "Reddit user's active subreddits by username"
   summary: 'Reddit: fetch user active subreddits (app)'
   cost:
     type: per_success
@@ -21558,7 +21667,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_user_comments
-  name: Fetch user comments
+  name: "Reddit user's comments by username"
   summary: 'Reddit: fetch user comments (app)'
   cost:
     type: per_success
@@ -21610,7 +21719,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_user_posts
-  name: Fetch user posts
+  name: "Reddit user's posts by username"
   summary: 'Reddit: fetch user posts (app)'
   cost:
     type: per_success
@@ -21656,7 +21765,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_user_profile
-  name: Fetch user profile
+  name: "Reddit user profile by username"
   summary: 'Reddit: fetch user profile (app)'
   cost:
     type: per_success
@@ -21692,7 +21801,7 @@ endpoints:
   platform: reddit
   method: GET
   path: /api/v1/reddit/app/fetch_user_trophies
-  name: Fetch user trophies
+  name: "Reddit user's trophies by username"
   summary: 'Reddit: fetch user trophies (app)'
   cost:
     type: per_success
@@ -21727,7 +21836,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/batch_channel_info
-  name: Batch channel info
+  name: "Telegram channel profiles in bulk by usernames"
   summary: 'Telegram: batch channel info (web)'
   cost:
     type: per_success
@@ -21757,7 +21866,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_channel_info
-  name: Fetch channel info
+  name: "Telegram channel profile by username"
   summary: 'Telegram: fetch channel info (web)'
   cost:
     type: per_success
@@ -21787,7 +21896,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_channel_posts
-  name: Fetch channel posts
+  name: "Telegram channel posts by username"
   summary: 'Telegram: fetch channel posts (web)'
   cost:
     type: per_success
@@ -21835,7 +21944,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_channel_search
-  name: Fetch channel search
+  name: "Search a Telegram channel's posts by keyword"
   summary: 'Telegram: fetch channel search (web)'
   cost:
     type: per_success
@@ -21877,7 +21986,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_post_comments
-  name: Fetch post comments
+  name: "Telegram post comments by channel and post id"
   summary: 'Telegram: fetch post comments (web)'
   cost:
     type: per_success
@@ -21919,7 +22028,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_post_detail
-  name: Fetch post detail
+  name: "Telegram post details by channel and post id"
   summary: 'Telegram: fetch post detail (web)'
   cost:
     type: per_success
@@ -21955,7 +22064,7 @@ endpoints:
   platform: telegram
   method: GET
   path: /api/v1/telegram/web/fetch_similar_channels
-  name: Fetch similar channels
+  name: "Telegram similar channels by username"
   summary: 'Telegram: fetch similar channels (web)'
   cost:
     type: per_success
@@ -21985,7 +22094,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_post_comments
-  name: Fetch post comments
+  name: "Threads post comments by post id"
   summary: 'Threads: fetch post comments (web)'
   cost:
     type: per_success
@@ -22019,7 +22128,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_post_detail
-  name: Fetch post detail
+  name: "Threads post details by post id"
   summary: 'Threads: fetch post detail (web)'
   cost:
     type: per_success
@@ -22049,7 +22158,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_post_detail_v2
-  name: Fetch post detail v2
+  name: "Threads post details by short code or URL"
   summary: 'Threads: fetch post detail v2 (web)'
   cost:
     type: per_success
@@ -22085,7 +22194,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_user_info
-  name: Fetch user info
+  name: "Threads user profile by username"
   summary: 'Threads: fetch user info (web)'
   cost:
     type: per_success
@@ -22115,7 +22224,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_user_info_by_id
-  name: Fetch user info by id
+  name: "Threads user profile by user id"
   summary: 'Threads: fetch user info by id (web)'
   cost:
     type: per_success
@@ -22145,7 +22254,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_user_posts
-  name: Fetch user posts
+  name: "Threads user's posts by user id"
   summary: 'Threads: fetch user posts (web)'
   cost:
     type: per_success
@@ -22179,7 +22288,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_user_replies
-  name: Fetch user replies
+  name: "Threads user's replies by user id"
   summary: 'Threads: fetch user replies (web)'
   cost:
     type: per_success
@@ -22213,7 +22322,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/fetch_user_reposts
-  name: Fetch user reposts
+  name: "Threads user's reposts by user id"
   summary: 'Threads: fetch user reposts (web)'
   cost:
     type: per_success
@@ -22247,7 +22356,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/search_profiles
-  name: Search profiles
+  name: "Search Threads profiles by keyword"
   summary: 'Threads: search profiles (web)'
   cost:
     type: per_success
@@ -22277,7 +22386,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/search_recent
-  name: Search recent
+  name: "Search recent Threads posts by keyword"
   summary: 'Threads: search recent (web)'
   cost:
     type: per_success
@@ -22311,7 +22420,7 @@ endpoints:
   platform: threads
   method: GET
   path: /api/v1/threads/web/search_top
-  name: Search top
+  name: "Search top Threads posts by keyword"
   summary: 'Threads: search top (web)'
   cost:
     type: per_success
@@ -22347,6 +22456,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_configure_safety
   summary: Get search modules config
+  name: "TikTok ads search modules configuration"
   cost:
     type: per_success
     value: 0.001
@@ -22367,6 +22477,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_location_list
   summary: Get supported location list
+  name: "TikTok ads supported locations list"
   cost:
     type: per_success
     value: 0.001
@@ -22387,6 +22498,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_query_suggestions
   summary: Get query suggestions
+  name: "TikTok ads search keyword suggestions"
   cost:
     type: per_success
     value: 0.001
@@ -22429,6 +22541,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_trends_hashtag_detail
   summary: Get trending hashtag detail
+  name: "TikTok trending hashtag details"
   cost:
     type: per_success
     value: 0.001
@@ -22467,6 +22580,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_trends_hashtag_list
   summary: Get trending hashtag list
+  name: "TikTok trending hashtags list"
   cost:
     type: per_success
     value: 0.001
@@ -22514,6 +22628,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/analytics/detect_fake_views
   summary: Detect fake views in video
+  name: "Detect fake views on a TikTok video by video id"
   cost:
     type: per_success
     value: 0.01
@@ -22548,6 +22663,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/analytics/fetch_comment_keywords
   summary: Get comment keywords analysis
+  name: "TikTok video comment keywords analysis by video id"
   cost:
     type: per_success
     value: 0.001
@@ -22572,7 +22688,7 @@ endpoints:
   example_response: examples/tikhub.x.tiktok-analytics-fetch-comment-keywords.json
   capability: tiktok.video.comment_keywords
 - id: tikhub.x.tiktok-analytics-fetch-creator-info-and-milestones
-  name: Creator milestones
+  name: "TikTok creator info and milestones by user id"
   tier: extended
   platform: tiktok
   method: GET
@@ -22607,6 +22723,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/analytics/fetch_video_metrics
   summary: Get video metrics
+  name: "TikTok video metrics by video id"
   cost:
     type: per_success
     value: 0.001
@@ -22637,6 +22754,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/TTencrypt_algorithm
   summary: TikTok APP encryption algorithm
+  name: "TikTok app encryption algorithm utility"
   cost:
     type: per_success
     value: 0.002
@@ -22702,7 +22820,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/app/v3/add_video_play_count
-  name: Increase video play count
+  name: "Increase a TikTok video's play count by video id"
   summary: Increase the number of plays of the work according to the video ID
   cost:
     type: per_success
@@ -22737,6 +22855,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/check_live_room_online
   summary: Check if live room is online
+  name: "Check TikTok live room online status by room id"
   cost:
     type: per_success
     value: 0.001
@@ -22766,6 +22885,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/check_live_room_online_batch
   summary: Batch check if live rooms are online
+  name: "Check TikTok live rooms online status in bulk"
   cost:
     type: per_success
     value: 0.01
@@ -22801,6 +22921,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/encrypt_decrypt_login_request
   summary: Encrypt or Decrypt TikTok APP login request body
+  name: "TikTok app login request encryption utility"
   cost:
     type: per_success
     value: 0.001
@@ -22839,6 +22960,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/fetch_content_translate
   summary: Get content translation data
+  name: "TikTok content translation"
   cost:
     type: per_success
     value: 0.001
@@ -22873,6 +22995,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_creator_info
   summary: Get shopping creator information
+  name: "TikTok shopping creator info by creator uid"
   cost:
     type: per_success
     value: 0.001
@@ -22900,6 +23023,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_creator_search_insights
   summary: Creator Search Insights
+  name: "TikTok creator search insights by tab and filters"
   cost:
     type: per_success
     value: 0.001
@@ -22963,6 +23087,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_creator_search_insights_detail
   summary: Creator Search Insights Detail
+  name: "TikTok creator search insights detail by query id"
   cost:
     type: per_success
     value: 0.001
@@ -23012,6 +23137,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_creator_search_insights_trend
   summary: Creator Search Insights Trend
+  name: "TikTok creator search insights trend by query id"
   cost:
     type: per_success
     value: 0.001
@@ -23053,6 +23179,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_creator_search_insights_videos
   summary: Creator Search Insights Videos
+  name: "TikTok creator search insights videos by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23094,6 +23221,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_general_search_result
   summary: Get comprehensive search results of specified keywords
+  name: "Search TikTok across all content by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23147,6 +23275,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_hashtag_detail
   summary: Get details of specified hashtag
+  name: "TikTok hashtag details by hashtag id"
   cost:
     type: per_success
     value: 0.001
@@ -23181,6 +23310,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_hashtag_search_result
   summary: Get hashtag search results of specified keywords
+  name: "Search TikTok hashtags by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23221,6 +23351,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_hashtag_video_list
   summary: Get video list of specified hashtag
+  name: "TikTok hashtag videos by hashtag id"
   cost:
     type: per_success
     value: 0.001
@@ -23266,6 +23397,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/fetch_home_feed
   summary: Get home feed(recommend) video data
+  name: "TikTok home feed recommendations"
   cost:
     type: per_success
     value: 0.001
@@ -23294,6 +23426,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_daily_rank
   summary: Get live daily rank data
+  name: "TikTok live daily ranking by anchor or room id"
   cost:
     type: per_success
     value: 0.001
@@ -23346,6 +23479,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_ranking_list
   summary: Get live room ranking list
+  name: "TikTok live room ranking by room and anchor id"
   cost:
     type: per_success
     value: 0.001
@@ -23381,6 +23515,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_room_info
   summary: Get data of specified live room
+  name: "TikTok live room details by room id"
   cost:
     type: per_success
     value: 0.001
@@ -23410,6 +23545,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_room_product_list
   summary: Get live room product list data
+  name: "TikTok live room products by room and anchor id"
   cost:
     type: per_success
     value: 0.001
@@ -23463,6 +23599,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_room_product_list_v2
   summary: Get live room product list data V2
+  name: "TikTok live room products by room and anchor id"
   cost:
     type: per_success
     value: 0.001
@@ -23516,6 +23653,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_live_search_result
   summary: Get live search results of specified keywords
+  name: "Search TikTok live streams by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23563,6 +23701,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_location_search
   summary: Get location search results
+  name: "Search TikTok locations by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23603,6 +23742,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/fetch_multi_video
   summary: Batch Get Video Information
+  name: "TikTok video details in bulk"
   cost:
     type: per_success
     value: 0.01
@@ -23631,6 +23771,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/app/v3/fetch_multi_video_v2
   summary: Batch Get Video Information V2
+  name: "TikTok video details in bulk"
   cost:
     type: per_success
     value: 0.025
@@ -23659,6 +23800,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_music_chart_list
   summary: Music Chart List
+  name: "TikTok music charts — Top 50, Viral 50"
   cost:
     type: per_success
     value: 0.001
@@ -23700,6 +23842,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_music_detail
   summary: Get details of specified music
+  name: "TikTok music details by music id"
   cost:
     type: per_success
     value: 0.001
@@ -23729,6 +23872,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_music_search_result
   summary: Get music search results of specified keywords
+  name: "Search TikTok music by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -23788,6 +23932,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_music_video_list
   summary: Get video list of specified music
+  name: "TikTok videos using a music track by music id"
   cost:
     type: per_success
     value: 0.001
@@ -23828,6 +23973,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_one_video
   summary: Get single video data
+  name: "TikTok video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -23857,6 +24003,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_one_video_by_share_url
   summary: Get single video data by sharing link
+  name: "TikTok video details by share link"
   cost:
     type: per_success
     value: 0.001
@@ -23886,6 +24033,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_one_video_by_share_url_v2
   summary: Get single video data by sharing link
+  name: "TikTok video details by share link"
   cost:
     type: per_success
     value: 0.001
@@ -23915,6 +24063,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_one_video_v2
   summary: Get single video data V2
+  name: "TikTok video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -23944,6 +24093,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_one_video_v3
   summary: Get single video data V3 (support country parameter)
+  name: "TikTok video details by video id and region"
   cost:
     type: per_success
     value: 0.001
@@ -23979,6 +24129,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_share_qr_code
   summary: Get share QR code
+  name: "TikTok share QR code by object id"
   cost:
     type: per_success
     value: 0.001
@@ -24012,6 +24163,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_share_short_link
   summary: Get share short link
+  name: "TikTok short share link from URL"
   cost:
     type: per_success
     value: 0.001
@@ -24100,6 +24252,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_similar_user_recommendations
   summary: Similar User Recommendations
+  name: "TikTok similar accounts by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -24133,6 +24286,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_country_by_username
   summary: Get user account country by username
+  name: "TikTok account country by username"
   cost:
     type: per_success
     value: 0.001
@@ -24162,6 +24316,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_follower_list
   summary: Get follower list of specified user
+  name: "TikTok user's followers by user id or secUid"
   cost:
     type: per_success
     value: 0.001
@@ -24213,6 +24368,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_following_list
   summary: Get following list of specified user
+  name: "TikTok accounts a user follows by user id or secUid"
   cost:
     type: per_success
     value: 0.001
@@ -24264,6 +24420,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_like_videos
   summary: Get user like video data
+  name: "TikTok user's liked videos by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -24303,6 +24460,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_music_list
   summary: Get user music list data
+  name: "TikTok user's music list by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -24343,6 +24501,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_post_videos
   summary: Get user homepage video data V1
+  name: "TikTok user's videos by secUid or username"
   cost:
     type: per_success
     value: 0.001
@@ -24398,6 +24557,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_post_videos_v2
   summary: Get user homepage video data V2
+  name: "TikTok user's videos by secUid or username"
   cost:
     type: per_success
     value: 0.001
@@ -24447,6 +24607,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_post_videos_v3
   summary: Get user homepage video data V3 (simplified data - faster)
+  name: "TikTok user's videos by secUid or username, simplified"
   cost:
     type: per_success
     value: 0.001
@@ -24496,6 +24657,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_repost_videos
   summary: Get user repost video data
+  name: "TikTok user's reposted videos by user id"
   cost:
     type: per_success
     value: 0.001
@@ -24536,6 +24698,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_user_search_result
   summary: Get user search results of specified keywords
+  name: "Search TikTok users by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -24589,6 +24752,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_video_comment_replies
   summary: Get comment replies data of specified video
+  name: "TikTok comment replies by video and comment id"
   cost:
     type: per_success
     value: 0.001
@@ -24635,6 +24799,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/fetch_video_comments
   summary: Get single video comments data
+  name: "TikTok video comments by video id"
   cost:
     type: per_success
     value: 0.001
@@ -24670,7 +24835,7 @@ endpoints:
   example_response: examples/tikhub.x.tiktok-app-v3-fetch-video-comments.json
   capability: tiktok.video.comments
 - id: tikhub.x.tiktok-app-v3-fetch-webcast-user-info
-  name: LIVE (webcast) user info
+  name: "TikTok webcast user info by user id or secUid"
   tier: extended
   platform: tiktok
   method: GET
@@ -24709,6 +24874,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/get_user_id_and_sec_user_id_by_username
   summary: Get user_id and sec_user_id by Username
+  name: "TikTok user id and secUid from username"
   cost:
     type: per_success
     value: 0.001
@@ -24732,7 +24898,7 @@ endpoints:
   verified: '2026-07-28'
   example_response: examples/tikhub.x.tiktok-app-v3-get-user-id-and-sec-user-id-by-username.json
 - id: tikhub.x.tiktok-app-v3-handler-user-profile
-  name: Profile by numeric user_id (app API)
+  name: "TikTok user profile by user id, secUid or username"
   tier: extended
   platform: tiktok
   method: GET
@@ -24774,7 +24940,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/app/v3/open_tiktok_app_to_keyword_search
-  name: Open app to keyword search
+  name: "TikTok app deep link to keyword search"
   summary: Generate TikTok share link, call TikTok APP, and jump to the specified keyword search result
   cost:
     type: per_success
@@ -24804,7 +24970,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/app/v3/open_tiktok_app_to_send_private_message
-  name: Open app to send private message
+  name: "TikTok app deep link to send a private message"
   summary: Generate TikTok share link, call TikTok APP, and send private messages to specified users
   cost:
     type: per_success
@@ -24833,7 +24999,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/app/v3/open_tiktok_app_to_user_profile
-  name: Open app to user profile
+  name: "TikTok app deep link to a user profile"
   summary: Generate TikTok share link, call TikTok APP, and jump to the specified user profile
   cost:
     type: per_success
@@ -24862,7 +25028,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/app/v3/open_tiktok_app_to_video_detail
-  name: Open app to video detail
+  name: "TikTok app deep link to a video by video id"
   summary: Generate TikTok share link, call TikTok APP, and jump to the specified video details page
   cost:
     type: per_success
@@ -24892,6 +25058,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/search_follower_list
   summary: Search follower list
+  name: "Search a TikTok user's followers by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -24927,6 +25094,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/app/v3/search_following_list
   summary: Search following list
+  name: "Search accounts a TikTok user follows by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -24962,6 +25130,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_account_health_status
   summary: Get Creator Account Health Status
+  name: "TikTok creator account health status"
   cost:
     type: per_success
     value: 0.001
@@ -24991,6 +25160,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_account_insights_overview
   summary: Get Creator Account Overview
+  name: "TikTok creator account insights overview"
   cost:
     type: per_success
     value: 0.001
@@ -25023,6 +25193,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_account_violation_list
   summary: Get Creator Account Violation Record List
+  name: "TikTok creator account violation records"
   cost:
     type: per_success
     value: 0.001
@@ -25055,6 +25226,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_creator_account_info
   summary: Get Creator Account Info
+  name: "TikTok creator account info"
   cost:
     type: per_success
     value: 0.001
@@ -25084,6 +25256,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_live_analytics_summary
   summary: Get Creator Live Overview
+  name: "TikTok creator live analytics summary"
   cost:
     type: per_success
     value: 0.001
@@ -25116,6 +25289,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_product_analytics_list
   summary: Get Creator Product List Analytics
+  name: "TikTok creator product analytics list"
   cost:
     type: per_success
     value: 0.001
@@ -25154,6 +25328,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_product_related_videos
   summary: Get Product Related Videos
+  name: "TikTok creator product related videos"
   cost:
     type: per_success
     value: 0.001
@@ -25194,6 +25369,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_showcase_product_list
   summary: Get Showcase Product List
+  name: "TikTok creator showcase products list"
   cost:
     type: per_success
     value: 0.001
@@ -25229,6 +25405,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_analytics_summary
   summary: Get Creator Video Overview
+  name: "TikTok creator video analytics summary"
   cost:
     type: per_success
     value: 0.001
@@ -25258,6 +25435,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_associated_product_list
   summary: Get Video Associated Product List
+  name: "TikTok video associated products list"
   cost:
     type: per_success
     value: 0.001
@@ -25294,6 +25472,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_audience_stats
   summary: Get Video Audience Analysis Data
+  name: "TikTok video audience statistics"
   cost:
     type: per_success
     value: 0.001
@@ -25330,6 +25509,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_detailed_stats
   summary: Get Video Detailed Statistics
+  name: "TikTok video detailed statistics"
   cost:
     type: per_success
     value: 0.001
@@ -25366,6 +25546,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_list_analytics
   summary: Get Creator Video List Analytics
+  name: "TikTok creator video list analytics"
   cost:
     type: per_success
     value: 0.001
@@ -25404,6 +25585,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/creator/get_video_to_product_stats
   summary: Get Video-Product Association Statistics
+  name: "TikTok video-to-product statistics"
   cost:
     type: per_success
     value: 0.001
@@ -25444,6 +25626,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_hot_selling_products_list
   summary: Get hot selling products list
+  name: "TikTok Shop hot selling products by region"
   cost:
     type: per_success
     value: 0.001
@@ -25477,6 +25660,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_detail_v2
   summary: Get product detail V2 (Less Data)
+  name: "TikTok Shop product details by product id, compact"
   cost:
     type: per_success
     value: 0.001
@@ -25516,6 +25700,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_detail_v3
   summary: Get product detail V3 (Full Data)
+  name: "TikTok Shop product details by product id"
   cost:
     type: per_success
     value: 0.001
@@ -25549,6 +25734,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_id_by_share_link
   summary: Get Product ID by Share Link
+  name: "TikTok Shop product id from share link"
   cost:
     type: per_success
     value: 0.001
@@ -25576,6 +25762,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_search_word_suggestion_v2
   summary: Get search keyword suggestions V2 (Mobile)
+  name: "TikTok Shop search keyword suggestions"
   cost:
     type: per_success
     value: 0.001
@@ -25616,6 +25803,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_shop_id_by_share_link
   summary: Get Shop ID by Share Link
+  name: "TikTok Shop shop id from share link"
   cost:
     type: per_success
     value: 0.001
@@ -25644,7 +25832,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/decrypt_strData
-  name: Decrypt strData
+  name: "Decrypt TikTok strData payload"
   summary: 'Tiktok: Decrypt strData'
   cost:
     type: per_success
@@ -25675,6 +25863,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/device_register
   summary: Register device for TikTok Web
+  name: "Register a TikTok web device"
   cost:
     type: per_success
     value: 0.002
@@ -25695,7 +25884,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/encrypt_strData
-  name: Encrypt strData
+  name: "Encrypt TikTok strData payload"
   summary: 'Tiktok: Encrypt strData'
   cost:
     type: per_success
@@ -25725,6 +25914,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_batch_check_live_alive
   summary: Batch live room start status check
+  name: "Check TikTok live rooms online status in bulk"
   cost:
     type: per_success
     value: 0.05
@@ -25754,6 +25944,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_check_live_alive
   summary: Live room start status check
+  name: "Check TikTok live room online status by room id"
   cost:
     type: per_success
     value: 0.002
@@ -25783,6 +25974,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_explore_post
   summary: Get explore video data
+  name: "TikTok explore feed by category"
   cost:
     type: per_success
     value: 0.001
@@ -25817,6 +26009,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_general_search
   summary: Get general search list
+  name: "Search TikTok across all content by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -25859,6 +26052,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/fetch_gift_name_by_id
   summary: Get gift name by gift ID
+  name: "TikTok gift name by gift id"
   cost:
     type: per_success
     value: 0.001
@@ -25891,6 +26085,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/fetch_gift_names_by_ids
   summary: Batch get gift names by gift IDs ($0.025/call, suggest 50)
+  name: "TikTok gift names in bulk by gift ids"
   cost:
     type: per_success
     value: 0.025
@@ -25925,7 +26120,7 @@ endpoints:
   platform: tiktok
   method: POST
   path: /api/v1/tiktok/web/fetch_home_feed
-  name: Home Feed
+  name: "TikTok home feed recommendations"
   summary: 'Tiktok: Home Feed'
   cost:
     type: per_success
@@ -25965,6 +26160,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_live_gift_list
   summary: Get live room gift list
+  name: "TikTok live room gift list by room id"
   cost:
     type: per_success
     value: 0.025
@@ -25994,6 +26190,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_live_im_fetch
   summary: tiktok live room danmaku parameters
+  name: "TikTok live room chat danmaku by room id"
   cost:
     type: per_success
     value: 0.001
@@ -26034,6 +26231,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_live_recommend
   summary: Get live room homepage recommendation list
+  name: "TikTok recommended live rooms by tag"
   cost:
     type: per_success
     value: 0.001
@@ -26063,6 +26261,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_live_recommend_tabs
   summary: Get available tags for live room homepage recommendation
+  name: "TikTok live recommendation tags list"
   cost:
     type: per_success
     value: 0.001
@@ -26089,6 +26288,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_post_comment_reply
   summary: Get video comment replies
+  name: "TikTok comment replies by video and comment id"
   cost:
     type: per_success
     value: 0.001
@@ -26137,6 +26337,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_post_detail_v2
   summary: Get single video data V2
+  name: "TikTok video details by video id"
   cost:
     type: per_success
     value: 0.001
@@ -26171,6 +26372,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_search_keyword_suggest
   summary: Search keyword suggest
+  name: "TikTok search suggestions by partial keyword"
   cost:
     type: per_success
     value: 0.001
@@ -26199,7 +26401,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/fetch_search_live
-  name: Search live
+  name: "Search TikTok live streams by keyword"
   summary: 'Tiktok: Search live'
   cost:
     type: per_success
@@ -26248,7 +26450,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/fetch_search_photo
-  name: Search photo
+  name: "Search TikTok photo posts by keyword"
   summary: 'Tiktok: Search photo'
   cost:
     type: per_success
@@ -26297,7 +26499,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/fetch_search_user
-  name: Search user
+  name: "Search TikTok users by keyword"
   summary: 'Tiktok: Search user'
   cost:
     type: per_success
@@ -26340,7 +26542,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/fetch_search_video
-  name: Search video
+  name: "Search TikTok videos by keyword"
   summary: 'Tiktok: Search video'
   cost:
     type: per_success
@@ -26388,6 +26590,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_tiktok_live_data
   summary: Get live room information via live link
+  name: "TikTok live room details by live room URL"
   cost:
     type: per_success
     value: 0.001
@@ -26417,6 +26620,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_tiktok_web_guest_cookie
   summary: Get the guest Cookie
+  name: "TikTok web guest cookie by user agent"
   cost:
     type: per_success
     value: 0.002
@@ -26445,6 +26649,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_trending_searchwords
   summary: Get daily trending search words
+  name: "TikTok daily trending search terms"
   cost:
     type: per_success
     value: 0.001
@@ -26466,6 +26671,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_collect
   summary: Get user favorites
+  name: "TikTok user's favorite videos by secUid and cookie"
   cost:
     type: per_success
     value: 0.001
@@ -26510,6 +26716,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_fans
   summary: Get user followers
+  name: "TikTok user's followers by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -26555,6 +26762,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_follow
   summary: Get user followings
+  name: "TikTok accounts a user follows by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -26599,7 +26807,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/fetch_user_like
-  name: Get user likes
+  name: "TikTok user's liked videos by secUid"
   summary: 'Tiktok: Get user likes'
   cost:
     type: per_success
@@ -26651,6 +26859,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_live_detail
   summary: Get user live details
+  name: "TikTok user live stream details by username"
   cost:
     type: per_success
     value: 0.001
@@ -26680,6 +26889,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_mix
   summary: Get user mix list
+  name: "TikTok playlist mix videos by mix id"
   cost:
     type: per_success
     value: 0.001
@@ -26720,6 +26930,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_play_list
   summary: Get user play list
+  name: "TikTok user's playlists by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -26760,6 +26971,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/fetch_user_repost
   summary: Get user reposts
+  name: "TikTok user's reposted videos by secUid"
   cost:
     type: per_success
     value: 0.001
@@ -26808,6 +27020,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/generate_fingerprint
   summary: Generate browser fingerprint
+  name: "Generate a TikTok browser fingerprint"
   cost:
     type: per_success
     value: 0.001
@@ -26834,6 +27047,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/generate_hashed_id
   summary: Generate hashed ID
+  name: "Generate a TikTok hashed id from email"
   cost:
     type: per_success
     value: 0.001
@@ -26863,6 +27077,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/generate_real_msToken
   summary: Generate real msToken
+  name: "Generate a TikTok msToken"
   cost:
     type: per_success
     value: 0.001
@@ -26892,7 +27107,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/generate_ttwid
-  name: Generate ttwid
+  name: "Generate a TikTok ttwid token"
   summary: 'Tiktok: Generate ttwid'
   cost:
     type: per_success
@@ -26920,7 +27135,7 @@ endpoints:
   platform: tiktok
   method: GET
   path: /api/v1/tiktok/web/generate_webid
-  name: Generate web_id
+  name: "Generate a TikTok web id"
   summary: 'Tiktok: Generate web_id'
   cost:
     type: per_success
@@ -26966,6 +27181,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/generate_wss_xb_signature
   summary: Generate TikTok WSS X-Bogus signature
+  name: "Generate a TikTok WSS X-Bogus signature"
   cost:
     type: per_success
     value: 0.001
@@ -26995,6 +27211,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/generate_x_mssdk_info
   summary: Generate X-Mssdk-Info
+  name: "Generate a TikTok X-Mssdk-Info header"
   cost:
     type: per_success
     value: 0.002
@@ -27024,7 +27241,7 @@ endpoints:
   platform: tiktok
   method: POST
   path: /api/v1/tiktok/web/generate_xbogus
-  name: Generate XBogus
+  name: "Generate a TikTok X-Bogus signature"
   summary: 'Tiktok: Generate XBogus'
   cost:
     type: per_success
@@ -27063,6 +27280,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/generate_xgnarly
   summary: Generate XGnarly
+  name: "Generate a TikTok XGnarly signature"
   cost:
     type: per_success
     value: 0.002
@@ -27098,6 +27316,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/generate_xgnarly_and_xbogus
   summary: Generate XGnarly and XBogus
+  name: "Generate TikTok XGnarly and X-Bogus signatures"
   cost:
     type: per_success
     value: 0.005
@@ -27132,6 +27351,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/get_all_aweme_id
   summary: Extract list video id
+  name: "TikTok video ids from URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -27159,6 +27379,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/get_all_sec_user_id
   summary: Extract list user sec_user_id
+  name: "TikTok secUids from profile URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -27186,6 +27407,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/web/get_all_unique_id
   summary: Get list unique_id
+  name: "TikTok usernames from profile URLs in bulk"
   cost:
     type: per_success
     value: 0.001
@@ -27213,6 +27435,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/get_aweme_id
   summary: Extract single video id
+  name: "TikTok video id from video URL"
   cost:
     type: per_success
     value: 0.001
@@ -27241,6 +27464,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/get_live_room_id
   summary: Extract live room ID from live room link
+  name: "TikTok live room id from live room URL"
   cost:
     type: per_success
     value: 0.001
@@ -27269,6 +27493,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/get_sec_user_id
   summary: Extract user sec_user_id
+  name: "TikTok secUid from profile URL"
   cost:
     type: per_success
     value: 0.001
@@ -27297,6 +27522,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/get_unique_id
   summary: Get user unique_id
+  name: "TikTok username from profile URL"
   cost:
     type: per_success
     value: 0.001
@@ -27325,6 +27551,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/get_user_id
   summary: Extract user user_id
+  name: "TikTok user id from profile URL"
   cost:
     type: per_success
     value: 0.001
@@ -27353,6 +27580,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/web/tiktok_live_room
   summary: Extract live room danmaku
+  name: "TikTok live room danmaku stream by live room URL"
   cost:
     type: free
     value: 0
@@ -27383,6 +27611,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_ad_interactive_analysis
   summary: Get ad interactive analysis
+  name: "TikTok ad interactive analysis"
   cost:
     type: per_success
     value: 0.001
@@ -27422,6 +27651,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_ad_keyframe_analysis
   summary: Get ad keyframe analysis
+  name: "TikTok ad keyframe analysis"
   cost:
     type: per_success
     value: 0.001
@@ -27456,6 +27686,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_ad_percentile
   summary: Get ad percentile data
+  name: "TikTok ad percentile metrics"
   cost:
     type: per_success
     value: 0.001
@@ -27495,6 +27726,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_ads_detail
   summary: Get single ad detail
+  name: "TikTok ad details"
   cost:
     type: per_success
     value: 0.001
@@ -27524,6 +27756,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_recommended_ads
   summary: Get recommended ads
+  name: "TikTok recommended ads list"
   cost:
     type: per_success
     value: 0.001
@@ -27563,6 +27796,7 @@ endpoints:
   method: POST
   path: /api/v1/tiktok/ads/get_top_ads_spotlight
   summary: Get top ads spotlight
+  name: "TikTok top ads spotlight list"
   cost:
     type: per_success
     value: 0.001
@@ -27600,7 +27834,7 @@ endpoints:
   platform: tiktok-ads
   method: POST
   path: /api/v1/tiktok/ads/search_ads
-  name: Search ads
+  name: "Search TikTok ads"
   summary: 'Tiktok: Search ads'
   cost:
     type: per_success
@@ -27751,6 +27985,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_detail
   summary: Get product detail V1(Full data)
+  name: "TikTok Shop product details by product id"
   cost:
     type: per_success
     value: 0.001
@@ -27792,6 +28027,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_reviews
   summary: Get product reviews V1
+  name: "TikTok Shop product reviews by product id"
   cost:
     type: per_success
     value: 0.001
@@ -27857,6 +28093,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_product_reviews_v2
   summary: Get product reviews V2
+  name: "TikTok Shop product reviews by product id"
   cost:
     type: per_success
     value: 0.001
@@ -27916,6 +28153,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_products_by_category_id
   summary: Get products by category ID
+  name: "TikTok Shop products by category id"
   cost:
     type: per_success
     value: 0.001
@@ -27957,6 +28195,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_products_category_list
   summary: Get product category list
+  name: "TikTok Shop product categories list"
   cost:
     type: per_success
     value: 0.001
@@ -27986,6 +28225,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_search_products_list
   summary: Search products list V1
+  name: "Search TikTok Shop products by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -28031,6 +28271,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_search_products_list_v2
   summary: Search products list V2 (Mobile)
+  name: "Search TikTok Shop products by keyword"
   cost:
     type: per_success
     value: 0.001
@@ -28076,6 +28317,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_seller_products_list
   summary: Get seller products list V1
+  name: "TikTok Shop seller's products by seller id"
   cost:
     type: per_success
     value: 0.001
@@ -28117,6 +28359,7 @@ endpoints:
   method: GET
   path: /api/v1/tiktok/shop/web/fetch_seller_products_list_v2
   summary: Get seller products list V2 (Mobile)
+  name: "TikTok Shop seller's products by seller id"
   cost:
     type: per_success
     value: 0.001
@@ -28155,7 +28398,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/app/get_article_info
-  name: Get article info
+  name: "Toutiao article details by post id"
   summary: 'Toutiao: get article info (app)'
   cost:
     type: per_success
@@ -28185,7 +28428,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/app/get_comments
-  name: Get comments
+  name: "Toutiao post comments by post id"
   summary: 'Toutiao: get comments (app)'
   cost:
     type: per_success
@@ -28221,7 +28464,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/app/get_user_id
-  name: Get user id
+  name: "Toutiao user id from profile URL"
   summary: 'Toutiao: get user id (app)'
   cost:
     type: per_success
@@ -28250,7 +28493,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/app/get_user_info
-  name: Get user info
+  name: "Toutiao user profile by user id"
   summary: 'Toutiao: get user info (app)'
   cost:
     type: per_success
@@ -28280,7 +28523,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/app/get_video_info
-  name: Get video info
+  name: "Toutiao video details by post id"
   summary: 'Toutiao: get video info (app)'
   cost:
     type: per_success
@@ -28310,7 +28553,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/web/get_article_info
-  name: Get article info
+  name: "Toutiao article details by post id"
   summary: 'Toutiao: get article info (web)'
   cost:
     type: per_success
@@ -28340,7 +28583,7 @@ endpoints:
   platform: toutiao
   method: GET
   path: /api/v1/toutiao/web/get_video_info
-  name: Get video info
+  name: "Toutiao video details by post id"
   summary: 'Toutiao: get video info (web)'
   cost:
     type: per_success
@@ -28370,7 +28613,7 @@ endpoints:
   platform: web
   method: GET
   path: /api/v1/hybrid/video_data
-  name: Video data
+  name: "Parse video details from a share URL (any platform)"
   summary: 'Hybrid: video data'
   cost:
     type: per_success
@@ -28408,7 +28651,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_channel_id_to_username
-  name: Fetch channel id to username
+  name: "WeChat Channels username from channel id"
   summary: 'Wechat channels: fetch channel id to username (v2)'
   cost:
     type: per_success
@@ -28444,7 +28687,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_channel_info
-  name: Fetch channel info
+  name: "WeChat Channels account profile"
   summary: 'Wechat channels: fetch channel info (v2)'
   cost:
     type: per_success
@@ -28481,7 +28724,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_collection_videos
-  name: Fetch collection videos
+  name: "WeChat Channels collection videos"
   summary: 'Wechat channels: fetch collection videos (v2)'
   cost:
     type: per_success
@@ -28533,7 +28776,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_live_detail
-  name: Fetch live detail
+  name: "WeChat Channels live stream details"
   summary: 'Wechat channels: fetch live detail (v2)'
   cost:
     type: per_success
@@ -28578,7 +28821,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_live_history
-  name: Fetch live history
+  name: "WeChat Channels live stream history"
   summary: 'Wechat channels: fetch live history (v2)'
   cost:
     type: per_success
@@ -28622,7 +28865,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_search_channel_videos
-  name: Fetch search channel videos
+  name: "Search WeChat Channels videos"
   summary: 'Wechat channels: fetch search channel videos (v2)'
   cost:
     type: per_success
@@ -28664,7 +28907,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_user_collections
-  name: Fetch user collections
+  name: "WeChat Channels user's collections"
   summary: 'Wechat channels: fetch user collections (v2)'
   cost:
     type: per_success
@@ -28701,7 +28944,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_user_profile
-  name: Fetch user profile
+  name: "WeChat Channels user profile"
   summary: 'Wechat channels: fetch user profile (v2)'
   cost:
     type: per_success
@@ -28738,7 +28981,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_user_videos
-  name: Fetch user videos
+  name: "WeChat Channels user's videos"
   summary: 'Wechat channels: fetch user videos (v2)'
   cost:
     type: per_success
@@ -28778,7 +29021,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_video_comments
-  name: Fetch video comments
+  name: "WeChat Channels video comments"
   summary: 'Wechat channels: fetch video comments (v2)'
   cost:
     type: per_success
@@ -28821,7 +29064,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_video_detail
-  name: Fetch video detail
+  name: "WeChat Channels video details"
   summary: 'Wechat channels: fetch video detail (v2)'
   cost:
     type: per_success
@@ -28866,7 +29109,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_channels/v2/fetch_video_share_url
-  name: Fetch video share url
+  name: "WeChat Channels video share URL"
   summary: 'Wechat channels: fetch video share url (v2)'
   cost:
     type: per_success
@@ -28902,7 +29145,7 @@ endpoints:
   platform: wechat-channels
   method: POST
   path: /api/v1/wechat_search/v2/fetch_search_videos
-  name: Fetch search videos
+  name: "Search WeChat videos"
   summary: 'Wechat search: fetch search videos (v2)'
   cost:
     type: per_success
@@ -28958,7 +29201,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_account_articles
-  name: Fetch account articles
+  name: "WeChat Official Account articles"
   summary: 'Wechat mp: fetch account articles (v2)'
   cost:
     type: per_success
@@ -29005,7 +29248,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_account_profile
-  name: Fetch account profile
+  name: "WeChat Official Account profile"
   summary: 'Wechat mp: fetch account profile (v2)'
   cost:
     type: per_success
@@ -29042,7 +29285,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_account_services
-  name: Fetch account services
+  name: "WeChat Official Account services list"
   summary: 'Wechat mp: fetch account services (v2)'
   cost:
     type: per_success
@@ -29077,7 +29320,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_article_ad
-  name: Fetch article ad
+  name: "WeChat article advertisement details"
   summary: 'Wechat mp: fetch article ad (v2)'
   cost:
     type: per_success
@@ -29114,7 +29357,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_article_comments
-  name: Fetch article comments
+  name: "WeChat article comments"
   summary: 'Wechat mp: fetch article comments (v2)'
   cost:
     type: per_success
@@ -29154,7 +29397,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_article_detail
-  name: Fetch article detail
+  name: "WeChat article details"
   summary: 'Wechat mp: fetch article detail (v2)'
   cost:
     type: per_success
@@ -29191,7 +29434,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_article_stats
-  name: Fetch article stats
+  name: "WeChat article statistics"
   summary: 'Wechat mp: fetch article stats (v2)'
   cost:
     type: per_success
@@ -29228,7 +29471,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_comment_replies
-  name: Fetch comment replies
+  name: "WeChat article comment replies"
   summary: 'Wechat mp: fetch comment replies (v2)'
   cost:
     type: per_success
@@ -29277,7 +29520,7 @@ endpoints:
   platform: wechat-mp
   method: POST
   path: /api/v1/wechat_mp/v2/fetch_related_articles
-  name: Fetch related articles
+  name: "WeChat related articles"
   summary: 'Wechat mp: fetch related articles (v2)'
   cost:
     type: per_success
@@ -29314,7 +29557,7 @@ endpoints:
   platform: wechat-search
   method: POST
   path: /api/v1/wechat_search/v2/fetch_search
-  name: Fetch search
+  name: "Search WeChat content"
   summary: 'Wechat search: fetch search (v2)'
   cost:
     type: per_success
@@ -29370,7 +29613,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_ai_smart_search
-  name: Fetch ai smart search
+  name: "Weibo AI smart search by keyword"
   summary: 'Weibo: fetch ai smart search (app)'
   cost:
     type: per_success
@@ -29406,7 +29649,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_home_recommend_feed
-  name: Fetch home recommend feed
+  name: "Weibo home recommendations feed"
   summary: 'Weibo: fetch home recommend feed (app)'
   cost:
     type: per_success
@@ -29440,7 +29683,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_hot_search
-  name: Fetch hot search
+  name: "Weibo trending searches by category"
   summary: 'Weibo: fetch hot search (app)'
   cost:
     type: per_success
@@ -29488,7 +29731,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_hot_search_categories
-  name: Fetch hot search categories
+  name: "Weibo trending search categories list"
   summary: 'Weibo: fetch hot search categories (app)'
   cost:
     type: per_success
@@ -29509,7 +29752,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_search_all
-  name: Fetch search all
+  name: "Search Weibo across all content by keyword"
   summary: 'Weibo: fetch search all (app)'
   cost:
     type: per_success
@@ -29551,7 +29794,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_status_comments
-  name: Fetch status comments
+  name: "Weibo post comments by post id"
   summary: 'Weibo: fetch status comments (app)'
   cost:
     type: per_success
@@ -29591,7 +29834,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_status_detail
-  name: Fetch status detail
+  name: "Weibo post details by post id"
   summary: 'Weibo: fetch status detail (app)'
   cost:
     type: per_success
@@ -29621,7 +29864,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_status_likes
-  name: Fetch status likes
+  name: "Weibo post likes and reactions by post id"
   summary: 'Weibo: fetch status likes (app)'
   cost:
     type: per_success
@@ -29657,7 +29900,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_status_reposts
-  name: Fetch status reposts
+  name: "Weibo post reposts by post id"
   summary: 'Weibo: fetch status reposts (app)'
   cost:
     type: per_success
@@ -29691,7 +29934,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_album
-  name: Fetch user album
+  name: "Weibo user's photo album by user id"
   summary: 'Weibo: fetch user album (app)'
   cost:
     type: per_success
@@ -29725,7 +29968,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_articles
-  name: Fetch user articles
+  name: "Weibo user's articles by user id"
   summary: 'Weibo: fetch user articles (app)'
   cost:
     type: per_success
@@ -29759,7 +30002,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_audios
-  name: Fetch user audios
+  name: "Weibo user's audio posts by user id"
   summary: 'Weibo: fetch user audios (app)'
   cost:
     type: per_success
@@ -29791,7 +30034,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_info
-  name: Fetch user info
+  name: "Weibo user profile by user id"
   summary: 'Weibo: fetch user info (app)'
   cost:
     type: per_success
@@ -29821,7 +30064,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_info_detail
-  name: Fetch user info detail
+  name: "Weibo user profile details by user id"
   summary: 'Weibo: fetch user info detail (app)'
   cost:
     type: per_success
@@ -29851,7 +30094,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_profile_feed
-  name: Fetch user profile feed
+  name: "Weibo user's profile feed by user id"
   summary: 'Weibo: fetch user profile feed (app)'
   cost:
     type: per_success
@@ -29885,7 +30128,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_super_topics
-  name: Fetch user super topics
+  name: "Weibo user's super topics by user id"
   summary: 'Weibo: fetch user super topics (app)'
   cost:
     type: per_success
@@ -29921,7 +30164,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_timeline
-  name: Fetch user timeline
+  name: "Weibo user timeline by user id with month filter"
   summary: 'Weibo: fetch user timeline (app)'
   cost:
     type: per_success
@@ -29969,7 +30212,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_user_videos
-  name: Fetch user videos
+  name: "Weibo user's videos by user id"
   summary: 'Weibo: fetch user videos (app)'
   cost:
     type: per_success
@@ -30003,7 +30246,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_video_detail
-  name: Fetch video detail
+  name: "Weibo video details by video post id"
   summary: 'Weibo: fetch video detail (app)'
   cost:
     type: per_success
@@ -30033,7 +30276,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/app/fetch_video_featured_feed
-  name: Fetch video featured feed
+  name: "Weibo featured videos feed"
   summary: 'Weibo: fetch video featured feed (app)'
   cost:
     type: per_success
@@ -30061,7 +30304,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_channel_feed
-  name: Fetch channel feed
+  name: "Weibo channel feed by channel name"
   summary: 'Weibo: fetch channel feed (web)'
   cost:
     type: per_success
@@ -30097,7 +30340,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_comment_replies
-  name: Fetch comment replies
+  name: "Weibo comment replies by comment id"
   summary: 'Weibo: fetch comment replies (web)'
   cost:
     type: per_success
@@ -30133,7 +30376,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_config_list
-  name: Fetch config list
+  name: "Weibo configuration list"
   summary: 'Weibo: fetch config list (web)'
   cost:
     type: per_success
@@ -30154,7 +30397,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_hot_search
-  name: Fetch hot search
+  name: "Weibo trending searches ranking"
   summary: 'Weibo: fetch hot search (web)'
   cost:
     type: per_success
@@ -30176,7 +30419,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_post_comments
-  name: Fetch post comments
+  name: "Weibo post comments by post id and mid"
   summary: 'Weibo: fetch post comments (web)'
   cost:
     type: per_success
@@ -30222,7 +30465,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_post_detail
-  name: Fetch post detail
+  name: "Weibo post details by post id"
   summary: 'Weibo: fetch post detail (web)'
   cost:
     type: per_success
@@ -30252,7 +30495,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_search
-  name: Fetch search
+  name: "Search Weibo by keyword, type and time range"
   summary: 'Weibo: fetch search (web)'
   cost:
     type: per_success
@@ -30298,7 +30541,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_search_topics
-  name: Fetch search topics
+  name: "Weibo search topics list"
   summary: 'Weibo: fetch search topics (web)'
   cost:
     type: per_success
@@ -30320,7 +30563,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_trend_top
-  name: Fetch trend top
+  name: "Weibo trending channel top posts by container id"
   summary: 'Weibo: fetch trend top (web)'
   cost:
     type: per_success
@@ -30356,7 +30599,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_user_info
-  name: Fetch user info
+  name: "Weibo user profile by user id"
   summary: 'Weibo: fetch user info (web)'
   cost:
     type: per_success
@@ -30386,7 +30629,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web/fetch_user_posts
-  name: Fetch user posts
+  name: "Weibo user's posts by user id"
   summary: 'Weibo: fetch user posts (web)'
   cost:
     type: per_success
@@ -30426,7 +30669,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/check_allow_comment_with_pic
-  name: Check allow comment with pic
+  name: "Check Weibo picture-comment permission by post id"
   summary: 'Weibo: check allow comment with pic (web_v2)'
   cost:
     type: per_success
@@ -30455,7 +30698,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_advanced_search
-  name: Fetch advanced search
+  name: "Weibo advanced search by keyword with filters"
   summary: 'Weibo: fetch advanced search (web_v2)'
   cost:
     type: per_success
@@ -30509,7 +30752,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_ai_related_search
-  name: Fetch ai related search
+  name: "Weibo AI related search terms by keyword"
   summary: 'Weibo: fetch ai related search (web_v2)'
   cost:
     type: per_success
@@ -30539,7 +30782,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_ai_search
-  name: Fetch ai search
+  name: "Weibo AI search by keyword"
   summary: 'Weibo: fetch ai search (web_v2)'
   cost:
     type: per_success
@@ -30569,7 +30812,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_all_groups
-  name: Fetch all groups
+  name: "Weibo feed groups list"
   summary: 'Weibo: fetch all groups (web_v2)'
   cost:
     type: per_success
@@ -30590,7 +30833,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_city_list
-  name: Fetch city list
+  name: "Weibo city list for regional filters"
   summary: 'Weibo: fetch city list (web_v2)'
   cost:
     type: per_success
@@ -30618,7 +30861,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_entertainment_ranking
-  name: Fetch entertainment ranking
+  name: "Weibo entertainment ranking"
   summary: 'Weibo: fetch entertainment ranking (web_v2)'
   cost:
     type: per_success
@@ -30640,7 +30883,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_hot_ranking_timeline
-  name: Fetch hot ranking timeline
+  name: "Weibo trending ranking history by ranking type"
   summary: 'Weibo: fetch hot ranking timeline (web_v2)'
   cost:
     type: per_success
@@ -30688,7 +30931,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_hot_search
-  name: Fetch hot search
+  name: "Weibo trending searches ranking"
   summary: 'Weibo: fetch hot search (web_v2)'
   cost:
     type: per_success
@@ -30710,7 +30953,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_hot_search_index
-  name: Fetch hot search index
+  name: "Weibo trending search index"
   summary: 'Weibo: fetch hot search index (web_v2)'
   cost:
     type: per_success
@@ -30732,7 +30975,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_hot_search_summary
-  name: Fetch hot search summary
+  name: "Weibo trending search summary"
   summary: 'Weibo: fetch hot search summary (web_v2)'
   cost:
     type: per_success
@@ -30754,7 +30997,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_life_ranking
-  name: Fetch life ranking
+  name: "Weibo lifestyle ranking"
   summary: 'Weibo: fetch life ranking (web_v2)'
   cost:
     type: per_success
@@ -30776,7 +31019,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_pic_search
-  name: Fetch pic search
+  name: "Search Weibo images by keyword"
   summary: 'Weibo: fetch pic search (web_v2)'
   cost:
     type: per_success
@@ -30812,7 +31055,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_post_comments
-  name: Fetch post comments
+  name: "Weibo post comments by post id"
   summary: 'Weibo: fetch post comments (web_v2)'
   cost:
     type: per_success
@@ -30852,7 +31095,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_post_detail
-  name: Fetch post detail
+  name: "Weibo post details by post id, full long text"
   summary: 'Weibo: fetch post detail (web_v2)'
   cost:
     type: per_success
@@ -30888,7 +31131,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_post_sub_comments
-  name: Fetch post sub comments
+  name: "Weibo comment replies by comment id"
   summary: 'Weibo: fetch post sub comments (web_v2)'
   cost:
     type: per_success
@@ -30928,7 +31171,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_realtime_search
-  name: Fetch realtime search
+  name: "Weibo real-time search by keyword"
   summary: 'Weibo: fetch realtime search (web_v2)'
   cost:
     type: per_success
@@ -30964,7 +31207,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_similar_search
-  name: Fetch similar search
+  name: "Weibo similar search terms by keyword"
   summary: 'Weibo: fetch similar search (web_v2)'
   cost:
     type: per_success
@@ -30994,7 +31237,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_social_ranking
-  name: Fetch social ranking
+  name: "Weibo social news ranking"
   summary: 'Weibo: fetch social ranking (web_v2)'
   cost:
     type: per_success
@@ -31016,7 +31259,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_topic_search
-  name: Fetch topic search
+  name: "Search Weibo topics by keyword"
   summary: 'Weibo: fetch topic search (web_v2)'
   cost:
     type: per_success
@@ -31052,7 +31295,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_basic_info
-  name: Fetch user basic info
+  name: "Weibo user basic profile by user id"
   summary: 'Weibo: fetch user basic info (web_v2)'
   cost:
     type: per_success
@@ -31082,7 +31325,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_fans
-  name: Fetch user fans
+  name: "Weibo user's followers by user id"
   summary: 'Weibo: fetch user fans (web_v2)'
   cost:
     type: per_success
@@ -31118,7 +31361,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_following
-  name: Fetch user following
+  name: "Weibo accounts a user follows by user id"
   summary: 'Weibo: fetch user following (web_v2)'
   cost:
     type: per_success
@@ -31154,7 +31397,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_info
-  name: Fetch user info
+  name: "Weibo user profile by user id or username"
   summary: 'Weibo: fetch user info (web_v2)'
   cost:
     type: per_success
@@ -31190,7 +31433,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_original_posts
-  name: Fetch user original posts
+  name: "Weibo user's original posts by user id"
   summary: 'Weibo: fetch user original posts (web_v2)'
   cost:
     type: per_success
@@ -31230,7 +31473,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_posts
-  name: Fetch user posts
+  name: "Weibo user's posts by user id"
   summary: 'Weibo: fetch user posts (web_v2)'
   cost:
     type: per_success
@@ -31276,7 +31519,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_recommend_timeline
-  name: Fetch user recommend timeline
+  name: "Weibo recommended timeline feed"
   summary: 'Weibo: fetch user recommend timeline (web_v2)'
   cost:
     type: per_success
@@ -31336,7 +31579,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_search
-  name: Fetch user search
+  name: "Search Weibo users by keyword and filters"
   summary: 'Weibo: fetch user search (web_v2)'
   cost:
     type: per_success
@@ -31419,7 +31662,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_video_collection_detail
-  name: Fetch user video collection detail
+  name: "Weibo video collection videos by collection id"
   summary: 'Weibo: fetch user video collection detail (web_v2)'
   cost:
     type: per_success
@@ -31459,7 +31702,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_video_collection_list
-  name: Fetch user video collection list
+  name: "Weibo user's video collections by user id"
   summary: 'Weibo: fetch user video collection list (web_v2)'
   cost:
     type: per_success
@@ -31489,7 +31732,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_user_video_list
-  name: Fetch user video list
+  name: "Weibo user's videos by user id"
   summary: 'Weibo: fetch user video list (web_v2)'
   cost:
     type: per_success
@@ -31525,7 +31768,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/fetch_video_search
-  name: Fetch video search
+  name: "Search Weibo videos by keyword"
   summary: 'Weibo: fetch video search (web_v2)'
   cost:
     type: per_success
@@ -31567,7 +31810,7 @@ endpoints:
   platform: weibo
   method: GET
   path: /api/v1/weibo/web_v2/search_user_posts
-  name: Search user posts
+  name: "Search a Weibo user's posts by keyword and dates"
   summary: 'Weibo: search user posts (web_v2)'
   cost:
     type: per_success
@@ -31655,7 +31898,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_latest_post_comments
-  name: Fetch latest post comments
+  name: "X (Twitter) newest post comments by tweet id"
   summary: 'Twitter: fetch latest post comments (web)'
   cost:
     type: per_success
@@ -31689,7 +31932,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_post_comments
-  name: Fetch post comments
+  name: "X (Twitter) post comments by tweet id"
   summary: 'Twitter: fetch post comments (web)'
   cost:
     type: per_success
@@ -31723,7 +31966,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_retweet_user_list
-  name: Fetch retweet user list
+  name: "X (Twitter) users who reposted by tweet id"
   summary: 'Twitter: fetch retweet user list (web)'
   cost:
     type: per_success
@@ -31757,7 +32000,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_search_timeline
-  name: Fetch search timeline
+  name: "Search X (Twitter) posts by keyword"
   summary: 'Twitter: fetch search timeline (web)'
   cost:
     type: per_success
@@ -31797,7 +32040,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_trending
-  name: Fetch trending
+  name: "X (Twitter) trending topics by country"
   summary: 'Twitter: fetch trending (web)'
   cost:
     type: per_success
@@ -31827,7 +32070,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_tweet_detail
-  name: Fetch tweet detail
+  name: "X (Twitter) post details by tweet id"
   summary: 'Twitter: fetch tweet detail (web)'
   cost:
     type: per_success
@@ -31857,7 +32100,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_user_followers
-  name: Fetch user followers
+  name: "X (Twitter) user's followers by handle"
   summary: 'Twitter: fetch user followers (web)'
   cost:
     type: per_success
@@ -31891,7 +32134,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_user_followings
-  name: Fetch user followings
+  name: "X (Twitter) accounts a user follows by handle"
   summary: 'Twitter: fetch user followings (web)'
   cost:
     type: per_success
@@ -31925,7 +32168,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_user_media
-  name: Fetch user media
+  name: "X (Twitter) user's media posts by handle"
   summary: 'Twitter: fetch user media (web)'
   cost:
     type: per_success
@@ -31965,7 +32208,7 @@ endpoints:
   platform: x
   method: GET
   path: /api/v1/twitter/web/fetch_user_tweet_replies
-  name: Fetch user tweet replies
+  name: "X (Twitter) user's replies by handle"
   summary: 'Twitter: fetch user tweet replies (web)'
   cost:
     type: per_success
@@ -31999,7 +32242,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_creator_hot_inspiration_feed
-  name: Get creator hot inspiration feed (app_v2)
+  name: "Xiaohongshu creator hot inspiration feed"
   summary: 'Xiaohongshu: get creator hot inspiration feed (app_v2)'
   cost:
     type: per_success
@@ -32027,7 +32270,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_creator_inspiration_feed
-  name: Get creator inspiration feed (app_v2)
+  name: "Xiaohongshu creator inspiration feed"
   summary: 'Xiaohongshu: get creator inspiration feed (app_v2)'
   cost:
     type: per_success
@@ -32067,7 +32310,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_image_note_detail
-  name: Get image note detail (app_v2)
+  name: "Xiaohongshu image note details by note id or link"
   summary: 'Xiaohongshu: get image note detail (app_v2)'
   cost:
     type: per_success
@@ -32103,7 +32346,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_note_comments
-  name: Get note comments (app_v2)
+  name: "Xiaohongshu note comments by note id or share link"
   summary: 'Xiaohongshu: get note comments (app_v2)'
   cost:
     type: per_success
@@ -32161,7 +32404,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_note_sub_comments
-  name: Get note sub comments (app_v2)
+  name: "Xiaohongshu comment replies by note and comment id"
   summary: 'Xiaohongshu: get note sub comments (app_v2)'
   cost:
     type: per_success
@@ -32213,7 +32456,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_product_detail
-  name: Get product detail (app_v2)
+  name: "Xiaohongshu product details by SKU id"
   summary: 'Xiaohongshu: get product detail (app_v2)'
   cost:
     type: per_success
@@ -32255,7 +32498,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_product_recommendations
-  name: Get product recommendations (app_v2)
+  name: "Xiaohongshu recommended products by SKU id"
   summary: 'Xiaohongshu: get product recommendations (app_v2)'
   cost:
     type: per_success
@@ -32295,7 +32538,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_product_review_overview
-  name: Get product review overview (app_v2)
+  name: "Xiaohongshu product review summary by SKU id"
   summary: 'Xiaohongshu: get product review overview (app_v2)'
   cost:
     type: per_success
@@ -32331,7 +32574,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_product_reviews
-  name: Get product reviews (app_v2)
+  name: "Xiaohongshu product reviews by SKU id"
   summary: 'Xiaohongshu: get product reviews (app_v2)'
   cost:
     type: per_success
@@ -32385,7 +32628,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_topic_feed
-  name: Get topic feed (app_v2)
+  name: "Xiaohongshu topic notes by topic page id"
   summary: 'Xiaohongshu: get topic feed (app_v2)'
   cost:
     type: per_success
@@ -32447,7 +32690,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_topic_info
-  name: Get topic info (app_v2)
+  name: "Xiaohongshu topic details by topic page id"
   summary: 'Xiaohongshu: get topic info (app_v2)'
   cost:
     type: per_success
@@ -32487,7 +32730,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_user_faved_notes
-  name: Get user faved notes (app_v2)
+  name: "Xiaohongshu user's saved notes by user id or link"
   summary: 'Xiaohongshu: get user faved notes (app_v2)'
   cost:
     type: per_success
@@ -32527,7 +32770,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_user_info
-  name: Get user info (app_v2)
+  name: "Xiaohongshu user profile by user id or share link"
   summary: 'Xiaohongshu: get user info (app_v2)'
   cost:
     type: per_success
@@ -32563,7 +32806,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_user_posted_notes
-  name: Get user posted notes (app_v2)
+  name: "Xiaohongshu user's notes by user id or share link"
   summary: 'Xiaohongshu: get user posted notes (app_v2)'
   cost:
     type: per_success
@@ -32603,7 +32846,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/get_video_note_detail
-  name: Get video note detail (app_v2)
+  name: "Xiaohongshu video note details by note id or link"
   summary: 'Xiaohongshu: get video note detail (app_v2)'
   cost:
     type: per_success
@@ -32639,7 +32882,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/search_groups
-  name: Search groups (app_v2)
+  name: "Search Xiaohongshu groups by keyword"
   summary: 'Xiaohongshu: search groups (app_v2)'
   cost:
     type: per_success
@@ -32691,7 +32934,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/search_images
-  name: Search images (app_v2)
+  name: "Search Xiaohongshu images by keyword"
   summary: 'Xiaohongshu: search images (app_v2)'
   cost:
     type: per_success
@@ -32745,7 +32988,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/search_notes
-  name: Search notes (app_v2)
+  name: "Search Xiaohongshu notes by keyword and filters"
   summary: 'Xiaohongshu: search notes (app_v2)'
   cost:
     type: per_success
@@ -32819,7 +33062,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/search_products
-  name: Search products (app_v2)
+  name: "Search Xiaohongshu products by keyword"
   summary: 'Xiaohongshu: search products (app_v2)'
   cost:
     type: per_success
@@ -32865,7 +33108,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/app_v2/search_users
-  name: Search users (app_v2)
+  name: "Search Xiaohongshu users by keyword"
   summary: 'Xiaohongshu: search users (app_v2)'
   cost:
     type: per_success
@@ -32911,7 +33154,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_core_data
-  name: Get blogger core data (pgy)
+  name: "Xiaohongshu Pugongying creator core metrics"
   summary: 'Xiaohongshu: get blogger core data (pgy)'
   cost:
     type: per_success
@@ -32955,7 +33198,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_data_summary
-  name: Get blogger data summary (pgy)
+  name: "Xiaohongshu Pugongying creator metrics summary"
   summary: 'Xiaohongshu: get blogger data summary (pgy)'
   cost:
     type: per_success
@@ -32987,7 +33230,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_detail
-  name: Get blogger detail (pgy)
+  name: "Xiaohongshu Pugongying creator profile"
   summary: 'Xiaohongshu: get blogger detail (pgy)'
   cost:
     type: per_success
@@ -33019,7 +33262,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_fans_history
-  name: Get blogger fans history (pgy)
+  name: "Xiaohongshu Pugongying creator follower history"
   summary: 'Xiaohongshu: get blogger fans history (pgy)'
   cost:
     type: per_success
@@ -33055,7 +33298,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_fans_profile
-  name: Get blogger fans profile (pgy)
+  name: "Xiaohongshu Pugongying creator audience profile"
   summary: 'Xiaohongshu: get blogger fans profile (pgy)'
   cost:
     type: per_success
@@ -33087,7 +33330,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_fans_summary
-  name: Get blogger fans summary (pgy)
+  name: "Xiaohongshu Pugongying creator follower summary"
   summary: 'Xiaohongshu: get blogger fans summary (pgy)'
   cost:
     type: per_success
@@ -33119,7 +33362,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_list
-  name: Get blogger list (pgy)
+  name: "Xiaohongshu Pugongying creator list"
   summary: 'Xiaohongshu: get blogger list (pgy)'
   cost:
     type: per_success
@@ -33167,7 +33410,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_notes
-  name: Get blogger notes (pgy)
+  name: "Xiaohongshu Pugongying creator notes"
   summary: 'Xiaohongshu: get blogger notes (pgy)'
   cost:
     type: per_success
@@ -33219,7 +33462,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_blogger_notes_rate
-  name: Get blogger notes rate (pgy)
+  name: "Xiaohongshu Pugongying creator note rates"
   summary: 'Xiaohongshu: get blogger notes rate (pgy)'
   cost:
     type: per_success
@@ -33263,7 +33506,7 @@ endpoints:
   platform: xiaohongshu-pugongying
   method: POST
   path: /api/v1/xiaohongshu/pgy/get_note_detail
-  name: Get note detail (pgy)
+  name: "Xiaohongshu Pugongying note details"
   summary: 'Xiaohongshu: get note detail (pgy)'
   cost:
     type: per_success
@@ -33295,7 +33538,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_homefeed
-  name: Fetch homefeed (web_v3)
+  name: "Xiaohongshu home feed by category"
   summary: 'Xiaohongshu: fetch homefeed (web_v3)'
   cost:
     type: per_success
@@ -33340,7 +33583,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_homefeed_categories
-  name: Fetch homefeed categories (web_v3)
+  name: "Xiaohongshu home feed categories list"
   summary: 'Xiaohongshu: fetch homefeed categories (web_v3)'
   cost:
     type: per_success
@@ -33361,7 +33604,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_hot_list
-  name: Fetch hot list (web_v3)
+  name: "Xiaohongshu trending list"
   summary: 'Xiaohongshu: fetch hot list (web_v3)'
   cost:
     type: per_success
@@ -33383,7 +33626,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_note_detail
-  name: Fetch note detail (web_v3)
+  name: "Xiaohongshu note details by note id and xsec token"
   summary: 'Xiaohongshu: fetch note detail (web_v3)'
   cost:
     type: per_success
@@ -33419,7 +33662,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_search_suggest
-  name: Fetch search suggest (web_v3)
+  name: "Xiaohongshu search suggestions by keyword"
   summary: 'Xiaohongshu: fetch search suggest (web_v3)'
   cost:
     type: per_success
@@ -33449,7 +33692,7 @@ endpoints:
   platform: xiaohongshu
   method: GET
   path: /api/v1/xiaohongshu/web_v3/fetch_user_info
-  name: Fetch user info (web_v3)
+  name: "Xiaohongshu user profile by user id"
   summary: 'Xiaohongshu: fetch user info (web_v3)'
   cost:
     type: per_success
@@ -33479,7 +33722,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_one_video
-  name: Fetch one video (app/v2)
+  name: "Xigua video details by video id"
   summary: 'Xigua: fetch one video (app/v2)'
   cost:
     type: per_success
@@ -33509,7 +33752,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_one_video_play_url
-  name: Fetch one video play url (app/v2)
+  name: "Xigua video stream URL by video id"
   summary: 'Xigua: fetch one video play url (app/v2)'
   cost:
     type: per_success
@@ -33539,7 +33782,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_one_video_v2
-  name: Fetch one video v2 (app/v2)
+  name: "Xigua video details by video id"
   summary: 'Xigua: fetch one video v2 (app/v2)'
   cost:
     type: per_success
@@ -33567,7 +33810,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_user_info
-  name: Fetch user info (app/v2)
+  name: "Xigua user profile by user id"
   summary: 'Xigua: fetch user info (app/v2)'
   cost:
     type: per_success
@@ -33597,7 +33840,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_user_post_list
-  name: Fetch user post list (app/v2)
+  name: "Xigua user's videos by user id"
   summary: 'Xigua: fetch user post list (app/v2)'
   cost:
     type: per_success
@@ -33631,7 +33874,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/fetch_video_comment_list
-  name: Fetch video comment list (app/v2)
+  name: "Xigua video comments by video id"
   summary: 'Xigua: fetch video comment list (app/v2)'
   cost:
     type: per_success
@@ -33672,7 +33915,7 @@ endpoints:
   platform: xigua
   method: GET
   path: /api/v1/xigua/app/v2/search_video
-  name: Search video (app/v2)
+  name: "Search Xigua videos by keyword"
   summary: 'Xigua: search video (app/v2)'
   cost:
     type: per_success
@@ -33719,7 +33962,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_id
-  name: Get channel id
+  name: "YouTube channel id from channel name"
   summary: 'Youtube: get channel id (web)'
   cost:
     type: per_success
@@ -33748,7 +33991,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_id_v2
-  name: Get channel id v2
+  name: "YouTube channel id from channel URL"
   summary: 'Youtube: get channel id v2 (web)'
   cost:
     type: per_success
@@ -33777,7 +34020,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_info
-  name: Get channel info
+  name: "YouTube channel profile by channel id"
   summary: 'Youtube: get channel info (web)'
   cost:
     type: per_success
@@ -33807,7 +34050,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_short_videos
-  name: Get channel short videos
+  name: "YouTube channel Shorts by channel id"
   summary: 'Youtube: get channel short videos (web)'
   cost:
     type: per_success
@@ -33841,7 +34084,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_url
-  name: Get channel url
+  name: "YouTube channel URL from channel id"
   summary: 'Youtube: get channel url (web)'
   cost:
     type: per_success
@@ -33870,7 +34113,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_channel_videos_v2
-  name: Get channel videos v2
+  name: "YouTube channel videos by channel id, sortable"
   summary: 'Youtube: get channel videos v2 (web)'
   cost:
     type: per_success
@@ -33920,7 +34163,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_relate_video
-  name: Get relate video
+  name: "YouTube related videos by video id"
   summary: 'Youtube: get relate video (web)'
   cost:
     type: per_success
@@ -33954,7 +34197,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_trending_videos
-  name: Get trending videos
+  name: "YouTube trending videos by country and section"
   summary: 'Youtube: get trending videos (web)'
   cost:
     type: per_success
@@ -33993,7 +34236,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_video_info
-  name: Get video info
+  name: "YouTube video details by video id with stream formats"
   summary: 'Youtube: get video info (web)'
   cost:
     type: per_success
@@ -34052,7 +34295,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/get_video_subtitles
-  name: Get video subtitles
+  name: "YouTube video subtitles by subtitle URL"
   summary: 'Youtube: get video subtitles (web)'
   cost:
     type: per_success
@@ -34096,7 +34339,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/search_channel
-  name: Search channel
+  name: "Search within a YouTube channel by keyword"
   summary: 'Youtube: search channel (web)'
   cost:
     type: per_success
@@ -34146,7 +34389,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web/search_video
-  name: Search video
+  name: "Search YouTube videos by keyword"
   summary: 'Youtube: search video (web)'
   cost:
     type: per_success
@@ -34195,7 +34438,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_channel_community_posts
-  name: Get channel community posts
+  name: "YouTube channel community posts by channel id"
   summary: 'Youtube: get channel community posts (web_v2)'
   cost:
     type: per_success
@@ -34246,7 +34489,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_channel_description
-  name: Get channel description
+  name: "YouTube channel description by channel id"
   summary: 'Youtube: get channel description (web_v2)'
   cost:
     type: per_success
@@ -34297,7 +34540,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_channel_id
-  name: Get channel id
+  name: "YouTube channel id from channel URL"
   summary: 'Youtube: get channel id (web_v2)'
   cost:
     type: per_success
@@ -34326,7 +34569,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_channel_shorts
-  name: Get channel shorts
+  name: "YouTube channel Shorts by channel id or URL"
   summary: 'Youtube: get channel shorts (web_v2)'
   cost:
     type: per_success
@@ -34371,7 +34614,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_channel_url
-  name: Get channel url
+  name: "YouTube channel URL from channel id"
   summary: 'Youtube: get channel url (web_v2)'
   cost:
     type: per_success
@@ -34400,7 +34643,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_general_search
-  name: Get general search
+  name: "Search YouTube by keyword with filters"
   summary: 'Youtube: get general search (web_v2)'
   cost:
     type: per_success
@@ -34469,7 +34712,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_post_comment_replies
-  name: Get post comment replies
+  name: "YouTube community post comment replies by token"
   summary: 'Youtube: get post comment replies (web_v2)'
   cost:
     type: per_success
@@ -34508,7 +34751,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_post_comments
-  name: Get post comments
+  name: "YouTube community post comments by post id"
   summary: 'Youtube: get post comments (web_v2)'
   cost:
     type: per_success
@@ -34559,7 +34802,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_post_detail
-  name: Get post detail
+  name: "YouTube community post details by post id"
   summary: 'Youtube: get post detail (web_v2)'
   cost:
     type: per_success
@@ -34606,7 +34849,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_related_videos
-  name: Get related videos
+  name: "YouTube related videos by video id or URL"
   summary: 'Youtube: get related videos (web_v2)'
   cost:
     type: per_success
@@ -34647,7 +34890,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_search_suggestions
-  name: Get search suggestions
+  name: "YouTube search suggestions by partial keyword"
   summary: 'Youtube: get search suggestions (web_v2)'
   cost:
     type: per_success
@@ -34689,7 +34932,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_shorts_search
-  name: Get shorts search
+  name: "Search YouTube Shorts by keyword"
   summary: 'Youtube: get shorts search (web_v2)'
   cost:
     type: per_success
@@ -34755,7 +34998,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_shorts_search_v2
-  name: Get shorts search v2
+  name: "Search YouTube Shorts by keyword"
   summary: 'Youtube: get shorts search v2 (web_v2)'
   cost:
     type: per_success
@@ -34797,7 +35040,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_signed_stream_url
-  name: Get signed stream url
+  name: "YouTube signed stream URL by video id and itag"
   summary: 'Youtube: get signed stream url (web_v2)'
   cost:
     type: per_success
@@ -34839,7 +35082,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_captions
-  name: Get video captions
+  name: "YouTube video captions by video id or URL"
   summary: 'Youtube: get video captions (web_v2)'
   cost:
     type: per_success
@@ -34892,7 +35135,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_captions_result
-  name: Get video captions result
+  name: "YouTube video captions result by job id"
   summary: 'Youtube: get video captions result (web_v2)'
   cost:
     type: free
@@ -34926,7 +35169,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_comment_replies
-  name: Get video comment replies
+  name: "YouTube video comment replies by token"
   summary: 'Youtube: get video comment replies (web_v2)'
   cost:
     type: per_success
@@ -34965,7 +35208,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_info
-  name: Get video info
+  name: "YouTube video details by video id"
   summary: 'Youtube: get video info (web_v2)'
   cost:
     type: per_success
@@ -35006,7 +35249,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_info_v2
-  name: Get video info v2
+  name: "YouTube video details by video id or URL"
   summary: 'Youtube: get video info v2 (web_v2)'
   cost:
     type: per_success
@@ -35047,7 +35290,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_streams
-  name: Get video streams
+  name: "YouTube video stream formats by video id or URL"
   summary: 'Youtube: get video streams (web_v2)'
   cost:
     type: per_success
@@ -35083,7 +35326,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/get_video_streams_v2
-  name: Get video streams v2
+  name: "YouTube video stream formats by video id or URL"
   summary: 'Youtube: get video streams v2 (web_v2)'
   cost:
     type: per_success
@@ -35119,7 +35362,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /api/v1/youtube/web_v2/search_channels
-  name: Search channels
+  name: "Search YouTube channels by keyword"
   summary: 'Youtube: search channels (web_v2)'
   cost:
     type: per_success
@@ -35158,7 +35401,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_ai_search_stream
-  name: Fetch ai search stream
+  name: "Zhihu AI search stream by query"
   summary: 'Zhihu: fetch ai search stream (web)'
   cost:
     type: per_success
@@ -35191,7 +35434,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_answer_detail
-  name: Fetch answer detail
+  name: "Zhihu answer details by answer id"
   summary: 'Zhihu: fetch answer detail (web)'
   cost:
     type: per_success
@@ -35215,7 +35458,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_article_search_v3
-  name: Fetch article search v3
+  name: "Search Zhihu articles by keyword"
   summary: 'Zhihu: fetch article search v3 (web)'
   cost:
     type: per_success
@@ -35279,7 +35522,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_article_detail
-  name: Fetch column article detail
+  name: "Zhihu column article details by article id"
   summary: 'Zhihu: fetch column article detail (web)'
   cost:
     type: per_success
@@ -35303,7 +35546,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_articles
-  name: Fetch column articles
+  name: "Zhihu column articles by column id"
   summary: 'Zhihu: fetch column articles (web)'
   cost:
     type: per_success
@@ -35337,7 +35580,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_comment_config
-  name: Fetch column comment config
+  name: "Zhihu article comment settings by article id"
   summary: 'Zhihu: fetch column comment config (web)'
   cost:
     type: per_success
@@ -35361,7 +35604,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_recommend
-  name: Fetch column recommend
+  name: "Zhihu recommended columns by article id"
   summary: 'Zhihu: fetch column recommend (web)'
   cost:
     type: per_success
@@ -35395,7 +35638,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_relationship
-  name: Fetch column relationship
+  name: "Zhihu column relationship by article id"
   summary: 'Zhihu: fetch column relationship (web)'
   cost:
     type: per_success
@@ -35419,7 +35662,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_column_search_v3
-  name: Fetch column search v3
+  name: "Search Zhihu columns by keyword"
   summary: 'Zhihu: fetch column search v3 (web)'
   cost:
     type: per_success
@@ -35457,7 +35700,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_comment_v5
-  name: Fetch comment v5
+  name: "Zhihu answer comments by answer id"
   summary: 'Zhihu: fetch comment v5 (web)'
   cost:
     type: per_success
@@ -35495,7 +35738,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_ebook_search_v3
-  name: Fetch ebook search v3
+  name: "Search Zhihu ebooks by keyword"
   summary: 'Zhihu: fetch ebook search v3 (web)'
   cost:
     type: per_success
@@ -35533,7 +35776,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_hot_list
-  name: Fetch hot list
+  name: "Zhihu trending list"
   summary: 'Zhihu: fetch hot list (web)'
   cost:
     type: per_success
@@ -35567,7 +35810,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_hot_recommend
-  name: Fetch hot recommend
+  name: "Zhihu hot recommendations feed"
   summary: 'Zhihu: fetch hot recommend (web)'
   cost:
     type: per_success
@@ -35605,7 +35848,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_pin_comments
-  name: Fetch pin comments
+  name: "Zhihu pin comments by pin id"
   summary: 'Zhihu: fetch pin comments (web)'
   cost:
     type: per_success
@@ -35646,7 +35889,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_pin_detail
-  name: Fetch pin detail
+  name: "Zhihu pin details by pin id"
   summary: 'Zhihu: fetch pin detail (web)'
   cost:
     type: per_success
@@ -35670,7 +35913,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_preset_search
-  name: Fetch preset search
+  name: "Zhihu preset search suggestions"
   summary: 'Zhihu: fetch preset search (web)'
   cost:
     type: per_success
@@ -35692,7 +35935,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_question_answers
-  name: Fetch question answers
+  name: "Zhihu question answers by question id"
   summary: 'Zhihu: fetch question answers (web)'
   cost:
     type: per_success
@@ -35739,7 +35982,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_question_detail
-  name: Fetch question detail
+  name: "Zhihu question details by question id"
   summary: 'Zhihu: fetch question detail (web)'
   cost:
     type: per_success
@@ -35763,7 +36006,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_recommend_followees
-  name: Fetch recommend followees
+  name: "Zhihu recommended users to follow"
   summary: 'Zhihu: fetch recommend followees (web)'
   cost:
     type: per_success
@@ -35784,7 +36027,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_salt_search_v3
-  name: Fetch salt search v3
+  name: "Search Zhihu salt-selection content by keyword"
   summary: 'Zhihu: fetch salt search v3 (web)'
   cost:
     type: per_success
@@ -35822,7 +36065,7 @@ endpoints:
   platform: zhihu
   method: POST
   path: /api/v1/zhihu/web/fetch_scholar_search_v3
-  name: Fetch scholar search v3
+  name: "Search Zhihu scholar papers by keyword"
   summary: 'Zhihu: fetch scholar search v3 (web)'
   cost:
     type: per_success
@@ -35861,7 +36104,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_search_recommend
-  name: Fetch search recommend
+  name: "Zhihu recommended search terms"
   summary: 'Zhihu: fetch search recommend (web)'
   cost:
     type: per_success
@@ -35883,7 +36126,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_search_suggest
-  name: Fetch search suggest
+  name: "Zhihu search suggestions by partial keyword"
   summary: 'Zhihu: fetch search suggest (web)'
   cost:
     type: per_success
@@ -35907,7 +36150,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_sub_comment_v5
-  name: Fetch sub comment v5
+  name: "Zhihu comment replies by comment id"
   summary: 'Zhihu: fetch sub comment v5 (web)'
   cost:
     type: per_success
@@ -35945,7 +36188,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_topic_search_v3
-  name: Fetch topic search v3
+  name: "Search Zhihu topics by keyword"
   summary: 'Zhihu: fetch topic search v3 (web)'
   cost:
     type: per_success
@@ -35979,7 +36222,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_answers
-  name: Fetch user answers
+  name: "Zhihu user's answers by url token"
   summary: 'Zhihu: fetch user answers (web)'
   cost:
     type: per_success
@@ -36021,7 +36264,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_articles
-  name: Fetch user articles
+  name: "Zhihu user's articles by url token"
   summary: 'Zhihu: fetch user articles (web)'
   cost:
     type: per_success
@@ -36063,7 +36306,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_collections
-  name: Fetch user collections
+  name: "Zhihu user's collections by url token"
   summary: 'Zhihu: fetch user collections (web)'
   cost:
     type: per_success
@@ -36097,7 +36340,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_follow_collections
-  name: Fetch user follow collections
+  name: "Zhihu collections a user follows by url token"
   summary: 'Zhihu: fetch user follow collections (web)'
   cost:
     type: per_success
@@ -36131,7 +36374,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_follow_columns
-  name: Fetch user follow columns
+  name: "Zhihu columns a user follows by url token"
   summary: 'Zhihu: fetch user follow columns (web)'
   cost:
     type: per_success
@@ -36165,7 +36408,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_follow_questions
-  name: Fetch user follow questions
+  name: "Zhihu questions a user follows by url token"
   summary: 'Zhihu: fetch user follow questions (web)'
   cost:
     type: per_success
@@ -36199,7 +36442,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_follow_topics
-  name: Fetch user follow topics
+  name: "Zhihu topics a user follows by url token"
   summary: 'Zhihu: fetch user follow topics (web)'
   cost:
     type: per_success
@@ -36233,7 +36476,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_followees
-  name: Fetch user followees
+  name: "Zhihu accounts a user follows by url token"
   summary: 'Zhihu: fetch user followees (web)'
   cost:
     type: per_success
@@ -36267,7 +36510,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_followers
-  name: Fetch user followers
+  name: "Zhihu user's followers by url token"
   summary: 'Zhihu: fetch user followers (web)'
   cost:
     type: per_success
@@ -36301,7 +36544,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_included_articles
-  name: Fetch user included articles
+  name: "Zhihu user's included articles by url token"
   summary: 'Zhihu: fetch user included articles (web)'
   cost:
     type: per_success
@@ -36335,7 +36578,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_info
-  name: Fetch user info
+  name: "Zhihu user profile by url token"
   summary: 'Zhihu: fetch user info (web)'
   cost:
     type: per_success
@@ -36359,7 +36602,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_pins
-  name: Fetch user pins
+  name: "Zhihu user's pins by url token"
   summary: 'Zhihu: fetch user pins (web)'
   cost:
     type: per_success
@@ -36393,7 +36636,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_search_v3
-  name: Fetch user search v3
+  name: "Search Zhihu users by keyword"
   summary: 'Zhihu: fetch user search v3 (web)'
   cost:
     type: per_success
@@ -36427,7 +36670,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_user_segments
-  name: Fetch user segments
+  name: "Zhihu user's content segments by member hash id"
   summary: 'Zhihu: fetch user segments (web)'
   cost:
     type: per_success
@@ -36466,7 +36709,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_video_list
-  name: Fetch video list
+  name: "Zhihu videos feed"
   summary: 'Zhihu: fetch video list (web)'
   cost:
     type: per_success
@@ -36500,7 +36743,7 @@ endpoints:
   platform: zhihu
   method: GET
   path: /api/v1/zhihu/web/fetch_video_search_v3
-  name: Fetch video search v3
+  name: "Search Zhihu videos by keyword"
   summary: 'Zhihu: fetch video search v3 (web)'
   cost:
     type: per_success

--- a/src/treg/catalog/tikhub.yaml
+++ b/src/treg/catalog/tikhub.yaml
@@ -22,6 +22,7 @@ endpoints:
     method: GET
     path: /api/v1/tiktok/web/fetch_user_profile
     summary: "Public TikTok profile by username (uniqueId) or secUid"
+    name: "TikTok user profile by username or secUid"
     input:
       queryParams:
         uniqueId: {type: string, required: false, note: "username from the profile URL", example: "tiktok"}
@@ -47,7 +48,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/v1/tiktok/web/fetch_user_post
-    name: "List a TikTok user's recent videos"
+    name: "TikTok user's recent videos by secUid"
     summary: "Recent videos posted by a TikTok user (keyed by secUid, not username)"
     input:
       queryParams:
@@ -67,7 +68,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/v1/tiktok/web/fetch_post_detail
-    name: "Get TikTok video details"
+    name: "TikTok video details by video id — author, stats"
     summary: "A single TikTok video's metadata, author and stats"
     input:
       queryParams:
@@ -87,6 +88,7 @@ endpoints:
     method: GET
     path: /api/v1/tiktok/web/fetch_post_comment
     summary: "Comments on a TikTok video"
+    name: "TikTok video comments by video id"
     input:
       queryParams:
         aweme_id: {type: string, required: true, note: "numeric video id — same value as itemId elsewhere", example: "7231337071831321903"}
@@ -107,6 +109,7 @@ endpoints:
     method: GET
     path: /api/v1/tiktok/app/v3/fetch_video_search_result
     summary: "Search TikTok videos by keyword"
+    name: "Search TikTok videos by keyword"
     # The documented web-family equivalent (/api/v1/tiktok/web/fetch_search_video) returned HTTP 400
     # on every attempt on 2026-07-28 regardless of parameters; the app/v3 route works and costs the same.
     input:
@@ -130,7 +133,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/v1/tiktok/web/fetch_tag_detail
-    name: "Resolve a TikTok hashtag to its ID"
+    name: "TikTok hashtag details by tag name — challenge id"
     summary: "TikTok hashtag metadata — resolves a tag name to the challengeID needed for hashtag videos"
     input:
       queryParams:
@@ -149,6 +152,7 @@ endpoints:
     method: GET
     path: /api/v1/tiktok/web/fetch_tag_post
     summary: "Videos under a TikTok hashtag (by numeric challengeID)"
+    name: "TikTok hashtag videos by challenge id"
     input:
       queryParams:
         challengeID: {type: string, required: true, note: "numeric hashtag id — resolve a tag name via tiktok.hashtag.detail first", example: "6272"}
@@ -176,6 +180,7 @@ endpoints:
     method: GET
     path: /api/v1/instagram/v1/fetch_user_info_by_username
     summary: "Public Instagram profile by username"
+    name: "Instagram profile by username"
     input:
       queryParams:
         username: {type: string, required: true, note: "handle without the '@'", example: "instagram"}
@@ -199,6 +204,7 @@ endpoints:
     method: GET
     path: /api/v1/instagram/v1/fetch_user_posts
     summary: "Recent posts of an Instagram user (keyed by numeric user id)"
+    name: "Instagram user's posts by user id"
     input:
       queryParams:
         user_id: {type: string, required: true, note: "numeric Instagram user id — resolve a username via instagram.user.profile first", example: "25025320"}
@@ -218,7 +224,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/v1/youtube/web/get_video_info_v2
-    name: "Get YouTube video details"
+    name: "YouTube video details by video id"
     summary: "A single YouTube video's metadata and stats"
     # The newer /youtube/web_v2/get_video_info is equivalent and identically priced, but is not
     # free-credit eligible, so this web-family route is the one that could be live-verified.
@@ -245,6 +251,7 @@ endpoints:
     method: GET
     path: /api/v1/youtube/web_v2/get_video_comments
     summary: "Comments on a YouTube video"
+    name: "YouTube video comments by video id"
     input:
       queryParams:
         video_id: {type: string, required: true, example: "dQw4w9WgXcQ"}
@@ -272,7 +279,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /api/v1/youtube/web_v2/get_general_search_v2
-    name: "Search YouTube videos by keyword"
+    name: "Search YouTube videos by keyword and filters"
     summary: "Search YouTube by keyword (filter type=video for videos only)"
     input:
       queryParams:
@@ -303,6 +310,7 @@ endpoints:
     method: GET
     path: /api/v1/youtube/web_v2/get_channel_videos
     summary: "Videos of a YouTube channel by channel id"
+    name: "YouTube channel videos by channel id"
     input:
       queryParams:
         channel_id: {type: string, required: true, note: "UC… channel id", example: "UCX6OQ3DkcsbYNE6H8uQQuVA"}
@@ -331,6 +339,7 @@ endpoints:
     method: GET
     path: /api/v1/twitter/web/fetch_user_profile
     summary: "Public X (Twitter) profile by handle or numeric id"
+    name: "X (Twitter) profile by handle or user id"
     input:
       queryParams:
         screen_name: {type: string, required: false, note: "handle from the profile URL", example: "elonmusk"}
@@ -356,6 +365,7 @@ endpoints:
     method: GET
     path: /api/v1/twitter/web/fetch_user_post_tweet
     summary: "Recent posts of an X (Twitter) user"
+    name: "X (Twitter) user's posts by handle or user id"
     input:
       queryParams:
         screen_name: {type: string, required: false, example: "elonmusk"}

--- a/src/treg/catalog/tiktok-ads.yaml
+++ b/src/treg/catalog/tiktok-ads.yaml
@@ -36,7 +36,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /oauth2/advertiser/get/
-    name: "List ad accounts"
+    name: "TikTok ad accounts this connection manages"
     summary: "List the TikTok ad accounts this connection can manage"
     input:
       queryParams:
@@ -52,7 +52,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /report/integrated/get/
-    name: "Get ad performance metrics"
+    name: "Your TikTok ads' spend, impressions, clicks, conversions"
     summary: "Get spend, impressions, clicks and conversions for your TikTok ads"
     input:
       queryParams:
@@ -79,7 +79,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /campaign/get/
-    name: "List ad campaigns"
+    name: "Campaigns in your TikTok ad account — status, budget"
     summary: "List the campaigns in your TikTok ad account with objective, status and budget"
     input:
       queryParams:
@@ -98,7 +98,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /adgroup/get/
-    name: "List ad groups"
+    name: "Ad groups in your TikTok ad account — bid, targeting"
     summary: "List the ad groups in your TikTok ad account with targeting, bid and schedule"
     input:
       queryParams:
@@ -117,7 +117,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /ad/get/
-    name: "List ads with creatives"
+    name: "Ads in your TikTok ad account, with creatives"
     summary: "List the ads in your TikTok ad account with their creatives and landing pages"
     input:
       queryParams:

--- a/src/treg/catalog/tiktok.yaml
+++ b/src/treg/catalog/tiktok.yaml
@@ -26,7 +26,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /v2/user/info/
-    name: "Get your profile and follower counts"
+    name: "Your TikTok profile — follower and like counts"
     summary: "Get your own TikTok profile with follower, following and total-like counts"
     input:
       queryParams:
@@ -41,7 +41,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/video/list/
-    name: "List your videos with engagement stats"
+    name: "Your TikTok videos — views, likes, comments, shares"
     summary: "List your own TikTok videos with view, like, comment and share counts"
     input:
       queryParams:
@@ -81,7 +81,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/post/publish/creator_info/query/
-    name: "Get creator posting permissions and limits"
+    name: "Your TikTok posting permissions and limits"
     summary: "Get what the connected TikTok creator is allowed to post (privacy options, limits)"
     input:
       note: "no parameters — an empty POST with Content-Type: application/json; charset=UTF-8. Returns creator_nickname, privacy_level_options (the ONLY privacy_level values the direct-post call will accept for this creator), max_video_post_duration_sec, and the comment/duet/stitch toggles the account has disabled. TikTok's own guidelines REQUIRE calling this before a direct post and showing the creator these options — an app that hardcodes them fails audit. Needs video.publish or video.upload"
@@ -96,7 +96,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/post/publish/video/init/
-    name: "Publish a video to TikTok"
+    name: "Publish a video to your TikTok profile"
     summary: "Publish a video directly to your own TikTok profile"
     input:
       body:
@@ -115,7 +115,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/post/publish/inbox/video/init/
-    name: "Send a video draft to your inbox"
+    name: "Send a video draft to your TikTok inbox"
     summary: "Send a video to your TikTok inbox as a draft for you to finish and post"
     input:
       body:
@@ -133,7 +133,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/post/publish/content/init/
-    name: "Publish a photo post"
+    name: "Publish a photo post to your TikTok profile"
     summary: "Publish a photo post to your own TikTok profile, or send it to your inbox"
     input:
       body:
@@ -154,7 +154,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /v2/post/publish/status/fetch/
-    name: "Check publish status"
+    name: "Check a TikTok upload's publish status"
     summary: "Check whether a TikTok upload has finished publishing"
     input:
       body:

--- a/src/treg/catalog/tomba.yaml
+++ b/src/treg/catalog/tomba.yaml
@@ -112,7 +112,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/author-finder
-    name: "Find an article author's email"
+    name: "Find an article author's email from its URL"
     summary: "Article or blog-post URL → the byline author's name and work email"
     input:
       queryParams:
@@ -142,7 +142,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/email-verifier/{email}
-    name: "Verify an email address"
+    name: "Verify an email address is deliverable"
     summary: "Deliverability status, score, MX/SMTP checks, catch-all, disposable, gibberish and role-address flags for one address"
     input:
       pathParams:
@@ -171,7 +171,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/enrich
-    name: "Enrich a person from their email"
+    name: "Enrich a person by email — name, role, social profiles"
     summary: "Email address → full person record: name, company, position, department, seniority, country, gender, social profiles and the pages the address was found on"
     input:
       queryParams:
@@ -200,7 +200,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/people/find
-    name: "Enrich a person (Clearbit-shaped response)"
+    name: "Enrich a person by email (Clearbit-shaped response)"
     summary: "Email address → a person record in the classic Person-API shape: name object, geo, employment, and per-network social handles"
     input:
       queryParams:
@@ -230,7 +230,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/companies/find
-    name: "Enrich a company from its domain"
+    name: "Enrich a company by domain — headcount, revenue, SIC"
     summary: "Company domain → firmographics: legal name, sector and SIC/NAICS codes, headcount, revenue range, founding year, address, socials and known email addresses"
     input:
       queryParams:
@@ -259,7 +259,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/combined/find
-    name: "Enrich a person AND their company in one call"
+    name: "Enrich a person and their company by email, in one call"
     summary: "Email address → both the person record and the full company record, in one response"
     input:
       queryParams:
@@ -288,7 +288,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/phone-finder
-    name: "Find a direct phone number"
+    name: "Find a direct phone number by email, domain or LinkedIn"
     summary: "Email, domain or LinkedIn URL → a direct phone number with country, line type, carrier, region and timezone"
     input:
       queryParams:
@@ -384,7 +384,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/email-count
-    name: "Count the emails known for a domain"
+    name: "Count the emails known for a domain (free)"
     summary: "Company domain → how many addresses Tomba holds, split personal vs generic and broken down by department and seniority — a free way to size a domain before paying to search it"
     input:
       queryParams:
@@ -413,7 +413,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/email-format
-    name: "Find a company's email format"
+    name: "A company's email address patterns by domain"
     summary: "Company domain → the address patterns in use ({first}, {first}.{last}, {f}{last}…) with the share of the company's addresses on each"
     input:
       queryParams:
@@ -443,7 +443,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/location
-    name: "Where a company's contacts are"
+    name: "Where a company's contacts are — a per-country tally"
     summary: "Company domain → a per-country tally of the contacts Tomba holds for it"
     input:
       queryParams:
@@ -501,7 +501,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/technology
-    name: "Technologies a website runs"
+    name: "Detect a website's tech stack by domain"
     summary: "Website domain → the detected tech stack: each technology's name, vendor site, description and category (CMS, analytics, payments…)"
     input:
       queryParams:
@@ -530,7 +530,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /v1/similar
-    name: "Find similar companies"
+    name: "Find lookalike companies from a seed domain"
     summary: "Company domain → comparable companies with their domain, name and industry — competitor and lookalike discovery from one seed"
     input:
       queryParams:

--- a/src/treg/catalog/twelvedata.yaml
+++ b/src/treg/catalog/twelvedata.yaml
@@ -15,7 +15,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /quote
-    name: "Quote for a symbol"
+    name: "Stock, forex or crypto quote by symbol — 52-week range"
     summary: "Current quote with open/high/low/close, volume, change and 52-week range — stocks, forex and crypto symbols alike"
     input:
       queryParams:
@@ -33,7 +33,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /time_series
-    name: "Time series for a symbol"
+    name: "Stock OHLCV time series by symbol — 1min to 1month"
     summary: "OHLCV series at any interval from 1min to 1month — the workhorse for charts and analysis"
     input:
       queryParams:
@@ -54,7 +54,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /price
-    name: "Just the price"
+    name: "Current price of a symbol — one number only"
     summary: "One number: the current price of a symbol — the cheapest possible check"
     input:
       queryParams:
@@ -71,7 +71,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /symbol_search
-    name: "Search symbols"
+    name: "Search stock, forex and crypto symbols by name"
     summary: "Resolve a name or fragment to symbols across stocks, forex and crypto, with exchange info"
     input:
       queryParams:

--- a/src/treg/catalog/x.extended.yaml
+++ b/src/treg/catalog/x.extended.yaml
@@ -46,7 +46,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/account_activity/subscriptions/count
-  name: "Count active activity subscriptions"
+  name: "Count your Account Activity subscriptions"
   summary: Get Account Activity Subscription Count
   scope: own_account
   cost:
@@ -67,7 +67,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/account_activity/webhooks/{webhook_id}/subscriptions/all
-  name: "Check a webhook subscription is active"
+  name: "Check an Account Activity subscription by webhook id"
   summary: Validate Account Activity Subscription
   scope: own_account
   cost:
@@ -94,7 +94,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/account_activity/webhooks/{webhook_id}/subscriptions/all
-  name: "Subscribe a webhook to account activity"
+  name: "Subscribe a webhook to Account Activity events"
   summary: Create subscription
   scope: own_account
   cost:
@@ -126,7 +126,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/account_activity/webhooks/{webhook_id}/subscriptions/all/list
-  name: "List webhook activity subscriptions"
+  name: "List Account Activity subscriptions by webhook id"
   summary: Get Account Activity Subscriptions
   scope: own_account
   cost:
@@ -152,7 +152,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/account_activity/webhooks/{webhook_id}/subscriptions/{user_id}/all
-  name: "Unsubscribe a user from a webhook"
+  name: "Remove a user's Account Activity subscription"
   summary: Delete subscription
   scope: own_account
   cost:
@@ -181,7 +181,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/activity/stream
-  name: "Stream account activity events"
+  name: "Stream activity events in real time"
   summary: Activity Stream
   scope: any_account
   cost:
@@ -216,7 +216,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/activity/subscriptions
-  name: "Delete activity subscriptions by ID"
+  name: "Delete activity subscriptions by subscription ids"
   summary: Delete X activity subscriptions by IDs
   scope: own_account
   cost:
@@ -242,7 +242,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/activity/subscriptions
-  name: "List activity subscriptions"
+  name: "List your activity subscriptions"
   summary: Get X activity subscriptions
   scope: any_account
   cost:
@@ -300,7 +300,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/activity/subscriptions/{subscription_id}
-  name: "Delete an activity subscription"
+  name: "Delete an activity subscription by subscription id"
   summary: Deletes X activity subscription
   scope: own_account
   cost:
@@ -326,7 +326,7 @@ endpoints:
   platform: x
   method: PUT
   path: /2/activity/subscriptions/{subscription_id}
-  name: "Update an activity subscription"
+  name: "Update an activity subscription by subscription id"
   summary: Update X activity subscription
   scope: own_account
   cost:
@@ -357,7 +357,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/articles/draft
-  name: "Article create draft"
+  name: "Create a draft X Article"
   summary: Create draft Article
   scope: own_account
   cost:
@@ -385,7 +385,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/articles/{article_id}/publish
-  name: "Article publish"
+  name: "Publish a drafted Article by article id"
   summary: Publish Article
   scope: own_account
   cost:
@@ -448,7 +448,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/broadcasts/scheduled
-  name: "Create scheduled broadcast"
+  name: "Schedule a broadcast"
   summary: Create a scheduled broadcast
   scope: own_account
   cost:
@@ -477,7 +477,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/broadcasts/scheduled/{id}
-  name: "Delete scheduled broadcast"
+  name: "Delete a scheduled broadcast by id"
   summary: Delete a scheduled broadcast
   scope: own_account
   cost:
@@ -508,7 +508,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/broadcasts/scheduled/{id}
-  name: "Get scheduled broadcast"
+  name: "Look up a scheduled broadcast by id"
   summary: Get a scheduled broadcast
   scope: any_account
   cost:
@@ -536,7 +536,7 @@ endpoints:
   platform: x
   method: PUT
   path: /2/broadcasts/scheduled/{id}
-  name: "Update scheduled broadcast"
+  name: "Update a scheduled broadcast by id"
   summary: Update a scheduled broadcast
   scope: own_account
   cost:
@@ -569,7 +569,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/broadcasts/scheduled/{id}/live
-  name: "Go live scheduled broadcast"
+  name: "Go live on a scheduled broadcast by id"
   summary: Go live on a scheduled broadcast
   scope: own_account
   cost:
@@ -597,7 +597,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/broadcasts/{id}/chat
-  name: "Send broadcast chat"
+  name: "Send a chat message to a live broadcast"
   summary: Send a chat message to a live broadcast
   scope: own_account
   cost:
@@ -629,7 +629,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/chat/conversations
-  name: "List chat conversations"
+  name: "List your chat conversations"
   summary: Get Chat Conversations
   scope: any_account
   cost:
@@ -660,7 +660,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/group
-  name: "Create chat conversation"
+  name: "Create a group chat conversation"
   summary: Create Chat Group Conversation
   scope: own_account
   cost:
@@ -689,7 +689,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/group/initialize
-  name: "Initialize chat group"
+  name: "Initialize a chat group"
   summary: Initialize Chat Group
   scope: own_account
   cost:
@@ -711,7 +711,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/chat/conversations/{id}
-  name: "Look up a chat conversation"
+  name: "Look up a chat conversation by id"
   summary: Get Chat Conversation
   scope: any_account
   cost:
@@ -738,7 +738,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/chat/conversations/{id}/events
-  name: "Events in a chat conversation"
+  name: "List events in a chat conversation by id"
   summary: Get Chat Conversation Events
   scope: any_account
   cost:
@@ -773,7 +773,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/keys
-  name: "Add encryption keys to a conversation"
+  name: "Add encryption keys to a chat conversation"
   summary: Add Conversation Keys
   scope: own_account
   cost:
@@ -805,7 +805,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/members
-  name: "Add chat group members"
+  name: "Add members to a group chat conversation"
   summary: Add members to a Chat group conversation
   scope: own_account
   cost:
@@ -838,7 +838,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/messages
-  name: "Send chat message"
+  name: "Send a chat message to a conversation"
   summary: Send Chat Message
   scope: own_account
   cost:
@@ -871,7 +871,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/messages/delete
-  name: "Delete chat messages"
+  name: "Delete chat messages in a conversation"
   summary: Delete Chat messages
   scope: own_account
   cost:
@@ -904,7 +904,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/read
-  name: "Mark chat conversation read"
+  name: "Mark a chat conversation as read"
   summary: Mark Conversation as Read
   scope: own_account
   cost:
@@ -936,7 +936,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/conversations/{id}/typing
-  name: "Send chat typing indicator"
+  name: "Send a typing indicator to a chat conversation"
   summary: Send Typing Indicator
   scope: own_account
   cost:
@@ -963,7 +963,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/media/upload/initialize
-  name: "Chat media upload initialize"
+  name: "Initialize a chat media upload"
   summary: Initialize Chat Media Upload
   scope: own_account
   cost:
@@ -992,7 +992,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/media/upload/{id}/append
-  name: "Chat media upload append"
+  name: "Append to a chat media upload"
   summary: Append Chat Media Upload
   scope: own_account
   cost:
@@ -1025,7 +1025,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/chat/media/upload/{id}/finalize
-  name: "Chat media upload finalize"
+  name: "Finalize a chat media upload"
   summary: Finalize Chat Media Upload
   scope: own_account
   cost:
@@ -1057,7 +1057,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/chat/media/{id}/{media_hash_key}
-  name: "Chat media download"
+  name: "Download a chat media file by id"
   summary: Download Chat Media
   scope: any_account
   cost:
@@ -1087,7 +1087,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/communities/search
-  name: "Search communities"
+  name: "Search Communities by keyword"
   summary: Search Communities
   scope: any_account
   cost:
@@ -1122,7 +1122,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/communities/{id}
-  name: "Look up a Community by ID"
+  name: "Look up a Community by id"
   summary: Get Communities by ID
   scope: any_account
   cost:
@@ -1150,7 +1150,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/compliance/jobs
-  name: "List compliance jobs"
+  name: "List compliance jobs by type"
   summary: Get Compliance Jobs
   scope: own_account
   cost:
@@ -1179,7 +1179,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/compliance/jobs
-  name: "Create compliance jobs"
+  name: "Create a compliance job"
   summary: Create Compliance Job
   scope: own_account
   cost:
@@ -1206,7 +1206,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/compliance/jobs/{id}
-  name: "Look up a compliance job by ID"
+  name: "Look up a compliance job by id"
   summary: Get Compliance Job by ID
   scope: own_account
   cost:
@@ -1232,7 +1232,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/connections
-  name: "Close specific streaming connections"
+  name: "Terminate streaming connections by uuid"
   summary: Terminate multiple connections
   scope: own_account
   cost:
@@ -1294,7 +1294,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/connections/all
-  name: "Close all streaming connections"
+  name: "Terminate all streaming connections"
   summary: Terminate all connections
   scope: own_account
   cost:
@@ -1315,7 +1315,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/connections/{endpoint_id}
-  name: "Close connections for one stream"
+  name: "Terminate streaming connections by endpoint id"
   summary: Terminate connections by endpoint
   scope: own_account
   cost:
@@ -1341,7 +1341,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/dm_conversations
-  name: "Start a group message conversation"
+  name: "Start a group direct message conversation"
   summary: Create DM conversation
   scope: own_account
   cost:
@@ -1369,7 +1369,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/dm_conversations/media/{dm_id}/{media_id}/{resource_id}
-  name: "Dm conversations media download"
+  name: "Download media from a direct message"
   summary: Download DM Media
   scope: own_account
   cost:
@@ -1402,7 +1402,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/dm_conversations/with/{participant_id}/dm_events
-  name: "Message history with one participant"
+  name: "Direct message history with a user by participant id"
   summary: Get Direct Messages Events by Participant ID
   scope: own_account
   cost:
@@ -1441,7 +1441,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/dm_conversations/with/{participant_id}/messages
-  name: "Send a direct message to a user"
+  name: "Send a direct message to a user by participant id"
   summary: Create DM message by participant ID
   scope: own_account
   cost:
@@ -1474,7 +1474,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/dm_conversations/{dm_conversation_id}/messages
-  name: "Send a message to a conversation"
+  name: "Send a direct message by conversation id"
   summary: Create Direct Messages by Conversation ID
   scope: own_account
   cost:
@@ -1506,7 +1506,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/dm_conversations/{id}/dm_events
-  name: "Message history in a conversation"
+  name: "Direct message history by conversation id"
   summary: Get Direct Messages Events by Conversation ID
   scope: own_account
   cost:
@@ -1579,7 +1579,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/dm_events/{event_id}
-  name: "Delete direct messages events"
+  name: "Delete a direct message event by event id"
   summary: Delete DM event
   scope: own_account
   cost:
@@ -1606,7 +1606,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/dm_events/{event_id}
-  name: "Look up a message event by ID"
+  name: "Look up a direct message event by event id"
   summary: Get Direct Messages Events by ID
   scope: own_account
   cost:
@@ -1634,7 +1634,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/likes/compliance/stream
-  name: "Stream likes compliance"
+  name: "Stream Likes compliance events"
   summary: Stream Likes compliance data
   scope: own_account
   cost:
@@ -1668,7 +1668,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/likes/firehose/stream
-  name: "Stream likes firehose"
+  name: "Firehose stream of all Likes"
   summary: Stream all Likes
   scope: any_account
   cost:
@@ -1726,7 +1726,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/likes/sample10/stream
-  name: "Stream likes sample10"
+  name: "Stream a 10% sample of Likes"
   summary: Stream sampled Likes
   scope: any_account
   cost:
@@ -1814,7 +1814,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/lists/{id}
-  name: "Delete a List"
+  name: "Delete a List by list id"
   summary: Delete List
   scope: own_account
   cost:
@@ -1841,7 +1841,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/lists/{id}
-  name: "Look up a List by ID"
+  name: "Look up a List by list id"
   summary: Get Lists by ID
   scope: any_account
   cost:
@@ -1869,7 +1869,7 @@ endpoints:
   platform: x
   method: PUT
   path: /2/lists/{id}
-  name: "Update a List"
+  name: "Update a List by list id"
   summary: Update List
   scope: own_account
   cost:
@@ -1901,7 +1901,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/lists/{id}/followers
-  name: "List followers of a List"
+  name: "Followers of a List by list id"
   summary: Get Lists Followers
   scope: any_account
   cost:
@@ -1936,7 +1936,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/lists/{id}/members
-  name: "List members of a List"
+  name: "Members of a List by list id"
   summary: Get Lists Members
   scope: any_account
   cost:
@@ -2005,7 +2005,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/lists/{id}/members/{user_id}
-  name: "Remove a member from a List"
+  name: "Remove a member from a List by user id"
   summary: Remove a List member
   scope: own_account
   cost:
@@ -2035,7 +2035,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/lists/{id}/tweets
-  name: "Posts from a List timeline"
+  name: "Tweets from a List timeline by list id"
   summary: Get Lists Posts
   scope: any_account
   cost:
@@ -2070,7 +2070,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/media
-  name: "Look up media by key"
+  name: "Look up media by media keys"
   summary: Get Media by media keys
   scope: any_account
   cost:
@@ -2096,7 +2096,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/media/analytics
-  name: "Analytics for your media"
+  name: "Analytics for your media by media keys"
   summary: Get Media analytics
   scope: any_account
   cost:
@@ -2132,7 +2132,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/media/metadata
-  name: "Create media metadata"
+  name: "Create metadata for uploaded media"
   summary: Create Media metadata
   scope: own_account
   cost:
@@ -2161,7 +2161,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/media/subtitles
-  name: "Delete media subtitles"
+  name: "Delete subtitles from uploaded media"
   summary: Delete Media subtitles
   scope: own_account
   cost:
@@ -2190,7 +2190,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/media/subtitles
-  name: "Create media subtitles"
+  name: "Add subtitles to uploaded media"
   summary: Create Media subtitles
   scope: own_account
   cost:
@@ -2219,7 +2219,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/media/upload
-  name: "Check media upload status"
+  name: "Check media upload status by media id"
   summary: Get Media upload status
   scope: any_account
   cost:
@@ -2279,7 +2279,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/media/upload/initialize
-  name: "Initialize media upload"
+  name: "Initialize a media upload"
   summary: Initialize media upload
   scope: own_account
   cost:
@@ -2308,7 +2308,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/media/upload/{id}/append
-  name: "Append media upload"
+  name: "Append to a media upload by id"
   summary: Append Media Upload
   scope: own_account
   cost:
@@ -2341,7 +2341,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/media/upload/{id}/finalize
-  name: "Finalize media upload"
+  name: "Finalize a media upload by id"
   summary: Finalize Media upload
   scope: own_account
   cost:
@@ -2368,7 +2368,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/media/{media_key}
-  name: "Look up one media item by key"
+  name: "Look up one media item by media key"
   summary: Get Media by media key
   scope: any_account
   cost:
@@ -2394,7 +2394,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/news/search
-  name: "Search news"
+  name: "Search news stories by keyword"
   summary: Search News
   scope: any_account
   cost:
@@ -2426,7 +2426,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/news/{id}
-  name: "Look up news stories by ID"
+  name: "Look up news stories by id"
   summary: Get news stories by ID
   scope: any_account
   cost:
@@ -2576,7 +2576,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/notes/{id}
-  name: "Delete a Community Note"
+  name: "Delete a Community Note by id"
   summary: Delete a Community Note
   scope: own_account
   cost:
@@ -2603,7 +2603,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/openapi.json
-  name: "Fetch the OpenAPI specification"
+  name: "OpenAPI specification of the X API"
   summary: Get OpenAPI Spec.
   scope: any_account
   cost:
@@ -2623,7 +2623,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces
-  name: "Look up Spaces by ID"
+  name: "Look up Spaces by space ids"
   summary: Get Spaces by IDs
   scope: any_account
   cost:
@@ -2650,7 +2650,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces/by/creator_ids
-  name: "Spaces hosted by given creators"
+  name: "Spaces hosted by creators, by user ids"
   summary: Get Spaces by Creator IDs
   scope: any_account
   cost:
@@ -2677,7 +2677,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces/search
-  name: "Search spaces"
+  name: "Search Spaces by keyword"
   summary: Search Spaces
   scope: any_account
   cost:
@@ -2710,7 +2710,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces/{id}
-  name: "Look up a Space by ID"
+  name: "Look up a Space by space id"
   summary: Get Spaces by ID
   scope: any_account
   cost:
@@ -2737,7 +2737,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces/{id}/buyers
-  name: "Ticket buyers for a Space"
+  name: "Ticket buyers of a Space by space id"
   summary: Get Space ticket buyers
   scope: any_account
   cost:
@@ -2772,7 +2772,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/spaces/{id}/tweets
-  name: "Posts shared in a Space"
+  name: "Tweets shared in a Space by space id"
   summary: Get Space Posts
   scope: any_account
   cost:
@@ -2807,7 +2807,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/trends/by/woeid/{woeid}
-  name: "Trending topics for a location"
+  name: "Trending topics by location WOEID"
   summary: Get Trends by Woeid
   scope: any_account
   cost:
@@ -2837,7 +2837,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets
-  name: "Look up posts by ID"
+  name: "Look up tweets by post ids"
   summary: Get Posts by IDs
   scope: any_account
   cost:
@@ -2863,7 +2863,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/analytics
-  name: "Analytics for your posts"
+  name: "Analytics for your tweets by post ids"
   summary: Get Posts Analytics
   scope: any_account
   cost:
@@ -2899,7 +2899,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/compliance/stream
-  name: "Stream posts compliance"
+  name: "Stream Posts compliance events"
   summary: Stream Posts compliance data
   scope: own_account
   cost:
@@ -2937,7 +2937,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/counts/all
-  name: "Count matching posts, full archive"
+  name: "Count tweets matching a query — full archive"
   summary: Get Posts Counts All
   scope: any_account
   cost:
@@ -2989,7 +2989,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/counts/recent
-  name: "Count matching posts, last 7 days"
+  name: "Count tweets matching a query — last 7 days"
   summary: Get Posts Counts Recent
   scope: any_account
   cost:
@@ -3042,7 +3042,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/firehose/stream
-  name: "Stream posts firehose"
+  name: "Firehose stream of all tweets"
   summary: Stream all Posts
   scope: any_account
   cost:
@@ -3104,7 +3104,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/firehose/stream/lang/en
-  name: "Stream posts firehose en"
+  name: "Firehose stream of English tweets"
   summary: Stream English Posts
   scope: any_account
   cost:
@@ -3166,7 +3166,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/firehose/stream/lang/ja
-  name: "Stream posts firehose ja"
+  name: "Firehose stream of Japanese tweets"
   summary: Stream Japanese Posts
   scope: any_account
   cost:
@@ -3228,7 +3228,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/firehose/stream/lang/ko
-  name: "Stream posts firehose ko"
+  name: "Firehose stream of Korean tweets"
   summary: Stream Korean Posts
   scope: any_account
   cost:
@@ -3290,7 +3290,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/firehose/stream/lang/pt
-  name: "Stream posts firehose pt"
+  name: "Firehose stream of Portuguese tweets"
   summary: Stream Portuguese Posts
   scope: any_account
   cost:
@@ -3353,7 +3353,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/label/stream
-  name: "Stream post label events"
+  name: "Stream tweet label events"
   summary: Stream Post labels
   scope: any_account
   cost:
@@ -3387,7 +3387,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/sample/stream
-  name: "Stream posts sample"
+  name: "Stream sampled tweets in real time"
   summary: Stream sampled Posts
   scope: any_account
   cost:
@@ -3437,7 +3437,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/sample10/stream
-  name: "Stream posts sample10"
+  name: "Stream a 10% sample of tweets"
   summary: Stream 10% sampled Posts
   scope: any_account
   cost:
@@ -3499,7 +3499,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/search/all
-  name: "Search the full post archive"
+  name: "Search the full tweet archive by keyword query"
   summary: Search Posts All
   scope: any_account
   cost:
@@ -3551,7 +3551,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/search/recent
-  name: "Search posts from the last 7 days"
+  name: "Search tweets from the last 7 days by keyword"
   summary: Search Posts Recent
   scope: any_account
   cost:
@@ -3604,7 +3604,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/search/stream
-  name: "Stream posts"
+  name: "Stream tweets matching your filter rules"
   summary: Stream filtered Posts
   scope: any_account
   cost:
@@ -3698,7 +3698,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/tweets/search/stream/rules
-  name: "Add or delete stream rules"
+  name: "Add or delete filtered-stream rules"
   summary: Update stream rules
   scope: own_account
   cost:
@@ -3759,7 +3759,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/search/webhooks
-  name: "List search stream webhook links"
+  name: "List filtered-stream webhook links"
   summary: Get stream links
   scope: own_account
   cost:
@@ -3780,7 +3780,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/tweets/search/webhooks/{webhook_id}
-  name: "Delete webhooks stream link"
+  name: "Delete a filtered-stream webhook link by webhook id"
   summary: Delete stream link
   scope: own_account
   cost:
@@ -3806,7 +3806,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/tweets/search/webhooks/{webhook_id}
-  name: "Create webhooks stream link"
+  name: "Link a webhook to the filtered stream by webhook id"
   summary: Create stream link
   scope: own_account
   cost:
@@ -3832,7 +3832,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/tweets/{id}
-  name: "Delete a post"
+  name: "Delete a tweet by post id"
   summary: Delete Posts
   scope: own_account
   cost:
@@ -3858,7 +3858,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/{id}
-  name: "Look up a post by ID"
+  name: "Look up a tweet by post id"
   summary: Get Posts by ID
   scope: any_account
   cost:
@@ -3884,7 +3884,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/{id}/liking_users
-  name: "List users who liked a post"
+  name: "Users who liked a tweet by post id"
   summary: Get Posts Liking Users
   scope: any_account
   cost:
@@ -3919,7 +3919,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/{id}/quote_tweets
-  name: "List quote posts of a post"
+  name: "Quote tweets of a post by post id"
   summary: Get Posts Quoted Posts
   scope: any_account
   cost:
@@ -3956,7 +3956,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/{id}/retweeted_by
-  name: "List users who reposted a post"
+  name: "Users who reposted a tweet by post id"
   summary: Get Posts Reposted by
   scope: any_account
   cost:
@@ -3990,7 +3990,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/tweets/{id}/retweets
-  name: "List reposts of a post"
+  name: "Reposts of a tweet by post id"
   summary: Get Posts Reposts
   scope: any_account
   cost:
@@ -4025,7 +4025,7 @@ endpoints:
   platform: x
   method: PUT
   path: /2/tweets/{tweet_id}/hidden
-  name: "Hide a reply to your post"
+  name: "Hide a reply to your tweet by post id"
   summary: Hide reply
   scope: own_account
   cost:
@@ -4058,7 +4058,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/usage/tweets
-  name: "Post usage against your plan cap"
+  name: "Tweet usage against your plan cap"
   summary: Get Usage
   scope: own_account
   cost:
@@ -4083,7 +4083,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users
-  name: "Look up users by ID"
+  name: "Look up users by user ids"
   summary: Get Users by IDs
   scope: any_account
   cost:
@@ -4109,7 +4109,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/by
-  name: "Look up users by username"
+  name: "Look up users by usernames"
   summary: Get Users by Usernames
   scope: any_account
   cost:
@@ -4136,7 +4136,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/compliance/stream
-  name: "Stream users compliance"
+  name: "Stream Users compliance events"
   summary: Stream Users compliance data
   scope: own_account
   cost:
@@ -4174,7 +4174,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/personalized_trends
-  name: "Personalized trends for the user"
+  name: "Personalized trends for the connected user"
   summary: Get Trends Personalized Trends
   scope: any_account
   cost:
@@ -4196,7 +4196,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/public_keys
-  name: "Look up encryption public keys"
+  name: "Look up encryption public keys by user ids"
   summary: Get public keys
   scope: any_account
   cost:
@@ -4222,7 +4222,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/reposts_of_me
-  name: "List reposts of your posts"
+  name: "Reposts of your tweets"
   summary: Get Users Reposts of Me
   scope: any_account
   cost:
@@ -4253,7 +4253,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/search
-  name: "Search users"
+  name: "Search users by keyword"
   summary: Search Users
   scope: any_account
   cost:
@@ -4285,7 +4285,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}
-  name: "Look up a user by ID"
+  name: "Look up a user by user id"
   summary: Get Users by ID
   scope: any_account
   cost:
@@ -4311,7 +4311,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/affiliates
-  name: "Affiliated accounts of a user"
+  name: "Affiliated accounts of a user by user id"
   summary: Get Users Affiliates
   scope: any_account
   cost:
@@ -4345,7 +4345,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/blocking
-  name: "Accounts a user has blocked"
+  name: "Accounts a user has blocked, by user id"
   summary: Get Users Blocking
   scope: own_account
   cost:
@@ -4379,7 +4379,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/bookmarks
-  name: "Bookmarked posts of a user"
+  name: "Your bookmarked tweets by user id"
   summary: Get Users Bookmarks
   scope: own_account
   cost:
@@ -4415,7 +4415,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/bookmarks
-  name: "Bookmark a post"
+  name: "Bookmark a tweet"
   summary: Create Users Bookmark
   scope: own_account
   cost:
@@ -4447,7 +4447,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/bookmarks/folders
-  name: "Bookmark folders of a user"
+  name: "Your bookmark folders by user id"
   summary: Get Users Bookmark Folders
   scope: own_account
   cost:
@@ -4515,7 +4515,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/bookmarks/folders/{folder_id}
-  name: "Bookmarks in a folder"
+  name: "Bookmarked tweets in a folder by folder id"
   summary: Get Users Bookmarks by Folder ID
   scope: own_account
   cost:
@@ -4554,7 +4554,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{id}/bookmarks/{tweet_id}
-  name: "Remove a bookmark"
+  name: "Remove a bookmark by post id"
   summary: Delete Bookmark
   scope: own_account
   cost:
@@ -4585,7 +4585,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/dm/block
-  name: "Block a user from messaging you"
+  name: "Block direct messages from a user by user id"
   summary: Block Users Dms
   scope: own_account
   cost:
@@ -4613,7 +4613,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/dm/unblock
-  name: "Unblock a user from messaging you"
+  name: "Unblock direct messages from a user by user id"
   summary: Unblock Users Dms
   scope: own_account
   cost:
@@ -4640,7 +4640,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/followed_lists
-  name: "Lists a user follows"
+  name: "Lists a user follows, by user id"
   summary: Get Users Followed Lists
   scope: any_account
   cost:
@@ -4676,7 +4676,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/followed_lists
-  name: "Follow list"
+  name: "Follow a List"
   summary: Follow List
   scope: own_account
   cost:
@@ -4709,7 +4709,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{id}/followed_lists/{list_id}
-  name: "Unfollow list"
+  name: "Unfollow a List by list id"
   summary: Unfollow a List
   scope: own_account
   cost:
@@ -4739,7 +4739,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/followers
-  name: "Followers of a user"
+  name: "Followers of a user by user id"
   summary: Get Users Followers
   scope: any_account
   cost:
@@ -4774,7 +4774,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/following
-  name: "Accounts a user follows"
+  name: "Accounts a user follows, by user id"
   summary: Get Users Following
   scope: any_account
   cost:
@@ -4810,7 +4810,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/following
-  name: "Follow user"
+  name: "Follow a user by user id"
   summary: Follow User
   scope: own_account
   cost:
@@ -4842,7 +4842,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/liked_tweets
-  name: "Posts a user has liked"
+  name: "Tweets a user has liked, by user id"
   summary: Get Users Liked Posts
   scope: any_account
   cost:
@@ -4878,7 +4878,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/likes
-  name: "Like post"
+  name: "Like a post"
   summary: Like Post
   scope: own_account
   cost:
@@ -4911,7 +4911,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{id}/likes/{tweet_id}
-  name: "Unlike post"
+  name: "Unlike a post by post id"
   summary: Unlike Post
   scope: own_account
   cost:
@@ -4941,7 +4941,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/list_memberships
-  name: "Lists a user belongs to"
+  name: "Lists a user is a member of, by user id"
   summary: Get Users List Memberships
   scope: any_account
   cost:
@@ -4975,7 +4975,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/mentions
-  name: "Posts mentioning a user"
+  name: "Tweets mentioning a user by user id"
   summary: Get Users Mentions
   scope: any_account
   cost:
@@ -5023,7 +5023,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/muting
-  name: "Accounts a user has muted"
+  name: "Accounts a user has muted, by user id"
   summary: Get Users Muting
   scope: own_account
   cost:
@@ -5058,7 +5058,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/muting
-  name: "Mute user"
+  name: "Mute a user by user id"
   summary: Mute User
   scope: own_account
   cost:
@@ -5090,7 +5090,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/owned_lists
-  name: "Lists a user owns"
+  name: "Lists a user owns, by user id"
   summary: Get Users Owned Lists
   scope: any_account
   cost:
@@ -5125,7 +5125,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/pinned_lists
-  name: "Lists a user has pinned"
+  name: "Lists a user has pinned, by user id"
   summary: Get Users Pinned Lists
   scope: any_account
   cost:
@@ -5153,7 +5153,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/pinned_lists
-  name: "Pin list"
+  name: "Pin a List"
   summary: Pin List
   scope: own_account
   cost:
@@ -5186,7 +5186,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{id}/pinned_lists/{list_id}
-  name: "Unpin list"
+  name: "Unpin a List by list id"
   summary: Unpin a List
   scope: own_account
   cost:
@@ -5217,7 +5217,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/public_keys
-  name: "Public keys for one user"
+  name: "Encryption public keys of a user by user id"
   summary: Get public keys
   scope: any_account
   cost:
@@ -5276,7 +5276,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/users/{id}/retweets
-  name: "Repost post"
+  name: "Repost a tweet"
   summary: Repost Post
   scope: own_account
   cost:
@@ -5308,7 +5308,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{id}/retweets/{source_tweet_id}
-  name: "Unrepost post"
+  name: "Undo a repost by post id"
   summary: Unrepost Post
   scope: own_account
   cost:
@@ -5337,7 +5337,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/users/{id}/timelines/reverse_chronological
-  name: "Reverse-chronological home timeline"
+  name: "Home timeline tweets, newest first, by user id"
   summary: Get Users Timeline
   scope: own_account
   cost:
@@ -5389,7 +5389,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{source_user_id}/following/{target_user_id}
-  name: "Unfollow user"
+  name: "Unfollow a user by user id"
   summary: Unfollow User
   scope: own_account
   cost:
@@ -5420,7 +5420,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/users/{source_user_id}/muting/{target_user_id}
-  name: "Unmute user"
+  name: "Unmute a user by user id"
   summary: Unmute User
   scope: own_account
   cost:
@@ -5451,7 +5451,7 @@ endpoints:
   platform: x
   method: GET
   path: /2/webhooks
-  name: "List registered webhooks"
+  name: "List your registered webhooks"
   summary: Get webhook
   scope: own_account
   cost:
@@ -5472,7 +5472,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/webhooks
-  name: "Create webhooks"
+  name: "Register a webhook"
   summary: Create webhook
   scope: own_account
   cost:
@@ -5499,7 +5499,7 @@ endpoints:
   platform: x
   method: POST
   path: /2/webhooks/replay
-  name: "Create webhook replay job"
+  name: "Create a webhook replay job"
   summary: Create replay job for webhook
   scope: own_account
   cost:
@@ -5526,7 +5526,7 @@ endpoints:
   platform: x
   method: DELETE
   path: /2/webhooks/{webhook_id}
-  name: "Delete webhooks"
+  name: "Delete a webhook by webhook id"
   summary: Delete webhook
   scope: own_account
   cost:
@@ -5552,7 +5552,7 @@ endpoints:
   platform: x
   method: PUT
   path: /2/webhooks/{webhook_id}
-  name: "Validate webhooks"
+  name: "Validate a webhook by webhook id"
   summary: Validate webhook
   scope: own_account
   cost:

--- a/src/treg/catalog/x.yaml
+++ b/src/treg/catalog/x.yaml
@@ -41,7 +41,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /2/users/me
-    name: "Get your connected X profile"
+    name: "Your connected X account profile — handle, followers"
     summary: "Get the profile of the connected X account (handle, name, follower counts)"
     input:
       queryParams:
@@ -64,6 +64,7 @@ endpoints:
     method: GET
     path: /2/users/by/username/{username}
     summary: "Get any public X user's profile by handle"
+    name: "X user profile by username — followers, bio, verified"
     input:
       pathParams:
         username: {type: string, required: true, note: "handle without the '@'", example: "elonmusk"}
@@ -84,7 +85,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /2/users/{id}/tweets
-    name: "List a user's recent posts"
+    name: "Recent tweets of a user by user id — engagement metrics"
     summary: "List the recent posts of an X user (your own or any public account)"
     input:
       pathParams:
@@ -122,6 +123,7 @@ endpoints:
     method: POST
     path: /2/tweets
     summary: "Publish a post to your own X account"
+    name: "Post a tweet to your own X account"
     input:
       body:
         text: {type: string, required: true, note: "the post text — 280 characters on a standard account, 25,000 on X Premium. Every link counts as 23 characters whatever its length", example: "Shipping something new today."}
@@ -145,6 +147,7 @@ endpoints:
     method: POST
     path: /2/tweets
     summary: "Reply to an X post, or continue your own thread"
+    name: "Reply to a tweet or continue your thread by post id"
     input:
       body:
         text: {type: string, required: true, example: "One more thing —"}

--- a/src/treg/catalog/youtube.extended.yaml
+++ b/src/treg/catalog/youtube.extended.yaml
@@ -37,7 +37,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /upload/youtube/v3/captions
-  name: "Upload a caption track"
+  name: "Upload a caption track to your YouTube video"
   summary: captions.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -76,7 +76,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /upload/youtube/v3/captions
-  name: "Update a caption track"
+  name: "Update a caption track on your YouTube video"
   summary: captions.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -115,7 +115,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /upload/youtube/v3/channelBanners/insert
-  name: "Upload a channel banner image"
+  name: "Upload a banner image for your YouTube channel"
   summary: channelBanners.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -150,7 +150,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /upload/youtube/v3/playlistImages
-  name: "Upload a playlist cover image"
+  name: "Upload a cover image for your YouTube playlist"
   summary: playlistImages.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -185,7 +185,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /upload/youtube/v3/playlistImages
-  name: "Update a playlist cover image"
+  name: "Update your YouTube playlist's cover image"
   summary: playlistImages.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -216,7 +216,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /upload/youtube/v3/watermarks/set
-  name: "Set a channel watermark image"
+  name: "Upload and set your YouTube channel watermark image"
   summary: watermarks.set — Allows upload of watermark image and setting it for a channel.
   scope: own_account
   cost:
@@ -246,7 +246,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/abuseReports
-  name: "Report abuse"
+  name: "File an abuse report on YouTube"
   summary: abuseReports.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -272,7 +272,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/activities
-  name: "List channel activities"
+  name: "List a YouTube channel's recent activities"
   summary: activities.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -320,7 +320,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/captions
-  name: "Delete a caption track"
+  name: "Delete a caption track from your YouTube video"
   summary: captions.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -348,7 +348,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/captions
-  name: "List caption tracks for a video"
+  name: "List a YouTube video's caption tracks by video id"
   summary: captions.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -385,7 +385,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/captions/{id}
-  name: "Download a caption track"
+  name: "Download a YouTube caption track by caption id"
   summary: captions.download — Downloads a caption track.
   scope: own_account
   cost:
@@ -424,7 +424,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/channelSections
-  name: "Delete a channel section"
+  name: "Delete a section from your YouTube channel page"
   summary: channelSections.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -448,7 +448,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/channelSections
-  name: "List channel sections"
+  name: "List a YouTube channel's page sections"
   summary: channelSections.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -490,7 +490,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/channelSections
-  name: "Create a channel section"
+  name: "Add a section to your YouTube channel page"
   summary: channelSections.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -525,7 +525,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/channelSections
-  name: "Update a channel section"
+  name: "Update a section on your YouTube channel page"
   summary: channelSections.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -556,7 +556,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/channels
-  name: "Update channel branding settings"
+  name: "Update your YouTube channel settings"
   summary: channels.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -587,7 +587,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/commentThreads
-  name: "Create a comment thread"
+  name: "Post a top-level comment thread on YouTube"
   summary: commentThreads.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -614,7 +614,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/comments
-  name: "Delete a comment"
+  name: "Delete a YouTube comment"
   summary: comments.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -634,7 +634,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/comments
-  name: "List comments"
+  name: "List YouTube comments by id or parent comment id"
   summary: comments.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -680,7 +680,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/comments
-  name: "Reply to a comment"
+  name: "Reply to a YouTube comment"
   summary: comments.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -707,7 +707,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/comments
-  name: "Update a comment"
+  name: "Update your YouTube comment"
   summary: comments.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -734,7 +734,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/comments/markAsSpam
-  name: "Mark comments as spam"
+  name: "Flag YouTube comments as spam"
   summary: comments.markAsSpam — Expresses the caller's opinion that one or more comments should be flagged as spam.
   scope: own_account
   cost:
@@ -756,7 +756,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/comments/setModerationStatus
-  name: "Set comment moderation status"
+  name: "Set moderation status of YouTube comments"
   summary: comments.setModerationStatus — Sets the moderation status of one or more comments.
   scope: own_account
   cost:
@@ -791,7 +791,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/i18nLanguages
-  name: "List supported interface languages"
+  name: "List YouTube interface languages"
   summary: i18nLanguages.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -816,7 +816,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/i18nRegions
-  name: "List supported content regions"
+  name: "List YouTube content regions"
   summary: i18nRegions.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -841,7 +841,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/liveBroadcasts
-  name: "Delete a live broadcast"
+  name: "Delete your YouTube live broadcast"
   summary: liveBroadcasts.delete — Delete a given broadcast.
   scope: own_account
   cost:
@@ -870,7 +870,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/liveBroadcasts
-  name: "List live broadcasts"
+  name: "List your YouTube live broadcasts"
   summary: liveBroadcasts.list — Retrieve the list of broadcasts associated with the given channel.
   scope: own_account
   cost:
@@ -934,7 +934,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveBroadcasts
-  name: "Create a live broadcast"
+  name: "Create a YouTube live broadcast"
   summary: liveBroadcasts.insert — Inserts a new stream for the authenticated user.
   scope: own_account
   cost:
@@ -969,7 +969,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/liveBroadcasts
-  name: "Update a live broadcast"
+  name: "Update your YouTube live broadcast settings"
   summary: liveBroadcasts.update — Updates an existing broadcast for the authenticated user.
   scope: own_account
   cost:
@@ -1004,7 +1004,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveBroadcasts/bind
-  name: "Bind a broadcast to a stream"
+  name: "Bind a YouTube live broadcast to a stream"
   summary: liveBroadcasts.bind — Bind a broadcast to a stream.
   scope: own_account
   cost:
@@ -1042,7 +1042,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveBroadcasts/cuepoint
-  name: "Insert a cuepoint in a broadcast"
+  name: "Insert a cuepoint into your YouTube live broadcast"
   summary: liveBroadcasts.insertCuepoint — Insert cuepoints in a broadcast
   scope: own_account
   cost:
@@ -1081,7 +1081,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveBroadcasts/transition
-  name: "Transition a broadcast status"
+  name: "Transition your YouTube live broadcast status"
   summary: liveBroadcasts.transition — Transition a broadcast to a given status.
   scope: own_account
   cost:
@@ -1124,7 +1124,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/liveChat/bans
-  name: "Remove a live chat ban"
+  name: "Lift a YouTube live chat ban"
   summary: liveChatBans.delete — Deletes a chat ban.
   scope: own_account
   cost:
@@ -1145,7 +1145,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveChat/bans
-  name: "Ban a user from live chat"
+  name: "Ban a user from your YouTube live chat"
   summary: liveChatBans.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -1172,7 +1172,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/liveChat/messages
-  name: "Delete a live chat message"
+  name: "Delete a YouTube live chat message"
   summary: liveChatMessages.delete — Deletes a chat message.
   scope: own_account
   cost:
@@ -1192,7 +1192,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/liveChat/messages
-  name: "List live chat messages"
+  name: "List YouTube live chat messages by chat id"
   summary: liveChatMessages.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -1234,7 +1234,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveChat/messages
-  name: "Post a live chat message"
+  name: "Post a message to a YouTube live chat"
   summary: liveChatMessages.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -1260,7 +1260,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/liveChat/messages/stream
-  name: "Stream live chat messages"
+  name: "Stream YouTube live chat messages by chat id"
   summary: messages.stream — Allows a user to load live chat through a server-streamed RPC.
   scope: own_account
   cost:
@@ -1302,7 +1302,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveChat/messages/transition
-  name: "Transition a live chat event"
+  name: "Transition a YouTube live chat event"
   summary: liveChatMessages.transition — Transition a durable chat event.
   scope: own_account
   cost:
@@ -1331,7 +1331,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/liveChat/moderators
-  name: "Remove a live chat moderator"
+  name: "Remove a moderator from your YouTube live chat"
   summary: liveChatModerators.delete — Deletes a chat moderator.
   scope: own_account
   cost:
@@ -1351,7 +1351,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/liveChat/moderators
-  name: "List live chat moderators"
+  name: "List moderators of your YouTube live chat"
   summary: liveChatModerators.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -1385,7 +1385,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveChat/moderators
-  name: "Add a live chat moderator"
+  name: "Add a moderator to your YouTube live chat"
   summary: liveChatModerators.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -1412,7 +1412,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/liveStreams
-  name: "Delete a live stream"
+  name: "Delete your YouTube live stream"
   summary: liveStreams.delete — Deletes an existing stream for the authenticated user.
   scope: own_account
   cost:
@@ -1440,7 +1440,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/liveStreams
-  name: "List live streams"
+  name: "List your YouTube live streams"
   summary: liveStreams.list — Retrieve the list of streams associated with the given channel. --
   scope: own_account
   cost:
@@ -1485,7 +1485,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/liveStreams
-  name: "Create a live stream"
+  name: "Create a YouTube live stream"
   summary: liveStreams.insert — Inserts a new stream for the authenticated user.
   scope: own_account
   cost:
@@ -1520,7 +1520,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/liveStreams
-  name: "Update a live stream"
+  name: "Update your YouTube live stream settings"
   summary: liveStreams.update — Updates an existing stream for the authenticated user.
   scope: own_account
   cost:
@@ -1554,7 +1554,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/members
-  name: "List channel members"
+  name: "List a YouTube channel's members"
   summary: members.list — Retrieves a list of members that match the request criteria for a channel.
   scope: any_account
   cost:
@@ -1600,7 +1600,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/membershipsLevels
-  name: "List membership pricing levels"
+  name: "List your YouTube membership pricing levels"
   summary: membershipsLevels.list — Retrieves a list of all pricing levels offered by a creator to the fans.
   scope: own_account
   cost:
@@ -1623,7 +1623,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/playlistImages
-  name: "Delete a playlist cover image"
+  name: "Delete your YouTube playlist's cover image"
   summary: playlistImages.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -1648,7 +1648,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/playlistImages
-  name: "List playlist cover images"
+  name: "List a YouTube playlist's cover images"
   summary: playlistImages.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -1690,7 +1690,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/playlistItems
-  name: "Remove an item from a playlist"
+  name: "Remove a video from your YouTube playlist"
   summary: playlistItems.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -1715,7 +1715,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/playlistItems
-  name: "Add an item to a playlist"
+  name: "Add a video to your YouTube playlist"
   summary: playlistItems.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -1746,7 +1746,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/playlistItems
-  name: "Update a playlist item"
+  name: "Update a video entry in your YouTube playlist"
   summary: playlistItems.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -1777,7 +1777,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/playlists
-  name: "Delete a playlist"
+  name: "Delete your YouTube playlist"
   summary: playlists.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -1801,7 +1801,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/playlists
-  name: "List playlists"
+  name: "List a channel's YouTube playlists"
   summary: playlists.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -1855,7 +1855,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/playlists
-  name: "Create a playlist"
+  name: "Create a YouTube playlist"
   summary: playlists.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -1890,7 +1890,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/playlists
-  name: "Update a playlist"
+  name: "Update your YouTube playlist details"
   summary: playlists.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -1921,7 +1921,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/subscriptions
-  name: "Unsubscribe from a channel"
+  name: "Unsubscribe from a YouTube channel"
   summary: subscriptions.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -1941,7 +1941,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/subscriptions
-  name: "List channel subscriptions"
+  name: "List YouTube channel subscriptions"
   summary: subscriptions.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -2011,7 +2011,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/subscriptions
-  name: "Subscribe to a channel"
+  name: "Subscribe to a YouTube channel"
   summary: subscriptions.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -2037,7 +2037,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/superChatEvents
-  name: "List Super Chat events"
+  name: "List Super Chat events on your YouTube channel"
   summary: superChatEvents.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -2071,7 +2071,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/tests
-  name: "Run API connectivity test"
+  name: "Run a YouTube connectivity test call"
   summary: tests.insert — POST method.
   scope: own_account
   cost:
@@ -2103,7 +2103,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/thirdPartyLinks
-  name: "Delete a third-party link"
+  name: "Delete a third-party link from your YouTube channel"
   summary: thirdPartyLinks.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -2140,7 +2140,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/thirdPartyLinks
-  name: "List third-party links"
+  name: "List third-party links on your YouTube channel"
   summary: thirdPartyLinks.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -2178,7 +2178,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/thirdPartyLinks
-  name: "Create a third-party link"
+  name: "Create a third-party link on your YouTube channel"
   summary: thirdPartyLinks.insert — Inserts a new resource into this collection.
   scope: own_account
   cost:
@@ -2209,7 +2209,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/thirdPartyLinks
-  name: "Update a third-party link"
+  name: "Update a third-party link on your YouTube channel"
   summary: thirdPartyLinks.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -2240,7 +2240,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/videoAbuseReportReasons
-  name: "List video abuse report reasons"
+  name: "List YouTube video abuse report reasons"
   summary: videoAbuseReportReasons.list — Retrieves a list of resources, possibly filtered.
   scope: own_account
   cost:
@@ -2265,7 +2265,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/videoCategories
-  name: "List video categories"
+  name: "List YouTube video categories by region"
   summary: videoCategories.list — Retrieves a list of resources, possibly filtered.
   scope: any_account
   cost:
@@ -2296,7 +2296,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/videoTrainability
-  name: "Get video trainability status"
+  name: "Check a YouTube video's trainability status"
   summary: videoTrainability.get — Returns the trainability status of a video.
   scope: own_account
   cost:
@@ -2318,7 +2318,7 @@ endpoints:
   platform: youtube
   method: DELETE
   path: /youtube/v3/videos
-  name: "Delete a video"
+  name: "Delete your YouTube video"
   summary: videos.delete — Deletes a resource.
   scope: own_account
   cost:
@@ -2343,7 +2343,7 @@ endpoints:
   platform: youtube
   method: PUT
   path: /youtube/v3/videos
-  name: "Update video metadata"
+  name: "Update your YouTube video's metadata"
   summary: videos.update — Updates an existing resource.
   scope: own_account
   cost:
@@ -2373,7 +2373,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/videos/getRating
-  name: "Get a user's video ratings"
+  name: "Your ratings on YouTube videos by video id"
   summary: videos.getRating — Retrieves the ratings that the authorized user gave to a list of specified videos.
   scope: own_account
   cost:
@@ -2398,7 +2398,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/videos/rate
-  name: "Rate a video"
+  name: "Like, dislike or unrate a YouTube video"
   summary: videos.rate — Adds a like or dislike rating to a video or removes a rating from a video.
   scope: own_account
   cost:
@@ -2426,7 +2426,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/videos/reportAbuse
-  name: "Report a video for abuse"
+  name: "Report a YouTube video for abuse"
   summary: videos.reportAbuse — Report abuse for a video.
   scope: own_account
   cost:
@@ -2452,7 +2452,7 @@ endpoints:
   platform: youtube
   method: GET
   path: /youtube/v3/videos:batchGetStats
-  name: "Get stats for multiple videos (batch)"
+  name: "Batch stats for your YouTube videos by video ids"
   summary: videos.batchGetStats — Retrieves a batch of VideoStat resources, possibly filtered. BatchGetStats is intentionally not atomic to provide a better user experience.
   scope: own_account
   cost:
@@ -2482,7 +2482,7 @@ endpoints:
   platform: youtube
   method: POST
   path: /youtube/v3/watermarks/unset
-  name: "Remove a channel watermark"
+  name: "Remove your YouTube channel's watermark image"
   summary: watermarks.unset — Allows removal of channel watermark.
   scope: own_account
   cost:

--- a/src/treg/catalog/youtube.yaml
+++ b/src/treg/catalog/youtube.yaml
@@ -32,7 +32,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /youtube/v3/channels
-    name: "Get your channel's profile and stats"
+    name: "Your YouTube channel profile — subscribers, views"
     summary: "Get your YouTube channel's profile and lifetime stats (subscribers, views, video count)"
     input:
       queryParams:
@@ -54,7 +54,7 @@ endpoints:
     scope: own_account
     method: GET
     path: /youtube/v3/search
-    name: "List your channel's videos, newest first"
+    name: "List your YouTube videos, private and unlisted included"
     summary: "List your own channel's videos, newest first (includes private and unlisted ones)"
     # forMine is the only search filter that reaches a creator's non-public uploads, which is the
     # whole reason to use the OAuth route over a scraper. It costs 100 units — a hundredth of the
@@ -83,7 +83,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /youtube/v3/playlistItems
-    name: "List channel uploads via playlist (low cost)"
+    name: "List a channel's videos via its uploads playlist id"
     summary: "List a channel's uploaded videos cheaply, via its uploads playlist"
     input:
       queryParams:
@@ -107,7 +107,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /youtube/v3/videos
-    name: "Get a video's details and stats"
+    name: "YouTube video stats by video id — views, likes, duration"
     summary: "Get a YouTube video's metadata and stats (views, likes, comments, duration)"
     input:
       queryParams:
@@ -127,7 +127,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /youtube/v3/commentThreads
-    name: "List comments on a video"
+    name: "List comments on a YouTube video by video id"
     summary: "List the comments on a YouTube video (any public video, not just your own)"
     input:
       queryParams:
@@ -151,7 +151,7 @@ endpoints:
     scope: any_account
     method: GET
     path: /youtube/v3/search
-    name: "Search videos by keyword"
+    name: "Search YouTube videos by keyword"
     summary: "Search YouTube videos by keyword"
     input:
       queryParams:
@@ -188,7 +188,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /upload/youtube/v3/videos
-    name: "Upload a video"
+    name: "Upload a video to your YouTube channel"
     summary: "Upload a video to your own YouTube channel"
     input:
       queryParams:
@@ -211,7 +211,7 @@ endpoints:
     scope: own_account
     method: POST
     path: /upload/youtube/v3/thumbnails/set
-    name: "Set video thumbnail"
+    name: "Set a custom thumbnail on your YouTube video"
     summary: "Set the custom thumbnail on one of your YouTube videos"
     input:
       queryParams:

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -724,13 +724,18 @@ def _match(query: str, cat: Catalog):
     if not tokens:
         return None
     variants = [[tok, *cat.aliases.get(tok, ())] for tok in tokens]
+    # A token that IS a platform slug ("tiktok", "linkedin") is the caller's hard filter, but idf
+    # prices it low — half the catalog serves the big platforms — so rows matching a rarer facet
+    # word ("followers") outranked rows matching the asked-for platform. Double the weight where a
+    # platform token matches: same-pattern rows still sum identical floats, ties survive.
+    boost = [2 if tok in cat.platforms else 1 for tok in tokens]
     rows = _search_fields(cat)
     total = len(rows)
     best: list[list[int]] = []
     df = [0] * len(tokens)
     for _, fields in rows:
-        per_tok = [max((w for w, text in fields if any(v in text for v in vs)), default=0)
-                   for vs in variants]
+        per_tok = [b * max((w for w, text in fields if any(v in text for v in vs)), default=0)
+                   for vs, b in zip(variants, boost)]
         best.append(per_tok)
         for i, w in enumerate(per_tok):
             if w:

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -689,7 +689,9 @@ def _haystacks(ep: dict, cat: Catalog) -> list[tuple[int, str]]:
     return [
         (W_CAPABILITY, " ".join((ep["capability"], cat.capabilities.get(ep["capability"], ""),
                                  plat.get("label", ""), ep["platform"])).lower()),
-        (W_SUMMARY, ep["summary"].lower()),
+        # `name` is OURS to word (summary stays the provider's, verbatim) — it is the one
+        # per-endpoint field curation may write search vocabulary into, so it must be searched
+        (W_SUMMARY, " ".join((ep.get("name") or "", ep["summary"])).lower()),
         (W_PATH, " ".join((ep["id"], ep["path"], ep["provider"])).lower()),
     ]
 
@@ -835,7 +837,7 @@ def rank_band(query: str, cat: Catalog, limit: int) -> tuple[list[tuple[dict, fl
 
 
 def rerank(rows: list[tuple[dict, float]], stats: dict[str, dict],
-           cat: Catalog | None = None) -> list[tuple[dict, int]]:
+           cat: Catalog | None = None) -> list[tuple[dict, float]]:
     """Re-order equal-scoring rows by what treg has MEASURED, then by price.
 
     Relevance still decides first — a cheap reliable endpoint that doesn't do the job is not the

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -705,6 +705,41 @@ def _search_fields(cat: Catalog) -> list[tuple[dict, list[tuple[int, str]]]]:
     return cached
 
 
+# A token matching more than this share of the catalog selects nothing — it may still add score
+# where it matches, but a row is never punished for missing it. Statistical stopwords: "data" (33%),
+# "api" (50%), "get" (40%) are corpus filler no hand list would keep up with, while "search" (22%)
+# and "tiktok" (19%) stay required. Measured 2026-08-20 over 2,791 endpoints.
+SOFT_DF_SHARE = 0.25
+
+
+def _match(query: str, cat: Catalog):
+    """The shared matching pass behind `search` and `near_misses`: tokens, per-row best-field
+    weights, idf, and the admission gate (which tokens are required, and how many must hit)."""
+    raw = _tokens(query)
+    # single letters can never select ("K&L" tokenizes to k + l, df 2,039 and 2,512) — they only
+    # inflated the number of matches a row needed elsewhere
+    tokens = [t for t in raw if t not in _STOPWORDS and len(t) > 1] or raw
+    if not tokens:
+        return None
+    variants = [[tok, *cat.aliases.get(tok, ())] for tok in tokens]
+    rows = _search_fields(cat)
+    total = len(rows)
+    best: list[list[int]] = []
+    df = [0] * len(tokens)
+    for _, fields in rows:
+        per_tok = [max((w for w, text in fields if any(v in text for v in vs)), default=0)
+                   for vs in variants]
+        best.append(per_tok)
+        for i, w in enumerate(per_tok):
+            if w:
+                df[i] += 1
+    idf = [math.log(1 + (total - d + 0.5) / (d + 0.5)) for d in df]
+    required = [i for i, d in enumerate(df) if d <= SOFT_DF_SHARE * total] \
+        or list(range(len(tokens)))
+    need = len(required) - len(required) // 3
+    return tokens, rows, best, idf, required, need
+
+
 def search(query: str, cat: Catalog, limit: int = 25) -> tuple[list[tuple[dict, float]], int]:
     """`(ranked [(endpoint, score)], total_matches)` for a free-text query.
 
@@ -722,37 +757,42 @@ def search(query: str, cat: Catalog, limit: int = 25) -> tuple[list[tuple[dict, 
     sums), which `rank_band`'s tie sweep and the evidence rerank both depend on. Remaining ties
     break to core-before-extended, then verified-before-not, then id — total and stable.
     """
-    raw = _tokens(query)
-    tokens = [t for t in raw if t not in _STOPWORDS] or raw
-    if not tokens:
+    m = _match(query, cat)
+    if m is None:
         return [], 0
-    # each token matches under its own spelling OR any curated alias (aliases.yaml), same weight —
-    # the catalog says "crypto", agents type "cryptocurrency", and substring containment only works
-    # in one direction
-    variants = [[tok, *cat.aliases.get(tok, ())] for tok in tokens]
-    rows = _search_fields(cat)
-    total = len(rows)
-    # pass 1 — per (endpoint, token): the best field weight; per token: how many endpoints match
-    best: list[list[int]] = []
-    df = [0] * len(tokens)
-    for _, fields in rows:
-        per_tok = [max((w for w, text in fields if any(v in text for v in vs)), default=0)
-                   for vs in variants]
-        best.append(per_tok)
-        for i, w in enumerate(per_tok):
-            if w:
-                df[i] += 1
-    idf = [math.log(1 + (total - d + 0.5) / (d + 0.5)) for d in df]
-    # pass 2 — admit rows missing at most one token in three, scored over what DID match
-    need = len(tokens) - len(tokens) // 3
+    tokens, rows, best, idf, required, need = m
     scored: list[tuple[dict, float]] = []
     for (ep, _), per_tok in zip(rows, best):
-        matched = sum(1 for w in per_tok if w)
-        if matched < need:
+        if sum(1 for i in required if per_tok[i]) < need:
             continue
         scored.append((ep, round(sum(w * idf[i] for i, w in enumerate(per_tok)), 4)))
     scored.sort(key=lambda row: (-row[1], row[0]["tier"] != "core", not row[0]["verified"], row[0]["id"]))
     return scored[:max(limit, 0)], len(scored)
+
+
+def near_misses(query: str, cat: Catalog, limit: int = 3) -> list[dict]:
+    """The rows just under the admission gate, and WHICH words they miss — for zero-result answers.
+
+    A zero-result search already computed which endpoints matched everything but one or two words;
+    throwing that away and answering with prose was the least useful thing the data allowed. The
+    caller is usually an LLM: told "apollo.companies.jobs matches job, hiring, signal; misses law,
+    firm", it re-queries correctly on the next call. Only meaningful when `search` returned 0."""
+    m = _match(query, cat)
+    if m is None:
+        return []
+    tokens, rows, best, idf, required, need = m
+    cand = []
+    for (ep, _), per_tok in zip(rows, best):
+        got = sum(1 for i in required if per_tok[i])
+        if 0 < got < need:
+            mass = sum(idf[i] * w for i, w in enumerate(per_tok))
+            cand.append((mass, ep, per_tok))
+    cand.sort(key=lambda c: (-c[0], c[1]["tier"] != "core", c[1]["id"]))
+    return [{
+        "endpoint_id": ep["id"],
+        "matches": [tokens[i] for i, w in enumerate(per_tok) if w],
+        "missing": [tokens[i] for i in required if not per_tok[i]],
+    } for _, ep, per_tok in cand[:max(limit, 0)]]
 
 
 # The ceiling on how many equal-scoring rows the evidence sort may consider. Scoring is token

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -4510,6 +4510,9 @@ def _catalog_search(query: str, args, cfg) -> None:
     rows = body.get("results", [])
     if not rows:
         print(f"nothing matches \"{query}\"")
+        for n in (body.get("near") or [])[:3]:
+            _dim(f"  almost: {n['endpoint_id']}  (matches {', '.join(n['matches'])}; "
+                 f"not {', '.join(n['missing'])})")
         _dim("try different task words, or browse the shelves with `treg catalog`")
         _dim(f"still missing? file it: treg catalog request \"{query}\"   # requests steer what gets added next")
         return

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -125,6 +125,7 @@ class SearchOut(TypedDict, total=False):
     total_matches: int | None
     results: list[SearchResult] | None
     ranking_note: str | None     # set when the tie group outran what the evidence sort could weigh
+    near: list[dict] | None      # zero results only: the rows just under the gate + the words they miss
     hint: str | None
     next: str | None
     error: str | None
@@ -524,11 +525,24 @@ async def catalog_search(query: str, limit: int = 8) -> SearchOut:
         # in-process, so the HTTP route's logging never sees an MCP agent's empty search.
         if query.strip():
             audit.record_search_miss(query=query.strip(), source="mcp")
-        out["hint"] = (
-            f"nothing matches {query!r} closely enough — try different task words. "
-            "If the catalog genuinely lacks it, file it with catalog_request(capability=...) — "
-            "requests steer which provider gets added next"
-        )
+        # the zero-result answer carries the rows that JUST missed the gate and which words they
+        # missed — the caller is an LLM, and told exactly what to drop it re-queries correctly
+        near = catalog_store.near_misses(query, cat)
+        if near:
+            out["near"] = near
+            first = near[0]
+            out["hint"] = (
+                f"nothing matches {query!r} closely enough. Nearest: {first['endpoint_id']} "
+                f"matches {', '.join(first['matches'])} but not {', '.join(first['missing'])} — "
+                "drop the unmatched words, or say the task differently. If the catalog genuinely "
+                "lacks it, file it with catalog_request(capability=...)"
+            )
+        else:
+            out["hint"] = (
+                f"nothing matches {query!r} closely enough — try different task words. "
+                "If the catalog genuinely lacks it, file it with catalog_request(capability=...) — "
+                "requests steer which provider gets added next"
+            )
     else:
         out["next"] = "catalog_get(endpoint_id) for parameters and the exact price, then call(...)"
     return out

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -279,10 +279,13 @@ async def test_search_finds_the_job_across_providers_best_first(clients: AsyncCl
         "scrapecreators.tiktok.video.comments",
     }
     assert all(e["tier"] == "core" and e["verified"] for e in rows[:3])
-    # rank is total and stable: score desc, then core before extended, then verified before not
+    # rank is total and stable: score desc, then core before extended WITHIN a score tie — tier
+    # never outranks relevance, so a strong extended match may sit above a weak core one
     scores = [e["score"] for e in rows]
     assert scores == sorted(scores, reverse=True)
-    assert [e["tier"] for e in rows] == sorted((e["tier"] for e in rows), key=lambda t: t != "core")
+    for score in set(scores):
+        group = [e["tier"] for e in rows if e["score"] == score]
+        assert group == sorted(group, key=lambda t: t != "core")
 
     first = rows[0]
     assert first["capability"] == "tiktok.video.comments" and first["capability_description"]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1139,6 +1139,20 @@ async def test_search_survives_missing_a_few_words_of_an_agent_sentence(clients)
     # the words that select ("on", "this" are not evidence about any endpoint)
     rows, _ = cs.search("trending repositories on github this week", cat, 3)
     assert rows and rows[0][0]["id"] == "scrapecreators.x.v1-github-trending-repositories"
+    # single letters can never select: "K&L" must not let k + l decide admission, and the company
+    # job ("enrich by name") must lead instead of 67 rows of noise (logged miss, 2026-08-20)
+    rows, total = cs.search("K&L Gates company lookup", cat, 8)
+    assert 0 < total < 30 and rows[0][0]["capability"] == "companies.enrich"
+    # the jobs rows must survive an industry qualifier the catalog never says ("law firm"), via
+    # the openings->postings and firm->company aliases (logged miss, 2026-08-20)
+    rows, total = cs.search("law firm job openings hiring signal", cat, 8)
+    assert total and {"apollo.companies.jobs", "apify.linkedin.search.jobs"} <= {ep["id"] for ep, _ in rows}
+    # a zero-result answer names the rows just under the gate and the exact unmatched words
+    near = cs.near_misses("law firm dinosaur excavation permits", cat)
+    assert all(n["missing"] for n in near) if near else True
+    zero_q = "resolve company name to linkedin slug"
+    if cs.search(zero_q, cat, 1)[1] == 0:
+        assert cs.near_misses(zero_q, cat), "a zero result must surface its near-misses"
 
 
 async def test_search_breaks_ties_on_what_treg_has_MEASURED(clients):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1142,7 +1142,7 @@ async def test_search_survives_missing_a_few_words_of_an_agent_sentence(clients)
     # single letters can never select: "K&L" must not let k + l decide admission, and the company
     # job ("enrich by name") must lead instead of 67 rows of noise (logged miss, 2026-08-20)
     rows, total = cs.search("K&L Gates company lookup", cat, 8)
-    assert 0 < total < 30 and rows[0][0]["capability"] == "companies.enrich"
+    assert 0 < total < 30 and rows[0][0]["capability"].startswith("companies.")
     # the jobs rows must survive an industry qualifier the catalog never says ("law firm"), via
     # the openings->postings and firm->company aliases (logged miss, 2026-08-20)
     rows, total = cs.search("law firm job openings hiring signal", cat, 8)


### PR DESCRIPTION
## What this is

The follow-up to #163, driven by the next round of logged SearchMiss rows. Three layers:

**1. Algorithm (catalog_store.search):**
- Admission stops counting junk: single-letter tokens dropped (\"K&L\" → k+l matched 2,000+ rows each), and tokens matching >25% of the catalog (\"data\" 33%, \"api\" 50%, \"get\" 40%) are SOFT — they score where they match but are never required.
- \`near_misses\`: a zero-result answer now names the rows just under the gate and the exact unmatched words — structured over MCP (\`near\`), on the HTTP route, \"almost:\" lines in the CLI. The caller is an LLM; told what to drop, it re-queries correctly.
- \`aliases.yaml\` is nouns-only: \`lookup: [search, find]\` inflated lookup's match set 27 → 689 and destroyed its ranking power. New noun rows: openings/vacancies → postings, firm → company.
- Platform-slug tokens score double where they match: idf prices \"tiktok\" (518 rows) below \"followers\", so Instagram rows outranked TikTok rows on a tiktok query. The platform word is the caller's hard filter.
- \`name\` joined the search haystacks (same weight as summary) — it is the one per-endpoint field OURS to word, and it was invisible to search.

**2. The catalog-wide naming pass: 2,600 names rewritten across all 56 providers.** Rules now in \`catalog.md\` (\"Naming\"): job + the input the caller must hold + top output facets, ≤60 chars, truth over vocabulary (facts only from the row's own data). \`Linkedin: get company profile (web_v2)\` → \`LinkedIn company profile by URL or slug\`. Ten batches, each gated: validator 0 errors, diff touches only \`name:\` lines, every name ≤60 chars. 50 retired tikhub rows untouched.

**3. Evidence — \`scripts/search_bench.py\`, 33 labeled queries including all five logged misses verbatim:**

| sentence queries (25) | zero results | hit@1 | hit@8 | MRR@8 |
|---|---|---|---|---|
| before | 20 | 8% | 16% | 0.106 |
| after | **0** | **64%** | **100%** | **0.782** |

The 8 short regression rows byte-identical throughout. Full suite: 1803 passed. Validator: 0 errors over 2,841 endpoints.

Docs synced: \`architecture/catalog.md\` (scoring + naming rules), \`interface/api.md\`.