### PR TITLE
fix(billing): settle Bright Data per_result calls by counting delivered records

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -272,6 +272,20 @@ old behaviour was an over-charge and is now fixed, for TikHub the charge is a pa
 upstream cost, and the answer is to probe with a provider whose misses are free (scrapecreators
 404s cost nothing) before spending TikHub calls on unverified slugs.
 
+**Bright Data** is the derived rule in the other direction — the UNDER-charge, and the largest one
+found: it bills $1.50 per 1000 records *delivered*, reports no charge field, and one call can
+deliver thousands of records, so settling per_result calls at the estimate billed a ~6,000-record
+Google Play reviews job as one record. Three weeks of traffic consumed $13.61 upstream and billed
+orgs $0.35 (2026-08-24, a 39x gap). `_brightdata_record_count` counts the response instead — a
+JSON array or csv/ndjson lines are the records; any JSON *object* is zero records (the >60s sync
+fallback's and /trigger's `snapshot_id` handoff, an early download's `status: running`), because
+the async job's records bill when `brightdata.web.scrape.job.results` downloads them (that
+endpoint's price moved from free to per_result for exactly this — which also means re-downloading
+a snapshot bills the caller again; the catalog note says to download once). A gzipped
+(`compress=true`) or buffer-truncated body settles at the estimate: when we cannot count, the
+estimate is the honest number. This needed `unit_micro` (the per-ROW price) to ride the
+`MarketplaceCall` on every tier, where before only oauth-billed calls carried it.
+
 Closing the hold runs on its **own session** (the request's may be mid-rollback from the very error
 being released for) and **never raises** — the caller already has their answer, and a ledger hiccup
 must not turn a served call into a 500. A hold that fails to close is not lost money either: the

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -10374,7 +10374,13 @@ async def _resolve_marketplace_call(
     info_est = _platform_estimate_micro(cv, request.query_params, body) if cv else 0
     common = dict(upstream=upstream, consumed=consumed, endpoint_id=ep["id"], provider=service,
                   params_hash=phash, cost_type=str((ep.get("cost") or {}).get("type") or ""),
-                  estimate_micro=info_est)
+                  estimate_micro=info_est,
+                  # The per-ROW price, carried on every tier (settle only reads it on metered calls):
+                  # a `per_result` settle that can't count rows can only ever bill the estimate,
+                  # which is how 6,000 delivered Bright Data records once billed as one (2026-08-24).
+                  unit_micro=(_usd_to_micro(cv["usd"])
+                              if cv and cv.get("type") in ("per_result", "quota_rows") and cv.get("usd")
+                              else 0))
     try:  # tier 1 — the org registered this provider: their tool, their bindings, their ACLs
         tool, resolved = await _resolve_call(upstream, caller, db)
         return MarketplaceCall(tool=tool, tier="tool", **{**common, "upstream": resolved})
@@ -11007,6 +11013,52 @@ def _redact_snippet(text: str, secrets: list[str], limit: int) -> str:
     return re.sub(r"[A-Za-z0-9_\-+/=.]{8,}$", "***", text[:limit]) + "…"
 
 
