### PR TITLE
SEO: 5 use-case pages (2026-08-21)

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -308,7 +308,24 @@ its page. `tests/test_agent_pages.py` asserts the route source contains no job-s
 verbatim with a link, each followed by what the page can honestly do about it (including "no
 comparison table can answer this"). The `.agents/skills/treg-page` skill runs that research with
 `agent-reach` before any page is written, and documents how to spot the vendor astroturf that
-dominates these searches.
+dominates these searches. It is not decoration: on the YouTube pass roughly half the corpus was
+vendor-written, thirteen distinguishable clusters, one posting the same body to three subreddits
+seven seconds apart. `voices` renders in HTML and in the `.md` mirror, and is optional in the spec
+(two of the first seven pages ship without it), so `test_no_use_case_page_ships_with_an_empty_section`
+requires `voices` and `voices_intro` together rather than requiring either.
+
+**The section order is comparison, then voices, then notes, then FAQ.** Copy inside `voices`,
+`notes` and `faq` that says "the comparison below" is pointing backwards; the first written pages
+say it anyway. Write position-neutral ("the comparison above", "the prices here") or the sentence
+is wrong for every reader who scrolls.
+
+**Written so far: 12 of the 66 jobs.** The YouTube & video cluster (transcript, video stats, channel
+stats, search, comments) landed 2026-08-21 and is the first `compare`-form cluster where one row is
+free: the official Data API on the reader's own connected Google account, at $0.00 with a 10,000
+unit daily quota. The free row is deliberately excluded from the "cheapest per unit" claim, because
+`_uc_providers` only ranks rows with a truthy USD price, and a free-but-rationed row is not a
+cheaper version of a metered one. Those pages carry the quota arithmetic instead, which is what the
+research said people actually get stuck on.
 
 Nested under the category on purpose: the five flat ad pages keep their URLs and `build_html.py`
 ownership, and `test_legacy_flat_use_case_pages_still_answer` proves the nested route cannot shadow

--- a/marketing/pseo-ship-plan.md
+++ b/marketing/pseo-ship-plan.md
@@ -49,6 +49,30 @@ Only if wave 1 indexes. Each is one pricing/comparison page plus its three or fo
   These are single-provider pages, so they follow the **short form**: prompt, why it works, connect
   steps, params, one call, FAQ. No comparison section.
 
+### Wave 2 progress
+
+**YouTube & video shipped 2026-08-21** (5 pages, not the 4 planned: `video-details-views-and-stats`
+came along because the quota argument is the same argument). Measured US volume behind the titles,
+via the free own-key Google Ads endpoint: `youtube transcript` 110,000 · `get youtube transcript`
+2,400 · `youtube channel stats` 1,300 · `youtube data api` 1,000 · `youtube transcript api` 880 ·
+`youtube video statistics` 590 · `youtube keyword search tool` 480 · `youtube scraper` 390 ·
+`youtube comment scraper` 210 · `youtube search api` 170 · `youtube mcp server` 140. Dead, do not
+target: `youtube video stats api` (0), `youtube channel data api` (0), `youtube subscriber count
+api` (10), `youtube video details api` (10), `youtube metadata api` (10), `youtube channel api` (30).
+The pattern from the enrichment pass holds: buyers type the **thing plus a verb** ("get youtube
+transcript") or **scraper**, not `<thing> api`, except where the thing is a named product
+(`youtube data api`).
+
+Two remain in the cluster for the next run: `trending-videos` and `transcripts-of-x-and-facebook-video-posts`.
+
+**Catalog gap found, needs a human.** `tikhub.x.youtube-web-search-channel` is mapped to capability
+`youtube.search.channels`, but it searches *within* one channel by id ("Search within a YouTube
+channel by keyword"), which is a different job from finding channels by keyword. It renders as a row
+on `/use-cases/youtube-video/search-videos-and-channels-by-keyword`, where the page's FAQ now names
+the distinction rather than papering over it. The real cross-channel search is
+`tikhub.x.youtube-web-v2-search-channels`. Either remap the endpoint or give within-channel search
+its own capability.
+
 ## Wave 3 — the rest, ordered by demand, not by catalog size (weeks 5+)
 
 SEO (8 jobs) · Social (9) · Local businesses (4) · Finance (7) · E-commerce (4) · Advertising (3) ·

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -215,6 +215,7 @@ PROVIDER_DOMAINS: dict[str, str] = {
     "scrapecreators": "scrapecreators.com", "tikhub": "tikhub.io", "justoneapi": "justoneapi.com",
     "predictleads": "predictleads.com", "finnhub": "finnhub.io", "twelvedata": "twelvedata.com",
     "eodhd": "eodhd.com", "lusha": "lusha.com", "crunchbase": "crunchbase.com",
+    "youtube": "youtube.com",
 }
 
 # Why go through treg.to at all: (lead, one short line). Same on every use-case page.
@@ -985,4 +986,498 @@ USE_CASE_PAGES[("data-enrichment-sales", "enrich-a-company")] = {
     ],
     "related": ("Build a company list by industry, size or tech", "Hiring, headcount and news signals",
                 "Find people by role, company or location", "A company's funding rounds"),
+}
+
+
+USE_CASE_PAGES[("youtube-video", "get-a-video-s-transcript")] = {
+    "label": "Get a video's transcript",
+    "sentence": "YouTube transcript API: a video's captions as plain text",
+    "title": "YouTube transcript API: {n} providers compared | treg.to",
+    "lede": (
+        "Give your agent a YouTube URL and get the spoken words back as text, ready to summarise, "
+        "search or quote. {n} providers do this through one treg.to key, from {cheapest} a video. "
+        "The official YouTube Data API cannot do it for a video you do not own, which is the whole "
+        "reason this job has a price at all."),
+    "prompt": "Using treg, get the transcript of https://www.youtube.com/watch?v=dQw4w9WgXcQ in "
+              "English. Show me the price first, then summarise it into five bullet points.",
+    "prompt_why": [
+        ("Give it the URL", "Both providers take a watch or Shorts URL. No video id lookup first."),
+        ("Name the language", "Ask for a language you know the video carries, or you get an empty result."),
+        ("Ask for the price first", "treg.to returns the cost before the call, so the agent can say what it will spend."),
+        ("Say what to do with it", "Transcript plus instruction in one turn beats fetching then pasting."),
+    ],
+    "result_noun": "transcript",
+    "result_image": None,
+    "voices_intro": (
+        "This job has a large and unusually honest literature, because everyone starts by doing it "
+        "themselves. From ~180 Reddit and X posts in August 2026, after excluding thirteen vendor "
+        "and self-promotion clusters that were roughly half the corpus, these five recur."),
+    "voices": [
+        ("It works on a laptop and stops working on a server",
+         "When I try to run it in the cloud, YouTube seems to block the IP.",
+         "r/SaaS, 5 points", "https://www.reddit.com/r/SaaS/comments/1fgjjd1/looking_for_a_saas_tool_to_fetch_youtube_video/",
+         "This is the single most repeated failure in the research, and it is structural: the "
+         "unofficial route reads from your address, and datacentre ranges get blocked. A call "
+         "through treg.to leaves the provider's infrastructure instead. What no table can tell you "
+         "is whether a given provider's pool is clear today at your volume, which is why the "
+         "observed success rates on this page are measured rather than promised."),
+        ("Nobody can promise it still works next month",
+         "it still feels like the whole feature could break the moment something changes on YouTube's end",
+         "r/sideprojects, 5 points", "https://www.reddit.com/r/sideprojects/comments/1v4zk6t/is_there_a_stable_way_to_pull_youtube_transcripts/",
+         "Correct, and no comparison table can tell you otherwise. The honest difference is who owns "
+         "the repair: on the unofficial route it is you, at the moment it breaks, and here it is the "
+         "provider, with the failure showing up as a billing line rather than an outage."),
+        ("The proxy is the real cost of doing it yourself",
+         "it needs ip address rotations (becuase youtube blocks transcript scrapers), so I set up a webshare proxy (costs like $3)",
+         "r/n8n, 285 points", "https://www.reddit.com/r/n8n/comments/1pd5gbx/turn_any_youtuber_into_an_ai_agent_001run_using/",
+         "A fair benchmark, and worth doing the arithmetic against: a proxy is a monthly floor you "
+         "pay whether or not you pull a transcript, plus the maintenance. The prices here are per "
+         "video with no floor, which wins at low volume and loses at very high volume."),
+        ("An agent cannot watch a video, so the transcript is the adapter",
+         "What's the best way to have an agent via API in my app auto-generate a transcript from a YouTube video",
+         "@waynesutton on X", "https://x.com/i/status/2087026783615168992",
+         "This framing was the largest single theme in the research, twelve posts. It is one call "
+         "here: the agent turns a URL into text and then does the actual work in the same turn, "
+         "which is what the prompt at the top of this page does."),
+        ("The DIY integrations people build for this keep not sticking",
+         "I built a couple of MCPs using APIs etc, but they didn't work out so well for pulling transcripts.",
+         "r/OpenAI, 25 points", "https://www.reddit.com/r/OpenAI/comments/1uq73nr/youtube_transcript_getter_extension_for_obsidian/",
+         "Worth being precise about why, because it is not the MCP part. It is that the transcript "
+         "source underneath was unofficial. Nothing here changes that for the two paid providers; "
+         "what changes is that maintaining it is their job, and you can compare what they charge "
+         "for the video where it fails."),
+    ],
+    "q_cheapest": "Which YouTube transcript API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What is a YouTube transcript API?",
+    "what_is": (
+        "It returns the caption track YouTube already holds for a video: the auto-generated one the "
+        "speech recogniser produced, or the human-uploaded one if the channel added it. You get the "
+        "text, usually with timestamps, in SRT, plain text or JSON. It is not transcription; nobody "
+        "here is running speech recognition on the audio, so a video with no caption track has "
+        "nothing to return."),
+    "notes": [
+        "Google's own Data API is missing from this comparison on purpose. Its captions.download "
+        "method only works on videos the connected account owns, so it cannot read anyone else's, "
+        "and that is why a job the platform does for free in the player costs money here.",
+        "ScrapeCreators takes a cache_max_age parameter: if a cached copy is newer than the number "
+        "of days you pass, it returns that for 0 credits instead of scraping again. On a rerun over "
+        "the same videos, this is the difference between paying and not.",
+        "Ask for a language the video actually has. ScrapeCreators returns transcript: null when "
+        "your two-letter code is missing rather than falling back; TikHub returns the list of "
+        "available caption tracks if you send no language code at all, which is the safer first call.",
+    ],
+    "faq": [
+        ("How much does a YouTube transcript cost?",
+         "A fraction of a cent per video at the provider's own rate, with $0.000 added by treg.to. "
+         "The live prices are in the comparison above, and one provider bills only on success while "
+         "the other bills the attempt."),
+        ("Why not use youtube-transcript-api myself?",
+         "You can, and it works until it does not: the library reads an undocumented endpoint from "
+         "your IP, and datacentre ranges get blocked, which is the failure everybody hits at the "
+         "point they move off a laptop. These providers run their own IP pools, and the failure "
+         "becomes a billing line instead of an outage."),
+        ("Does this work on Shorts and live streams?",
+         "Shorts, yes; both providers accept a Shorts URL. A live stream only has captions once the "
+         "recording is processed, and a video whose channel disabled captions has no track to "
+         "return at any price."),
+        ("Can I get transcripts in bulk?",
+         "Yes, it is one call per video and you tell your agent the list. There is no batch "
+         "endpoint, so the cost is linear, and the billing unit in the comparison tells you which "
+         "of the two charges for a video that turns out to have no captions."),
+    ],
+    "related": ("Video details, views and stats", "A video's comments",
+                "Transcripts of X and Facebook video posts", "Search videos and channels by keyword"),
+}
+
+USE_CASE_PAGES[("youtube-video", "video-details-views-and-stats")] = {
+    "label": "Video details, views and stats",
+    "sentence": "YouTube video statistics: views, likes and metadata by video id",
+    "title": "YouTube video statistics API: {n} providers | treg.to",
+    "lede": (
+        "Views, likes, comment count, duration, title, description, tags and publish date, for any "
+        "public video. {n} providers do this through one treg.to key, and one of them is Google's "
+        "own API on the account you already have, which is free but rationed."),
+    "prompt": "Using treg, get the view count, like count and publish date for these 30 YouTube "
+              "video ids and put them in a table sorted by views. Show me the price first.",
+    "prompt_why": [
+        ("Give it video ids", "The v= parameter of the watch URL. Most providers take the id, not the URL."),
+        ("Ask for a batch", "Google's API takes 50 ids in one call for the price of one."),
+        ("Name the fields you want", "Views, likes and duration live in different parts of the response."),
+        ("Say which account to use", "Your own Google connection is free; the paid providers need no account."),
+    ],
+    "result_noun": "video",
+    "result_image": None,
+    "voices_intro": (
+        "Almost nobody complains about the price of this call. They complain about the daily cap, "
+        "and about whether the number they got is today's number. From ~180 Reddit and X posts in "
+        "August 2026, with the vendor clusters excluded, these five recur."),
+    "voices": [
+        ("The free quota runs out in the middle of something",
+         "i exceeded youtubes API quota. womp womp. Anyway, it should be back and updating properly at midnight pacific time.",
+         "r/Destiny, 575 points", "https://www.reddit.com/r/Destiny/comments/1vafc5k/dave_comment_tracker_i_made/",
+         "The daily budget resets at midnight Pacific, so a bug in the morning costs the rest of the "
+         "day. Reading a video costs 1 unit of 10,000 and batches 50 ids into that one unit, so most "
+         "people who hit the wall were spending it on search. The paid rows have no daily ceiling; "
+         "treg.to shows you both and you pick, it does not switch over on its own."),
+        ("You cannot tell whether you ran out or something else broke",
+         "The strange thing is, my daily usage counter (which I'm tracking in the script) shows that I'm nowhere near the daily quota limit.",
+         "r/pythontips, 2 points", "https://www.reddit.com/r/pythontips/comments/1epf9dk/youtube_api_quota_issue_despite_not_reaching_the/",
+         "The recurring complaint is not running out, it is not knowing why. We cannot fix Google's "
+         "quota accounting. What a metered call gives you instead is a definite price before it goes "
+         "and a definite outcome after, so the ambiguous middle disappears."),
+        ("Leaving your laptop changes the failure mode",
+         "Apparently that IP address is for AWS.",
+         "r/MailChimp, 6 points", "https://www.reddit.com/r/MailChimp/comments/1g9ft0z/youtube_api_error/",
+         "The error underneath that thread is API_KEY_IP_ADDRESS_BLOCKED, and it is the same story as "
+         "the transcript job: it worked until it was deployed. A call through treg.to leaves the "
+         "provider's infrastructure, not your host's. Whether your own host is blocked is a property "
+         "of your host, and no comparison table has that column."),
+        ("The counts themselves are not stable at fine granularity",
+         "during certain intervals, views increase without likes/comments scaling proportionally, while at the hourly aggregate level everything looks perfectly normal",
+         "r/HiddenTrueCrimeChat, 23 points", "https://www.reddit.com/r/HiddenTrueCrimeChat/comments/1prow46/ive_been_logging_htc_youtube_views_likes_and/",
+         "This is the honest limit of every row on this page. View counts are aggregated and "
+         "sometimes revised downward by YouTube itself, and every provider here is downstream of "
+         "that. A table can compare price and measured success rate; it cannot tell you whose number "
+         "is right, because on some hours no number is."),
+        ("The folk remedy is more keys, which is not a plan",
+         "Google youtube API has a quota limits, so I added over 45 API",
+         "r/MetaRayBanDisplay, 4 points", "https://www.reddit.com/r/MetaRayBanDisplay/comments/1tyuxrx/viewtube_v20_question_for_all_google_youtube_api/",
+         "Forty-five keys is a lot of Google projects to own, and it is the shape people reach for "
+         "when the only lever is a daily cap. The alternative here is a per-call price with no cap "
+         "and no rotation to maintain. Spend the free quota first if you have it."),
+    ],
+    "q_cheapest": "Which YouTube video stats API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What does a YouTube video stats API return?",
+    "what_is": (
+        "One video's public record: the snippet (title, description, tags, channel, publish date), "
+        "the statistics (view count, like count, comment count) and the content details (duration, "
+        "definition, caption availability). It is the same data the watch page shows, as JSON. "
+        "Watch time, impressions, click-through rate and audience retention are not here; those are "
+        "YouTube Analytics, and only the channel owner can read them."),
+    "notes": [
+        "Google's Data API charges 1 quota unit whether you pass one video id or fifty, out of a "
+        "default 10,000 units a day. Batching is not an optimisation here, it is a fifty-fold "
+        "difference in what a day's quota buys you.",
+        "The billing units are not comparable. Bright Data bills per record delivered, TikHub and "
+        "Just One API bill per successful call, ScrapeCreators bills the call whether or not it "
+        "found the video. A run over a list with dead ids costs differently on each.",
+        "Like counts are returned as the channel chose to expose them, and a channel that hides its "
+        "like count returns no field rather than a zero. Treat a missing field and a zero as "
+        "different answers when you aggregate.",
+    ],
+    "faq": [
+        ("Is the YouTube Data API free?",
+         "Yes, on your own Google account, and treg.to never meters a call on your own key. What it "
+         "is not is unlimited: 10,000 quota units a day by default, which this method spends 1 at a "
+         "time. The paid providers exist for when that runs out."),
+        ("Can I get watch time or retention?",
+         "No. Those are YouTube Analytics numbers and only the channel's owner can read them, "
+         "through a connected account. Everything on this page is the public record of the video."),
+        ("Do I need a Google account for this?",
+         "Only for the free row. The other providers are called on treg.to's keys and billed per "
+         "call from your prepaid balance, so you can read a video's stats with no Google project at all."),
+        ("How current are the view counts?",
+         "They are what the platform is publishing at the moment of the call. YouTube itself updates "
+         "public view counts on its own schedule, so two providers reading a minute apart can "
+         "legitimately disagree on a fast-moving video."),
+    ],
+    "related": ("Get a video's transcript", "A video's comments",
+                "A channel's profile and lifetime stats", "Search videos and channels by keyword"),
+}
+
+USE_CASE_PAGES[("youtube-video", "a-channel-s-profile-and-lifetime-stats")] = {
+    "label": "A channel's profile and lifetime stats",
+    "sentence": "YouTube channel stats API: subscribers, total views and profile",
+    "title": "YouTube channel stats API: {n} providers | treg.to",
+    "lede": (
+        "Subscriber count, lifetime views, video count, description, country and links, for any "
+        "public channel. {n} providers do this through one treg.to key, including Google's own API "
+        "on your account, which resolves an @handle without you having to find the UC id first."),
+    "prompt": "Using treg, get the subscriber count, total views and video count for @MrBeast and "
+              "@mkbhd, and tell me which has more views per video. Show me the price first.",
+    "prompt_why": [
+        ("A handle is enough", "Google's API resolves @handle directly. The scrapers vary; some need the UC id."),
+        ("Ask for the pair you need", "Profile and statistics are separate parts of the response. Name both."),
+        ("Ask it to do the arithmetic", "Views per video and subscribers per video are one line, not a spreadsheet."),
+        ("Say whose key to use", "Your own Google connection is free and never metered."),
+    ],
+    "result_noun": "channel",
+    "result_image": None,
+    "voices_intro": (
+        "Two things stop people here, and neither is the price: how fresh the numbers are, and "
+        "whether touching the API can hurt the channel they already run. From ~180 Reddit and X "
+        "posts in August 2026, with the vendor clusters excluded."),
+    "voices": [
+        ("One response, and its fields disagree about how current they are",
+         "So one field in the response was stale while the other two were fresh.",
+         "r/googlecloud, 1 point", "https://www.reddit.com/r/googlecloud/comments/1tjofun/youtube_data_api_v3_channelstatisticsviewcount/",
+         "Documented day by day in that thread: lifetime viewCount frozen for over a day while "
+         "subscriberCount and videoCount kept moving, inside Google's own API. Every provider on "
+         "this page reads from the same well, so no comparison table can rank them on whether a "
+         "number is today's. Record when you pulled and treat a flat total as suspect, not as news."),
+        ("People are afraid the API itself will hurt their channel",
+         "Is there any risk that my main channel could be shadowbanned, restricted, or lose its algorithmic reach just by using the official API",
+         "r/youtube, 3 points", "https://www.reddit.com/r/youtube/comments/1vlva1i/question_regarding_youtube_data_api_v3_readonly/",
+         "A fair question that almost nobody answers in writing. Reading public channel data through "
+         "one of the paid providers here happens server side on a credential that has nothing to do "
+         "with your creator account, so there is no account of yours in the request at all. If you "
+         "use the free Google row instead, that is your connected account, by design."),
+        ("Quota is why people stop tracking channels, not why they start",
+         "spending more api quota to start tracking a third channel from scratch",
+         "r/HiddenTrueCrimeChat, 20 points", "https://www.reddit.com/r/HiddenTrueCrimeChat/comments/1q1eryk/are_htcs_views_real_what_im_measuring_with_public/",
+         "A researcher dropped a control channel because a third one cost more quota than they had. "
+         "A channel read is 1 unit, so the free cap is roughly 10,000 snapshots a day; what actually "
+         "burns it is polling often. Paid rows have no daily ceiling, which is the whole difference "
+         "for anything long running."),
+        ("Whether you may keep and show the data is a separate question",
+         "Can I legally use YouTube channel profile pictures and public stats from the YouTube API in a collectible card game?",
+         "r/legaladvice", "https://www.reddit.com/r/legaladvice/comments/1v6c5ni/can_i_legally_use_youtube_channel_profile/",
+         "No comparison table can answer this and we are not going to pretend otherwise. Public and "
+         "reusable are different things; storing, republishing and putting someone's avatar on a "
+         "product are governed by YouTube's terms and by the law where you are. Read the terms, "
+         "and take advice if money is involved."),
+        ("Nobody wants a channel endpoint, they want the channel",
+         "I want to archive everything from the videos, to the likes, view and comments on it, lives and the same for it",
+         "r/DataHoarder, 20 points", "https://www.reddit.com/r/DataHoarder/comments/1s426uf/need_help_with_youtube_channel_archivescraping/",
+         "That is four jobs chained: the profile, the uploads list, per video stats, then comments. "
+         "Asking Google for part=contentDetails hands you the uploads playlist id, which is the "
+         "cheap way into the catalogue without spending a search. Your agent runs the chain; "
+         "treg.to prices each step."),
+    ],
+    "q_cheapest": "Which YouTube channel stats API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What counts as a channel's lifetime stats?",
+    "what_is": (
+        "The three totals a channel publishes about itself: subscribers, views across every video, "
+        "and how many public videos it has. Alongside them come the profile fields: title, "
+        "description, custom URL, country, keywords, banner and thumbnail. These are cumulative "
+        "totals, not a time series, so measuring growth means reading them repeatedly and keeping "
+        "your own history."),
+    "notes": [
+        "The three providers disagree about what identifies a channel. Google's API takes exactly "
+        "one of mine, id or forHandle, so an @handle resolves in a single call; ScrapeCreators "
+        "accepts a channel id, a handle or a URL; TikHub needs the UC channel id, so a handle costs "
+        "you a lookup first.",
+        "Subscriber counts come back as YouTube publishes them, which is rounded once a channel is "
+        "past a thousand. Two providers reading the same channel will agree on the rounded "
+        "figure and neither has the exact one, because the platform does not expose it.",
+        "Asking Google for part=contentDetails also returns the uploads playlist id, which is how "
+        "you list a channel's videos without spending a search call. It is the cheapest path from a "
+        "channel to its catalogue by a wide margin.",
+    ],
+    "faq": [
+        ("Can I get a channel's subscriber history?",
+         "Not from any of these. They return the current totals, because that is all YouTube "
+         "publishes. A growth curve means calling on a schedule and storing what you get."),
+        ("How do I find a channel by name?",
+         "Search for it first, then read the profile. Channel search is a separate job on this menu "
+         "and returns the ids these endpoints take."),
+        ("Is Google's API really free here?",
+         "Yes. It runs on the Google account you connect, so treg.to relays the call and meters "
+         "nothing. Only calls on treg.to's own provider keys are billed."),
+        ("Can I read another channel's analytics?",
+         "No, and no provider can. Watch time, traffic sources and audience data are visible only to "
+         "the channel's owner through a connected account. Everything here is public."),
+    ],
+    "related": ("Video details, views and stats", "Search videos and channels by keyword",
+                "A creator's profile and stats", "Get a video's transcript"),
+}
+
+USE_CASE_PAGES[("youtube-video", "search-videos-and-channels-by-keyword")] = {
+    "label": "Search videos and channels by keyword",
+    "sentence": "YouTube search API: find videos and channels by keyword",
+    "title": "YouTube search API: {n} providers compared | treg.to",
+    "lede": (
+        "Run a YouTube search from your agent and get the results as data: titles, video ids, "
+        "channels, publish dates and thumbnails, with the filters the site itself offers. {n} "
+        "providers do this through one treg.to key. Google's own API is free on your account and "
+        "the single most quota-expensive call it has, which is why the others are here."),
+    "prompt": "Using treg, search YouTube for videos about home espresso uploaded in the last month, "
+              "sorted by view count. Show me the price first, then give me the top 20 with links.",
+    "prompt_why": [
+        ("Say what to search for", "A keyword, the way you would type it into the site's own box."),
+        ("Name the filters", "Upload date, duration, type and sort order are parameters on every provider."),
+        ("Ask for videos or channels", "The same query returns either. Say which, or you get a mix."),
+        ("Ask for stats separately", "Search results carry no view counts. The agent fetches those next."),
+    ],
+    "result_noun": "result",
+    "result_image": None,
+    "voices_intro": (
+        "This is the job where the free route runs out first, and the people who have hit it are "
+        "unusually precise about why. From ~180 Reddit and X posts in August 2026, with the vendor "
+        "clusters excluded."),
+    "voices": [
+        ("One number decides this whole page",
+         "The official Data API v3 search.list costs 100 units/call against a 10k/day quota, which dies almost immediately once you're polling multiple keyword combos",
+         "r/webscraping, 7 points", "https://www.reddit.com/r/webscraping/comments/1uaq3lk/keywordsearching_youtube_at_scale_official_api_vs/",
+         "Exactly right, and worth stating as arithmetic: 100 units a search against a 10,000 unit "
+         "day is about 100 searches for the entire project, before you spend anything hydrating the "
+         "results with view counts. Every other call on this page costs 1 unit. That gap is the "
+         "reason the paid rows on this page exist."),
+        ("Trading a hard cap for an unknown one",
+         "Roughly what request rate gets you rate-limited / soft-banned on the InnerTube route?",
+         "r/webscraping, 7 points", "https://www.reddit.com/r/webscraping/comments/1uaq3lk/keywordsearching_youtube_at_scale_official_api_vs/",
+         "Nobody in the research knew, including the person who asked, and we do not either. What we "
+         "can say is that the request leaves the provider's infrastructure rather than yours, and "
+         "that the measured success rates shown here are live traffic rather than a claim. That is the "
+         "honest version of an answer to this question."),
+        ("Search results are not what a person sees",
+         "I want an API or scraper which helps me replicate the same results when I do a search on mobile. Is there a way?",
+         "r/n8n, 1 point", "https://www.reddit.com/r/n8n/comments/1rkmsj4/youtube_scraper/",
+         "No, not exactly, from anyone. On the site the ranking is personalised, regional and "
+         "signed in; these calls are none of those. Pass a region and language to get nearer a "
+         "market. No comparison table can tell you whose ordering matches your users, so run your "
+         "own query through two providers for a cent and diff the two lists."),
+        ("An agent will write the expensive version by default",
+         "The problem is my playlist contains 1.2k songs but I can only transfer around 60 songs and after that its an error",
+         "r/learnpython", "https://www.reddit.com/r/learnpython/comments/1hk199a/help_needed_exceeded_youtube_api_quota_while/",
+         "ChatGPT wrote them a loop that runs one search per track, which at 100 units each is a dead "
+         "project at song 100. This is the failure this page is really about: the code is fine and "
+         "the quota model is what nobody read. Tell your agent the price first and it can tell you "
+         "the run is unaffordable before it starts."),
+        ("The actual job is a sweep, not a search",
+         "So I built a Python script to scrape YouTube Shorts from a specific niche (AI kids bedtime stories), pull stats, transcripts",
+         "r/shortsAlgorithm, 78 points", "https://www.reddit.com/r/shortsAlgorithm/comments/1rh2bek/i_scraped_53_youtube_shorts_from_a_single_niche/",
+         "Search, then details, then transcripts, over a niche, on a schedule. That is three jobs on "
+         "this menu chained, and it is what almost everyone doing this actually wants. Per call "
+         "pricing makes the sweep something you can size in advance instead of a quota you discover "
+         "the edge of."),
+    ],
+    "q_cheapest": "Which YouTube search API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What does a YouTube search API return?",
+    "what_is": (
+        "A page of search results as structured records: video id, title, description snippet, "
+        "channel name and id, publish date and thumbnails, plus a token to fetch the next page. It "
+        "is the site's own ranking, not a fresh index, so results move as YouTube's does and two "
+        "calls minutes apart can legitimately differ."),
+    "notes": [
+        "Search results carry no statistics anywhere. To rank what you found by views you take the "
+        "video ids and call the video details job, which on Google's own API costs 1 quota unit for "
+        "50 ids. Budget for two steps, not one.",
+        "Google's search method costs 100 quota units against a default 10,000 a day, so about 100 "
+        "searches exhausts a day for the whole project. Every other call on this page costs 1. That "
+        "single number is why paid search providers exist at all.",
+        "SerpApi's parameter is search_query, not q. Sending q to its YouTube engine returns nothing "
+        "rather than an error, which is the kind of failure that looks like an empty result set.",
+    ],
+    "faq": [
+        ("Why does YouTube search cost so much quota?",
+         "Google prices the search method at 100 units against a 10,000 unit daily default, roughly "
+         "100 searches a day for an entire project. Reading a video, a channel or a comment thread "
+         "costs 1. A quota increase means an application and a review."),
+        ("Can I search a single channel's videos?",
+         "Yes. Google's search takes a channelId, and one TikHub endpoint searches within a channel "
+         "by id. The comparison above names which endpoint does which."),
+        ("Do search results include view counts?",
+         "No, on any provider. That is a second call to the video details job, which is cheap and "
+         "batches, so ask your agent for both and it will chain them."),
+        ("Is this the same ranking a user sees?",
+         "Close, but not guaranteed. Results are personalised and regional on the site, and these "
+         "calls are not signed in as you. Pass a region and language to get nearer a given market."),
+    ],
+    "related": ("Video details, views and stats", "A channel's profile and lifetime stats",
+                "Trending videos", "Find creators by keyword"),
+}
+
+USE_CASE_PAGES[("youtube-video", "a-video-s-comments")] = {
+    "label": "A video's comments",
+    "sentence": "YouTube comment scraper: every comment on a video, as data",
+    "title": "YouTube comment scraper API: {n} providers | treg.to",
+    "lede": (
+        "Pull a video's comments with authors, like counts, timestamps and replies, so your agent "
+        "can read the audience instead of you scrolling. {n} providers do this through one treg.to "
+        "key, and Google's own API is free on the account you already have."),
+    "prompt": "Using treg, get the comments on https://www.youtube.com/watch?v=dQw4w9WgXcQ sorted by "
+              "relevance. Show me the price first, then group them into the five things people complain about.",
+    "prompt_why": [
+        ("Give it the video", "A URL or a video id, depending on the provider. Both are one field."),
+        ("Choose the sort", "Relevance surfaces the comments people upvoted. Time gets you the newest."),
+        ("Ask for the analysis, not the dump", "A thousand comments is not an answer. Ask for the themes."),
+        ("Say how deep to go", "Replies are nested and paginated. Top-level threads are usually enough."),
+    ],
+    "result_noun": "comment",
+    "result_image": None,
+    "voices_intro": (
+        "The people doing this job are not chasing volume, they are chasing the forty comments that "
+        "matter. From ~180 Reddit and X posts in August 2026, with the vendor clusters excluded, "
+        "these five are what they actually complain about."),
+    "voices": [
+        ("The data is easy, the filtering is the job",
+         "a video with 3,000 comments might have 40 that are actually useful to me and the rest is noise",
+         "r/claude, 3 points", "https://www.reddit.com/r/claude/comments/1ragfjd/im_building_a_youtube_comment_filtering_tool_with/",
+         "The most useful document in the whole research pass. They are on version six of that "
+         "filter and get about 50% agreement with their own judgment. No provider on this page fixes that, "
+         "and any that claims to is selling you something: getting the comments is the cheap half."),
+        ("YouTube gives you no way to search or export a comment section",
+         "I find myself wanting to search youtube comments all the time. Because youtube lacks this feature (for some reason)",
+         "r/SideProject, 2 points", "https://www.reddit.com/r/SideProject/comments/1uzurwc/made_a_free_chrome_extension_that_lets_you_search/",
+         "True, and it is the whole reason this job exists. Every provider here hands back the "
+         "comments as records with author, likes and timestamps, so searching, sorting and grouping "
+         "them becomes something your agent does rather than something the site has to offer."),
+        ("Quota is what stops a long-running tracker",
+         "it would also mean spending more api quota to start tracking a third channel from scratch",
+         "r/HiddenTrueCrimeChat, 20 points", "https://www.reddit.com/r/HiddenTrueCrimeChat/comments/1q1eryk/are_htcs_views_real_what_im_measuring_with_public/",
+         "A researcher dropping a control channel because a third one costs more quota than they have "
+         "is the clearest argument on this page. Google's route is free and rationed; the paid rows "
+         "have no daily ceiling, and you can mix them, spending quota first and paying past it."),
+        ("What comes back is not stable between two pulls",
+         "How has youtube given me the wrong comments section on a video bro 💀",
+         "r/Quadeca, 19 points", "https://www.reddit.com/r/Quadeca/comments/1mhjev8/how_has_youtube_given_me_the_wrong_comments/",
+         "Comment sections move: held-for-review, author-deleted and creator-hidden comments differ "
+         "between two calls minutes apart, and the sort you ask for changes which arrive first. No "
+         "provider here, and no comparison table, can tell you that you got all of them. Pin the "
+         "sort order and record when you pulled."),
+        ("People want the whole channel, not one video",
+         "I want to archive everything from the videos, to the likes, view and comments on it, lives and the same for it",
+         "r/DataHoarder, 20 points", "https://www.reddit.com/r/DataHoarder/comments/1s426uf/need_help_with_youtube_channel_archivescraping/",
+         "That is several jobs chained, not one call: list the channel's videos, then pull comments "
+         "per video, then paginate each. Your agent can run that loop and treg.to prices every "
+         "step, but it does not run the loop for you, and on a large channel the bill is the sum of "
+         "the parts."),
+    ],
+    "q_cheapest": "Which YouTube comment API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What does a YouTube comment scraper return?",
+    "what_is": (
+        "The public comment threads on a video: each comment's text, author name and channel, like "
+        "count, published and updated times, and the replies underneath it. Comments are paginated, "
+        "so a video with tens of thousands of them is many calls, and the order you ask for changes "
+        "which ones arrive first."),
+    "notes": [
+        "Google's commentThreads method returns top-level threads with up to 5 replies inlined. "
+        "Past that you fetch the rest by parent id, so a thread with hundreds of replies is a "
+        "second and third call rather than a deeper response.",
+        "A video with comments turned off answers 403 commentsDisabled on Google's API rather than "
+        "an empty list. Treat that as a distinct outcome; the scraping providers signal it "
+        "differently, and on a per-call biller you have still paid for the attempt.",
+        "Bright Data bills per comment delivered, not per video. On a heavily commented video that "
+        "is a materially different bill from a per-call provider, in either direction "
+        "depending on how many you actually pull.",
+    ],
+    "faq": [
+        ("Can I download all the comments on a video?",
+         "Yes, by paginating. It is one call per page on every provider here, so a heavily "
+         "commented video costs proportionally more. The comparison shows the per-call and "
+         "per-record rates side by side."),
+        ("Does this include replies?",
+         "Top-level threads come back with their first replies attached. Deeper replies are a "
+         "further call per thread, which is worth knowing before you ask an agent for everything."),
+        ("Is scraping YouTube comments allowed?",
+         "The comments are public and Google's own API serves them, which is the route this page "
+         "recommends first. The third-party providers read the public page; you are responsible for "
+         "what you do with the data, including the privacy law that applies to you."),
+        ("Can I get comments from a whole channel?",
+         "Not in one call. List the channel's videos first, then fetch comments per video. Your "
+         "agent can chain that; treg.to prices each step but does not run the loop for you."),
+    ],
+    "related": ("Get a video's transcript", "Video details, views and stats",
+                "Mine the comments", "A channel's profile and lifetime stats"),
 }

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -343,8 +343,13 @@ async def test_use_cases_hub_lists_every_written_page(clients: AsyncClient):
     assert '<a href="/use-cases">' in (await clients.get(USECASE)).text   # breadcrumb points here
 
 
-@pytest.mark.parametrize("path", ["/agents/chatgpt", "/agents/claude", "/agents/claude-code",
-                                  "/agents/cursor", "/use-cases", USECASE])
+# Every page that ships, not a hand-kept list: this set grows by 59 as the use-case pages land, and
+# a title that overflows is invisible in exactly the way nobody notices during review.
+ALL_PAGES = ([f"/agents/{a}" for a in agent_pages.AGENTS] + ["/use-cases"]
+             + [f"/use-cases/{c}/{j}" for c, j in agent_pages.USE_CASE_PAGES])
+
+
+@pytest.mark.parametrize("path", ALL_PAGES)
 async def test_titles_and_descriptions_fit_a_search_result(clients: AsyncClient, path: str):
     """Google prints roughly 60 characters of a title and 155 of a description; past that it cuts
     mid-word, and the cut usually lands on the part that would have made someone click."""
@@ -368,3 +373,30 @@ async def test_non_canonical_casing_redirects_to_the_one_spelling(clients: Async
     r = await clients.get(f"/use-cases/{cat.upper()}/{job}", follow_redirects=False)
     assert r.status_code == 301 and r.headers["location"] == f"/use-cases/{cat}/{job}"
     assert (await clients.get("/agents/<script>")).status_code == 404
+@pytest.mark.parametrize("key", list(agent_pages.USE_CASE_PAGES))
+def test_no_use_case_page_ships_with_an_empty_section(key):
+    """The template renders whatever the spec holds, so a missing field is a heading with nothing
+    under it rather than an error. The counts are the house shape: 4 reasons, 3 notes, 4 FAQ."""
+    spec = agent_pages.USE_CASE_PAGES[key]
+    for field in ("label", "sentence", "title", "lede", "prompt", "what_is"):
+        assert spec.get(field), (key, field)
+    assert len(spec["prompt_why"]) == 4, (key, "prompt_why")
+    assert len(spec["notes"]) == 3, (key, "notes")
+    assert len(spec["faq"]) == 4, (key, "faq")
+    assert len(spec["related"]) == 4, (key, "related")
+    # the voices section is optional, but half of one is a heading over nothing
+    assert bool(spec.get("voices")) == bool(spec.get("voices_intro")), (key, "voices without intro")
+    for v in spec.get("voices") or ():
+        heading, quote, who, url, answer = v
+        assert all((heading, quote, who, url, answer)), (key, heading)
+        assert url.startswith("https://"), (key, url)
+        assert len(quote.split()) <= 25, (key, "quote over 25 words", quote)
+
+
+def test_related_links_point_at_jobs_that_exist():
+    """`related` is rendered as links to other pages. A label that is not on the menu is a 404, and
+    the four ad landing pages already taught us that a dead internal link is never noticed."""
+    menu = {lbl for _, jobs in agent_pages.USE_CASES for lbl, _ in jobs}
+    for key, spec in agent_pages.USE_CASE_PAGES.items():
+        for label in spec["related"]:
+            assert label in menu, (key, label)


### PR DESCRIPTION
The YouTube & video cluster from wave 2 of `marketing/pseo-ship-plan.md`. Five pages, all `compare` form:

| Page | Providers | H1 term (measured US/mo) |
|---|---|---|
| `/use-cases/youtube-video/get-a-video-s-transcript` | 2 | `youtube transcript api` 880, `get youtube transcript` 2,400 |
| `/use-cases/youtube-video/video-details-views-and-stats` | 5 | `youtube video statistics` 590 |
| `/use-cases/youtube-video/a-channel-s-profile-and-lifetime-stats` | 4 | `youtube channel stats` 1,300 |
| `/use-cases/youtube-video/search-videos-and-channels-by-keyword` | 5 | `youtube search api` 170, `youtube keyword search tool` 480 |
| `/use-cases/youtube-video/a-video-s-comments` | 5 | `youtube comment scraper` 210 |

**Based on this branch, not `main`.** `agent_pages.py` only exists here, so this stacks on #174 and should merge after it.

## Three things that need a human

**1. A catalog mis-mapping.** `tikhub.x.youtube-web-search-channel` is mapped to `youtube.search.channels`, but it searches *within* one channel by id, which is a different job from finding channels by keyword. It renders as a row on the search page. The page's FAQ names the distinction rather than papering over it, but the mapping is still wrong; the real cross-channel search is `tikhub.x.youtube-web-v2-search-channels`. Either remap it or give within-channel search its own capability. Also noted in the ship plan.

**2. The shipped pages point the wrong way.** Section order renders comparison → voices → notes → FAQ, so copy saying "the comparison below" inside voices or the FAQ is pointing backwards. These five are position-neutral. `find-professional-emails` and `verify-an-email` say "below" in four places and I left them alone rather than widen this PR. One-word fixes if you want them.

**3. Two of the first seven pages have no `voices` section at all** (`search-console-queries`, `find-creators-by-keyword`). The research is what the skill treats as the point of a page, so those two are thinner than the rest. The new shape test requires `voices` and `voices_intro` together rather than requiring either, so it does not fail them.

## Research

~180 Reddit and X posts via `agent-reach`, read by two subagents so the dump stayed out of the writing context. Roughly half the corpus was vendor-written: thirteen distinguishable clusters, one of which posted the same body to three subreddits seven seconds apart with a synonym-swapped rewrite and an affiliate parameter. All excluded. Every quote was re-checked verbatim against the raw YAML and every URL confirmed present before publishing.

The finding that shaped the pages: nobody is stuck on the price of these calls. They are stuck on the 10,000 unit daily quota (and on `search.list` costing 100 units of it, which is ~100 searches a day for a whole project), on datacentre IPs getting blocked the moment they deploy, and on not trusting that the number they got is today's number. Each page carries that arithmetic, and says plainly where no comparison table can help.

## Tests

`1862 passed`. The SERP-fit check now parametrises over every page that ships instead of a hand-kept list of six, so the remaining 54 pages are guarded as they land. Added a shape check (no empty section; 4 reasons, 3 notes, 4 FAQ, 4 related; quotes under 25 words with an https URL) and a check that every `related` label exists on the menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
