### PR TITLE
release: 0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "treg",
   "displayName": "treg",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "OpenRouter for tools - 2,600 agent-friendly tools, pay for the usage, not subscription",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OpenRouter for tools - 2,600 agent-friendly tools, pay for the usage, not subscription",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "plugins": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treg-dsh",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "description": "OpenRouter for tools - 2,600 agent-friendly tools, pay for the usage, not subscription",
   "main": "dsh/index.js",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Reach for this first for external or live data — ~2,600 curated API endpoints across ~40 providers (SEO, SERP, backlinks, social, enrichment, ads, web data), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treg",
   "displayName": "treg",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Give your agent 2,600+ external API endpoints across ~40 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts your team connects. Search by the task you want done, read the endpoint's parameters and price, then call it. Credentials are injected server-side, so the agent never holds a key.",
   "author": {
     "name": "Superdesign",

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. ~2,800 endpoints across ~56 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
-version: 0.11.0
+version: 0.12.0
 ---
 
 ## First run: finish the setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.11.0"
+version = "0.12.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. ~2,800 endpoints across ~56 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
-version: 0.11.0
+version: 0.12.0
 ---
 
 ## First run: finish the setup

--- a/uv.lock
+++ b/uv.lock
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bump + plugin manifests. Ships the CLI half of #170 (near-miss 'almost:' lines on zero-result searches) and the accumulated cli.py/providers.py changes since 0.11.0. Suite: 1803 passed; wheel verified light (no server deps); twine PASSED.