### PR TITLE
SEO: 5 use-case pages (2026-08-24)

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -278,7 +278,7 @@ what makes it a template rather than one page's prose:
 
 | Form | Condition | Renders |
 |---|---|---|
-| `short` | one provider | "How it works": the one call, on the reader's own account. No comparison |
+| `short` | one provider | "How it works": the one call. Own-account copy when the cost is `free`; otherwise the rate and the $0.000 markup. No comparison |
 | `platforms` | the job spans several platforms | providers grouped per platform, cheapest claimed per platform |
 | `compare` | several providers, one platform | the full comparison |
 
@@ -320,7 +320,7 @@ requires `voices` and `voices_intro` together rather than requiring either.
 say it anyway. Write position-neutral ("the comparison above", "the prices here") or the sentence
 is wrong for every reader who scrolls.
 
-**Written so far: 17 of the 66 jobs**, and from 2026-08-24 the remaining set is no longer "all of
+**Written so far: 22 of the 66 jobs**, and from 2026-08-24 the remaining set is no longer "all of
 them". Every unwritten job was measured against Google Ads keyword volume that day; the ones
 clearing 50 US searches a month became a worklist ordered by volume, and the rest are parked as
 rows on the menu with no page. A page nobody searches for is the scaled-content shape the risk
@@ -349,6 +349,18 @@ its `cost_view` carries no USD and the page labelled the dearest option on it as
 reader's own account. Free is now read off the cost's own `type`; anything else without a figure
 prints "no dollar rate published", which is what the pages say about Semrush in prose too. It was
 found by reading the rendered page, which is the argument for that step in the skill.