+
+def _brightdata_record_count(body: bytes) -> int | None:
+    """How many RECORDS a Bright Data Web Scraper response delivered, or None for "settle at the
+    estimate". Bright Data bills $1.50/1000 records *delivered* and reports no charge field, so the
+    response body is the only bill we will ever see. Counting it is what closed the 39x gap found
+    2026-08-24: $13.61 consumed upstream in three weeks vs $0.35 billed, because a per_result call
+    always settled as ONE record — a Google Play reviews job that delivered ~6,000 records billed
+    $0.0015.
+
+    Shapes, per docs + live traffic:
+      - sync /scrape and /snapshot downloads, format=json → a JSON ARRAY, one element per record;
+      - the >60s sync fallback and /trigger → a JSON OBJECT carrying `snapshot_id` — zero records
+        HERE; the job's records bill when the snapshot is downloaded (its catalog entry is priced
+        per_result for exactly that reason);
+      - format=ndjson → one JSON object per line; format=csv → header line + one line per record.
+    A body that STARTS like JSON but does not parse is treated as truncated (the metered buffer
+    caps at _PLATFORM_BODY_MAX and drops the tail) → None, settle at the estimate, never a
+    line-count guess over a partial payload. Any other unrecognised shape → None for the same
+    reason: when we cannot count, the estimate is the honest number."""
+    if body[:2] == b"\x1f\x8b":  # compress=true gzips the download — we can't count, estimate wins
+        return None
+    text = body.decode("utf-8", "replace").strip()
+    if not text:
+        return None
+    try:
+        doc = json.loads(text)
+    except ValueError:
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        try:  # ndjson: every line is its own record — EVERY line must parse, or it isn't ndjson
+            for ln in lines:
+                json.loads(ln)
+            return len(lines)
+        except ValueError:
+            pass
+        if text[0] in "[{":  # JSON that broke mid-stream: the 8MB buffer truncated it
+            return None
+        return len(lines) - 1 if len(lines) > 1 else None  # csv: header + rows
+    if isinstance(doc, list):
+        return len(doc)
+    if isinstance(doc, dict):
+        # Zero records delivered, whatever the object says: the async handoff (`snapshot_id` — the
+        # records bill at the snapshot download), an early download's {"status": "running"}, or any
+        # other envelope. Pay-per-success means an answer with no records costs nothing.
+        return 0
+    return None
+
 def _observed_cost_micro(mk: MarketplaceCall, body: bytes) -> int | None:
     """The provider's OWN reported charge for this call, in micro-USD, or None when it doesn't say.
 
@@ -11051,6 +11103,11 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes) -> int | None:
     provider = mk.provider
     if not body:
         return None
+    if provider == "brightdata" and mk.cost_type == "per_result" and mk.unit_micro > 0:
+        # DERIVED by counting records — Bright Data's bill is per record delivered and the body is
+        # the only place that number exists (see _brightdata_record_count for the shapes).
+        n = _brightdata_record_count(body)
+        return None if n is None else n * mk.unit_micro
     try:
         doc = json.loads(body)
     except (ValueError, UnicodeDecodeError):

--- a/src/treg/catalog/brightdata.yaml
+++ b/src/treg/catalog/brightdata.yaml
@@ -94,7 +94,7 @@ endpoints:
     test_request:
       queryParams: {dataset_id: "gd_l1vikfch901nx3by4"}
       body: [{"url": "https://www.instagram.com/instagram"}]
-    cost: {type: per_result, value: 0.0015, currency: USD, per: 1, unit: record, source: docs, source_url: 'https://brightdata.com/pricing', checked: '2026-07-28', confidence: documented, note: '$1.50 per 1000 records delivered, pay-per-success; the trigger call itself is free — the job''s records are what bill'}
+    cost: {type: per_result, value: 0.0015, currency: USD, per: 1, unit: record, source: docs, source_url: 'https://brightdata.com/pricing', checked: '2026-07-28', confidence: documented, note: '$1.50 per 1000 records delivered, pay-per-success; the trigger call itself settles at zero — the job''s records are billed when brightdata.web.scrape.job.results downloads them'}
     verified: 2026-07-28
     example_response: examples/brightdata.web.scrape.job.start.json
     docs_url: https://docs.brightdata.com/api-reference/web-scraper-api/asynchronous-requests
@@ -139,7 +139,7 @@ endpoints:
     test_request:
       pathParams: {snapshot_id: "sd_ms4lyair2704eraq24"}
       queryParams: {format: "json"}
-    cost: {type: free, value: 0, currency: USD, unit: call, note: management API — re-downloading a snapshot is not billed; the records were charged when the job ran}
+    cost: {type: per_result, value: 0.0015, currency: USD, per: 1, unit: record, source: docs, source_url: 'https://brightdata.com/pricing', checked: '2026-08-24', confidence: documented, note: 'THIS is where an async job''s records are billed to the caller — the trigger and the >60s sync fallback settle at zero, and treg counts the rows this download returns ($1.50 per 1000 records, pay-per-success). Bright Data itself charged the records when the job ran, so RE-downloading the same snapshot bills the caller again: download once, or use batch_size/part to fetch each slice once'}
     verified: 2026-07-28
     example_response: examples/brightdata.web.scrape.job.results.json
     docs_url: https://docs.brightdata.com/api-reference/scrapers/delivery-apis/download-snapshot

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1452,3 +1452,46 @@ def test_marketplace_resolution_carries_the_per_row_price():
     that can't see the row price can only ever bill the estimate."""
     cv = {"type": "per_result", "usd": 0.0015}
     assert A._usd_to_micro(cv["usd"]) == 1500
