### PR TITLE
fix(cli): first-run failures for agents following official skill v0.12.0

### DIFF
--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -58,12 +58,14 @@ _JSON_OVERRIDE: bool = False
 
 
 # ---- config (identity-first: one bearer token + an active org slug) -----------------------
+PRODUCTION_BASE_URL = "https://treg.to"
+
 def _load_config() -> dict:
     try:
         raw = json.loads(CONFIG_PATH.read_text()) if CONFIG_PATH.exists() else {}
     except (json.JSONDecodeError, OSError):
         raw = {}  # a corrupt/half-written config must not brick every command (incl. login/logout)
-    base = raw.get("base_url", "http://localhost:18790")
+    base = raw.get("base_url", PRODUCTION_BASE_URL)
     if "orgs" in raw:  # migrate legacy multi-org config → the active org's token as the bearer
         active = raw.get("active_org")
         tok = (raw.get("orgs", {}).get(active) or {}).get("token")
@@ -149,6 +151,13 @@ def _pin_token_to_active_org(cfg: dict) -> None:
 
 def _effective_org(cfg: dict) -> str | None:
     return _ORG_OVERRIDE or os.environ.get("TREG_ORG") or cfg.get("active_org")
+
+
+def _is_loopback_url(url: str) -> bool:
+    """True if the URL points to a loopback address (localhost, 127.x.x.x, [::1]).
+    Used to detect a misconfigured first-run where the CLI defaults to a local dev server that isn't running."""
+    host = urlsplit(url).hostname or ""
+    return host in ("localhost", "127.0.0.1", "::1") or host.startswith("127.")
 
 
 class _RegistryClient(httpx.Client):
@@ -373,22 +382,37 @@ def cmd_login(args, cfg) -> None:
     # /login?cli=… link — can't be approved into a token for them. If the server is too old to know
     # /start, fall back to a locally-minted id (no code) so login still works.
     code = None
+    start_exc = None
     try:
         st = httpx.post(f"{base}/auth/cli/start", headers={"ngrok-skip-browser-warning": "1"}, timeout=10)
         if st.status_code == 200:
             j = st.json(); lid = j["login_id"]; code = j.get("code")
         else:
             lid = _secrets.token_urlsafe(18)
-    except Exception:
+    except Exception as exc:
+        start_exc = exc
         lid = _secrets.token_urlsafe(18)
+    # Detect localhost-with-nothing-listening: the install.sh sets base_url but if that failed, the
+    # default is production treg.to. If someone explicitly points at localhost (for local dev) and
+    # nothing is there, fail early with a helpful message rather than opening a dead browser page.
+    if start_exc and _is_loopback_url(base):
+        sys.exit(
+            f"Cannot reach {base} — is a local treg server running?\n"
+            f"  If you meant to use the production registry, run:\n"
+            f"    treg config --base-url {PRODUCTION_BASE_URL}\n"
+            f"  then retry `treg login`.\n"
+            f"  (error: {start_exc})"
+        )
     # The code rides in the URL FRAGMENT (never sent to the server, so it stays out of request logs):
     # the /login page displays it for a visual match against this terminal instead of making the user
     # type it. The server still validates the code at approve time — the guard itself is unchanged.
     url = f"{base}/login?cli={lid}" + (f"#code={code}" if code else "")
-    print(f"Opening your browser to sign in…\nIf it doesn't open, visit:\n  {url}\n")
+    # flush=True for non-TTY agent shells where stdout is block-buffered — the pairing code must
+    # appear immediately so an agent driving a browser can see and verify it.
+    print(f"Opening your browser to sign in…\nIf it doesn't open, visit:\n  {url}\n", flush=True)
     if code:
-        print(f"  The sign-in page shows this code — check it matches:  {_B}{_TEAL}{code}{_R}\n")
-    print("Waiting for authorization…")
+        print(f"  The sign-in page shows this code — check it matches:  {_B}{_TEAL}{code}{_R}\n", flush=True)
+    print("Waiting for authorization…", flush=True)
     try:
         webbrowser.open(url)
     except Exception:
@@ -3429,6 +3453,20 @@ def cmd_mcp_use_team(args, cfg) -> None:
     _dim(f"  {body.get('note', '')}")
 
 
