### PR TITLE
fix(proxy): release the DB connection before the upstream relay — 15 concurrent calls deadlocked the pool for 30s

### DIFF
--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -187,8 +187,10 @@ The API builds a single-binding tool from flat fields via `_flat_binding()`; inj
 [auth-secrets](auth-secrets.md).
 
 ## Async DB (`db.py`)
-One async SQLAlchemy engine (`_engine`) + a public `session_maker` (the audit writer opens its own
-session here). `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` —
+One async SQLAlchemy engine (`_engine`, Postgres pool 5 + 10 overflow per instance, `pool_timeout=5`)
++ a public `session_maker` (the audit writer opens its own session here; so do the post-relay
+bookkeeping steps of `/call/` — the request session is committed before the relay so none of them
+ever waits on it, see [proxy-model](proxy-model.md) § Connection discipline). `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` —
 see [multi-tenancy](multi-tenancy.md)); that migration also does the small additive `ADD COLUMN` steps for
 columns added after a table shipped (e.g. `tool.examples`, `tool.cli` for local runs, `org.public_demo`
 (A15), the seven `secret` connection-metadata columns (A16), and the eight `pendingoauth` marketplace/quirk

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -289,7 +289,12 @@ estimate is the honest number. This needed `unit_micro` (the per-ROW price) to r
 Closing the hold runs on its **own session** (the request's may be mid-rollback from the very error
 being released for) and **never raises** — the caller already has their answer, and a ledger hiccup
 must not turn a served call into a 500. A hold that fails to close is not lost money either: the
-reaper releases it, which errs in the org's favour.
+reaper releases it, which errs in the org's favour. That "errs in the org's favour" is still forfeited
+revenue, so the one failure that is transient by nature — no pool slot within `pool_timeout`
+(`sqlalchemy.exc.TimeoutError`) — gets exactly one retry after 0.5 s before the log line; anything else
+falls straight through. The request session itself is committed before the relay precisely so this
+second session never has to wait on the first (see [proxy-model](proxy-model.md) § Connection
+discipline).
 
 ## Shared-plan pricing: flat-fee providers, and the rate treg sets
 

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -77,6 +77,27 @@ body raw (`aiter_raw`), so if the caller doesn't ask for compression httpx would
 `Accept-Encoding: gzip` and hand a plain HTTP client / agent compressed bytes it never requested. Asking
 for `identity` keeps what the caller receives matching what the caller requested.
 
+## Connection discipline: a call in flight holds no DB connection
+`call_tool` ends its DB phase with an explicit `await db.commit()` immediately before `relay()` (and
+before `_relay_live_demo()`), so from the moment the upstream is called until the settle, the request
+holds **zero** pooled connections. Everything after the relay — `_platform_settle`, `_record_first_call`,
+`_store_idempotent` — already runs on its own short-lived session, and the request session is
+`expire_on_commit=False`, so `tool`, `secrets` and `caller.org` stay usable without a reload.
+
+Why this is load-bearing: `ledger.reserve` commits, but the org refresh after it, the secret loads and
+an OAuth token refresh each auto-begin a fresh transaction on the request session, and SQLAlchemy keeps
+that transaction's connection checked out until the next commit — i.e. for the entire upstream round
+trip. `_platform_settle` then needs a second connection from its own session. Two per in-flight call
+against the 15-slot pool (`db.py`: 5 + 10 overflow) deadlocked at 15 concurrent calls: every settle
+waited on a slot that only another waiting call could free, until `pool_timeout` killed one (a bare
+500, or a settle that forfeited its charge and left the hold to the reaper) and the rest cascaded — so
+every call in a burst "took 30 s" while the provider had answered in under a second. Reproduced live
+2026-08-24 from a customer's parallel-agent workload (13–29 calls per `Promise.all`), and the pool is
+per instance and shared by every org, so one team's burst stalled everyone's settles. The pool now
+bounds concurrent DB *phases* (milliseconds), not concurrent calls; there is no per-token or per-team
+concurrency limit, and `llms.txt` says so. `tests/test_call_pool_discipline.py` pins the invariant
+(`_engine.pool.checkedout() == 0` at relay time, metered and own-key) and a 20-call burst.
+
 ## Tool resolution (`_resolve_call` in api.py)
 `* /call/{rest:path}` → `call_tool()` → `_resolve_call(rest, caller, db)` returns
 `(tool, upstream_url)`. **Both shapes are scoped to the caller's org** (`Tool.org_id == org_id`), so two

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -515,7 +515,10 @@ what they created; `_require_admin_of` gates the org-admin endpoints. See
 - **The proxy:** `call_tool` (`* /call/{rest:path}`) → `_resolve_call` → (on a dotted 404,
   catalog lookup + retirement gate + credential ladder) → `_enforce_daily_cap` (the
   per-user daily cap; 429 when over) → (public-demo token → `_enforce_public_demo_ip_cap`) → load secrets
-  (+ `ensure_fresh`) → `relay()` → `audit.record_call`. A **platform binding** carries no `secret_id`
+  (+ `ensure_fresh`) → **`db.commit()` — the DB phase ends here; a call in flight holds no pooled
+  connection** → `relay()` → `audit.record_call`. A pool that has no slot within 5 s answers
+  `503 {"treg_saturated": true}` + `Retry-After: 2` (`_pool_saturated`, the handler for
+  `sqlalchemy.exc.TimeoutError`) rather than a 30 s wait and an anonymous 500. A **platform binding** carries no `secret_id`
   (its value comes from settings at relay time), so secret-loading now skips `secret_id is None`. Detail
   in [proxy-model](../architecture/proxy-model.md).
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -27,8 +27,13 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`.
   SQLite, `init_db` raises (an ephemeral key would make every stored secret undecryptable after a
   restart — silent total loss). On SQLite dev it only logs a warning.
 - **Postgres pool hygiene:** for non-SQLite URLs the async engine adds `pool_pre_ping=True`,
-  `pool_recycle=300`, and sizing (`pool_size=20`, `max_overflow=40`) — avoids post-idle dropped-connection
-  500s and pool starvation against the relay's 200-concurrency client.
+  `pool_recycle=300`, sizing (`pool_size=5`, `max_overflow=10` — per instance; a rolling deploy runs two
+  against a basic-plan Postgres ceiling of ~100, the 2026-08-15 outage) and `pool_timeout=5`. A request
+  that gets no slot in 5 s is answered `503 {"treg_saturated": true}` with `Retry-After: 2` (api.py
+  `_pool_saturated`) instead of SQLAlchemy's default 30 s wait and an anonymous 500. 15 slots is plenty
+  because a `/call/` holds no connection during its upstream round trip — `call_tool` commits before
+  `relay()`; holding one there deadlocked 15 concurrent calls for 30 s on 2026-08-24 (see
+  [proxy-model](../architecture/proxy-model.md) § Connection discipline).
 
 ## Config (`config.py`)
 `Settings` (pydantic-settings, env prefix `TREG_`, reads `.env`), cached via `get_settings()`:

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -49,6 +49,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer
 from sqlmodel import select
@@ -323,6 +324,19 @@ async def _id_out_of_range(request: Request, exc: OverflowError) -> JSONResponse
     # A huge all-digit path param (e.g. /secrets/999…) overflows SQLite's 64-bit INTEGER at bind
     # time; that's a non-existent id, not a server fault — surface a 404 instead of a 500.
     return JSONResponse({"detail": "identifier out of range"}, status_code=404)
+
+
+@app.exception_handler(PoolTimeoutError)
+async def _pool_saturated(request: Request, exc: PoolTimeoutError) -> JSONResponse:
+    """The DB pool had no connection to give within `pool_timeout` (db.py). That is treg being
+    saturated, not the caller's fault and not the provider's — so say so, typed, and fast. Before this
+    handler the same condition surfaced as a bare `500 Internal Server Error` after a 30 s wait (the
+    exception escaped the router and Starlette's BaseHTTPMiddleware reported "No response returned"),
+    which an agent cannot tell from a provider bug. `treg_saturated` is the key a retrying client
+    should branch on; `Retry-After` is how long to wait before doing so."""
+    return JSONResponse(
+        {"detail": "treg's database pool is saturated — retry in a moment", "treg_saturated": True},
+        status_code=503, headers={"Retry-After": "2"})
 
 
 def _refusal_kind(status_code: int) -> str | None:
@@ -11283,16 +11297,27 @@ async def _platform_settle(
     observed = _observed_cost_micro(mk, body) if billable else None
     call_id, mk.call_id = mk.call_id, None  # closing is once-only, even if two paths try
     charged = 0
-    try:
+
+    async def _close() -> int:
         async with session_maker() as db:
             if billable:
-                charged = await ledger.settle(db, call_id, observed, meta={
+                return await ledger.settle(db, call_id, observed, meta={
                     "provider": mk.provider, "status_code": status_code, "cost_type": mk.cost_type,
                     "cost_source": "provider" if observed is not None else "estimate"})
-            else:
-                await ledger.release(db, call_id, reason=reason or f"not_billable_{status_code}",
-                                     meta={"provider": mk.provider, "cost_type": mk.cost_type,
-                                           "status_code": status_code})
+            await ledger.release(db, call_id, reason=reason or f"not_billable_{status_code}",
+                                 meta={"provider": mk.provider, "cost_type": mk.cost_type,
+                                       "status_code": status_code})
+            return 0
+
+    try:
+        try:
+            charged = await _close()
+        except PoolTimeoutError:
+            # No pool slot within `pool_timeout`: a transient wait, not a broken ledger. A settle that
+            # gives up here forfeits the charge (the hold is reaped in the org's favour) — real revenue,
+            # so one short retry is worth it. Anything else falls straight through to the log.
+            await asyncio.sleep(0.5)
+            charged = await _close()
     except Exception as exc:  # noqa: BLE001 — loudly, but never into the caller's response
         logging.getLogger("treg.ledger").error(
             "settle/release failed for call %s (%s, status %s): %s",
@@ -11540,6 +11565,7 @@ async def call_tool(
         live_key = get_settings().demo_stripe_key
         if live_key and demo_sandbox.is_live_tool(tool) and request.method in ("GET", "POST"):
             await _enforce_public_demo_ip_cap(request, db)  # one shared wire → meter by client IP
+            await db.commit()  # end the DB phase before network I/O (see the same call before relay())
             try:
                 response = await _relay_live_demo(
                     request, upstream_url, live_key, demo_sandbox.visitor_name(caller.org.slug))
@@ -11633,6 +11659,18 @@ async def call_tool(
                 await oauth.ensure_fresh(secret, db, request.app.state.http)
             except Exception as exc:  # noqa: BLE001 — surface a clear 502 instead of injecting a dead token
                 raise HTTPException(status_code=502, detail=f"oauth refresh failed: {exc}")
+        # END THE DB PHASE BEFORE NETWORK I/O. From here until the settle this request must hold NO
+        # pooled connection. `ledger.reserve` already committed, but the org refresh after it, the
+        # secret loads and a token refresh each auto-began a fresh transaction on this session, and
+        # SQLAlchemy keeps that transaction's connection checked out until commit — i.e. for the whole
+        # upstream round trip. `_platform_settle` then opens its OWN session for a second connection.
+        # Two per in-flight call against a 15-slot pool (db.py) deadlocked at 15 concurrent calls: every
+        # settle waited on a slot only another waiting call could free, until `pool_timeout` killed one
+        # (a bare 500, or a settle that forfeited its charge) and the rest cascaded — every call in a
+        # burst "took 30 s" (2026-08-24, reproduced from bootoshi's #9/#10). Nothing below reads `db`
+        # (settle, first-call and the idempotent store all run on their own sessions), and the session
+        # is `expire_on_commit=False`, so `tool`/`secrets`/`caller.org` stay usable without a reload.
+        await db.commit()
         try:
             response = await relay(request, upstream_url, tool, secrets, request.app.state.http,
                                    drop_params=drop_params or None,

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -29,7 +29,15 @@ if "sqlite" not in _db_url:
     # ceiling of ~100, so a deploy could starve the database with no bug anywhere. 15 is generous for
     # an async app on this plan; saturation now surfaces as our own pool queueing (visible, bounded)
     # rather than Postgres refusing connections for everyone (the 2026-08-15 outage).
-    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300, pool_size=5, max_overflow=10)
+    #
+    # `pool_timeout` 5 s, not SQLAlchemy's default 30: a request that cannot get a slot is treg
+    # saturated, and the caller should hear that fast and typed (api.py maps the TimeoutError to a
+    # `503 treg_saturated` with Retry-After) rather than sit 30 s and receive an anonymous 500. The
+    # slot count itself only bounds concurrent DB PHASES, which are milliseconds — a /call/ holds no
+    # connection during its upstream round trip (call_tool commits before relay()). Holding one
+    # there is what turned 15 concurrent calls into a 30 s deadlock on 2026-08-24.
+    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300, pool_size=5, max_overflow=10,
+                          pool_timeout=5)
 _engine = create_async_engine(_db_url, **_engine_kwargs)
 # Public: the audit writer opens its own session here (off the request path — rule #2).
 session_maker = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -60,6 +60,11 @@ resolves the tool by host and injects the credential:
   treg sees it, base64-encode the body and add `X-Treg-Body-Encoding: base64` (also `gzip` or
   `base64+gzip`); treg decodes it server-side, so the upstream still gets the real bytes. The
   `treg` CLI does this automatically on a WAF 403 - you only need it over raw HTTP.
+- **Concurrency:** there is no per-token or per-team concurrency limit - fire calls in parallel
+  (`Promise.all`, `asyncio.gather`); a call in flight holds nothing on treg's side. The only limits
+  are the provider's own rate limits, relayed verbatim. If treg itself is saturated you get a
+  `503` with `{"treg_saturated": true}` and a `Retry-After` header - wait that long and retry the
+  same request; nothing was billed. A bare 5xx with no JSON `detail` is never treg's own answer.
 
 ### Retrying a call: `Idempotency-Key`
 

--- a/tests/test_call_pool_discipline.py
+++ b/tests/test_call_pool_discipline.py
@@ -1,0 +1,146 @@
+"""Connection discipline on `/call/`: a call in flight holds NO pooled DB connection.
+
+Found live 2026-08-24 (bootoshi's feedback #9/#10, reproduced from our own token): 15 concurrent
+metered calls each took ~31 s and one died as a bare 500, while the provider answered every one in
+under a second. The request session had auto-begun a transaction after `ledger.reserve` committed
+(the org refresh, the secret loads) and held that connection for the whole upstream round trip;
+`_platform_settle` then opened its own session for a SECOND connection. Two per in-flight call
+against a 15-slot pool deadlocked at 15: every settle waited on a slot only another waiting call
+could free, until `pool_timeout` killed one and the rest cascaded.
+
+The fix is one commit before `relay()`. These tests pin (a) the invariant itself — zero checked-out
+connections while the upstream is being called — on both the metered and the own-key paths, (b) a
+burst larger than the pool completing at provider speed with every charge settled, and (c) the
+typed 503 a genuinely saturated pool now answers instead of an anonymous 500.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from treg import api as A
+from treg import audit, ledger
+from treg.db import _engine, session_maker
+from treg.models import Hold
+
+from test_marketplace_call import EP, EP_MICRO, platform_on  # noqa: F401 — fixture reuse
+
+PoolTimeoutError = A.PoolTimeoutError
+
+
+def _relay_that_checks_the_pool(seen: list[int]):
+    """The real relay, with the pool's checked-out count sampled at the moment the upstream is
+    called. Recorded rather than asserted here: an assertion inside the relay would surface as a
+    502, not a test failure."""
+    original = A.relay
+
+    async def _relay(*args, **kwargs):
+        seen.append(_engine.pool.checkedout())
+        return await original(*args, **kwargs)
+
+    return _relay
+
+
+async def test_a_metered_call_holds_no_db_connection_while_upstream_is_called(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    await audit.drain()  # an earlier test's fire-and-forget audit row must not be counted
+    seen: list[int] = []
+    monkeypatch.setattr(A, "relay", _relay_that_checks_the_pool(seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200, r.text
+    assert seen == [0], f"pooled connections held during the upstream round trip: {seen}"
+
+
+async def test_an_own_key_call_holds_no_db_connection_while_upstream_is_called(
+    clients: AsyncClient, monkeypatch,
+):
+    """The unmetered path pins one too (the secret loads auto-begin a transaction), and it has no
+    second session to deadlock against — it just eats a slot per in-flight call for nothing."""
+    await clients.post("/secrets", json={"name": "tikhub", "value": "MKKEY"})
+    await audit.drain()
+    seen: list[int] = []
+    monkeypatch.setattr(A, "relay", _relay_that_checks_the_pool(seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and r.json()["auth"] == "Bearer MKKEY"
+    assert seen == [0], f"pooled connections held during the upstream round trip: {seen}"
+
+
+async def test_a_burst_larger_than_the_pool_settles_every_call_at_provider_speed(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    """20 metered calls, all forced INTO the upstream window at once (each waits at the relay until
+    every one has arrived). The pool has 15 slots (5 + 10 overflow, the same defaults the test engine
+    uses). Before the fix this deadlocked: 20 requests × a held connection, 20 settles waiting for a
+    slot nobody could free, until the 30 s pool_timeout killed some and the rest cascaded."""
+    N = 20
+    original = A.relay
+    arrived = 0
+    everyone_in = asyncio.Event()
+
+    async def _relay_after_everyone_arrives(*args, **kwargs):
+        nonlocal arrived
+        arrived += 1
+        if arrived == N:
+            everyone_in.set()
+        await asyncio.wait_for(everyone_in.wait(), timeout=10)
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(A, "relay", _relay_after_everyone_arrives)
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    before = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+
+    t0 = time.monotonic()
+    responses = await asyncio.gather(*(
+        clients.get(f"/call/{EP}?aweme_id=burst-{i}") for i in range(N)))
+    wall = time.monotonic() - t0
+
+    assert [r.status_code for r in responses] == [200] * N, [r.status_code for r in responses]
+    assert wall < 10, f"a {N}-call burst took {wall:.1f}s — that is the pool timeout, not the provider"
+    after = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+    assert after == before - N * EP_MICRO, "every call settled at its price"
+    async with session_maker() as db:
+        open_holds = (await db.execute(select(Hold).where(Hold.org_id == org_id))).scalars().all()
+    assert open_holds == [], "no settle was lost to the pool"
+
+
+async def test_a_saturated_pool_answers_a_typed_503_not_an_anonymous_500(
+    clients: AsyncClient, monkeypatch,
+):
+    async def _no_slot(*args, **kwargs):
+        raise PoolTimeoutError("QueuePool limit of size 5 overflow 10 reached, connection timed out")
+
+    monkeypatch.setattr(A, "_resolve_call", _no_slot)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503, r.text
+    assert r.json()["treg_saturated"] is True
+    assert r.headers.get("Retry-After") == "2"
+
+
+async def test_a_settle_that_loses_the_pool_once_retries_and_still_charges(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    """A settle that gives up forfeits real revenue (the hold is reaped in the org's favour), so a
+    transient pool wait gets exactly one retry — and nothing else does."""
+    original = ledger.settle
+    calls = 0
+
+    async def _flaky_settle(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise PoolTimeoutError("QueuePool limit reached")
+        return await original(*args, **kwargs)
+
+    monkeypatch.setattr(ledger, "settle", _flaky_settle)
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    before = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and calls == 2
+    assert r.headers.get("X-Treg-Cost-Micro") == str(EP_MICRO)
+    assert (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"] == before - EP_MICRO


### PR DESCRIPTION
## What broke

A customer running parallel agents (13–29 `/call/`s per `Promise.all`) reported that **every call in a burst took ~32 s** and some came back as a **bare 500 at ~30.4 s, charged $0** (their feedback #9 and #10). Reproduced deterministically from our own token 2026-08-24: solo 0.7 s; 15 in parallel → all 30.5–32 s, one bare 500 with no `X-Treg-Call-Id`, two 200s charged $0. Render logs carried ≥4,000 `QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00` lines over the preceding five days — this was firing fleet-wide, and the pool is per instance and shared by every org.

## Why

A metered call held a pooled DB connection across its whole upstream round trip. `ledger.reserve` commits, but the `db.refresh(caller.org)` after it (and the secret loads, and an OAuth token refresh) auto-began a new transaction on the request session, and SQLAlchemy keeps that connection checked out until the next commit. `_platform_settle` then opens its **own** session for a second connection. Two per in-flight call against a 15-slot pool → at 15 concurrent calls every settle waits on a slot only another waiting call can free → 30 s `pool_timeout` kills one (bare 500, or a settle that forfeits its charge and leaves the hold to the reaper) → the rest cascade through. The provider had answered in 0.5 s; our own `duration_ms` (which starts after reserve) showed 400–590 ms, which is why the dashboard never saw it.

## Fix

- `call_tool`: `await db.commit()` immediately before `relay()` (and `_relay_live_demo`). Nothing after the relay reads the request session; it's `expire_on_commit=False`, so nothing reloads.
- `db.py`: `pool_timeout=5` (was 30). `api.py` maps `sqlalchemy.exc.TimeoutError` → `503 {"treg_saturated": true}` + `Retry-After: 2`, replacing the anonymous 500 (`RuntimeError: No response returned` out of BaseHTTPMiddleware).
- `_platform_settle`: one 0.5 s retry on a pool timeout only (a forfeited settle is real revenue), then the existing never-raises log.

## Tests

`tests/test_call_pool_discipline.py`: `_engine.pool.checkedout() == 0` at relay time on the metered and own-key paths (both read `1` on pre-fix code), a 20-call burst that settles every charge at provider speed (hung on pre-fix code — sqlite's `AsyncAdaptedQueuePool` has the same 5+10/30 defaults), the 503 mapping, and the settle retry. `test_walking_skeleton`'s pool-literal pin and `test_operational`'s audit cap still pass.

Full suite: everything green except `tests/test_agent_pages.py` (26), which fails identically on `origin/main` in this checkout (environment: `_hosted()` vs the repo `.env`) and passes in a bare worktree — unrelated.

## Docs (same commit)

proxy-model § Connection discipline, money.md settle retry, deploy.md pool numbers (which still said 20+40), api.md + data-model.md pipeline/engine lines, `llms.txt` "Concurrency" note (no per-token limit; what `503 treg_saturated` means).

## Verify after deploy

`burst.py 15` / `30` against prod → every call ≈ solo latency, all 200, no `$0`-charged rows; ledger reserve→settle gap < 2 s; Render `QueuePool limit` lines stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTyC97iMBcWCEuSpf34oa4
