### PR TITLE
fix(balances): read Apollo's unified credit meter, not the stale legacy field

### DIFF
--- a/scripts/provider_balances.py
+++ b/scripts/provider_balances.py
@@ -166,13 +166,21 @@ async def _thecompaniesapi(c, key):
 
 
 async def _apollo(c, key):
-    # api_profile with include_credit_usage returns the caller's remaining balances directly;
-    # num_credits_remaining is the (lead) credit pool the search/enrich endpoints draw from.
+    # api_profile with include_credit_usage returns the caller's remaining balances directly.
+    # `num_credits_remaining` is the LEGACY field and went stale at 0 on 2026-08-24 while the
+    # account was still fine: a live 1-credit /people/match returned a verified email (200) with
+    # the field still reading 0, and only `total_unified_credits_used` moved. Apollo has moved
+    # this account to unified credits, so derive what is left from the granted lead pool minus
+    # unified usage, and keep the legacy field as a fallback for accounts still on the old model.
     d = await _get(c, "https://api.apollo.io/api/v1/users/api_profile",
                    params={"include_credit_usage": "true"}, headers={"X-Api-Key": key})
-    return {"value": d.get("num_credits_remaining"), "unit": "credits",
-            "note": f"direct-dial {d.get('effective_num_direct_dial_credits')} left, "
-                    f"ai {d.get('effective_num_ai_credits')} left"}
+    granted, used = d.get("effective_num_lead_credits"), d.get("total_unified_credits_used")
+    left = (granted - used if isinstance(granted, (int, float)) and isinstance(used, (int, float))
+            else d.get("num_credits_remaining"))
+    return {"value": left, "unit": "credits",
+            "note": f"lead pool {granted} granted / {used} unified credits used, "
+                    f"direct-dial {d.get('effective_num_direct_dial_credits')}, "
+                    f"ai {d.get('effective_num_ai_credits')}"}
 
 
 async def _companyenrich(c, key):


### PR DESCRIPTION
## Why

The provider-balance loop has been alerting `apollo low: 0 left (threshold 250)` since the 2026-08-24 11:00 Sydney fire. Apollo is **not** out of credits.

Evidence gathered this run:
- `GET /users/api_profile?include_credit_usage=true` returns `num_credits_remaining: 0` while `effective_num_lead_credits: 2520`, `num_lead_credits_used: 0`.
- A live **1-credit** `POST /people/match` returned **HTTP 200 with a verified email** — i.e. the billable enrich path that tier-4 callers use still works with the field reading 0.
- Across three reads minutes apart, only `total_unified_credits_used` moved (448 → 512 → 544). `num_credits_remaining` stayed pinned at 0.

So Apollo has moved this account to **unified credits** and `num_credits_remaining` is a legacy field that no longer tracks the pool the search/enrich endpoints draw from. Leaving it in place means (a) a false alert every 30 minutes and (b) a meter that reads 0 whether or not the pool is genuinely empty — the alert would be worthless when apollo *does* run dry.

## What

`_apollo` now derives remaining as `effective_num_lead_credits - total_unified_credits_used`, keeping `num_credits_remaining` as a fallback for accounts still on the old model. Reads **1976 credits** now, comfortably above the 250 line.

No threshold change; only free endpoints are touched, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)