+def _is_transient_network_error(exc: Exception) -> bool:
+    """True if the exception looks like a transient SSL/connection error that a retry might fix.
+    Covers SSL handshake failures, connection refused, timeouts, and similar network glitches."""
+    import ssl
+    if isinstance(exc, ssl.SSLError):
+        return True
+    if isinstance(exc, (ConnectionError, TimeoutError, OSError)):
+        return True
+    if isinstance(exc, httpx.TransportError):
+        return True
+    exc_str = str(exc).lower()
+    return any(s in exc_str for s in ("ssl", "connection", "timeout", "refused", "reset"))
+
+
 def cmd_mcp_install(args, cfg) -> None:
     """Register the treg MCP server into every supported agent on this machine, header-authed with
     the logged-in token (which bakes in the team, so no org to pass). The MCP sibling of
@@ -3444,11 +3482,29 @@ def cmd_mcp_install(args, cfg) -> None:
     # whichever agent tries a call — looking like a provider problem, not a setup one. `_client`
     # applies the same TREG_TOKEN-beats-config precedence used above, so this validates exactly the
     # token that would be written.
-    try:
-        with _client(cfg) as c:
-            who = c.get("/auth/me")
-    except Exception as exc:  # noqa: BLE001 — network/DNS: report, don't write a maybe-bad token
-        sys.exit(f"Could not reach {cfg['base_url']} to verify the token: {exc}")
+    #
+    # Retry transient SSL/connection errors: the SSL: WRONG_VERSION_NUMBER bug often clears on a
+    # second attempt (TLS handshake race, proxy hiccup). Max 3 tries with 1s/2s backoff.
+    who = None
+    last_exc = None
+    for attempt in range(3):
+        try:
+            with _client(cfg) as c:
+                who = c.get("/auth/me")
+            break  # success
+        except Exception as exc:  # noqa: BLE001 — network/DNS: report, don't write a maybe-bad token
+            last_exc = exc
+            if attempt < 2 and _is_transient_network_error(exc):
+                time.sleep(1 << attempt)  # 1s, 2s
+                continue
+            break
+    if who is None:
+        base = cfg.get("base_url") or PRODUCTION_BASE_URL
+        sys.exit(
+            f"Could not reach {base} to verify the token: {last_exc}\n"
+            f"  If this is an SSL or connection error, retry in a moment.\n"
+            f"  If it persists, check your network or try: curl -I {base}"
+        )
     if who.status_code == 401:
         sys.exit("That token was rejected (401 invalid token) — nothing was written. It's expired "
                  "or from a different server; run `treg login` (or copy a fresh token from the "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,52 @@ def test_load_config_default(tmp_path, monkeypatch):
     assert cfg["token"] is None and cfg["active_org"] is None and cfg["base_url"].startswith("http")
 
 
+def test_load_config_defaults_to_production_not_localhost(tmp_path, monkeypatch):
+    """A fresh CLI (no ~/.treg/config.json) must default to https://treg.to, NOT localhost.
+    The first-run bug was: install.sh's `treg config --base-url` failed silently, so login
+    opened Chrome to http://localhost:18790/login — nothing listening, connection refused."""
+    monkeypatch.setattr(cli, "CONFIG_PATH", tmp_path / "missing" / "config.json")
+    cfg = cli._load_config()
+    assert cfg["base_url"] == cli.PRODUCTION_BASE_URL
+    assert "localhost" not in cfg["base_url"]
+    assert "127.0.0.1" not in cfg["base_url"]
+
+
+def test_is_loopback_url_detects_localhost_variants():
+    """_is_loopback_url recognises localhost, 127.x.x.x, and [::1] so the login flow can warn
+    when pointed at a local server that isn't running."""
+    assert cli._is_loopback_url("http://localhost:18790") is True
+    assert cli._is_loopback_url("http://127.0.0.1:8000") is True
+    assert cli._is_loopback_url("http://127.0.0.42/path") is True
+    assert cli._is_loopback_url("https://[::1]/") is True  # IPv6 needs brackets in URLs
+    assert cli._is_loopback_url("https://[::1]:8000/") is True
+    assert cli._is_loopback_url("https://treg.to") is False
+    assert cli._is_loopback_url("https://api.example.com:443/v1") is False
+    assert cli._is_loopback_url("") is False  # empty URL shouldn't crash
+
+
+def test_login_exits_with_helpful_message_when_localhost_unreachable(monkeypatch):
+    """When base_url is localhost and the server can't be reached, login must fail early with
+    a message that tells the user how to fix it (point at production), not silently open a
+    dead browser page."""
+    import httpx
+
+    def fake_post(url, **kw):
+        raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+    args = type("A", (), {"token": None, "email": None})()
+    cfg = {"base_url": "http://localhost:18790", "token": None}
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.cmd_login(args, cfg)
+
+    error_msg = str(exc_info.value)
+    assert "localhost" in error_msg.lower() or "Cannot reach" in error_msg
+    assert "treg config --base-url" in error_msg
+    assert cli.PRODUCTION_BASE_URL in error_msg
+
+
 def test_token_org_claim_reads_a_team_pinned_token():
     """`_token_org_claim` decodes the org slug a team-pinned identity token carries — without the
     signature check (the server still authorizes), and returning None on anything else."""

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -115,3 +115,57 @@ def test_cmd_mcp_install_REFUSES_a_bad_token_before_writing(tmp_path, monkeypatc
                             {"token": "K", "base_url": "https://treg.to"})
     assert "rejected" in str(e.value)
     assert not (tmp_path / ".config" / "opencode" / "opencode.json").exists()  # nothing written