+
+**A trial-pool row is a fourth state, and a metered single provider is not an own-account one**
+(2026-08-25). Finnhub, Tiingo and Twelve Data are served at $0 on treg.to's own free-tier keys with
+a per-team daily allowance (`catalog.trial_pools`); `cost_view` gives them `usd == 0`, so they fell
+through to "free, your own account", and with no priced row on the page the hero and the `{cheapest}`
+placeholder said the same. `_uc_providers` now carries `trial` (calls per team per day) and the
+cell, the `.md` table, the hero and `{cheapest}` state the allowance ("free, 50 calls a day on
+treg.to's key, then your own key"). Separately, the `short` form assumed its one provider was an
+OAuth connection; the AI-mentions job has one provider, DataForSEO, and it is metered, so the form
+branches on the row's `free` flag: `metered_single` states the rate and the markup, and the meta
+description does not claim "never metered". Both were found the same way as the Semrush one: by
+reading the stock and AI-visibility pages after the tests went green.
 
 Nested under the category on purpose: the five flat ad pages keep their URLs and `build_html.py`
 ownership, and `test_legacy_flat_use_case_pages_still_answer` proves the nested route cannot shadow

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -320,13 +320,35 @@ requires `voices` and `voices_intro` together rather than requiring either.
 say it anyway. Write position-neutral ("the comparison above", "the prices here") or the sentence
 is wrong for every reader who scrolls.
 
-**Written so far: 12 of the 66 jobs.** The YouTube & video cluster (transcript, video stats, channel
-stats, search, comments) landed 2026-08-21 and is the first `compare`-form cluster where one row is
+**Written so far: 17 of the 66 jobs**, and from 2026-08-24 the remaining set is no longer "all of
+them". Every unwritten job was measured against Google Ads keyword volume that day; the ones
+clearing 50 US searches a month became a worklist ordered by volume, and the rest are parked as
+rows on the menu with no page. A page nobody searches for is the scaled-content shape the risk
+audit says to avoid, so the loop writes demand first and the remainder is a decision rather than a
+backlog.
+
+The YouTube & video cluster (transcript, video stats, channel stats, search, comments) landed
+2026-08-21 and is the first `compare`-form cluster where one row is
 free: the official Data API on the reader's own connected Google account, at $0.00 with a 10,000
 unit daily quota. The free row is deliberately excluded from the "cheapest per unit" claim, because
 `_uc_providers` only ranks rows with a truthy USD price, and a free-but-rationed row is not a
 cheaper version of a metered one. Those pages carry the quota arithmetic instead, which is what the
 research said people actually get stuck on.
+
+**A `related` card resolves by label, not inside the current category.** Four categories carry
+fewer than five jobs (advertising and market research three, e-commerce and local businesses four),
+so their pages have to point at least one of their four cards outside the category. The card used to
+look the label up in the current page's category and, on a miss, fall back to that category's anchor
+under a caption naming that category: a wrong link nothing failed on, because the test only asks
+whether the label exists somewhere on the menu. The 66 labels are unique, so `_related_link` finds
+the owner from the label alone.
+
+**A row with no dollar price is not a free row.** The price cell had one `else` branch and it read
+"free, your own account" in green. Semrush prices both SERP jobs in API units bought up front, so
+its `cost_view` carries no USD and the page labelled the dearest option on it as free on the
+reader's own account. Free is now read off the cost's own `type`; anything else without a figure
+prints "no dollar rate published", which is what the pages say about Semrush in prose too. It was
+found by reading the rendered page, which is the argument for that step in the skill.
 
 Nested under the category on purpose: the five flat ad pages keep their URLs and `build_html.py`
 ownership, and `test_legacy_flat_use_case_pages_still_answer` proves the nested route cannot shadow

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2096,3 +2096,106 @@ USE_CASE_PAGES[("seo", "keywords-a-domain-ranks-for")] = {
     "related": ("Google results for a keyword", "Keyword volume, CPC and competition",
                 "Backlink profile of a domain", "Keywords a domain bids on"),
 }
+
+USE_CASE_PAGES[("seo", "how-ai-answers-mention-your-brand")] = {
+    "label": "How AI answers mention your brand",
+    "sentence": "AI visibility tracking: how ChatGPT and Perplexity answers mention your brand, run by your agent",
+    "title": "AI visibility tracking API, from {cheapest} a check | treg.to",
+    "lede": (
+        "Every AI visibility tool sells the same loop: run a set of prompts through ChatGPT and "
+        "Perplexity, note who gets named, repeat next week. Your agent can run that loop itself. "
+        "One provider serves it through treg.to, as live answers to a prompt and as aggregated "
+        "mention metrics for a keyword or domain, priced per call from {cheapest}, with no "
+        "subscription and no dashboard to pay for."),
+    "prompt": "Using treg, run these 12 buyer prompts through ChatGPT and Perplexity, US, web search "
+              "on, and tell me for each one whether treg.to or any of Composio, Pipedream or Zapier "
+              "is named, and in what position. Show me the total price before you start.",
+    "prompt_why": [
+        ("Fix the prompt set first", "The check is only comparable week to week if the prompts do not move."),
+        ("Name the competitors", "Presence on its own says little; share of the answer against named rivals is the number."),
+        ("Ask for the price up front", "The two answer endpoints differ five times in price; the metrics call is dearer again."),
+        ("Run it more than once", "Answers vary run to run. Two passes on the same day show you the noise floor."),
+    ],
+    "result_noun": "answer",
+    "result_image": None,
+    "what_is_heading": "What is AI visibility tracking?",
+    "what_is": (
+        "AI visibility tracking is the practice of measuring whether, and how, AI answer engines "
+        "such as ChatGPT, Perplexity and Google's AI Overviews mention a brand when someone asks "
+        "the questions its buyers ask. It borrows the shape of rank tracking, a fixed prompt set "
+        "checked on a schedule, but the answers are generated rather than ranked, so the same "
+        "prompt can name different brands on different days. The tools sold under this name "
+        "charge a monthly subscription for running the prompts and charting the result; the "
+        "underlying data is a call to the model and a count."),
+    "notes": [
+        "There are two kinds of endpoint here and they answer different questions. The two live "
+        "answer endpoints send your prompt to ChatGPT or Perplexity, with web search on if you ask "
+        "for it and a country to search from, and return the answer as data for your agent to read: "
+        "that is the check. The two mention-metrics endpoints return aggregated counts of how often "
+        "a keyword or a domain appears across a platform's answers, which is the trend line. Run "
+        "the first on your prompt set and the second on your domain.",
+        "The prices are not alike. On the catalog's verified rates a Perplexity answer is about "
+        "half a cent, a ChatGPT answer about three cents, and a mention-metrics call about a dime. "
+        "A weekly run of fifty prompts on both engines is therefore under two dollars, which is the "
+        "argument against a subscription; a daily run across many domains is where the metrics "
+        "call starts to matter.",
+        "The answer is a sample, not a fact. The same prompt to the same model on the same day can "
+        "name a different set of brands, and every engine changes what it cites without notice. "
+        "Nothing on this page smooths that, and no tool that charts it can either. What the "
+        "per-call price buys you is the ability to repeat the run cheaply enough to see the noise "
+        "before you read a trend into it.",
+    ],
+    "faq": [
+        ("Is this a scrape of the ChatGPT website?",
+         "No. The provider calls the model's own API with web search enabled and returns the "
+         "answer as structured data. You choose the model name and the country to search from. "
+         "It is the same generated answer, without a browser."),
+        ("Can it tell me how to get mentioned?",
+         "No. It tells you whether you are named, in which answers, and how that count moves. "
+         "Earning the mention is a content and citation problem, and the neighbouring pages on "
+         "Google results and a domain's backlinks are the places to start on it."),
+        ("Which engines are covered?",
+         "Live answers from ChatGPT and Perplexity. The mention metrics take a platform parameter, "
+         "and the catalog's verified examples use ChatGPT and Google. Gemini and Claude are not "
+         "on this shelf today."),
+        ("Do I need a DataForSEO account?",
+         "No. treg.to serves this on its own key at the provider's rate with $0.000 markup, "
+         "metered from your team's balance. If you already have an account, register the key "
+         "and those calls are never metered."),
+    ],
+    "voices_intro": (
+        "This is the most astroturfed category on the menu: 10 of the 22 relevant posts in "
+        "August 2026 were tool launches, vendor data dumps posted twice, or a vendor's employee "
+        "asking the question their product answers. These four are people doing the job by hand."),
+    "voices": [
+        ("The check is a weekly copy-and-paste job",
+         "who's still manually prompting ChatGPT and Claude to check if their brand shows up in AI answers?",
+         "r/seogrowth, 22 points", "https://www.reddit.com/r/seogrowth/comments/1sm5t9r/whos_still_manually_prompting_chatgpt_and_claude/",
+         "This is exactly the loop an agent should own. Hand it the prompt list and the competitor "
+         "names, and it runs the set through both engines and returns a table, at a few cents a "
+         "prompt, on whatever schedule you give it."),
+        ("Nobody is sure what the method should even be",
+         "API calls on a schedule, a paid tool, something manual in a spreadsheet?",
+         "r/aeo, 16 points", "https://www.reddit.com/r/aeo/comments/1vqugjg/how_do_you_actually_track_ai_visibility_across/",
+         "The first of those three, and it is less work than it sounds. The schedule is the "
+         "agent's, the API is one call per prompt per engine, and the spreadsheet is the table it "
+         "hands back. Which prompts represent your buyers is still your judgement; no API makes "
+         "that call."),
+        ("The numbers feel made up",
+         "curious what youre actually tracking for AI citations because the methodology feels kind of made up right now",
+         "r/DigitalMarketing, 54 points", "https://www.reddit.com/r/DigitalMarketing/comments/1staemu/added_ai_citation_tracking_to_our_monthly_reports/",
+         "It is, a little, everywhere: a generated answer is a sample. The honest version of the "
+         "metric is a fixed prompt set, run more than once, with the run-to-run variance reported "
+         "next to the share. A per-call price makes the repeat runs affordable; it does not make "
+         "the engines consistent."),
+        ("Doing it yourself, the API bill ran past the estimate",
+         "I ran 1,564 real ChatGPT answers through the numbers to check if its Reddit citations actually cratered",
+         "r/aeo", "https://www.reddit.com/r/aeo/comments/1vwuthp/i_ran_1564_real_chatgpt_answers_through_the/",
+         "A self-built run with web search on, cut short at seven of ten categories when the "
+         "per-call cost overran. That is the case for seeing the price before the run: the agent "
+         "shows the total for the prompt set first, and a thousand ChatGPT answers here is a known "
+         "figure, not an estimate."),
+    ],
+    "related": ("Google results for a keyword", "Keywords a domain ranks for",
+                "Backlink profile of a domain", "Search Console: clicks, impressions and top queries"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1604,3 +1604,120 @@ USE_CASE_PAGES[("seo", "google-results-for-a-keyword")] = {
     "related": ("Keywords a domain ranks for", "Keyword volume, CPC and competition",
                 "Backlink profile of a domain", "How AI answers mention your brand"),
 }
+
+
+USE_CASE_PAGES[("advertising", "your-own-campaign-performance")] = {
+    "label": "Your own campaign performance",
+    "sentence": "Google Ads API and Meta Ads API: your own campaign numbers",
+    "title": "Google Ads API and Meta Ads API, free | treg.to",
+    "lede": (
+        "Spend, impressions, clicks and conversions for the campaigns you are already running, read "
+        "by {agent} off your own connected accounts. Both platforms are free through treg.to: you "
+        "connect once, the token stays server side, and nothing here is metered. The research behind "
+        "this page says the wall was never the endpoint. It was getting a credential in front of it."),
+    "prompt": "Using treg, pull last month's spend, impressions, clicks and conversions for every "
+              "campaign in my Google Ads and Meta Ads accounts, then tell me which three lost the "
+              "most money against a target of $40 per conversion.",
+    "prompt_why": [
+        ("Name the window", "Both take an explicit range. Ask for last month and you get last month, not lifetime to date."),
+        ("Ask for both platforms in one turn", "They are two calls, not two conversations. One turn gets you one table you can compare."),
+        ("Say which level you want", "Meta answers at account, campaign, ad set or ad. Pick one, or the totals will not mean what you think."),
+        ("Say what the answer is for", "Losing money is a judgement, not a field. Give it the threshold and it does the arithmetic."),
+    ],
+    "result_noun": "row",
+    "result_image": None,
+    "voices_intro": (
+        "From 82 Reddit and X posts read in August 2026, of which 17 were both on topic and "
+        "organic. Forty-three were dropped, including one X account that posted the same "
+        "build-it-in-Claude-Code lead magnet eighteen times. Two themes people say are the problem "
+        "here, the GAQL learning curve and rate limits, produced no organic posts at all, so this "
+        "page does not claim them."),
+    "voices": [
+        ("The wall is the credential, not the endpoint",
+         "A test developer token can only access whitelisted accounts. Move to standard access before you rely on it.",
+         "r/PPC, 50 points", "https://www.reddit.com/r/PPC/comments/1ubluzq/i_got_tired_of_logging_into_google_ads_every/",
+         "This was the largest theme in the research and it is the one thing treg.to genuinely "
+         "changes the shape of: the credential is injected server side, so it never reaches your "
+         "agent, your prompt or your repository. Be clear about what that does not do. It does not "
+         "grant you access you do not have, and a token that only sees whitelisted accounts still "
+         "only sees whitelisted accounts when the call goes through here."),
+        ("Meta can switch you off and not tell you why",
+         "I've been trying to connect my Meta Ads account to Claude via the MCP connector and I'm completely stuck.",
+         "r/FacebookAds, 7 points", "https://www.reddit.com/r/FacebookAds/comments/1t01u3w/meta_ads_mcp_connector_is_ads_mcp_enabled_false/",
+         "Worth being precise, because the reader's problem is a specific flag on Meta's own "
+         "connector rollout rather than the Marketing API. The row on this page is the ordinary "
+         "insights endpoint on your connected ad account, so that flag is not in its path. What "
+         "nobody outside Meta can tell you is why a permission is off on one portfolio and on for "
+         "another, and no proxy makes that legible."),
+        ("One account is a weekend, twenty clients is a product",
+         "I need to securely pull data from multiple client accounts, each with their own credentials and permissions.",
+         "r/claude, 2 points", "https://www.reddit.com/r/claude/comments/1t3ynsq/looking_for_developer_to_build_multi_client_api/",
+         "That is a paid job posting, which is the strongest evidence in the research that this is "
+         "real work rather than an inconvenience. Holding a credential per connection and keeping "
+         "it out of the agent is what a registry is for. Deciding which client an agent may read on "
+         "a given turn is still yours to design, and this page will not pretend otherwise."),
+        ("An agent will make the numbers up with total confidence",
+         "The only way I trust it is when it runs scripts and saves outputs.",
+         "r/PPC, 83 points", "https://www.reddit.com/r/PPC/comments/1sy40pq/my_experience_using_claude_code_codex_to_actually/",
+         "No good answer, and anyone claiming one is selling you something. Nothing here stops a "
+         "model inventing a figure. Two things do help and both are small: the platform's own "
+         "response is relayed verbatim rather than reshaped by a layer in between, and every call "
+         "is on the ledger, so the number in the answer has a call you can point at. Checking the "
+         "total against the platform's own dashboard is still worth the thirty seconds."),
+        ("The numbers move under you, and that is not going to stop",
+         "Meta deprecated Reach in the Facebook Graph API and it is breaking dashboards everywhere.",
+         "r/GoogleDataStudio, 6 points", "https://www.reddit.com/r/GoogleDataStudio/comments/1uv8e3n/meta_deprecated_reach_in_the_facebook_graph_api/",
+         "Honest answer: this is the opposite of a fix. treg.to never models an upstream API, it "
+         "relays the response as it came, so a deprecated field reaches you as a deprecated field "
+         "rather than as a mapping layer quietly returning something stale. You find out faster and "
+         "you find out truthfully. What no page can tell you is what Meta deprecates next."),
+    ],
+    "q_compare": "How do the two platforms compare?",
+    "what_is_heading": "What do these two APIs actually return?",
+    "what_is": (
+        "The reporting surface of each platform, not a copy of its dashboard. Google Ads answers a "
+        "query you write against a customer account and returns the campaign fields and metrics you "
+        "named, over the date range you named. Meta answers on an ad account and returns spend, "
+        "impressions, clicks and conversion counts at whichever level you ask for, optionally split "
+        "by day or by a breakdown. Both are read paths on accounts you already own, which is why "
+        "they carry no price."),
+    "notes": [
+        "Neither call costs money and both are rationed. Google Ads adds no per call charge and "
+        "counts the request against the developer token's daily operation limit instead, which is "
+        "15,000 operations a day on Basic access. Meta's insights call is included with the "
+        "connected account and spends that ad account's rate limit budget, and a wide breakdown "
+        "spends it fast, so ask for the split you will actually read.",
+        "The two platforms want the request in different shapes. Google Ads takes a query against a "
+        "customer id, so the fields, the metrics and the date range all travel in one string. Meta "
+        "takes the ad account in the path and everything else as parameters: fields, either a date "
+        "preset or an explicit range, the level, an optional daily increment and the breakdowns. "
+        "Your agent writes both, and the level is where a wrong answer looks right.",
+        "These two rows read, they do not spend. The capabilities behind this page are campaign "
+        "performance and insights, so an agent pointed at them can report on a budget and cannot "
+        "change one. If you want an agent that also edits campaigns, that is a different set of "
+        "capabilities and a separate decision to make on purpose.",
+    ],
+    "faq": [
+        ("Does this cost anything?",
+         "No. Both rows run on accounts you already own, so treg.to relays the call and meters "
+         "nothing, and the price shown before the call is zero. The provider's rate is the "
+         "provider's rate with $0.000 added, and here the provider's rate is nothing."),
+        ("Do I still need API access from Google and Meta?",
+         "Yes. treg.to holds the credential server side so it never reaches your agent, and it does "
+         "not stand between you and each platform's own access rules. A test developer token still "
+         "sees only the accounts it was whitelisted for, and a Meta permission you were not granted "
+         "is still not granted when the call arrives through here."),
+        ("Which numbers come back?",
+         "Spend, impressions, clicks and conversions at minimum. Meta will split them by day and by "
+         "the breakdown you ask for, at account, campaign, ad set or ad level. Google Ads returns "
+         "whichever campaign fields and metrics your query names, so the shape is yours to choose "
+         "rather than fixed."),
+        ("Can the agent change my campaigns?",
+         "Not through this page. Both capabilities behind it are read paths, so the worst an agent "
+         "can do here is read your numbers and be wrong about them. Changing a budget or pausing an "
+         "ad is a different capability and you would be asking for it deliberately."),
+    ],
+    "related": ("Ads a competitor is running now", "Keywords a domain bids on",
+                "Google Ads: the search terms triggering your ads",
+                "Search Console: clicks, impressions and top queries"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1481,3 +1481,126 @@ USE_CASE_PAGES[("youtube-video", "a-video-s-comments")] = {
     "related": ("Get a video's transcript", "Video details, views and stats",
                 "Mine the comments", "A channel's profile and lifetime stats"),
 }
+
+
+USE_CASE_PAGES[("seo", "google-results-for-a-keyword")] = {
+    "label": "Google results for a keyword",
+    "sentence": "SERP API: Google organic results for a keyword",
+    "title": "SERP API: {n} providers compared, from {cheapest} | treg.to",
+    "lede": (
+        "Send a keyword, get Google's organic results back as data: the ranking URLs in order, with "
+        "their titles and snippets. {n} providers do this through one treg.to key, from {cheapest} a "
+        "call, billed from a prepaid balance instead of a monthly plan. What you are really choosing "
+        "between is the billing unit, how deep each one goes, and how much of the page beyond ten "
+        "blue links it can see."),
+    "prompt": "Using treg, get the top 10 Google organic results for best crm for startups in the "
+              "United States, in English. Show me the price first, then list the ranking domains "
+              "with their titles.",
+    "prompt_why": [
+        ("Give it the keyword, not a URL", "These take a query the way a person types it. Keep multi-word phrases together."),
+        ("Say where and in what language", "A result set is location specific. Leave it out and you get whichever default the provider picked."),
+        ("Say how deep to go", "Depth is the cost dial on every row here: ten results is one unit of work, a hundred is ten."),
+        ("Ask for the price first", "treg.to returns the cost before the call, so the agent can say what it will spend."),
+    ],
+    "result_noun": "result",
+    "result_image": None,
+    "voices_intro": (
+        "From roughly 180 Reddit and X posts read in August 2026. The X half was almost entirely "
+        "promotion; Reddit carried the signal, and thirteen posts from four confirmed vendor rings "
+        "were excluded, including one account running the same question through three scraping "
+        "subreddits with a different persona each time. These five are organic."),
+    "voices": [
+        ("An agent search API and a SERP API are not the same product",
+         "My current take is that most “search APIs” are really context providers for LLM grounding.",
+         "r/AI_Agents, 2 points", "https://www.reddit.com/r/AI_Agents/comments/1urn878/highrecall_web_search_apis_for_agent_data/",
+         "This was the most useful distinction in the whole research pass, and it decides whether "
+         "this page is for you. Tools that return cleaned passages for a model to read are solving "
+         "grounding. The rows here return the result set itself, in order, with the domains that "
+         "hold each position. If you need to know who ranks where, cleaned context will not tell "
+         "you, and if you only need something true to quote, you are overpaying here."),
+        ("There is no pay as you go, and that is the objection",
+         "What bothers me mostly is that there's no pay-as-yo-go option for SerpAPI or Firecrawl as far as I can tell.",
+         "r/TypingMind, 3 points", "https://www.reddit.com/r/TypingMind/comments/1qri4jd/help_needed_customization_of_typingmind_deep/",
+         "The complaint that came up most often was about the shape of the bill rather than the "
+         "size of it: a monthly plan is the wrong instrument for someone running twenty searches a "
+         "day. Every row here is charged per call from a prepaid balance, at the provider's own "
+         "rate with nothing added, so the honest counterpoint is that at that volume the price "
+         "differences between providers are noise and the real cost is your setup time."),
+        ("Google stopped serving a hundred results on one page",
+         "The removal created a 10x increase in the workload for data collection.",
+         "r/AgentsOfAI, 204 points", "https://www.reddit.com/r/AgentsOfAI/comments/1nxut66/google_trying_to_retain_its_search_engine_monopoly/",
+         "This is the single best explanation of why a cheap looking per search rate can still "
+         "surprise you. When one fetch stopped returning a hundred results, reading the top hundred "
+         "became ten fetches, and every provider passes that through somewhere: as depth billed in "
+         "tens, as rows, or as ten separate searches. Read the unit column above before the price "
+         "column."),
+        ("The free tier runs out before the project starts",
+         "APIs like SerpAPI have pretty limited free tiers, so I'm looking into alternative ways to handle search without running into those limits.",
+         "r/Playwright, 2 points", "https://www.reddit.com/r/Playwright/comments/1u8h42h/google_search_using_playwright/",
+         "A new treg.to team starts with a dollar of prepaid balance and no card, which at these "
+         "rates is hundreds of searches rather than a fortnight of a trial. What that does not buy "
+         "you is a decision: the same dollar spread across three of these providers on your own "
+         "queries is a better answer than any table, and it is the experiment this page would "
+         "rather you ran."),
+        ("Every thread on this question is full of vendors",
+         "please be understandable and provide your take, examples and opinion, not just straight up promo bs",
+         "r/ProxyEngineering, 10 points", "https://www.reddit.com/r/ProxyEngineering/comments/1vrjmy7/what_are_some_good_serpapi_alternatives/",
+         "This page is one of those threads, so the only decent thing it can do is show its working. "
+         "Every price above is read from the provider's own rate card or documentation on the date "
+         "in the row, where a provider publishes no dollar price the row says so rather than "
+         "guessing, and any reliability figure comes from live treg.to traffic rather than a "
+         "benchmark we designed. What no comparison can tell you is which of these companies still "
+         "exists in eighteen months. Nobody selling you a table knows that either."),
+    ],
+    "q_cheapest": "Which SERP API is cheapest?",
+    "q_reliable": "Which SERP API is the most reliable?",
+    "q_compare": "How do the SERP APIs compare?",
+    "what_is_heading": "What is a SERP API?",
+    "what_is": (
+        "A SERP API returns what Google returns for one query, already parsed: the organic results "
+        "in order, with titles, URLs and snippets. You are not renting an index, you are paying for "
+        "one search run somewhere else on the parameters you send. That is why it is priced per "
+        "search rather than per month, and why the parameters that change what a person would have "
+        "seen, the location, the language, the device and how far down the page you go, are also "
+        "the parameters that change what you are billed."),
+    "notes": [
+        "The billing unit is not the same across these rows, so the cheapest number is not the "
+        "cheapest provider for your job. DataForSEO charges a flat rate per request but bills depth "
+        "in tens of results, and multiplies the price by five if you use advanced search operators. "
+        "Serpstat bills one credit per returned row and still bills the one credit minimum when the "
+        "result is empty. SerpApi bills per successful search and charges nothing for a failure or "
+        "for a repeat it serves from cache.",
+        "Semrush shows no dollar price here on purpose. It prices in API units, ten per line "
+        "returned, bought in packages up front, so a full top hundred pull is a thousand units and "
+        "what that costs depends on the package you bought rather than on a public per call rate. "
+        "The comparison prints a price only where the provider publishes one.",
+        "SerpApi appears in the catalog twice and the difference matters. Its light endpoint returns "
+        "a trimmed, faster payload for when you only want the ranking URLs, while its full endpoint "
+        "accepts the whole parameter surface, including an explicit location or coordinates, device, "
+        "the search vertical and a starting offset, which is what you need for city level results or "
+        "for anything past the first page.",
+    ],
+    "faq": [
+        ("How much does one Google search cost?",
+         "The provider's own rate with $0.000 added by treg.to, taken from a prepaid balance rather "
+         "than a subscription. The live figure per provider is in the comparison above, and the "
+         "units differ: one row bills the request, one bills each returned row, one bills only the "
+         "searches that succeed."),
+        ("Is this the same as Tavily, Exa or Firecrawl?",
+         "No, and conflating the two is the commonest mistake in the research behind this page. "
+         "Those return cleaned text for a model to read. These return the Google result set itself, "
+         "in position order, with the domains holding each slot. If the question is who ranks, you "
+         "need this kind; if the question is what is true, you probably do not."),
+        ("Why does reading the top 100 cost more than it used to?",
+         "Because Google stopped serving a hundred results on a single page, so what was one fetch "
+         "became ten. Providers pass that through as depth, as rows, or as separate searches, which "
+         "is why the depth or size parameter is the real cost dial on every row here."),
+        ("Can I get results for one city rather than the whole country?",
+         "Yes, on the rows that take it. SerpApi accepts a location string or explicit coordinates "
+         "with a radius, and DataForSEO accepts a location code or name. A national result set is "
+         "not a local one, so if you are checking a local pack you have to say where you are "
+         "standing."),
+    ],
+    "related": ("Keywords a domain ranks for", "Keyword volume, CPC and competition",
+                "Backlink profile of a domain", "How AI answers mention your brand"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1843,3 +1843,126 @@ USE_CASE_PAGES[("e-commerce", "amazon-product-detail-by-asin")] = {
     "related": ("Amazon search and best sellers", "TikTok Shop products and reviews",
                 "App store search", "Product reviews"),
 }
+
+
+USE_CASE_PAGES[("local-businesses-reviews", "find-local-businesses-by-keyword-and-location")] = {
+    "label": "Find local businesses by keyword and location",
+    "sentence": "Yelp API and Tripadvisor API: local businesses by keyword",
+    "title": "Yelp API and Tripadvisor API, from {cheapest} | treg.to",
+    "lede": (
+        "Ask for a kind of business and a place, and get the listings back as data: names, ratings, "
+        "review counts, addresses and categories. Two sources through one treg.to key, from "
+        "{cheapest} a call, with no Yelp or Tripadvisor developer programme to be admitted to "
+        "first. They are different listings rather than two copies of one, so the comparison below "
+        "groups them rather than ranking them against each other."),
+    "prompt": "Using treg, find ramen restaurants in Austin, Texas on Yelp and on Tripadvisor. Show "
+              "me the price first, then give me one list with each place's name, rating, review "
+              "count and address.",
+    "prompt_why": [
+        ("Give the thing and the place separately", "Both sources take a description and a location as two fields. One blob of text resolves badly."),
+        ("Name the city and the state", "The commonest empty result on this job is a location string neither source recognises."),
+        ("Say which source you want", "Yelp and Tripadvisor hold different businesses. Ask for both and you get both, side by side."),
+        ("Ask for the price first", "treg.to returns the cost before the call, so the agent can say what it will spend."),
+    ],
+    "result_noun": "business",
+    "result_image": None,
+    "voices_intro": (
+        "From roughly 200 Reddit and X posts read in August 2026, with eleven vendor items "
+        "excluded, among them three accounts seeding the same Google Maps scraper across three "
+        "subreddits with the same story about a family member's small business. One finding is "
+        "worth stating before the quotes: nobody in the organic posts says Yelp has closed its API "
+        "programme, so this page does not say it either. The pain people actually report is "
+        "different and more mundane."),
+    "voices": [
+        ("It works in Postman and dies in the application",
+         "my call is successful in postman but I'm experiencing this error when making the call locally from the app",
+         "r/Angular2, 2 points", "https://www.reddit.com/r/Angular2/comments/7ns9gv/experiencing_403_when_making_get_call_to_yelp_api/",
+         "This shape recurred six times in the research and it is the one theme this page can "
+         "honestly own. The key is fine and the request is fine; what is wrong is where the call "
+         "came from, usually a browser preflight or a key that ended up inside a front end bundle. "
+         "A call through treg.to leaves a server with the credential injected there, so that class "
+         "of failure stops existing. It will not rescue you from a parameter the source rejects."),
+        ("A thousand results is the ceiling, and no proxy raises it",
+         "don't expect to pull more than 1,000 results as the Yelp Fusion API has a hard limitation in that regard",
+         "r/learnpython, 7 points", "https://www.reddit.com/r/learnpython/comments/92hcf7/how_to_loop_api_call_requests_yelp_fusion/",
+         "No good answer, and it would be dishonest to imply otherwise. A ceiling on a source is a "
+         "property of the source; buying the call from someone else does not lift it. The only "
+         "thing that actually works is fanning the question out, splitting a metro into its "
+         "suburbs and a trade into its categories, and paying per call for each slice. That is a "
+         "loop your agent can run and it is why the per call price matters more than it looks."),
+        ("Nobody reads the content rights until something makes them",
+         "I got to the Content rights part and hadn't looked into what rights I actually need for that information.",
+         "r/webdev, 3 points", "https://www.reddit.com/r/webdev/comments/1jekz4a/yelp_fusion_api_as_third_party_info_rights/",
+         "Also no good answer, and the place where a page like this is most tempted to be vague. "
+         "Having a credential injected for you changes who holds a key. It does not change who is "
+         "bound by the source's terms, which is still you, and a listing you pull here is still "
+         "Yelp's or Tripadvisor's content. If the plan is to republish it, that is a question for "
+         "their terms and not for a price table."),
+        ("Tripadvisor will not let you build on localhost",
+         "But problem is tripadvisor api does not allow to type localhost:3000.",
+         "r/node, 5 points", "https://www.reddit.com/r/node/comments/14hvtrp/how_do_i_allow_localhost3000_whem_i_am_using/",
+         "A narrow but real win. Tripadvisor's own programme issues keys tied to a domain, which is "
+         "exactly the thing a laptop does not have, and the thread underneath is people inventing "
+         "workarounds for it. The row here does not use that key at all, so there is nothing to "
+         "restrict and nothing to register before you can try it from your own machine."),
+        ("Most people already left for Google Maps, and it stops at the front desk",
+         "The issue I’m running into is that most tools (Google Maps, etc.) only give me the public front-desk phone number.",
+         "r/ClaudeCowork, 8 points", "https://www.reddit.com/r/ClaudeCowork/comments/1uxezdz/what_are_you_using_to_scrape_local_business/",
+         "The loudest theme in the whole research, so it deserves a straight answer rather than a "
+         "deflection. If Google Maps is the source you want, this page is not it: treg.to has no "
+         "Places keyword search on the menu today, and the Google rows it does have for local are "
+         "for a Business Profile you already own. On the second half, no listings source anywhere "
+         "carries the owner's address, because the listing does not have one. Getting past the "
+         "front desk is a second step against the business's own site, and it is the step with a "
+         "hard floor."),
+    ],
+    "q_compare": "How do the two sources compare?",
+    "what_is_heading": "What does a local business search return?",
+    "what_is": (
+        "A page of listings for one kind of business in one place, as data: the name, the rating "
+        "and how many reviews it is averaged over, the address, the categories the source files it "
+        "under, and its own page on that source. It is a directory lookup, not a lead list. "
+        "Nothing here is scored, deduplicated across sources or checked against a company register, "
+        "and the two sources will disagree about which businesses exist because they hold different "
+        "directories."),
+    "notes": [
+        "The two rows work differently, and one of them is not a single round trip. SerpApi reads "
+        "Yelp's own results page from a description and a location and answers immediately. "
+        "DataForSEO posts an asynchronous task against Tripadvisor which you collect afterwards, so "
+        "that side is two calls with a wait in between. Tell the agent to expect it rather than to "
+        "treat the empty first response as a failure.",
+        "Location is where this job fails quietly rather than loudly. DataForSEO takes a location "
+        "name or a numeric location code and will return a perfectly valid answer for the wrong "
+        "market if the code is not the one you meant. SerpApi takes free text, which is forgiving "
+        "until two places share a name. Give both the city and the state and check the first "
+        "result's address before you loop over three hundred queries.",
+        "Neither row makes you a Yelp or Tripadvisor developer, and neither changes whose content "
+        "it is. There is no Fusion key to be approved for and no domain restricted Tripadvisor key "
+        "to register, which removes the step people in the research got stuck on. What does not "
+        "move is the licence: the listings belong to Yelp and to Tripadvisor, and their terms bind "
+        "whoever republishes them, credential injection or not.",
+    ],
+    "faq": [
+        ("How much does one local business search cost?",
+         "The provider's own rate with $0.000 added by treg.to, from a prepaid balance rather than a "
+         "plan. The two sources are priced differently and are billed in different units, so the "
+         "comparison above gives each one separately rather than a single headline number."),
+        ("Is this the Yelp Fusion API?",
+         "No. The Yelp row reads Yelp's public results page for a description and a location, so "
+         "there is no Fusion key, no application and no approval to wait for. It also means you get "
+         "what the results page shows rather than the Fusion field set, and that Yelp's terms still "
+         "govern what you may do with the listings."),
+        ("Can I search Google Maps or Google Business Profile this way?",
+         "Not from this page. treg.to has no Google Places keyword search in the catalog today, and "
+         "the Google rows it does carry for local businesses read a Business Profile you already "
+         "own, on your own connected account. If Maps is the source you need, this job cannot serve "
+         "it and saying so is more useful than a near miss."),
+        ("Will I get the owner's email address?",
+         "No, and no listings source will. A directory entry carries the business's public contact "
+         "details, which in practice means the front desk. Going further means visiting each "
+         "business's own site and verifying what you find there, which is a separate job with its "
+         "own failure rate rather than a field you can ask for here."),
+    ],
+    "related": ("A business's reviews", "Hotel listing details", "Product reviews",
+                "Your Google Business Profile reviews, and reply to them"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1966,3 +1966,130 @@ USE_CASE_PAGES[("local-businesses-reviews", "find-local-businesses-by-keyword-an
     "related": ("A business's reviews", "Hotel listing details", "Product reviews",
                 "Your Google Business Profile reviews, and reply to them"),
 }
+
+
+USE_CASE_PAGES[("seo", "keywords-a-domain-ranks-for")] = {
+    "label": "Keywords a domain ranks for",
+    "sentence": "Rank tracking API: the keywords a domain ranks for",
+    "title": "Rank tracking API: {n} providers from {cheapest} | treg.to",
+    "lede": (
+        "Ask for a domain and get the keywords it already ranks for in Google, with the position it "
+        "holds and the volume behind each one. {n} providers do this through one treg.to key, from "
+        "{cheapest} a call, billed per call from a prepaid balance rather than an annual seat. It "
+        "works on any domain, which is exactly the question your own Search Console cannot answer."),
+    "prompt": "Using treg, get the top 200 keywords stripe.com ranks for in Google in the United "
+              "States, with position and monthly volume. Show me the price first, then group them "
+              "by position band.",
+    "prompt_why": [
+        ("Name the domain and the market", "A domain ranks differently in each country's index. Say which one, or you get the provider's default."),
+        ("Say how many keywords you want", "Row count is the cost dial on most of these rows. A limit you chose beats a default you did not."),
+        ("Ask for position and volume together", "Both arrive in the same row. Asking for them separately is two calls for one answer."),
+        ("Ask for the price first", "treg.to returns the cost before the call, so the agent can say what it will spend."),
+    ],
+    "result_noun": "keyword",
+    "result_image": None,
+    "voices_intro": (
+        "From eight searches across Reddit and X in August 2026, of which only about 13 posts were "
+        "both on topic and organic. Thirteen more were a single coordinated cluster promoting one "
+        "vendor across three small subreddits, seeding the question in one and answering it in "
+        "another, with non-breaking spaces left mid-sentence in the bodies. SEO is the most "
+        "astroturfed category this loop has researched, so the surviving posts are quoted and the "
+        "rest are only counted."),
+    "voices": [
+        ("The number people quote is the API tier, not the subscription",
+         "Don't really want to drop $14K to have access to the ahrefs API, so I'm hoping there are other, high-quality options",
+         "r/bigseo, 1 point", "https://www.reddit.com/r/bigseo/comments/1fyki5o/if_i_want_to_identify_ranking_keywords_for_a/",
+         "Worth quoting and then correcting, because the correction is the useful part. That figure "
+         "is an old enterprise tier and the research found it has since moved, so check the vendor's "
+         "current page rather than a thread. Then apply the same suspicion here: every price in the "
+         "comparison above carries the date it was read off the provider's own rate card or "
+         "documentation, because a price without a date is the thing that misled this reader."),
+        ("A subscription is the wrong instrument for uneven work",
+         "Semrush starts at $120/month. Ahrefs is up there too. For a bootstrapped operation that's a real cost",
+         "r/DigitalMarketing, 82 points", "https://www.reddit.com/r/DigitalMarketing/comments/1shurkl/replaced_semrush_with_the_gemini_api_and_search/",
+         "The objection in the research was almost never the total, it was the variance: a flat "
+         "monthly fee prices the quiet months wrong, and this work arrives in bursts. Every row "
+         "here is per call from a prepaid balance with no minimum and no commitment. The honest "
+         "trade is that you get an index and a raw response rather than a curated keyword universe "
+         "with a difficulty score on top, and the difference is your own development time."),
+        ("The databases disagree with each other and with your browser",
+         "Sometimes it works perfectly, other times it gives a completely different result to what we see if we visit Google in the browser",
+         "r/SEO, 7 points", "https://www.reddit.com/r/SEO/comments/1t8s9wq/rank_tracking_for_localised_results/",
+         "No comparison table can tell you whose index is right, and this one will not pretend to. "
+         "Nobody publishes a methodology, every accuracy claim is made by the vendor selling it, "
+         "and the phrase keywords a domain ranks for means a different keyword universe at each "
+         "provider before you compare a single position. The only honest offer is a procedure: run "
+         "the same fifty keywords through two of these for a week, diff both against your own "
+         "Search Console, and keep the one whose error is stable rather than the one whose number "
+         "is highest. At these prices that experiment costs less than a coffee."),
+        ("The people asking are already writing the script",
+         "I wanted to do some keyword research yesterday and was surprised by how expensive Ahrefs / Semrush were.",
+         "r/TechSEO, 36 points", "https://www.reddit.com/r/TechSEO/comments/1r7qifp/open_source_seo_tool_that_uses_your_own/",
+         "This post ends in an open source interface over a raw data API, and it was the most "
+         "common constructive answer in the research by some distance. That audience does not need "
+         "a feature grid, it needs the call, the response shape and the real per call price, which "
+         "is what the comparison above and the runnable call under it are for. The part nobody "
+         "warns them about is the unit: two of these rows bill the request and two bill the row."),
+        ("Ask for traffic and you may be handed a model's opinion",
+         "Tried DataForSEO but couldn't get the traffic endpoint working properly - they provide estimated traffic value instead of traffic.",
+         "r/Agentic_SEO, 12 points", "https://www.reddit.com/r/Agentic_SEO/comments/1u6avvw/any_cheap_api_for_url_traffic_estimates/",
+         "Fair criticism of a provider on this very page, and it generalises past that provider. "
+         "Position is close to observable, since somebody looked at a result page. Volume and "
+         "traffic are not: every vendor here derives them, none of them measures them, and the "
+         "numbers differ because the models differ. Treat position as data and traffic as an "
+         "opinion with a price on it, and the disagreements stop being surprising."),
+    ],
+    "q_cheapest": "Which ranked keywords API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What is in a ranked keywords pull?",
+    "what_is": (
+        "One row per keyword the domain appears for in the provider's index of Google: the keyword, "
+        "the position it holds, the search volume behind it and usually a cost per click and a "
+        "landing URL. It is a snapshot taken from an index that vendor already maintains, not a "
+        "live search run for you, which is why it can return thousands of rows for the price of one "
+        "request and why two vendors will hand you different lists for the same domain."),
+    "notes": [
+        "The billing unit changes per row and it changes which one is cheapest for you. DataForSEO "
+        "charges per request plus a fraction of a cent for each keyword returned. SE Ranking charges "
+        "a flat hundred credits per request and nothing per record, so one page of a thousand rows "
+        "costs a fraction of ten pages of a hundred. Serpstat charges a credit per keyword and bills "
+        "its one credit minimum even when nothing comes back. Read the unit column before the price "
+        "column.",
+        "SpyFu's figure here is the top of a published band rather than a quoted rate. Its pricing "
+        "table gives a range per thousand rows across the research endpoints and does not say which "
+        "tier this one sits in, so the catalog carries the upper bound instead of guessing low. Read "
+        "that row as a ceiling and the others as rates. Its page size also defaults to five, so set "
+        "it explicitly or the call returns almost nothing.",
+        "Semrush shows no dollar figure, and that is the honest thing to print. It bills in API "
+        "units bought in packages up front, ten per line returned, so what a pull costs depends on "
+        "the package you hold rather than on any public per call rate. A default request there "
+        "returns ten thousand lines, which is a hundred thousand units, so send a display limit "
+        "before you send anything else.",
+    ],
+    "faq": [
+        ("Is this rank tracking?",
+         "Not in the sense of a tracker you configure and leave running. These return the keywords a "
+         "domain ranks for right now, from each vendor's index, in one call. Nothing here schedules "
+         "itself, keeps a history for you or alerts you to a drop; if you want positions over time "
+         "you run the call on your own schedule and store the results. treg.to has no scheduled rank "
+         "tracker on the menu, and saying so is more useful than a near miss."),
+        ("How much does one domain pull cost?",
+         "A cent or two per request on the rows that bill the request, and a fraction of a cent per "
+         "keyword on the rows that bill the row, at the provider's own rate with $0.000 added by "
+         "treg.to. The comparison above prints both, and which is cheaper depends entirely on how "
+         "many keywords you ask for."),
+        ("Why do the providers disagree about the same domain?",
+         "Because each one is answering from its own index, built by its own crawl on its own "
+         "schedule, and the phrase keywords a domain ranks for is a keyword universe that differs "
+         "before a single position is compared. No table settles this. Running two of them against "
+         "your own Search Console for a week does."),
+        ("Can I do this for a competitor's domain?",
+         "Yes, and that is the point. Search Console is ground truth for sites you own and silent "
+         "about everybody else, so a competitor's ranked keywords have no first party source at all. "
+         "The target is just a domain on every row here, which is why this job exists as something "
+         "you pay for."),
+    ],
+    "related": ("Google results for a keyword", "Keyword volume, CPC and competition",
+                "Backlink profile of a domain", "Keywords a domain bids on"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2199,3 +2199,91 @@ USE_CASE_PAGES[("seo", "how-ai-answers-mention-your-brand")] = {
     "related": ("Google results for a keyword", "Keywords a domain ranks for",
                 "Backlink profile of a domain", "Search Console: clicks, impressions and top queries"),
 }
+
+USE_CASE_PAGES[("connect-your-own-accounts", "your-google-business-profile-reviews-and-reply-to-them")] = {
+    "label": "Your Google Business Profile reviews, and reply to them",
+    "sentence": "Google Business Profile API: your Google reviews, read and replied to by your agent",
+    "title": "Google Business Profile API: read and reply to reviews | treg.to",
+    "lede": (
+        "Connect the Google Business Profile you already manage and your agent can read every "
+        "review on every location, and reply as the business. This is the Google My Business API "
+        "as it is now called, on your own account, so treg.to never meters it; and the API access "
+        "request that stops most people at zero quota is one treg.to has already made."),
+    "prompt": "Using treg, list every review on our Austin location from the last 30 days with three "
+              "stars or fewer, draft a reply to each in our voice, and post them only after I approve.",
+    "prompt_why": [
+        ("Connect once", "One consent screen for the Google account that manages the listing. No Cloud project of your own."),
+        ("Name the location", "A profile holds many locations; the reviews call is per location, or batched across them."),
+        ("Keep a human gate on replies", "A reply publishes under the business name. Ask for drafts, then approve."),
+        ("It costs nothing", "Your own account, so the call is never metered."),
+    ],
+    "result_image": None,
+    "what_is_heading": "What is the Google Business Profile API?",
+    "what_is": (
+        "The Google Business Profile API, formerly the Google My Business API, is how a business "
+        "reads and manages its own listings on Google Search and Maps as data: locations, hours, "
+        "posts, performance, and the customer reviews with their star rating, text and date, plus "
+        "the reply the business has posted to each. It is scoped to listings the connected account "
+        "owns or manages. It is not a way to read another business's reviews; that is a separate "
+        "job on the menu."),
+    "notes": [
+        "The gate on this API is not the OAuth scope, it is the access request. Google starts every "
+        "Cloud project at zero requests a day on the Business Profile API until it approves the "
+        "project, and that is the wall in most of the forum posts. The request belongs to the "
+        "project making the call, and that project is treg.to's: you consent, you do not apply.",
+        "Reviews still live on the older v4 surface while the rest of the profile moved to the v1 "
+        "services, so the review calls take an account id and a location id rather than a resource "
+        "name. Your agent lists accounts first, then locations, then reviews; a batch endpoint "
+        "reads reviews across several locations in one call.",
+        "Replying is an action, not a read. The reply publishes publicly under the business name, "
+        "it can be edited or deleted later through the same API, and a reply signals to Google that "
+        "the review is a real customer's. Ask the agent to draft, and to flag anything that reads "
+        "like a policy violation before you answer it rather than after.",
+    ],
+    "faq": [
+        ("Does this cost anything?",
+         "No. The Business Profile API runs on your own Google account, so treg.to relays the call "
+         "and meters nothing. Only calls on treg.to's own provider keys are billed."),
+        ("Do I need to apply for Google Business Profile API access?",
+         "No. Google grants that access to the Cloud project making the calls, and treg.to holds "
+         "the approved app. You need to be an owner or manager of the listing, and to consent once."),
+        ("Can my agent read a competitor's reviews this way?",
+         "No. The API returns only the listings your connected account manages. Reading any "
+         "business's public reviews is the neighbouring job, served by scraping providers."),
+        ("Does it work across several locations?",
+         "Yes. The reviews call is per location, and there is a batch call that reads reviews "
+         "across several of your listings at once. The agent lists your locations first."),
+    ],
+    "voices_intro": (
+        "The Google Business Profile subreddits are a queue of people waiting on Google. From ~40 "
+        "Reddit and X posts in August 2026, ten were vendors selling reply tools, including one "
+        "study posted word for word to two subreddits. These four are people stuck at the door."),
+    "voices": [
+        ("The access request gets rejected, even when you follow the rules",
+         "GBP API access rejected even though I followed their \"client account\" rule?",
+         "r/GoogleMyBusiness", "https://www.reddit.com/r/GoogleMyBusiness/comments/1sx6686/gbp_api_access_rejected_even_though_i_followed/",
+         "The request is judged per Cloud project, and it is opaque: several posters waited weeks "
+         "with no reply at all. That is the part treg.to takes off the table. You are consenting "
+         "to an app that already has access, not applying for your own."),
+        ("Approved, and the quota is still zero",
+         "I'm currently stuck with the Google Business Profile API where the quota is set to 0 and the API is basically unusable.",
+         "r/localseo", "https://www.reddit.com/r/localseo/comments/1r64f1s/google_business_profile_api_quota_stuck_at_0_has/",
+         "Zero is the default for every new project and the quota bump is a second request. Both "
+         "belong to the project, not the user, which is why a hosted connection helps here and a "
+         "tutorial does not."),
+        ("It only ever shows you your own listing",
+         "Google's own APIs will hand you your own listing and nothing else.",
+         "r/n8n", "https://www.reddit.com/r/n8n/comments/1vms0uu/i_built_a_free_template_that_logs_every/",
+         "True, and this page will not pretend otherwise. This job is your reviews; a competitor's "
+         "public reviews are the neighbouring job, on Yelp, TripAdvisor and Trustpilot, and the "
+         "local pack comes through the SERP providers."),
+        ("Replying to a bad review can make it harder to remove",
+         "if you reply to the review, it treats it as a real customer, making it harder to get it taken down.",
+         "X, 142 likes", "https://x.com/i/status/2090034289811288369",
+         "One reason to keep the reply step behind your approval. Have the agent read each new "
+         "review against Google's review policy first and flag the ones worth reporting, then reply "
+         "to the rest."),
+    ],
+    "related": ("A business's reviews", "Find local businesses by keyword and location",
+                "Search terms that surfaced your listing on Maps", "Search Console: clicks, impressions and top queries"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2380,3 +2380,97 @@ USE_CASE_PAGES[("local-businesses-reviews", "a-business-s-reviews")] = {
                 "Your Google Business Profile reviews, and reply to them",
                 "Product reviews", "Hotel listing details"),
 }
+
+USE_CASE_PAGES[("connect-your-own-accounts", "google-analytics-traffic-and-behaviour-reports")] = {
+    "label": "Google Analytics: traffic and behaviour reports",
+    "sentence": "Google Analytics MCP or API: GA4 traffic and behaviour reports, read by your agent",
+    "title": "Google Analytics API for {agent}: any GA4 report | treg.to",
+    "lede": (
+        "Connect the GA4 property you already own and your agent can run any report the Data API "
+        "can: sessions, users, conversions and events by channel, page, country, device or date, "
+        "with filters and ordering, in plain words. It is the Google Analytics API without the "
+        "Cloud project, and it runs on your own Google account, so treg.to never meters it."),
+    "prompt": "Using treg, show me sessions and key events by default channel group for the last "
+              "28 days ending 3 days ago, next to the 28 days before, and flag any channel that is "
+              "down by more than a fifth.",
+    "prompt_why": [
+        ("Connect once", "One consent screen for the Google account that can see the property. No Cloud project, no service account."),
+        ("Name the property, or let it list them", "A Google account often sees several GA4 properties. The agent can list them and ask."),
+        ("End the window a few days back", "GA4 keeps processing recent days. A window that ends on yesterday is still settling."),
+        ("It costs nothing", "Your own account, so the call is never metered."),
+    ],
+    "result_image": None,
+    "what_is_heading": "What is the Google Analytics API?",
+    "what_is": (
+        "The Google Analytics Data API is the programmatic side of GA4: you send a property id, a "
+        "date range, dimensions, metrics and optional filters, and it returns the rows the UI's "
+        "Reports and Explore views are built from. It is the same data with none of the Explore "
+        "date-range or sampling-pool caps, and the reason to read it through an agent is that "
+        "the request body, with its dimension and metric names, is fiddly to write and easy to "
+        "get subtly wrong by hand."),
+    "notes": [
+        "The official path to an agent on GA4 is Google's own Analytics MCP server, and its setup "
+        "is a Cloud project, a service account with the API enabled, and admin-level access on "
+        "the property. Here the app is treg.to's, the consent is one screen, and read access on "
+        "the property is enough, which is what makes it usable by a consultant who does not own "
+        "the account.",
+        "Totals move with the dimensions you ask for, and that is GA4, not the relay. A metric "
+        "scoped by session counts differently once you break it down by an event-scoped "
+        "dimension, and the API returns exactly what the UI would for the same request. When the "
+        "number disagrees with the report you remember, ask the agent to run both shapes and "
+        "show the request, rather than assuming one is wrong.",
+        "The API can only return what the property retains. GA4 keeps event-level data for two "
+        "months by default, so a year-on-year or cohort question beyond that window comes back "
+        "empty from the API exactly as it does from Explore. The Data API also enforces per "
+        "property token quotas per hour and per day, so a wide report with many dimension "
+        "combinations is dearer in quota than a narrow one, and the agent should ask before "
+        "running a loop over every page.",
+    ],
+    "faq": [
+        ("Does this cost anything?",
+         "No. Google Analytics runs on your own Google account, so treg.to relays the call and "
+         "meters nothing. Only calls on treg.to's own provider keys are billed."),
+        ("Do I need a Cloud project or a service account?",
+         "No. treg.to holds the Google app; you consent once with the account that can see the "
+         "property, and treg.to keeps the token server side. Your agent never sees it."),
+        ("Which reports can it run?",
+         "Anything runReport accepts: any combination of dimensions and metrics, date ranges, "
+         "filters, ordering and paging. Realtime visitors are a separate call, on the "
+         "neighbouring row of the menu."),
+        ("Will it fix numbers that look wrong?",
+         "No. If the tagging or consent setup is feeding GA4 the wrong events, the API returns "
+         "the same wrong numbers. The agent can show you the request it made, which is the first "
+         "step in finding out why."),
+    ],
+    "voices_intro": (
+        "Around 34 of the ~75 relevant posts in August 2026 were launches of one more GA4 MCP or "
+        "dashboard, several posted word for word across five subreddits. These four are people "
+        "asking for the thing rather than selling it."),
+    "voices": [
+        ("People are asking for exactly this, by name",
+         "What AI agent tools can I use to connect to the Google Analytics API and retrieve data through a chat-based conversational interface",
+         "r/GoogleAnalytics, 17 points", "https://www.reddit.com/r/GoogleAnalytics/comments/1vpw1m9/what_ai_agent_tools_can_i_use_to_connect_to_the/",
+         "Any of them, once the agent can reach a connected property. That is what the setup line "
+         "on this page does: the agent gets the report call and the token stays with treg.to."),
+        ("Writing the API call by hand fails, even with help",
+         "I asked 6 LLMs for code samples and I got 6 different answers that all failed to do the API call.",
+         "r/dataengineering", "https://www.reddit.com/r/dataengineering/comments/1im3fpx/does_anyone_know_how_to_export_the_audience/",
+         "The request body is the hard part and here nobody writes it. The agent builds it from "
+         "the question, runs it, and shows it back, so a wrong dimension name is a visible "
+         "mistake rather than a silent one."),
+        ("The API and the interface disagree",
+         "according to the interface I'm getting 2.2M event counts, whereas the API says 495k event counts for the same page.",
+         "r/GoogleAnalytics", "https://www.reddit.com/r/GoogleAnalytics/comments/vwhssp/ga4_data_api_vs_interface_discrepancy/",
+         "No relay can settle this, and this page will not claim to. Both numbers can be correct "
+         "for two differently scoped requests. What the agent adds is the request itself, in the "
+         "open, so you can see which shape produced which number."),
+        ("The data is visible on screen and still out of reach",
+         "I feel like I'm missing something obvious in GA4 about how to get at that data since I can SEE it right there",
+         "r/GoogleAnalytics", "https://www.reddit.com/r/GoogleAnalytics/comments/1n09huf/export_daily_views_data_for_a_single_page/",
+         "Daily views for one page is a two-line report on the API: a date dimension, a page "
+         "filter, a views metric. Ask for it in those words and the agent returns the table, no "
+         "export ritual."),
+    ],
+    "related": ("Search Console: clicks, impressions and top queries", "Realtime visitors on your site",
+                "Is this page indexed, and why not", "Your own campaign performance"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1916,6 +1916,9 @@ USE_CASE_PAGES[("local-businesses-reviews", "find-local-businesses-by-keyword-an
          "front desk is a second step against the business's own site, and it is the step with a "
          "hard floor."),
     ],
+    # Not "which is cheapest": one provider per platform, so ranking the two rows against each
+    # other would compare a Yelp search with a Tripadvisor one. The heading makes it a price list.
+    "q_cheapest": "What does each source cost?",
     "q_compare": "How do the two sources compare?",
     "what_is_heading": "What does a local business search return?",
     "what_is": (

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2474,3 +2474,102 @@ USE_CASE_PAGES[("connect-your-own-accounts", "google-analytics-traffic-and-behav
     "related": ("Search Console: clicks, impressions and top queries", "Realtime visitors on your site",
                 "Is this page indexed, and why not", "Your own campaign performance"),
 }
+
+USE_CASE_PAGES[("finance-markets", "current-quote-for-a-ticker")] = {
+    "label": "Current quote for a ticker",
+    "sentence": "Stock price API: the current quote for a ticker from four providers, free to start",
+    "title": "Stock price API: {n} providers, free to try | treg.to",
+    "lede": (
+        "Ask for a ticker and get the quote back as data: price, day change, open, high, low and "
+        "previous close. {n} providers answer through one treg.to key. Three of them are served "
+        "on treg.to's own free-tier keys, {cheapest}, then on your own key; the fourth is your own "
+        "plan only. Each one says whether its quote is real time or delayed, and the page says it "
+        "too, because that word is where stock APIs go wrong."),
+    "prompt": "Using treg, get the current price, day change and previous close for AAPL, MSFT and "
+              "NVDA. Tell me which provider you will use and whether its quote is real time or "
+              "delayed before you call, and stop if the free allowance is used up.",
+    "prompt_why": [
+        ("Ask whether it is delayed", "One of these is 15 to 20 minutes behind by design. The agent should say which before it quotes."),
+        ("One ticker is one call", "The free allowance is counted in calls per team per day, so a watchlist of fifty is a day's allowance."),
+        ("Try on the allowance, build on your key", "The daily pool is for finding out which feed you want. A bot needs a key of its own."),
+        ("Compare, then pick", "treg.to shows the four side by side and does not choose for you. Say which one you want, or say why."),
+    ],
+    "result_noun": "quote",
+    "result_image": None,
+    "what_is_heading": "What is a stock price API?",
+    "what_is": (
+        "A stock price API returns the current quote for a ticker symbol as data: last price, "
+        "the day's change, open, high, low, previous close and usually volume, sometimes the "
+        "52-week range. The catch is the word current. A feed is real time, delayed by an "
+        "exchange-mandated window, or a single exchange's view rather than the consolidated tape, "
+        "and the free tier of most providers is small enough that a script polling every minute "
+        "runs out before lunch. The unofficial Yahoo Finance endpoints most free scripts lean on "
+        "are not an API at all, and break without notice."),
+    "notes": [
+        "The free allowance is real and it is small on purpose. Finnhub is served at fifty calls "
+        "per team per day on treg.to's key, Tiingo and Twelve Data at twenty each; past that the "
+        "call is refused with a hint to connect your own key, and with your own key the calls "
+        "are never metered. It is enough to try each feed on the tickers you care about. It is "
+        "not a data plan for a trading bot, and this page will not pretend it is.",
+        "Real time means four different things here. Finnhub's quote is documented as real time "
+        "for US tickers. Tiingo's is the IEX feed, one exchange's top of book rather than the "
+        "consolidated tape. Twelve Data returns stocks, forex and crypto in one quote shape with "
+        "the 52-week range, and has a one-number price call for the cheapest possible check. "
+        "EODHD's live quote is 15 to 20 minutes delayed, and since EODHD publishes no per-call "
+        "rate it is served on your own EODHD plan only.",
+        "Providers disagree, occasionally by a lot, and treg.to does not referee. A quote is one "
+        "provider's number at one moment; a second provider on the same ticker is the cheap "
+        "sanity check, and the agent can run both. Symbol formats differ too: EODHD wants an "
+        "exchange suffix, AAPL.US, where the others take the bare US ticker.",
+    ],
+    "faq": [
+        ("Is it really free?",
+         "Three of the four are, up to a daily allowance per team, on treg.to's own free-tier "
+         "keys: fifty calls on Finnhub, twenty each on Tiingo and Twelve Data. After that, "
+         "connect your own key and the calls are never metered."),
+        ("Is the quote real time?",
+         "Depends on the provider, and the page says which. Finnhub is real time for US tickers, "
+         "Tiingo is the IEX feed, EODHD is 15 to 20 minutes delayed. Ask the agent to name the "
+         "provider before it quotes."),
+        ("Can I run a trading bot on this?",
+         "Not on the allowance. A bot polling every minute exhausts fifty calls before the open. "
+         "Register your own key with the provider you settle on and treg.to stops counting."),
+        ("What about tickers outside the US?",
+         "Coverage is each provider's, not treg.to's. Finnhub's quote is documented for US "
+         "tickers; EODHD and Twelve Data take exchange-suffixed symbols. Check the ticker you "
+         "need on the allowance before you build on it."),
+    ],
+    "voices_intro": (
+        "The stock API forums are a long argument about yfinance. From ~200 Reddit and X posts in "
+        "August 2026, about thirty were vendors, including one founder seeding eight tweets for "
+        "his own product and one listicle pasted into three subreddits. These four are people who "
+        "hit the wall."),
+    "voices": [
+        ("The model cannot see a live price on its own",
+         "It doubled my money on the first trade. Then it told me it can't see live stock prices.",
+         "r/smallstreetbets, 574 points", "https://www.reddit.com/r/smallstreetbets/comments/1r883gd/i_spent_8_months_asking_claude_dumb_questions_now/",
+         "The poster spent eight months wiring a quote feed into the model by hand. The setup line "
+         "on this page is the short version: the agent gets four quote providers and a price "
+         "shown before the call, and never holds a key."),
+        ("The free library breaks and blocks you",
+         "yfinance is so unreliable; any other free apis?",
+         "r/algotrading, 117 points", "https://www.reddit.com/r/algotrading/comments/1kdw27f/yfinance_is_so_unreliable_any_other_free_apis/",
+         "These are documented, metered APIs rather than a reverse-engineered Yahoo endpoint, "
+         "which is the whole difference. The honest caveat is the allowance: free to try, your "
+         "own key to run."),
+        ("By the time it arrives it is stale",
+         "By the time I get the data, the prices are already stale.",
+         "r/algotrading, 23 points", "https://www.reddit.com/r/algotrading/comments/1jjj6cb/need_a_better_alternative_to_yfinance_any_good/",
+         "Stale has a cause, and here it is named per provider: a delayed feed, or a single "
+         "exchange's view. Pick the feed for the latency you need rather than discovering it "
+         "from a bad fill."),
+        ("Public numbers, priced like a secret",
+         "How is it possible that you need to pay hundreds of dollars just to access historical data / facts that are publicly known?",
+         "r/webdev, 114 points", "https://www.reddit.com/r/webdev/comments/151zk8y/is_there_any_free_stock_market_api_that_allows/",
+         "Exchange licensing, mostly, and nothing on this page changes it. What the page can do "
+         "is show the provider's own terms next to each other before you commit to one, and let "
+         "you try three of them for nothing."),
+    ],
+    "related": ("Daily price history", "News for a ticker",
+                "Live crypto prices and history", "Company profile and fundamentals behind a ticker"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -1721,3 +1721,125 @@ USE_CASE_PAGES[("advertising", "your-own-campaign-performance")] = {
                 "Google Ads: the search terms triggering your ads",
                 "Search Console: clicks, impressions and top queries"),
 }
+
+
+USE_CASE_PAGES[("e-commerce", "amazon-product-detail-by-asin")] = {
+    "label": "Amazon product detail by ASIN",
+    "sentence": "Amazon product API: any product's detail by ASIN",
+    "title": "Amazon product API: {n} providers from {cheapest} | treg.to",
+    "lede": (
+        "Give your agent an ASIN and get the listing back as data: title, current price, images, "
+        "specifications and the review summary. {n} providers do this through one treg.to key, from "
+        "{cheapest} a product, with no Amazon programme to be approved for first. That last part is "
+        "most of the reason this job has a price at all."),
+    "prompt": "Using treg, get the Amazon product detail for ASIN B08N5WRWNW on amazon.com. Show me "
+              "the price first, then give me the title, current price, rating and review count.",
+    "prompt_why": [
+        ("Give it the ASIN and the marketplace", "One ASIN is a different listing and a different price on each Amazon domain. Name the one you mean."),
+        ("Ask for the price first", "treg.to returns the cost before the call, so the agent can say what it will spend."),
+        ("Name the fields you want back", "A product payload is large. Saying which fields matter keeps the answer short and the context small."),
+        ("Say what to do on a miss", "Dead and region locked ASINs are normal in any list. Tell it to skip and report rather than retry."),
+    ],
+    "result_noun": "product",
+    "result_image": None,
+    "voices_intro": (
+        "From roughly 28 on-topic Reddit posts in August 2026, of which 16 were vendor written and "
+        "excluded: four in one vendor's own subreddit, two of those word for word identical, plus "
+        "one account running the same buying question through three scraping subreddits. The X half "
+        "of the research held nothing organic on this job at all. What survived says something "
+        "different from the marketing, so this page is built on it."),
+    "voices": [
+        ("The official API is gated behind a business you may not be in",
+         "I applied for the official Amazon Product Advertising API (PA-API), got my keys, but for some reason, they never actually granted me functional access.",
+         "r/developersIndia, 103 points", "https://www.reddit.com/r/developersIndia/comments/1q4i0l8/amazon_denied_my_api_access_so_i_built_my_own/",
+         "The highest scoring organic post in the research, and the theme the marketing around this "
+         "job never mentions, because it is easier to sell you a fix for blocking. Amazon's product "
+         "API belongs to its affiliate programme, so it is granted to people earning it commission, "
+         "not to people who want product data. Every row on this page sidesteps that by inverting "
+         "the relationship: you are paying for data rather than being paid for referrals."),
+        ("The deadlock: no API without sales, no sales without the API",
+         "How do you get approved for Amazon Affiliate marketing if you cannot use the product advertising API without being approved first?",
+         "r/Affiliatemarketing, 2 points", "https://www.reddit.com/r/Affiliatemarketing/comments/1alp1an/how_do_you_get_approved_for_amazon_affiliate/",
+         "A fair question with an uncomfortable answer, and worth spelling out because the same "
+         "poster goes on to ask whether to host Amazon's images anyway. Buying the data from a "
+         "third party breaks the deadlock and does not touch the licence: these rows return image "
+         "URLs, they do not grant you Amazon's rights to those images. If your plan needs the "
+         "images, the affiliate programme is still the route, and this page is not a way around it."),
+        ("An agent asked to read a listing will invent one instead",
+         "You cannot use Chatgpt to search Amazon products - it won't even open links",
+         "r/OpenAI, 50 points", "https://www.reddit.com/r/OpenAI/comments/1ph2nul/you_cannot_use_chatgpt_to_search_amazon_products/",
+         "The thread underneath is the interesting part: the model did not fail loudly, it "
+         "substituted a price from elsewhere and insisted it had read the listing. That is the "
+         "failure mode that matters for agents, because it looks like an answer. A priced call "
+         "against a named ASIN turns it into a fetch with a cost and a result, which is checkable "
+         "in a way a confident paragraph is not."),
+        ("A hand rolled scraper meets the CAPTCHA within a few dozen pages",
+         "I tried using random user agents, time.sleep() to avoid that darned captcha page.",
+         "r/webscraping, 4 points", "https://www.reddit.com/r/webscraping/comments/yn1cvl/bot_detection_with_python_requests/",
+         "This is the second act of nearly every story in the research: the official route is shut, "
+         "so people write the script, and the script dies somewhere in the first hundred pages. "
+         "What changes here is who owns the repair. What does not change is that every provider in "
+         "this space fails some proportion of requests, so the honest question is not who never "
+         "fails but who tells you when they did, and what that failure costs you."),
+        ("The proxy fixes the blocking and hands you the latency",
+         "Requests without the proxy had an average response time of 1.5 seconds. However, with the proxy, the response time increased to around 6-10 seconds.",
+         "r/scrapy, 1 point", "https://www.reddit.com/r/scrapy/comments/187goqh/requests_through_the_rotating_residential_proxy/",
+         "Worth quoting precisely because it is not the complaint the vendor content wants you to "
+         "have. In the organic posts the grievance about proxies is speed and upkeep, not price; "
+         "the same poster calls his provider the cheapest he found. So compare on the whole cost of "
+         "the do it yourself path, the maintenance and the seconds, rather than on a monthly proxy "
+         "bill, and be sceptical of any page here or elsewhere that opens on how expensive proxies "
+         "are."),
+    ],
+    "q_cheapest": "Which Amazon product API is cheapest?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the providers compare?",
+    "what_is_heading": "What is an Amazon product API?",
+    "what_is": (
+        "It returns one Amazon listing as structured data rather than as a page: the title, the "
+        "price showing at the moment of the call, images, the specification table, the rating and "
+        "the review count. It is not Amazon's own API and it is not a feed. Each call reads a "
+        "public product page as an anonymous visitor would see it, which is what makes it available "
+        "without an Associates account and also what sets the edges of what it can ever return."),
+    "notes": [
+        "The three rows do not take the same key, which is work before it is price. Bright Data "
+        "takes a product URL and returns records from its Amazon dataset. JustOneAPI takes the ASIN "
+        "with a country code. SerpApi takes the ASIN with an Amazon domain. If what you hold is a "
+        "list of bare ASINs, two of these are a direct call and the third needs a URL built first.",
+        "There is no single true price for an ASIN, and that is not a gap in this comparison. What "
+        "a product page shows depends on the marketplace, the delivery address, whether the viewer "
+        "has Prime and which seller holds the buy box that second, so no provider can be more "
+        "accurate in the abstract. The checkable difference is which of them lets you pin the "
+        "context: a country code here, an Amazon domain there, and on the URL based row whatever "
+        "marketplace the URL points at.",
+        "Every row bills only what succeeds, which is what makes a long unverified list safe to "
+        "hand an agent. Two are priced per successful call and the third per record actually "
+        "delivered, so an ASIN that is dead, region locked or withdrawn costs nothing. What you can "
+        "still run up is your own retry loop, so tell the agent to skip and report rather than to "
+        "try harder.",
+    ],
+    "faq": [
+        ("How much does one product lookup cost?",
+         "A fraction of a cent to about a cent and a half depending on the row, at the provider's "
+         "own rate with $0.000 added by treg.to. The live figures are in the comparison above, and "
+         "all three bill only when the lookup works."),
+        ("Why not use Amazon's own API?",
+         "Because neither of Amazon's APIs is a general read any product API. The Product "
+         "Advertising API belongs to the affiliate programme and is granted to accounts earning "
+         "qualifying commission, which is why people report keys that never became working access. "
+         "The Selling Partner API is for managing your own selling account. If you are in neither "
+         "programme, there is no official door."),
+        ("Do these give me the right to use Amazon's product images?",
+         "No, and it is worth being blunt because the research is full of people asking. A data API "
+         "returns image URLs; it does not hand you Amazon's licence to host or republish them. "
+         "Rights to product imagery come from the affiliate programme or from the brand, and no "
+         "amount of paying for data changes that."),
+        ("Can I look up thousands of ASINs?",
+         "Yes, and the cost is linear because it is one call per ASIN with no batch endpoint. Your "
+         "agent runs the list; treg.to prices each call and shows the running total, and since all "
+         "three rows bill only on success, the dead entries in a scraped list do not cost you "
+         "anything."),
+    ],
+    "related": ("Amazon search and best sellers", "TikTok Shop products and reviews",
+                "App store search", "Product reviews"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2287,3 +2287,96 @@ USE_CASE_PAGES[("connect-your-own-accounts", "your-google-business-profile-revie
     "related": ("A business's reviews", "Find local businesses by keyword and location",
                 "Search terms that surfaced your listing on Maps", "Search Console: clicks, impressions and top queries"),
 }
+
+USE_CASE_PAGES[("local-businesses-reviews", "a-business-s-reviews")] = {
+    "label": "A business's reviews",
+    "sentence": "Review scraper API: a business's reviews from Tripadvisor, Trustpilot and Yelp, as data",
+    "title": "Tripadvisor, Trustpilot and Yelp reviews API | treg.to",
+    "lede": (
+        "Give your agent a business's page and get its reviews back as rows: rating, text, date "
+        "and reviewer, ready to sort, count or read. Three review sites answer through one treg.to "
+        "key, from {cheapest}, without a Tripadvisor API key, a Yelp Fusion application or a "
+        "browser of your own. They are not alternatives to each other; the site is the choice."),
+    "prompt": "Using treg, pull the last 200 Tripadvisor reviews for this hotel URL, show me the "
+              "price first, then give me the rating distribution by month and the ten most recent "
+              "reviews of two stars or fewer in full.",
+    "prompt_why": [
+        ("Give the page, not the name", "Every provider here takes a URL, a path or a domain. Find the listing first if you only have a name."),
+        ("Say how many you want", "The Trustpilot and Tripadvisor tasks take a depth. The count you ask for is the count you pay for."),
+        ("Compare on the unit", "One provider bills per record delivered, the other per task. Ask which is cheaper for your count."),
+        ("Bring your own analysis", "The rows carry the text. Sentiment, themes and summaries are the agent's job on top."),
+    ],
+    "result_noun": "review",
+    "result_image": None,
+    "what_is_heading": "What is a review scraper API?",
+    "what_is": (
+        "A review scraper API returns the public reviews on a business's listing as structured "
+        "records, rating, text, date, reviewer and the business's reply where there is one, "
+        "without you running a browser against the site. It exists because the official routes "
+        "are narrow: Yelp's Fusion API is an application and a plan, Tripadvisor's Content API "
+        "is an approval, and neither is built for pulling every review of one business. The "
+        "providers here read the public page and hand back the rows."),
+    "notes": [
+        "The two providers bill in different units and the difference matters for a long pull. "
+        "Bright Data delivers records and bills per record delivered, on Yelp and Trustpilot. "
+        "DataForSEO runs a task, on Tripadvisor and Trustpilot, and bills per task at a fraction of "
+        "a cent whatever the depth returns. For a few dozen reviews the difference is nothing; for "
+        "a business with thousands, ask the agent to price both before it starts.",
+        "The input is the listing, not the business name. Tripadvisor wants the review page's "
+        "path, Trustpilot the business's domain, Yelp the page URL, so the agent resolves a name "
+        "to a listing first, which is the neighbouring job on this menu. A wrong page returns "
+        "someone else's reviews, not an error.",
+        "This is the public page as it stands. A review the site has removed is gone from here "
+        "too, the rows are as fresh as the crawl behind them, and what you may do with the text "
+        "is governed by each site's terms and your own use, which no provider settles for you.",
+    ],
+    "faq": [
+        ("Do I need a Yelp Fusion or Tripadvisor API key?",
+         "No. Neither provider here uses the sites' official APIs. They read the public listing "
+         "page and return the reviews as records, billed to your treg.to balance at the provider's "
+         "rate with $0.000 markup."),
+        ("Which site should I use?",
+         "The one the business is reviewed on. Tripadvisor for hotels, restaurants and attractions, "
+         "Trustpilot for online businesses by domain, Yelp for local services in North America. "
+         "Pulling from the wrong site returns a short, misleading list."),
+        ("What about Google reviews?",
+         "The reviews on a listing you own or manage are the Business Profile job on this menu, "
+         "free on your own account. This page covers the three public review sites."),
+        ("Can I get all of a business's reviews?",
+         "You can ask for a depth, and the task returns up to that many. Whether every review "
+         "of a business with thousands comes back is a property of the site, so check the count "
+         "against the listing rather than assuming."),
+    ],
+    "voices_intro": (
+        "Review data is sold hard: about 25 of the ~120 posts on these three sites in August 2026 "
+        "were scraper vendors, Apify listings posted from template accounts, and the same lead-gen "
+        "thread pasted twice. These four are people who tried the official door first."),
+    "voices": [
+        ("The official Yelp API returns nothing for a valid business",
+         "Yelp Fusion API \"NOT_FOUND\" error when requesting reviews (Python)",
+         "r/webscraping", "https://www.reddit.com/r/webscraping/comments/1ivggvp/yelp_fusion_api_not_found_error_when_requesting/",
+         "The Yelp provider on this page does not go through Fusion at all. It reads the public "
+         "page by URL and bills per record delivered, so a business that Fusion cannot find is "
+         "still a page you can point at."),
+        ("Yelp at any scale fights back",
+         "Is Yelp just a nightmare to scrape, or are no-code tools just not built for this at scale?",
+         "r/scrapingtheweb, 9 points", "https://www.reddit.com/r/scrapingtheweb/comments/1t6pyca/have_you_ever_tried_scraping_yelp_without_coding/",
+         "Both, and the answer is to stop running the browser yourself. A per-record provider "
+         "carries the blocking, the retries and the proxies, and you pay for the rows that arrive. "
+         "That is what the fraction of a cent buys."),
+        ("Trustpilot stops at a couple of hundred without a login",
+         "they cap you at 200 reviews without auth. A `jwt` cookie removes the cap.",
+         "r/webscraping, 7 points", "https://www.reddit.com/r/webscraping/comments/1vw95dz/scraper_for_pulling_trustpilot_reviews/",
+         "A self-built scraper's workaround, and the kind of thing that breaks quietly. The "
+         "Trustpilot task here takes a depth parameter instead; ask for what you need and read "
+         "the count that comes back rather than assuming the whole history arrived."),
+        ("The official price is the reason people scrape",
+         "their API is horrifically expensive for poor old me, and I was not in the mood to build a web scraper",
+         "r/gis, ~800 points", "https://www.reddit.com/r/gis/comments/1iph0yy/the_closer_to_the_railway_station_the_less_tasty/",
+         "The page shows the provider's rate before the call, in fractions of a cent per record "
+         "or per task, so the choice between paying and building is a number rather than a mood."),
+    ],
+    "related": ("Find local businesses by keyword and location",
+                "Your Google Business Profile reviews, and reply to them",
+                "Product reviews", "Hotel listing details"),
+}

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1104,6 +1104,22 @@ def _use_case_page_for(category: str, label: str) -> str | None:
     return None
 
 
+def _related_link(label: str, agent_slug: str) -> tuple[str, str]:
+    """(href, owning category) for a `related` job, resolved by LABEL across the whole menu.
+
+    Four categories carry fewer than five jobs, so `related` has to cross categories there. It used
+    to resolve inside the current page's category only, which sent those cards to the wrong anchor
+    under a caption naming the wrong category. The 66 labels are unique (tested), so the label is
+    enough to find the owner.
+    """
+    for category, jobs in agent_pages.USE_CASES:
+        for lbl, _ in jobs:
+            if lbl == label:
+                return (_use_case_page_for(category, label)
+                        or f"/agents/{agent_slug}#{agent_pages.category_slug(category)}"), category
+    return f"/agents/{agent_slug}", ""
+
+
 def _use_case_caps(category_slug: str, label: str) -> tuple[str, ...]:
     for category, jobs in agent_pages.USE_CASES:
         if agent_pages.category_slug(category) == category_slug:
@@ -1705,10 +1721,12 @@ async def use_case_job_page(request: Request, category: str, job: str,
                       if spec.get("voices") else "")
     notes = "".join(f'<h4>{_esc_html(x.split(".")[0])}.</h4><p>{_esc_html(x.split(".", 1)[1].strip())}</p>'
                     if "." in x else f"<p>{_esc_html(x)}</p>" for x in spec["notes"])
-    related = "".join(
-        f'<a class="card" href="{_use_case_page_for(cat_label, lbl) or ("/agents/" + agent_slug + "#" + agent_pages.category_slug(cat_label))}">'
-        f'<h4>{_esc_html(lbl)}</h4><p>Another job in {_esc_html(cat_label.lower())}.</p></a>'
-        for lbl in spec.get("related", ()))
+    def _related_card(lbl: str) -> str:
+        href, owner = _related_link(lbl, agent_slug)
+        return (f'<a class="card" href="{href}"><h4>{_esc_html(lbl)}</h4>'
+                f'<p>Another job in {_esc_html((owner or cat_label).lower())}.</p></a>')
+
+    related = "".join(_related_card(lbl) for lbl in spec.get("related", ()))
     faq_html = "".join(f'<h3>{_esc_html(q)}</h3><p>{_esc_html(a)}</p>' for q, a in spec["faq"])
 
     # The "instead of" anchor: what the same job costs on subscriptions from the providers on this

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1418,8 +1418,13 @@ def _uc_providers(cat, eps: list[dict], obs: dict) -> list[dict]:
         # prices this job in pre-bought API units, so its cost_view has no USD, and the price cell
         # read "free, your own account" for the dearest option on the page.
         free = any((e.get("cost") or {}).get("type") == "free" for e in peps)
+        # A $0 trial row is a third fact again: served on treg.to's own free-tier key with a daily
+        # allowance per team (catalog.trial_pools), so neither "free, your own account" nor a price
+        # is true of it. Carry the allowance so the cell can state it.
+        trial = max((cv.get("trial_calls_per_team_day") or 0) for e in peps
+                    if (cv := cat.cost_view(e.get("cost"), e.get("provider"))))
         out.append({
-            "id": prov, "name": _provider_display(prov), "eps": peps, "free": free,
+            "id": prov, "name": _provider_display(prov), "eps": peps, "free": free, "trial": trial,
             "domain": agent_pages.PROVIDER_DOMAINS.get(prov),
             "platform": slug, "platform_label": (cat.platforms.get(slug) or {}).get("label") or slug,
             "usd": priced[0][0] if priced else None,
@@ -1507,6 +1512,11 @@ async def use_case_job_page(request: Request, category: str, job: str,
     headline = cheapest_by_unit[units[0]] if units else None
     reliable = sorted([p for p in provs if p["samples"] and p["ok_rate"] is not None],
                       key=lambda p: (-p["ok_rate"], p["p50"] or 9e9, -p["samples"]))
+    # No priced row is two different facts: own-account rows are free on the reader's key; trial
+    # rows are free on treg.to's key up to a daily allowance. Say whichever is true.
+    trial_max = max((p["trial"] for p in provs), default=0)
+    free_words = (f"free, up to {trial_max} calls a day on treg.to's key" if trial_max
+                  else "free on your own account")
     n = str(len({p["id"] for p in provs}))
     n_ver = sum(1 for e in eps if e.get("verified"))
     latest_verified = max((e.get("verified") or "" for e in eps), default="")
@@ -1526,11 +1536,15 @@ async def use_case_job_page(request: Request, category: str, job: str,
 
     title = spec.get("title", "{sentence}: {n} providers | treg.to").format(
         sentence=spec["sentence"], n=n, agent=agent_name,
-        cheapest=money(headline["usd"]) if headline else "free on your own account")
+        cheapest=money(headline["usd"]) if headline else free_words)
     lede = spec["lede"].format(n=n, agent=agent_name,
-                               cheapest=money(headline["usd"]) if headline else "free on your own account")
+                               cheapest=money(headline["usd"]) if headline else free_words)
     bits_desc = [spec["sentence"] + "."]
-    if form == "short":
+    metered_single = form == "short" and not provs[0]["free"]
+    if metered_single:
+        bits_desc.append(f"One provider, {money(headline['usd'])} per {headline['unit']} on treg.to's key, no signup."
+                         if headline else "One provider, served on treg.to's key.")
+    elif form == "short":
         bits_desc.append("Runs on the account you already own, so treg.to never meters it.")
     elif headline:
         bits_desc.append(f"{n} providers compared, cheapest {money(headline['usd'])} per {headline['unit']}.")
@@ -1544,7 +1558,15 @@ async def use_case_job_page(request: Request, category: str, job: str,
               f'Then ask: "{spec["prompt"]}"', ""]
         md += [f"- **{t}** {d}" for t, d in spec["prompt_why"]]
         md += ["", "## Why go through treg.to", ""] + [f"- **{t}** {d}" for t, d in agent_pages.WHY_TREG]
-        if form == "short":
+        if metered_single:
+            e0 = provs[0]["cheapest_ep"] or provs[0]["eps"][0]
+            md += ["", "## How it works", "",
+                   f"One provider does this job: {provs[0]['name']} (`{e0['id']}`), served on treg.to's own key at "
+                   + (f"{money(provs[0]['usd'])} per {provs[0]['unit']}, " if provs[0]["usd"] else "")
+                   + "the provider's own rate with $0.000 markup, metered from your team's balance. "
+                   "No account with the provider, and no key of your own, unless you would rather bring one.",
+                   "", f"    {_uc_call(e0)}", ""]
+        elif form == "short":
             e0 = provs[0]["eps"][0]
             md += ["", "## How it works", "",
                    f"One provider does this job: {provs[0]['name']} (`{e0['id']}`), on the account you already own. "
@@ -1575,7 +1597,8 @@ async def use_case_job_page(request: Request, category: str, job: str,
                 md += ["| Provider | Price | Accepts | Verified |", "|---|---|---|---|"]
                 for p in sorted(rows_, key=lambda p: (p["usd"] is None, p["usd"] or 0)):
                     price = (f"{money(p['usd'])} per {p['unit']}" if p["usd"]
-                             else ("own account, free" if p["free"] else "no dollar rate published"))
+                             else (f"free, {p['trial']} calls a day on treg.to's key, then your own key" if p["trial"]
+                                   else ("own account, free" if p["free"] else "no dollar rate published")))
                     md.append(f"| {p['name']} | {price} | {', '.join(p['inputs'])} | {p['verified'] or 'unverified'} |")
                 md.append("")
         md += ["Endpoints:", ""] + [f"- `{e['id']}`: {_uc_call(e)}" for e in eps]
@@ -1603,7 +1626,7 @@ async def use_case_job_page(request: Request, category: str, job: str,
         f'<img src="https://unpkg.com/@lobehub/icons-static-png@latest/light/{icon}.png" alt="{_esc_html(label)}" loading="lazy"/></span>'
         for aid, label, icon in agent_pages.AGENT_ICONS[:6])
     hero_price = (f"from {_esc_html(money(headline['usd']))} per {headline['unit']}"
-                  if headline else "free on the account you already own")
+                  if headline else _esc_html(free_words if trial_max else "free on the account you already own"))
 
     def promptbox(label: str, text: str) -> str:
         return ('<div class="promptbox"><div class="ph">'
@@ -1619,6 +1642,9 @@ async def use_case_job_page(request: Request, category: str, job: str,
     def price_cell(p: dict) -> str:
         if p["usd"]:
             return f'{_esc_html(money(p["usd"]))} <span style="color:var(--muted2)">per {p["unit"]}</span>'
+        if p["trial"]:
+            return (f'<span style="color:var(--green)">free, {p["trial"]} calls a day</span> '
+                    '<span style="color:var(--muted2)">on treg.to\'s key, then your own key</span>')
         if p["free"]:
             return '<span style="color:var(--green)">free, your own account</span>'
         return '<span style="color:var(--muted2)">no dollar rate published</span>'
@@ -1641,7 +1667,21 @@ async def use_case_job_page(request: Request, category: str, job: str,
                 f'</tr></thead><tbody>{body_rows}</tbody></table></div>')
 
     sections = []
-    if form == "short":
+    if metered_single:
+        p0 = provs[0]
+        e0 = p0["cheapest_ep"] or p0["eps"][0]
+        rate = f'{_esc_html(money(p0["usd"]))} per {p0["unit"]}, ' if p0["usd"] else ""
+        sections.append(
+            '<section id="how"><div class="wrap"><div class="seclab">How it works</div>'
+            f'<h2>One provider, served on treg.to\'s key</h2>'
+            f'<p>{_logo(p0["domain"], p0["name"])}<b>{_esc_html(p0["name"])}</b> answers this job, at {rate}'
+            'the provider\'s own rate with $0.000 markup, metered from your team\'s balance. No account with the '
+            'provider and no key of your own, unless you would rather bring one.</p>'
+            f'<div class="sample"><div class="sbar">the call</div><pre>{_esc_html(_uc_call(e0))}</pre></div>'
+            f'<p style="font-size:12.5px;color:var(--muted)">Every endpoint on this shelf is listed on the '
+            f'<a href="/catalog/{_esc_html(e0["platform"])}">{_esc_html((cat.platforms.get(e0["platform"]) or {}).get("label") or e0["platform"])} shelf</a>.</p>'
+            + '</div></section>')
+    elif form == "short":
         p0, e0 = provs[0], provs[0]["eps"][0]
         sections.append(
             '<section id="how"><div class="wrap"><div class="seclab">How it works</div>'

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1414,8 +1414,12 @@ def _uc_providers(cat, eps: list[dict], obs: dict) -> list[dict]:
                     if isinstance(v, dict) and k not in ins:
                         ins.append(k)
         slug = plat
+        # "no dollar price" and "free" are different facts and were rendering as one. Semrush
+        # prices this job in pre-bought API units, so its cost_view has no USD, and the price cell
+        # read "free, your own account" for the dearest option on the page.
+        free = any((e.get("cost") or {}).get("type") == "free" for e in peps)
         out.append({
-            "id": prov, "name": _provider_display(prov), "eps": peps,
+            "id": prov, "name": _provider_display(prov), "eps": peps, "free": free,
             "domain": agent_pages.PROVIDER_DOMAINS.get(prov),
             "platform": slug, "platform_label": (cat.platforms.get(slug) or {}).get("label") or slug,
             "usd": priced[0][0] if priced else None,
@@ -1570,7 +1574,8 @@ async def use_case_job_page(request: Request, category: str, job: str,
                     md += [f"#### {plat}", ""]
                 md += ["| Provider | Price | Accepts | Verified |", "|---|---|---|---|"]
                 for p in sorted(rows_, key=lambda p: (p["usd"] is None, p["usd"] or 0)):
-                    price = f"{money(p['usd'])} per {p['unit']}" if p["usd"] else "own account, free"
+                    price = (f"{money(p['usd'])} per {p['unit']}" if p["usd"]
+                             else ("own account, free" if p["free"] else "no dollar rate published"))
                     md.append(f"| {p['name']} | {price} | {', '.join(p['inputs'])} | {p['verified'] or 'unverified'} |")
                 md.append("")
         md += ["Endpoints:", ""] + [f"- `{e['id']}`: {_uc_call(e)}" for e in eps]
@@ -1612,8 +1617,11 @@ async def use_case_job_page(request: Request, category: str, job: str,
                          for t, d in agent_pages.WHY_TREG)
 
     def price_cell(p: dict) -> str:
-        return (f'{_esc_html(money(p["usd"]))} <span style="color:var(--muted2)">per {p["unit"]}</span>'
-                if p["usd"] else '<span style="color:var(--green)">free, your own account</span>')
+        if p["usd"]:
+            return f'{_esc_html(money(p["usd"]))} <span style="color:var(--muted2)">per {p["unit"]}</span>'
+        if p["free"]:
+            return '<span style="color:var(--green)">free, your own account</span>'
+        return '<span style="color:var(--muted2)">no dollar rate published</span>'
 
     def rel_cell(p: dict) -> str:
         return (f'{pct(p["ok_rate"])} <span style="color:var(--muted2)">({p["samples"]} calls)</span>'

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -400,3 +400,17 @@ def test_related_links_point_at_jobs_that_exist():
     for key, spec in agent_pages.USE_CASE_PAGES.items():
         for label in spec["related"]:
             assert label in menu, (key, label)
+
+
+def test_related_cards_resolve_to_the_job_s_own_category():
+    """Four categories carry fewer than five jobs, so `related` has to cross categories there.
+    Resolving inside the current page's category sent those cards to the wrong anchor under a
+    caption naming the wrong category, and no test noticed because the label still existed."""
+    from treg.api import _related_link, _use_case_page_for
+    owner = {lbl: c for c, jobs in agent_pages.USE_CASES for lbl, _ in jobs}
+    for key, spec in agent_pages.USE_CASE_PAGES.items():
+        for lbl in spec["related"]:
+            href, cat = _related_link(lbl, "chatgpt")
+            assert cat == owner[lbl], (key, lbl, cat)
+            assert href == (_use_case_page_for(owner[lbl], lbl)
+                            or f"/agents/chatgpt#{agent_pages.category_slug(owner[lbl])}"), (key, lbl)

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -414,3 +414,21 @@ def test_related_cards_resolve_to_the_job_s_own_category():
             assert cat == owner[lbl], (key, lbl, cat)
             assert href == (_use_case_page_for(owner[lbl], lbl)
                             or f"/agents/chatgpt#{agent_pages.category_slug(owner[lbl])}"), (key, lbl)
+
+
+async def test_a_provider_with_no_dollar_rate_is_not_labelled_free(clients: AsyncClient):
+    """`free` and `no published rate` are different facts. Semrush prices the SERP and ranked
+    keyword jobs in pre-bought API units, so its `cost_view` carries no USD, and the price cell
+    read "free, your own account" for what is in fact the dearest option on the page."""
+    cat = catalog_store.load()
+    page = "/use-cases/seo/google-results-for-a-keyword"
+    eps = [e for e in cat.for_capability("google.serp.organic")
+           if e["kind"] not in catalog_store.HIDDEN_KINDS]
+    unpriced = [e for e in eps
+                if not ((c := cat.cost_view(e.get("cost"), e.get("provider"))) and c["usd"])]
+    assert unpriced, "this test needs a row the provider publishes no dollar rate for"
+    assert all((e.get("cost") or {}).get("type") != "free" for e in unpriced)
+    for text in ((await clients.get(page)).text, (await clients.get(page + ".md")).text):
+        assert "no dollar rate published" in text
+        assert "free, your own account" not in text
+        assert "own account, free" not in text


### PR DESCRIPTION
Five use-case pages, the next five off the demand worklist Jason set on 2026-08-24, taken top down
and skipping the two already written.

| Page | Form | Term measured | Vol | CPC |
|---|---|---|---|---|
| `seo/google-results-for-a-keyword` | compare, 5 providers | `serp api` | 12,100 | $18.71 |
| `advertising/your-own-campaign-performance` | platforms, both free | `google ads api` / `meta ads api` | 1,600 / 390 | $82.80 / $102.57 |
| `e-commerce/amazon-product-detail-by-asin` | compare, 3 providers | `amazon product api` | 1,300 | $12.55 |
| `local-businesses-reviews/find-local-businesses-by-keyword-and-location` | platforms, 2 sources | `yelp api` | 1,000 | $39.78 |
| `seo/keywords-a-domain-ranks-for` | compare, 5 providers | `rank tracking api` | 880 | $36.10 |

Demand measured on the own-key Google Ads endpoint (US, English), 76 phrasings across three
batches. Reddit and X research is ~690 posts across 20 searches, read by five subagents.

## A live bug on treg.to, and the only thing here that is urgent

The use-case price cell had a single `else` branch reading **"free, your own account"** in green for
any row with no dollar figure. That is not what no-dollar-figure means. It is currently mislabelling
paid providers as free on **five pages already merged to main**:

- `enrich-a-person`, `people-search`, `enrich-a-company` — Crunchbase and Ocean.io
- `find-professional-emails` — Ocean.io
- `verify-an-email` — Findymail

Fixed here, but the fix sits behind #175 in the stack. If you would rather not wait, `2a6579a`
cherry-picks onto main cleanly on its own.

## Two other things that need you

**A duplicate row on the menu.** `advertising / Your own campaign performance` and
`connect-your-own-accounts / Google Ads and Meta Ads campaign performance` carry **identical
capabilities** (`google-ads.campaigns.performance`, `meta-ads.insights`). Writing both would be two
pages with the same providers, the same table and the same target term, which is the shape the risk
audit warns about. I wrote the advertising one, per the worklist, and left the other alone. It needs
either a merge or a genuinely different angle before anyone writes it.

**A catalog gap.** The loudest theme in the local businesses research, by a distance, is people who
already gave up on Yelp and Tripadvisor and moved to Google Maps. treg.to has no Google Places
keyword search on the menu; the Google rows for local read a Business Profile the caller owns. The
page says so plainly in a voices answer and an FAQ rather than steering around it, but if there is
one local endpoint worth adding, it is that one.

## What the research changed about the plan

Three of the five pages ended up somewhere other than where they started, which is the argument for
doing the reading before the writing:

- **Local businesses.** Not one organic first-hand post says Yelp Fusion signups are closed or that
  an application was rejected. The only source for that claim in 200 posts is a vendor's own post.
  The page is built on what is actually there: auth that fails opaquely and works in Postman, which
  server-side credential injection does fix; a hard thousand-result ceiling, which nothing fixes;
  and content rights, which stay the caller's problem however the key is held.
- **Campaign performance.** The three angles a marketer would expect, the developer-token approval
  ordeal, the GAQL learning curve and rate limits, produced one, zero and zero organic posts. The
  page claims none of them. `meta ads mcp` measures 720 against `meta ads api` at 390, the third
  time this loop has measured the MCP wording outselling the API wording.
- **Amazon.** The dominant complaint is not that scraping is hard, which is the frame the astroturf
  prefers. It is that both official routes are gated behind a business model the reader is not in:
  PA-API belongs to the affiliate programme, SP-API to sellers. And in organic posts the grievance
  about proxies is latency and upkeep, not price, so a page opening on expensive proxies is reciting
  the vendor script.

Astroturf excluded and reported per page: 13 posts across four rings on SERP, 43 of 82 items on ads
(one X account posted the same lead magnet 18 times), 16 of 28 on Amazon, 11 on local, 13 on SEO
where a single cluster seeds the question in one subreddit and answers it in another.

## Also in here

- **`related` resolved inside the current category.** Fine for the twelve pages so far, wrong for
  these: advertising and market research carry three jobs, e-commerce and local businesses four, so
  those pages must point at least one of their four cards outside the category. Those cards landed
  on the wrong anchor under a caption naming the wrong category, and nothing failed because the
  existing test only asks whether the label exists somewhere on the menu. Labels are unique, so the
  label alone finds the owner. Test added.
- Three new tests. Full suite green, 1873 passed. All five pages rendered and read, HTML and `.md`.
- `docs/context/interface/seo.md` updated.

Both template bugs were found by reading the rendered page rather than by a test, which is the
argument for that step staying in the skill.

## Stack

#174 merged on 2026-08-22, so `agent_pages.py` is on main. #175 is still open, so this branches from
it and targets it. Worth noting #175's base branch, `JayZeeDesign/SEO-for-treg`, is itself merged
into main now, so #175 can be retargeted straight at main whenever you want it.

The 2026-08-22 and 2026-08-23 runs produced nothing, both lost to the machine sleeping mid-response.
Their branches are deleted. The 08-23 one had branched from main, which would have silently dropped
the five YouTube pages from #175, so the pre-stage that resolves the base ref earned its keep twice.