+
+
+async def test_brightdata_sync_scrape_settles_per_record_through_the_ledger(
+        clients: AsyncClient, platform_on, monkeypatch):
+    """End-to-end: a 1-url sync scrape that DELIVERS five records debits five records' worth —
+    the settle counts the response, the hold's 1-record estimate is an overrun, and the ledger
+    charges what was delivered ($13.61-vs-$0.35 incident, 2026-08-24)."""
+    records = [{"url": f"https://x/{i}", "title": f"r{i}"} for i in range(5)]
+    monkeypatch.setattr(A, "relay", _fake_relay(200, json.dumps(records).encode()))
+    before = await _balance(clients)
+    r = await clients.post("/call/brightdata.web.scrape.structured?dataset_id=gd_x",
+                           json=[{"url": "https://x/0"}])
+    assert r.status_code == 200, r.text
+    assert await _balance(clients) == before - 5 * 1500, "five records at $0.0015 each"
+    assert (await _telemetry(clients))["cost_observed_micro"] == 5 * 1500
+
+
+async def test_brightdata_sync_timeout_202_charges_nothing(
+        clients: AsyncClient, platform_on, monkeypatch):
+    """The >60s sync fallback answers 202 + snapshot_id: zero records delivered HERE, so the hold
+    releases to a zero charge — the records bill when the snapshot is downloaded. Before the fix
+    this billed the estimate while the job kept running (and billing) upstream."""
+    monkeypatch.setattr(A, "relay", _fake_relay(202, b'{"snapshot_id": "sd_test123"}'))
+    before = await _balance(clients)
+    r = await clients.post("/call/brightdata.web.scrape.structured?dataset_id=gd_x",
+                           json=[{"url": "https://x/0"}])
+    assert r.status_code == 202, r.text
+    assert await _balance(clients) == before, "a snapshot handoff must not charge"
+    assert (await _telemetry(clients))["cost_observed_micro"] == 0
+
+
+async def test_brightdata_snapshot_download_bills_the_jobs_records(
+        clients: AsyncClient, platform_on, monkeypatch):
+    """The async job's records bill at the snapshot download — the endpoint that was cataloged
+    `free` while $9.09 of Google Play reviews rode through it unbilled."""
+    records = [{"review": f"r{i}"} for i in range(40)]
+    monkeypatch.setattr(A, "relay", _fake_relay(200, json.dumps(records).encode()))
+    before = await _balance(clients)
+    r = await clients.get("/call/brightdata.web.scrape.job.results"
+                          "?snapshot_id=sd_test123&format=json")
+    assert r.status_code == 200, r.text
+    assert await _balance(clients) == before - 40 * 1500, "40 records at $0.0015 each"
+    assert (await _telemetry(clients))["cost_observed_micro"] == 40 * 1500

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1420,3 +1420,35 @@ async def test_a_byo_x_connection_is_never_metered(clients: AsyncClient, x_bille
     r = await clients.get("/call/x.x.get-webhooks")
     assert r.status_code == 200, r.text
     assert await _balance(clients) == before, "a BYO app's bill is the org's, not ours"
+
+
+def test_observed_cost_counts_brightdata_records():
+    """Bright Data bills per record DELIVERED and reports no charge field — the body is the bill.
+    Before this settled-by-count existed, every per_result call settled as one record: $13.61
+    consumed upstream vs $0.35 billed over three weeks (2026-08-24)."""
+    bd = _mk("brightdata", cost_type="per_result", unit_micro=1500)
+    # sync scrape / snapshot download, format=json: an array, one element per record
+    assert A._observed_cost_micro(bd, b'[{"url": "a"}, {"url": "b"}, {"url": "c"}]') == 4500
+    assert A._observed_cost_micro(bd, b"[]") == 0
+    # the >60s sync fallback and /trigger hand back a snapshot id: zero records HERE — they bill
+    # when the snapshot is downloaded
+    assert A._observed_cost_micro(bd, b'{"snapshot_id": "sd_x"}') == 0
+    # an early snapshot download answers the job's state, not rows: nothing delivered, nothing billed
+    assert A._observed_cost_micro(bd, b'{"status": "running", "message": "not ready"}') == 0
+    # ndjson: one record per line
+    assert A._observed_cost_micro(bd, b'{"url": "a"}\n{"url": "b"}\n') == 3000
+    # csv: header + rows
+    assert A._observed_cost_micro(bd, b"url,name\na,x\nb,y\n") == 3000
+    # a payload the 8MB metered buffer truncated must settle at the estimate, never a partial count
+    assert A._observed_cost_micro(bd, b'[{"url": "a"}, {"url"') is None
+    # gzipped (compress=true): can't count, estimate wins
+    assert A._observed_cost_micro(bd, b"\x1f\x8b\x08\x00junk") is None
+    # a free management route (progress polls) never reaches the counter
+    assert A._observed_cost_micro(_mk("brightdata", cost_type="free"), b'{"status": "ready"}') is None
+
+
+def test_marketplace_resolution_carries_the_per_row_price():
+    """`unit_micro` must ride the MarketplaceCall on every tier for per_result endpoints — a settle
+    that can't see the row price can only ever bill the estimate."""
+    cv = {"type": "per_result", "usd": 0.0015}
+    assert A._usd_to_micro(cv["usd"]) == 1500


### PR DESCRIPTION
## The bug

Bright Data bills **$1.50 per 1000 records delivered** and reports no charge field. treg settled every `per_result` call at the estimate (~one record), so a ~6,000-record Google Play reviews job billed the org **$0.0015**. Prod, Aug 1–23: **$13.61 consumed upstream vs $0.35 billed to orgs — a 39× gap** (verified against the Bright Data billing dashboard and prod callrecords).

## The fix

- `_brightdata_record_count`: the response body is the bill. A JSON array / ndjson / csv rows count as records; **any JSON object is zero records** — the `snapshot_id` handoff from `/trigger` and the >60s sync 202 fallback, or an early download's `{"status": "running"}`. Gzipped (`compress=true`) or 8MB-buffer-truncated bodies settle at the estimate — when we can't count, the estimate is the honest number.
- `unit_micro` (the per-row price) now rides `MarketplaceCall` on **every** tier — before, only oauth-billed calls carried it, so a platform-tier per_result settle could never count.
- Catalog: `brightdata.web.scrape.job.results` moves **free → per_result 0.0015** — the snapshot download is where an async job's records are countable, so it's where they bill. Note added: re-downloading a snapshot re-bills, download once.
- `docs/context/architecture/money.md`: Bright Data added to the derived-cost rules as the under-charge case.

## Tests

`tests/test_marketplace_call.py`: 87 pass (new: array/ndjson/csv counting, snapshot handoff → 0, early download → 0, truncated → estimate, gzip → estimate, free routes untouched). Full suite: only the 26 pre-existing `test_agent_pages` failures also present on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6ZSwUBJHc94BryBKBagUm