+
+
+def test_cmd_mcp_install_retries_transient_ssl_errors(tmp_path, monkeypatch):
+    """The SSL: WRONG_VERSION_NUMBER bug from the repro: first mcp install attempt gets an SSL
+    error, but a retry succeeds. The command must retry transient errors instead of failing."""
+    import ssl
+    import time as time_module
+    from types import SimpleNamespace
+
+    import httpx
+
+    from treg import cli
+
+    attempts = []
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def get(self, url):
+            attempts.append(url)
+            if len(attempts) == 1:
+                raise ssl.SSLError(1, "[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1029)")
+            return httpx.Response(200, json={"email": "test@x.dev"},
+                                  request=httpx.Request("GET", "http://t/auth/me"))
+
+    monkeypatch.setattr(cli, "_client", lambda cfg, **k: FakeClient())
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setattr(mcp_install, "install_mcp", lambda **k: {"results": [], "manual": [], "mcp_url": k["base_url"] + "/mcp/"})
+    monkeypatch.setattr(time_module, "sleep", lambda s: None)
+
+    cli.cmd_mcp_install(SimpleNamespace(name=None), {"token": "K", "base_url": "https://treg.to"})
+    assert len(attempts) == 2  # first failed, second succeeded
+
+
+def test_is_transient_network_error_detects_ssl_and_connection_errors():
+    """_is_transient_network_error classifies errors so mcp install knows what to retry."""
+    import ssl
+    import httpx
+    from treg import cli
+
+    # Create an SSL error the same way Python's ssl module does
+    ssl_err = ssl.SSLError(1, "[SSL: WRONG_VERSION_NUMBER] wrong version number")
+    assert cli._is_transient_network_error(ssl_err)
+    assert cli._is_transient_network_error(ConnectionRefusedError())
+    assert cli._is_transient_network_error(TimeoutError("connection timed out"))
+    assert cli._is_transient_network_error(httpx.ConnectError("connection failed"))
+    assert cli._is_transient_network_error(OSError("network unreachable"))
+    assert cli._is_transient_network_error(Exception("SSL: WRONG_VERSION_NUMBER"))
+    assert not cli._is_transient_network_error(ValueError("bad value"))
+    assert not cli._is_transient_network_error(KeyError("missing key"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes three bugs that blocked a fresh agent (Grok Bot / Cursor) following the official first-run steps on a Linux box with no prior `~/.treg/config.json`:

### Bug A — login opened localhost, connection refused

**Root cause:** `_load_config()` defaulted `base_url` to `http://localhost:18790` when config file was missing. If install.sh's `treg config --base-url` failed silently, the first `treg login` opened a dead localhost URL.

**Fix:** Default to `https://treg.to` (new `PRODUCTION_BASE_URL` constant). When login fails to reach a localhost base_url, exit with a helpful message telling the user how to point at production.

### Bug B — `treg mcp install` SSL error, then success on retry

**Root cause:** Token verification before writing MCP configs had no retry logic. Transient SSL handshake failures (SSL: WRONG_VERSION_NUMBER) caused immediate exit even though a retry would succeed.

**Fix:** Add retry logic (3 attempts, 1s/2s backoff) for transient SSL/connection errors via `_is_transient_network_error()`. Clearer error message with recovery instructions.

### Bug C — pairing code not visible in non-TTY agent shells

**Root cause:** `print()` calls for the login URL and pairing code were block-buffered in non-TTY environments (agent-captured shells).

**Fix:** Add `flush=True` to the critical print statements so the pairing code appears immediately.

## How it was tested

```bash
uv run pytest tests/test_cli.py tests/test_mcp_install.py -v  # 66 passed
uv run pytest -q  # 1882 passed
```

New tests added:
- `test_load_config_defaults_to_production_not_localhost` — verifies missing config defaults to production URL
- `test_is_loopback_url_detects_localhost_variants` — verifies localhost/127.x/[::1] detection
- `test_login_exits_with_helpful_message_when_localhost_unreachable` — verifies helpful error when localhost is down
- `test_cmd_mcp_install_retries_transient_ssl_errors` — verifies SSL errors are retried
- `test_is_transient_network_error_detects_ssl_and_connection_errors` — verifies transient error classification

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed) — reviewed `docs/context/interface/cli.md`; these are defensive improvements (default URL, retry logic, output flushing), not new features, so the documented behavior is unchanged
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf7e0b2b-c03a-4833-beef-c4e73e11d1ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf7e0b2b-c03a-4833-beef-c4e73e11d1ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

