### PR TITLE
SEO: 5 use-case pages (2026-08-25)

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -278,7 +278,7 @@ what makes it a template rather than one page's prose:
 
 | Form | Condition | Renders |
 |---|---|---|
-| `short` | one provider | "How it works": the one call, on the reader's own account. No comparison |
+| `short` | one provider | "How it works": the one call. Own-account copy when the cost is `free`; otherwise the rate and the $0.000 markup. No comparison |
 | `platforms` | the job spans several platforms | providers grouped per platform, cheapest claimed per platform |
 | `compare` | several providers, one platform | the full comparison |
 
@@ -320,7 +320,7 @@ requires `voices` and `voices_intro` together rather than requiring either.
 say it anyway. Write position-neutral ("the comparison above", "the prices here") or the sentence
 is wrong for every reader who scrolls.
 
-**Written so far: 17 of the 66 jobs**, and from 2026-08-24 the remaining set is no longer "all of
+**Written so far: 22 of the 66 jobs**, and from 2026-08-24 the remaining set is no longer "all of
 them". Every unwritten job was measured against Google Ads keyword volume that day; the ones
 clearing 50 US searches a month became a worklist ordered by volume, and the rest are parked as
 rows on the menu with no page. A page nobody searches for is the scaled-content shape the risk
@@ -349,6 +349,18 @@ its `cost_view` carries no USD and the page labelled the dearest option on it as
 reader's own account. Free is now read off the cost's own `type`; anything else without a figure
 prints "no dollar rate published", which is what the pages say about Semrush in prose too. It was
 found by reading the rendered page, which is the argument for that step in the skill.
+
+**A trial-pool row is a fourth state, and a metered single provider is not an own-account one**
+(2026-08-25). Finnhub, Tiingo and Twelve Data are served at $0 on treg.to's own free-tier keys with
+a per-team daily allowance (`catalog.trial_pools`); `cost_view` gives them `usd == 0`, so they fell
+through to "free, your own account", and with no priced row on the page the hero and the `{cheapest}`
+placeholder said the same. `_uc_providers` now carries `trial` (calls per team per day) and the
+cell, the `.md` table, the hero and `{cheapest}` state the allowance ("free, 50 calls a day on
+treg.to's key, then your own key"). Separately, the `short` form assumed its one provider was an
+OAuth connection; the AI-mentions job has one provider, DataForSEO, and it is metered, so the form
+branches on the row's `free` flag: `metered_single` states the rate and the markup, and the meta
+description does not claim "never metered". Both were found the same way as the Semrush one: by
+reading the stock and AI-visibility pages after the tests went green.
 
 Nested under the category on purpose: the five flat ad pages keep their URLs and `build_html.py`
 ownership, and `test_legacy_flat_use_case_pages_still_answer` proves the nested route cannot shadow

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2096,3 +2096,106 @@ USE_CASE_PAGES[("seo", "keywords-a-domain-ranks-for")] = {
     "related": ("Google results for a keyword", "Keyword volume, CPC and competition",
                 "Backlink profile of a domain", "Keywords a domain bids on"),
 }
+
+USE_CASE_PAGES[("seo", "how-ai-answers-mention-your-brand")] = {
+    "label": "How AI answers mention your brand",
+    "sentence": "AI visibility tracking: how ChatGPT and Perplexity answers mention your brand, run by your agent",
+    "title": "AI visibility tracking API, from {cheapest} a check | treg.to",
+    "lede": (
+        "Every AI visibility tool sells the same loop: run a set of prompts through ChatGPT and "
+        "Perplexity, note who gets named, repeat next week. Your agent can run that loop itself. "
+        "One provider serves it through treg.to, as live answers to a prompt and as aggregated "
+        "mention metrics for a keyword or domain, priced per call from {cheapest}, with no "
+        "subscription and no dashboard to pay for."),
+    "prompt": "Using treg, run these 12 buyer prompts through ChatGPT and Perplexity, US, web search "
+              "on, and tell me for each one whether treg.to or any of Composio, Pipedream or Zapier "
+              "is named, and in what position. Show me the total price before you start.",
+    "prompt_why": [
+        ("Fix the prompt set first", "The check is only comparable week to week if the prompts do not move."),
+        ("Name the competitors", "Presence on its own says little; share of the answer against named rivals is the number."),
+        ("Ask for the price up front", "The two answer endpoints differ five times in price; the metrics call is dearer again."),
+        ("Run it more than once", "Answers vary run to run. Two passes on the same day show you the noise floor."),
+    ],
+    "result_noun": "answer",
+    "result_image": None,
+    "what_is_heading": "What is AI visibility tracking?",
+    "what_is": (
+        "AI visibility tracking is the practice of measuring whether, and how, AI answer engines "
+        "such as ChatGPT, Perplexity and Google's AI Overviews mention a brand when someone asks "
+        "the questions its buyers ask. It borrows the shape of rank tracking, a fixed prompt set "
+        "checked on a schedule, but the answers are generated rather than ranked, so the same "
+        "prompt can name different brands on different days. The tools sold under this name "
+        "charge a monthly subscription for running the prompts and charting the result; the "
+        "underlying data is a call to the model and a count."),
+    "notes": [
+        "There are two kinds of endpoint here and they answer different questions. The two live "
+        "answer endpoints send your prompt to ChatGPT or Perplexity, with web search on if you ask "
+        "for it and a country to search from, and return the answer as data for your agent to read: "
+        "that is the check. The two mention-metrics endpoints return aggregated counts of how often "
+        "a keyword or a domain appears across a platform's answers, which is the trend line. Run "
+        "the first on your prompt set and the second on your domain.",
+        "The prices are not alike. On the catalog's verified rates a Perplexity answer is about "
+        "half a cent, a ChatGPT answer about three cents, and a mention-metrics call about a dime. "
+        "A weekly run of fifty prompts on both engines is therefore under two dollars, which is the "
+        "argument against a subscription; a daily run across many domains is where the metrics "
+        "call starts to matter.",
+        "The answer is a sample, not a fact. The same prompt to the same model on the same day can "
+        "name a different set of brands, and every engine changes what it cites without notice. "
+        "Nothing on this page smooths that, and no tool that charts it can either. What the "
+        "per-call price buys you is the ability to repeat the run cheaply enough to see the noise "
+        "before you read a trend into it.",
+    ],
+    "faq": [
+        ("Is this a scrape of the ChatGPT website?",
+         "No. The provider calls the model's own API with web search enabled and returns the "
+         "answer as structured data. You choose the model name and the country to search from. "
+         "It is the same generated answer, without a browser."),
+        ("Can it tell me how to get mentioned?",
+         "No. It tells you whether you are named, in which answers, and how that count moves. "
+         "Earning the mention is a content and citation problem, and the neighbouring pages on "
+         "Google results and a domain's backlinks are the places to start on it."),
+        ("Which engines are covered?",
+         "Live answers from ChatGPT and Perplexity. The mention metrics take a platform parameter, "
+         "and the catalog's verified examples use ChatGPT and Google. Gemini and Claude are not "
+         "on this shelf today."),
+        ("Do I need a DataForSEO account?",
+         "No. treg.to serves this on its own key at the provider's rate with $0.000 markup, "
+         "metered from your team's balance. If you already have an account, register the key "
+         "and those calls are never metered."),
+    ],
+    "voices_intro": (
+        "This is the most astroturfed category on the menu: 10 of the 22 relevant posts in "
+        "August 2026 were tool launches, vendor data dumps posted twice, or a vendor's employee "
+        "asking the question their product answers. These four are people doing the job by hand."),
+    "voices": [
+        ("The check is a weekly copy-and-paste job",
+         "who's still manually prompting ChatGPT and Claude to check if their brand shows up in AI answers?",
+         "r/seogrowth, 22 points", "https://www.reddit.com/r/seogrowth/comments/1sm5t9r/whos_still_manually_prompting_chatgpt_and_claude/",
+         "This is exactly the loop an agent should own. Hand it the prompt list and the competitor "
+         "names, and it runs the set through both engines and returns a table, at a few cents a "
+         "prompt, on whatever schedule you give it."),
+        ("Nobody is sure what the method should even be",
+         "API calls on a schedule, a paid tool, something manual in a spreadsheet?",
+         "r/aeo, 16 points", "https://www.reddit.com/r/aeo/comments/1vqugjg/how_do_you_actually_track_ai_visibility_across/",
+         "The first of those three, and it is less work than it sounds. The schedule is the "
+         "agent's, the API is one call per prompt per engine, and the spreadsheet is the table it "
+         "hands back. Which prompts represent your buyers is still your judgement; no API makes "
+         "that call."),
+        ("The numbers feel made up",
+         "curious what youre actually tracking for AI citations because the methodology feels kind of made up right now",
+         "r/DigitalMarketing, 54 points", "https://www.reddit.com/r/DigitalMarketing/comments/1staemu/added_ai_citation_tracking_to_our_monthly_reports/",
+         "It is, a little, everywhere: a generated answer is a sample. The honest version of the "
+         "metric is a fixed prompt set, run more than once, with the run-to-run variance reported "
+         "next to the share. A per-call price makes the repeat runs affordable; it does not make "
+         "the engines consistent."),
+        ("Doing it yourself, the API bill ran past the estimate",
+         "I ran 1,564 real ChatGPT answers through the numbers to check if its Reddit citations actually cratered",
+         "r/aeo", "https://www.reddit.com/r/aeo/comments/1vwuthp/i_ran_1564_real_chatgpt_answers_through_the/",
+         "A self-built run with web search on, cut short at seven of ten categories when the "
+         "per-call cost overran. That is the case for seeing the price before the run: the agent "
+         "shows the total for the prompt set first, and a thousand ChatGPT answers here is a known "
+         "figure, not an estimate."),
+    ],
+    "related": ("Google results for a keyword", "Keywords a domain ranks for",
+                "Backlink profile of a domain", "Search Console: clicks, impressions and top queries"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2199,3 +2199,91 @@ USE_CASE_PAGES[("seo", "how-ai-answers-mention-your-brand")] = {
     "related": ("Google results for a keyword", "Keywords a domain ranks for",
                 "Backlink profile of a domain", "Search Console: clicks, impressions and top queries"),
 }
+
+USE_CASE_PAGES[("connect-your-own-accounts", "your-google-business-profile-reviews-and-reply-to-them")] = {
+    "label": "Your Google Business Profile reviews, and reply to them",
+    "sentence": "Google Business Profile API: your Google reviews, read and replied to by your agent",
+    "title": "Google Business Profile API: read and reply to reviews | treg.to",
+    "lede": (
+        "Connect the Google Business Profile you already manage and your agent can read every "
+        "review on every location, and reply as the business. This is the Google My Business API "
+        "as it is now called, on your own account, so treg.to never meters it; and the API access "
+        "request that stops most people at zero quota is one treg.to has already made."),
+    "prompt": "Using treg, list every review on our Austin location from the last 30 days with three "
+              "stars or fewer, draft a reply to each in our voice, and post them only after I approve.",
+    "prompt_why": [
+        ("Connect once", "One consent screen for the Google account that manages the listing. No Cloud project of your own."),
+        ("Name the location", "A profile holds many locations; the reviews call is per location, or batched across them."),
+        ("Keep a human gate on replies", "A reply publishes under the business name. Ask for drafts, then approve."),
+        ("It costs nothing", "Your own account, so the call is never metered."),
+    ],
+    "result_image": None,
+    "what_is_heading": "What is the Google Business Profile API?",
+    "what_is": (
+        "The Google Business Profile API, formerly the Google My Business API, is how a business "
+        "reads and manages its own listings on Google Search and Maps as data: locations, hours, "
+        "posts, performance, and the customer reviews with their star rating, text and date, plus "
+        "the reply the business has posted to each. It is scoped to listings the connected account "
+        "owns or manages. It is not a way to read another business's reviews; that is a separate "
+        "job on the menu."),
+    "notes": [
+        "The gate on this API is not the OAuth scope, it is the access request. Google starts every "
+        "Cloud project at zero requests a day on the Business Profile API until it approves the "
+        "project, and that is the wall in most of the forum posts. The request belongs to the "
+        "project making the call, and that project is treg.to's: you consent, you do not apply.",
+        "Reviews still live on the older v4 surface while the rest of the profile moved to the v1 "
+        "services, so the review calls take an account id and a location id rather than a resource "
+        "name. Your agent lists accounts first, then locations, then reviews; a batch endpoint "
+        "reads reviews across several locations in one call.",
+        "Replying is an action, not a read. The reply publishes publicly under the business name, "
+        "it can be edited or deleted later through the same API, and a reply signals to Google that "
+        "the review is a real customer's. Ask the agent to draft, and to flag anything that reads "
+        "like a policy violation before you answer it rather than after.",
+    ],
+    "faq": [
+        ("Does this cost anything?",
+         "No. The Business Profile API runs on your own Google account, so treg.to relays the call "
+         "and meters nothing. Only calls on treg.to's own provider keys are billed."),
+        ("Do I need to apply for Google Business Profile API access?",
+         "No. Google grants that access to the Cloud project making the calls, and treg.to holds "
+         "the approved app. You need to be an owner or manager of the listing, and to consent once."),
+        ("Can my agent read a competitor's reviews this way?",
+         "No. The API returns only the listings your connected account manages. Reading any "
+         "business's public reviews is the neighbouring job, served by scraping providers."),
+        ("Does it work across several locations?",
+         "Yes. The reviews call is per location, and there is a batch call that reads reviews "
+         "across several of your listings at once. The agent lists your locations first."),
+    ],
+    "voices_intro": (
+        "The Google Business Profile subreddits are a queue of people waiting on Google. From ~40 "
+        "Reddit and X posts in August 2026, ten were vendors selling reply tools, including one "
+        "study posted word for word to two subreddits. These four are people stuck at the door."),
+    "voices": [
+        ("The access request gets rejected, even when you follow the rules",
+         "GBP API access rejected even though I followed their \"client account\" rule?",
+         "r/GoogleMyBusiness", "https://www.reddit.com/r/GoogleMyBusiness/comments/1sx6686/gbp_api_access_rejected_even_though_i_followed/",
+         "The request is judged per Cloud project, and it is opaque: several posters waited weeks "
+         "with no reply at all. That is the part treg.to takes off the table. You are consenting "
+         "to an app that already has access, not applying for your own."),
+        ("Approved, and the quota is still zero",
+         "I'm currently stuck with the Google Business Profile API where the quota is set to 0 and the API is basically unusable.",
+         "r/localseo", "https://www.reddit.com/r/localseo/comments/1r64f1s/google_business_profile_api_quota_stuck_at_0_has/",
+         "Zero is the default for every new project and the quota bump is a second request. Both "
+         "belong to the project, not the user, which is why a hosted connection helps here and a "
+         "tutorial does not."),
+        ("It only ever shows you your own listing",
+         "Google's own APIs will hand you your own listing and nothing else.",
+         "r/n8n", "https://www.reddit.com/r/n8n/comments/1vms0uu/i_built_a_free_template_that_logs_every/",
+         "True, and this page will not pretend otherwise. This job is your reviews; a competitor's "
+         "public reviews are the neighbouring job, on Yelp, TripAdvisor and Trustpilot, and the "
+         "local pack comes through the SERP providers."),
+        ("Replying to a bad review can make it harder to remove",
+         "if you reply to the review, it treats it as a real customer, making it harder to get it taken down.",
+         "X, 142 likes", "https://x.com/i/status/2090034289811288369",
+         "One reason to keep the reply step behind your approval. Have the agent read each new "
+         "review against Google's review policy first and flag the ones worth reporting, then reply "
+         "to the rest."),
+    ],
+    "related": ("A business's reviews", "Find local businesses by keyword and location",
+                "Search terms that surfaced your listing on Maps", "Search Console: clicks, impressions and top queries"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2380,3 +2380,97 @@ USE_CASE_PAGES[("local-businesses-reviews", "a-business-s-reviews")] = {
                 "Your Google Business Profile reviews, and reply to them",
                 "Product reviews", "Hotel listing details"),
 }
+
+USE_CASE_PAGES[("connect-your-own-accounts", "google-analytics-traffic-and-behaviour-reports")] = {
+    "label": "Google Analytics: traffic and behaviour reports",
+    "sentence": "Google Analytics MCP or API: GA4 traffic and behaviour reports, read by your agent",
+    "title": "Google Analytics API for {agent}: any GA4 report | treg.to",
+    "lede": (
+        "Connect the GA4 property you already own and your agent can run any report the Data API "
+        "can: sessions, users, conversions and events by channel, page, country, device or date, "
+        "with filters and ordering, in plain words. It is the Google Analytics API without the "
+        "Cloud project, and it runs on your own Google account, so treg.to never meters it."),
+    "prompt": "Using treg, show me sessions and key events by default channel group for the last "
+              "28 days ending 3 days ago, next to the 28 days before, and flag any channel that is "
+              "down by more than a fifth.",
+    "prompt_why": [
+        ("Connect once", "One consent screen for the Google account that can see the property. No Cloud project, no service account."),
+        ("Name the property, or let it list them", "A Google account often sees several GA4 properties. The agent can list them and ask."),
+        ("End the window a few days back", "GA4 keeps processing recent days. A window that ends on yesterday is still settling."),
+        ("It costs nothing", "Your own account, so the call is never metered."),
+    ],
+    "result_image": None,
+    "what_is_heading": "What is the Google Analytics API?",
+    "what_is": (
+        "The Google Analytics Data API is the programmatic side of GA4: you send a property id, a "
+        "date range, dimensions, metrics and optional filters, and it returns the rows the UI's "
+        "Reports and Explore views are built from. It is the same data with none of the Explore "
+        "date-range or sampling-pool caps, and the reason to read it through an agent is that "
+        "the request body, with its dimension and metric names, is fiddly to write and easy to "
+        "get subtly wrong by hand."),
+    "notes": [
+        "The official path to an agent on GA4 is Google's own Analytics MCP server, and its setup "
+        "is a Cloud project, a service account with the API enabled, and admin-level access on "
+        "the property. Here the app is treg.to's, the consent is one screen, and read access on "
+        "the property is enough, which is what makes it usable by a consultant who does not own "
+        "the account.",
+        "Totals move with the dimensions you ask for, and that is GA4, not the relay. A metric "
+        "scoped by session counts differently once you break it down by an event-scoped "
+        "dimension, and the API returns exactly what the UI would for the same request. When the "
+        "number disagrees with the report you remember, ask the agent to run both shapes and "
+        "show the request, rather than assuming one is wrong.",
+        "The API can only return what the property retains. GA4 keeps event-level data for two "
+        "months by default, so a year-on-year or cohort question beyond that window comes back "
+        "empty from the API exactly as it does from Explore. The Data API also enforces per "
+        "property token quotas per hour and per day, so a wide report with many dimension "
+        "combinations is dearer in quota than a narrow one, and the agent should ask before "
+        "running a loop over every page.",
+    ],
+    "faq": [
+        ("Does this cost anything?",
+         "No. Google Analytics runs on your own Google account, so treg.to relays the call and "
+         "meters nothing. Only calls on treg.to's own provider keys are billed."),
+        ("Do I need a Cloud project or a service account?",
+         "No. treg.to holds the Google app; you consent once with the account that can see the "
+         "property, and treg.to keeps the token server side. Your agent never sees it."),
+        ("Which reports can it run?",
+         "Anything runReport accepts: any combination of dimensions and metrics, date ranges, "
+         "filters, ordering and paging. Realtime visitors are a separate call, on the "
+         "neighbouring row of the menu."),
+        ("Will it fix numbers that look wrong?",
+         "No. If the tagging or consent setup is feeding GA4 the wrong events, the API returns "
+         "the same wrong numbers. The agent can show you the request it made, which is the first "
+         "step in finding out why."),
+    ],
+    "voices_intro": (
+        "Around 34 of the ~75 relevant posts in August 2026 were launches of one more GA4 MCP or "
+        "dashboard, several posted word for word across five subreddits. These four are people "
+        "asking for the thing rather than selling it."),
+    "voices": [
+        ("People are asking for exactly this, by name",
+         "What AI agent tools can I use to connect to the Google Analytics API and retrieve data through a chat-based conversational interface",
+         "r/GoogleAnalytics, 17 points", "https://www.reddit.com/r/GoogleAnalytics/comments/1vpw1m9/what_ai_agent_tools_can_i_use_to_connect_to_the/",
+         "Any of them, once the agent can reach a connected property. That is what the setup line "
+         "on this page does: the agent gets the report call and the token stays with treg.to."),
+        ("Writing the API call by hand fails, even with help",
+         "I asked 6 LLMs for code samples and I got 6 different answers that all failed to do the API call.",
+         "r/dataengineering", "https://www.reddit.com/r/dataengineering/comments/1im3fpx/does_anyone_know_how_to_export_the_audience/",
+         "The request body is the hard part and here nobody writes it. The agent builds it from "
+         "the question, runs it, and shows it back, so a wrong dimension name is a visible "
+         "mistake rather than a silent one."),
+        ("The API and the interface disagree",
+         "according to the interface I'm getting 2.2M event counts, whereas the API says 495k event counts for the same page.",
+         "r/GoogleAnalytics", "https://www.reddit.com/r/GoogleAnalytics/comments/vwhssp/ga4_data_api_vs_interface_discrepancy/",
+         "No relay can settle this, and this page will not claim to. Both numbers can be correct "
+         "for two differently scoped requests. What the agent adds is the request itself, in the "
+         "open, so you can see which shape produced which number."),
+        ("The data is visible on screen and still out of reach",
+         "I feel like I'm missing something obvious in GA4 about how to get at that data since I can SEE it right there",
+         "r/GoogleAnalytics", "https://www.reddit.com/r/GoogleAnalytics/comments/1n09huf/export_daily_views_data_for_a_single_page/",
+         "Daily views for one page is a two-line report on the API: a date dimension, a page "
+         "filter, a views metric. Ask for it in those words and the agent returns the table, no "
+         "export ritual."),
+    ],
+    "related": ("Search Console: clicks, impressions and top queries", "Realtime visitors on your site",
+                "Is this page indexed, and why not", "Your own campaign performance"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2474,3 +2474,102 @@ USE_CASE_PAGES[("connect-your-own-accounts", "google-analytics-traffic-and-behav
     "related": ("Search Console: clicks, impressions and top queries", "Realtime visitors on your site",
                 "Is this page indexed, and why not", "Your own campaign performance"),
 }
+
+USE_CASE_PAGES[("finance-markets", "current-quote-for-a-ticker")] = {
+    "label": "Current quote for a ticker",
+    "sentence": "Stock price API: the current quote for a ticker from four providers, free to start",
+    "title": "Stock price API: {n} providers, free to try | treg.to",
+    "lede": (
+        "Ask for a ticker and get the quote back as data: price, day change, open, high, low and "
+        "previous close. {n} providers answer through one treg.to key. Three of them are served "
+        "on treg.to's own free-tier keys, {cheapest}, then on your own key; the fourth is your own "
+        "plan only. Each one says whether its quote is real time or delayed, and the page says it "
+        "too, because that word is where stock APIs go wrong."),
+    "prompt": "Using treg, get the current price, day change and previous close for AAPL, MSFT and "
+              "NVDA. Tell me which provider you will use and whether its quote is real time or "
+              "delayed before you call, and stop if the free allowance is used up.",
+    "prompt_why": [
+        ("Ask whether it is delayed", "One of these is 15 to 20 minutes behind by design. The agent should say which before it quotes."),
+        ("One ticker is one call", "The free allowance is counted in calls per team per day, so a watchlist of fifty is a day's allowance."),
+        ("Try on the allowance, build on your key", "The daily pool is for finding out which feed you want. A bot needs a key of its own."),
+        ("Compare, then pick", "treg.to shows the four side by side and does not choose for you. Say which one you want, or say why."),
+    ],
+    "result_noun": "quote",
+    "result_image": None,
+    "what_is_heading": "What is a stock price API?",
+    "what_is": (
+        "A stock price API returns the current quote for a ticker symbol as data: last price, "
+        "the day's change, open, high, low, previous close and usually volume, sometimes the "
+        "52-week range. The catch is the word current. A feed is real time, delayed by an "
+        "exchange-mandated window, or a single exchange's view rather than the consolidated tape, "
+        "and the free tier of most providers is small enough that a script polling every minute "
+        "runs out before lunch. The unofficial Yahoo Finance endpoints most free scripts lean on "
+        "are not an API at all, and break without notice."),
+    "notes": [
+        "The free allowance is real and it is small on purpose. Finnhub is served at fifty calls "
+        "per team per day on treg.to's key, Tiingo and Twelve Data at twenty each; past that the "
+        "call is refused with a hint to connect your own key, and with your own key the calls "
+        "are never metered. It is enough to try each feed on the tickers you care about. It is "
+        "not a data plan for a trading bot, and this page will not pretend it is.",
+        "Real time means four different things here. Finnhub's quote is documented as real time "
+        "for US tickers. Tiingo's is the IEX feed, one exchange's top of book rather than the "
+        "consolidated tape. Twelve Data returns stocks, forex and crypto in one quote shape with "
+        "the 52-week range, and has a one-number price call for the cheapest possible check. "
+        "EODHD's live quote is 15 to 20 minutes delayed, and since EODHD publishes no per-call "
+        "rate it is served on your own EODHD plan only.",
+        "Providers disagree, occasionally by a lot, and treg.to does not referee. A quote is one "
+        "provider's number at one moment; a second provider on the same ticker is the cheap "
+        "sanity check, and the agent can run both. Symbol formats differ too: EODHD wants an "
+        "exchange suffix, AAPL.US, where the others take the bare US ticker.",
+    ],
+    "faq": [
+        ("Is it really free?",
+         "Three of the four are, up to a daily allowance per team, on treg.to's own free-tier "
+         "keys: fifty calls on Finnhub, twenty each on Tiingo and Twelve Data. After that, "
+         "connect your own key and the calls are never metered."),
+        ("Is the quote real time?",
+         "Depends on the provider, and the page says which. Finnhub is real time for US tickers, "
+         "Tiingo is the IEX feed, EODHD is 15 to 20 minutes delayed. Ask the agent to name the "
+         "provider before it quotes."),
+        ("Can I run a trading bot on this?",
+         "Not on the allowance. A bot polling every minute exhausts fifty calls before the open. "
+         "Register your own key with the provider you settle on and treg.to stops counting."),
+        ("What about tickers outside the US?",
+         "Coverage is each provider's, not treg.to's. Finnhub's quote is documented for US "
+         "tickers; EODHD and Twelve Data take exchange-suffixed symbols. Check the ticker you "
+         "need on the allowance before you build on it."),
+    ],
+    "voices_intro": (
+        "The stock API forums are a long argument about yfinance. From ~200 Reddit and X posts in "
+        "August 2026, about thirty were vendors, including one founder seeding eight tweets for "
+        "his own product and one listicle pasted into three subreddits. These four are people who "
+        "hit the wall."),
+    "voices": [
+        ("The model cannot see a live price on its own",
+         "It doubled my money on the first trade. Then it told me it can't see live stock prices.",
+         "r/smallstreetbets, 574 points", "https://www.reddit.com/r/smallstreetbets/comments/1r883gd/i_spent_8_months_asking_claude_dumb_questions_now/",
+         "The poster spent eight months wiring a quote feed into the model by hand. The setup line "
+         "on this page is the short version: the agent gets four quote providers and a price "
+         "shown before the call, and never holds a key."),
+        ("The free library breaks and blocks you",
+         "yfinance is so unreliable; any other free apis?",
+         "r/algotrading, 117 points", "https://www.reddit.com/r/algotrading/comments/1kdw27f/yfinance_is_so_unreliable_any_other_free_apis/",
+         "These are documented, metered APIs rather than a reverse-engineered Yahoo endpoint, "
+         "which is the whole difference. The honest caveat is the allowance: free to try, your "
+         "own key to run."),
+        ("By the time it arrives it is stale",
+         "By the time I get the data, the prices are already stale.",
+         "r/algotrading, 23 points", "https://www.reddit.com/r/algotrading/comments/1jjj6cb/need_a_better_alternative_to_yfinance_any_good/",
+         "Stale has a cause, and here it is named per provider: a delayed feed, or a single "
+         "exchange's view. Pick the feed for the latency you need rather than discovering it "
+         "from a bad fill."),
+        ("Public numbers, priced like a secret",
+         "How is it possible that you need to pay hundreds of dollars just to access historical data / facts that are publicly known?",
+         "r/webdev, 114 points", "https://www.reddit.com/r/webdev/comments/151zk8y/is_there_any_free_stock_market_api_that_allows/",
+         "Exchange licensing, mostly, and nothing on this page changes it. What the page can do "
+         "is show the provider's own terms next to each other before you commit to one, and let "
+         "you try three of them for nothing."),
+    ],
+    "related": ("Daily price history", "News for a ticker",
+                "Live crypto prices and history", "Company profile and fundamentals behind a ticker"),
+}

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2287,3 +2287,96 @@ USE_CASE_PAGES[("connect-your-own-accounts", "your-google-business-profile-revie
     "related": ("A business's reviews", "Find local businesses by keyword and location",
                 "Search terms that surfaced your listing on Maps", "Search Console: clicks, impressions and top queries"),
 }
+
+USE_CASE_PAGES[("local-businesses-reviews", "a-business-s-reviews")] = {
+    "label": "A business's reviews",
+    "sentence": "Review scraper API: a business's reviews from Tripadvisor, Trustpilot and Yelp, as data",
+    "title": "Tripadvisor, Trustpilot and Yelp reviews API | treg.to",
+    "lede": (
+        "Give your agent a business's page and get its reviews back as rows: rating, text, date "
+        "and reviewer, ready to sort, count or read. Three review sites answer through one treg.to "
+        "key, from {cheapest}, without a Tripadvisor API key, a Yelp Fusion application or a "
+        "browser of your own. They are not alternatives to each other; the site is the choice."),
+    "prompt": "Using treg, pull the last 200 Tripadvisor reviews for this hotel URL, show me the "
+              "price first, then give me the rating distribution by month and the ten most recent "
+              "reviews of two stars or fewer in full.",
+    "prompt_why": [
+        ("Give the page, not the name", "Every provider here takes a URL, a path or a domain. Find the listing first if you only have a name."),
+        ("Say how many you want", "The Trustpilot and Tripadvisor tasks take a depth. The count you ask for is the count you pay for."),
+        ("Compare on the unit", "One provider bills per record delivered, the other per task. Ask which is cheaper for your count."),
+        ("Bring your own analysis", "The rows carry the text. Sentiment, themes and summaries are the agent's job on top."),
+    ],
+    "result_noun": "review",
+    "result_image": None,
+    "what_is_heading": "What is a review scraper API?",
+    "what_is": (
+        "A review scraper API returns the public reviews on a business's listing as structured "
+        "records, rating, text, date, reviewer and the business's reply where there is one, "
+        "without you running a browser against the site. It exists because the official routes "
+        "are narrow: Yelp's Fusion API is an application and a plan, Tripadvisor's Content API "
+        "is an approval, and neither is built for pulling every review of one business. The "
+        "providers here read the public page and hand back the rows."),
+    "notes": [
+        "The two providers bill in different units and the difference matters for a long pull. "
+        "Bright Data delivers records and bills per record delivered, on Yelp and Trustpilot. "
+        "DataForSEO runs a task, on Tripadvisor and Trustpilot, and bills per task at a fraction of "
+        "a cent whatever the depth returns. For a few dozen reviews the difference is nothing; for "
+        "a business with thousands, ask the agent to price both before it starts.",
+        "The input is the listing, not the business name. Tripadvisor wants the review page's "
+        "path, Trustpilot the business's domain, Yelp the page URL, so the agent resolves a name "
+        "to a listing first, which is the neighbouring job on this menu. A wrong page returns "
+        "someone else's reviews, not an error.",
+        "This is the public page as it stands. A review the site has removed is gone from here "
+        "too, the rows are as fresh as the crawl behind them, and what you may do with the text "
+        "is governed by each site's terms and your own use, which no provider settles for you.",
+    ],
+    "faq": [
+        ("Do I need a Yelp Fusion or Tripadvisor API key?",
+         "No. Neither provider here uses the sites' official APIs. They read the public listing "
+         "page and return the reviews as records, billed to your treg.to balance at the provider's "
+         "rate with $0.000 markup."),
+        ("Which site should I use?",
+         "The one the business is reviewed on. Tripadvisor for hotels, restaurants and attractions, "
+         "Trustpilot for online businesses by domain, Yelp for local services in North America. "
+         "Pulling from the wrong site returns a short, misleading list."),
+        ("What about Google reviews?",
+         "The reviews on a listing you own or manage are the Business Profile job on this menu, "
+         "free on your own account. This page covers the three public review sites."),
+        ("Can I get all of a business's reviews?",
+         "You can ask for a depth, and the task returns up to that many. Whether every review "
+         "of a business with thousands comes back is a property of the site, so check the count "
+         "against the listing rather than assuming."),
+    ],
+    "voices_intro": (
+        "Review data is sold hard: about 25 of the ~120 posts on these three sites in August 2026 "
+        "were scraper vendors, Apify listings posted from template accounts, and the same lead-gen "
+        "thread pasted twice. These four are people who tried the official door first."),
+    "voices": [
+        ("The official Yelp API returns nothing for a valid business",
+         "Yelp Fusion API \"NOT_FOUND\" error when requesting reviews (Python)",
+         "r/webscraping", "https://www.reddit.com/r/webscraping/comments/1ivggvp/yelp_fusion_api_not_found_error_when_requesting/",
+         "The Yelp provider on this page does not go through Fusion at all. It reads the public "
+         "page by URL and bills per record delivered, so a business that Fusion cannot find is "
+         "still a page you can point at."),
+        ("Yelp at any scale fights back",
+         "Is Yelp just a nightmare to scrape, or are no-code tools just not built for this at scale?",
+         "r/scrapingtheweb, 9 points", "https://www.reddit.com/r/scrapingtheweb/comments/1t6pyca/have_you_ever_tried_scraping_yelp_without_coding/",
+         "Both, and the answer is to stop running the browser yourself. A per-record provider "
+         "carries the blocking, the retries and the proxies, and you pay for the rows that arrive. "
+         "That is what the fraction of a cent buys."),
+        ("Trustpilot stops at a couple of hundred without a login",
+         "they cap you at 200 reviews without auth. A `jwt` cookie removes the cap.",
+         "r/webscraping, 7 points", "https://www.reddit.com/r/webscraping/comments/1vw95dz/scraper_for_pulling_trustpilot_reviews/",
+         "A self-built scraper's workaround, and the kind of thing that breaks quietly. The "
+         "Trustpilot task here takes a depth parameter instead; ask for what you need and read "
+         "the count that comes back rather than assuming the whole history arrived."),
+        ("The official price is the reason people scrape",
+         "their API is horrifically expensive for poor old me, and I was not in the mood to build a web scraper",
+         "r/gis, ~800 points", "https://www.reddit.com/r/gis/comments/1iph0yy/the_closer_to_the_railway_station_the_less_tasty/",
+         "The page shows the provider's rate before the call, in fractions of a cent per record "
+         "or per task, so the choice between paying and building is a number rather than a mood."),
+    ],
+    "related": ("Find local businesses by keyword and location",
+                "Your Google Business Profile reviews, and reply to them",
+                "Product reviews", "Hotel listing details"),
+}

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -1418,8 +1418,13 @@ def _uc_providers(cat, eps: list[dict], obs: dict) -> list[dict]:
         # prices this job in pre-bought API units, so its cost_view has no USD, and the price cell
         # read "free, your own account" for the dearest option on the page.
         free = any((e.get("cost") or {}).get("type") == "free" for e in peps)
+        # A $0 trial row is a third fact again: served on treg.to's own free-tier key with a daily
+        # allowance per team (catalog.trial_pools), so neither "free, your own account" nor a price
+        # is true of it. Carry the allowance so the cell can state it.
+        trial = max((cv.get("trial_calls_per_team_day") or 0) for e in peps
+                    if (cv := cat.cost_view(e.get("cost"), e.get("provider"))))
         out.append({
-            "id": prov, "name": _provider_display(prov), "eps": peps, "free": free,
+            "id": prov, "name": _provider_display(prov), "eps": peps, "free": free, "trial": trial,
             "domain": agent_pages.PROVIDER_DOMAINS.get(prov),
             "platform": slug, "platform_label": (cat.platforms.get(slug) or {}).get("label") or slug,
             "usd": priced[0][0] if priced else None,
@@ -1507,6 +1512,11 @@ async def use_case_job_page(request: Request, category: str, job: str,
     headline = cheapest_by_unit[units[0]] if units else None
     reliable = sorted([p for p in provs if p["samples"] and p["ok_rate"] is not None],
                       key=lambda p: (-p["ok_rate"], p["p50"] or 9e9, -p["samples"]))
+    # No priced row is two different facts: own-account rows are free on the reader's key; trial
+    # rows are free on treg.to's key up to a daily allowance. Say whichever is true.
+    trial_max = max((p["trial"] for p in provs), default=0)
+    free_words = (f"free, up to {trial_max} calls a day on treg.to's key" if trial_max
+                  else "free on your own account")
     n = str(len({p["id"] for p in provs}))
     n_ver = sum(1 for e in eps if e.get("verified"))
     latest_verified = max((e.get("verified") or "" for e in eps), default="")
@@ -1526,11 +1536,15 @@ async def use_case_job_page(request: Request, category: str, job: str,
 
     title = spec.get("title", "{sentence}: {n} providers | treg.to").format(
         sentence=spec["sentence"], n=n, agent=agent_name,
-        cheapest=money(headline["usd"]) if headline else "free on your own account")
+        cheapest=money(headline["usd"]) if headline else free_words)
     lede = spec["lede"].format(n=n, agent=agent_name,
-                               cheapest=money(headline["usd"]) if headline else "free on your own account")
+                               cheapest=money(headline["usd"]) if headline else free_words)
     bits_desc = [spec["sentence"] + "."]
-    if form == "short":
+    metered_single = form == "short" and not provs[0]["free"]
+    if metered_single:
+        bits_desc.append(f"One provider, {money(headline['usd'])} per {headline['unit']} on treg.to's key, no signup."
+                         if headline else "One provider, served on treg.to's key.")
+    elif form == "short":
         bits_desc.append("Runs on the account you already own, so treg.to never meters it.")
     elif headline:
         bits_desc.append(f"{n} providers compared, cheapest {money(headline['usd'])} per {headline['unit']}.")
@@ -1544,7 +1558,15 @@ async def use_case_job_page(request: Request, category: str, job: str,
               f'Then ask: "{spec["prompt"]}"', ""]
         md += [f"- **{t}** {d}" for t, d in spec["prompt_why"]]
         md += ["", "## Why go through treg.to", ""] + [f"- **{t}** {d}" for t, d in agent_pages.WHY_TREG]
-        if form == "short":
+        if metered_single:
+            e0 = provs[0]["cheapest_ep"] or provs[0]["eps"][0]
+            md += ["", "## How it works", "",
+                   f"One provider does this job: {provs[0]['name']} (`{e0['id']}`), served on treg.to's own key at "
+                   + (f"{money(provs[0]['usd'])} per {provs[0]['unit']}, " if provs[0]["usd"] else "")
+                   + "the provider's own rate with $0.000 markup, metered from your team's balance. "
+                   "No account with the provider, and no key of your own, unless you would rather bring one.",
+                   "", f"    {_uc_call(e0)}", ""]
+        elif form == "short":
             e0 = provs[0]["eps"][0]
             md += ["", "## How it works", "",
                    f"One provider does this job: {provs[0]['name']} (`{e0['id']}`), on the account you already own. "
@@ -1575,7 +1597,8 @@ async def use_case_job_page(request: Request, category: str, job: str,
                 md += ["| Provider | Price | Accepts | Verified |", "|---|---|---|---|"]
                 for p in sorted(rows_, key=lambda p: (p["usd"] is None, p["usd"] or 0)):
                     price = (f"{money(p['usd'])} per {p['unit']}" if p["usd"]
-                             else ("own account, free" if p["free"] else "no dollar rate published"))
+                             else (f"free, {p['trial']} calls a day on treg.to's key, then your own key" if p["trial"]
+                                   else ("own account, free" if p["free"] else "no dollar rate published")))
                     md.append(f"| {p['name']} | {price} | {', '.join(p['inputs'])} | {p['verified'] or 'unverified'} |")
                 md.append("")
         md += ["Endpoints:", ""] + [f"- `{e['id']}`: {_uc_call(e)}" for e in eps]
@@ -1603,7 +1626,7 @@ async def use_case_job_page(request: Request, category: str, job: str,
         f'<img src="https://unpkg.com/@lobehub/icons-static-png@latest/light/{icon}.png" alt="{_esc_html(label)}" loading="lazy"/></span>'
         for aid, label, icon in agent_pages.AGENT_ICONS[:6])
     hero_price = (f"from {_esc_html(money(headline['usd']))} per {headline['unit']}"
-                  if headline else "free on the account you already own")
+                  if headline else _esc_html(free_words if trial_max else "free on the account you already own"))
 
     def promptbox(label: str, text: str) -> str:
         return ('<div class="promptbox"><div class="ph">'
@@ -1619,6 +1642,9 @@ async def use_case_job_page(request: Request, category: str, job: str,
     def price_cell(p: dict) -> str:
         if p["usd"]:
             return f'{_esc_html(money(p["usd"]))} <span style="color:var(--muted2)">per {p["unit"]}</span>'
+        if p["trial"]:
+            return (f'<span style="color:var(--green)">free, {p["trial"]} calls a day</span> '
+                    '<span style="color:var(--muted2)">on treg.to\'s key, then your own key</span>')
         if p["free"]:
             return '<span style="color:var(--green)">free, your own account</span>'
         return '<span style="color:var(--muted2)">no dollar rate published</span>'
@@ -1641,7 +1667,21 @@ async def use_case_job_page(request: Request, category: str, job: str,
                 f'</tr></thead><tbody>{body_rows}</tbody></table></div>')
 
     sections = []
-    if form == "short":
+    if metered_single:
+        p0 = provs[0]
+        e0 = p0["cheapest_ep"] or p0["eps"][0]
+        rate = f'{_esc_html(money(p0["usd"]))} per {p0["unit"]}, ' if p0["usd"] else ""
+        sections.append(
+            '<section id="how"><div class="wrap"><div class="seclab">How it works</div>'
+            f'<h2>One provider, served on treg.to\'s key</h2>'
+            f'<p>{_logo(p0["domain"], p0["name"])}<b>{_esc_html(p0["name"])}</b> answers this job, at {rate}'
+            'the provider\'s own rate with $0.000 markup, metered from your team\'s balance. No account with the '
+            'provider and no key of your own, unless you would rather bring one.</p>'
+            f'<div class="sample"><div class="sbar">the call</div><pre>{_esc_html(_uc_call(e0))}</pre></div>'
+            f'<p style="font-size:12.5px;color:var(--muted)">Every endpoint on this shelf is listed on the '
+            f'<a href="/catalog/{_esc_html(e0["platform"])}">{_esc_html((cat.platforms.get(e0["platform"]) or {}).get("label") or e0["platform"])} shelf</a>.</p>'
+            + '</div></section>')
+    elif form == "short":
         p0, e0 = provs[0], provs[0]["eps"][0]
         sections.append(
             '<section id="how"><div class="wrap"><div class="seclab">How it works</div>'


### PR DESCRIPTION
Five more pages off the measured-demand worklist, top down, stacked on #178 (`seo/pages-20260824`). 22 of 66 jobs written, 20 worklist jobs left.

| Page | Form | Term | Vol | CPC |
|---|---|---|---|---|
| `connect-your-own-accounts/google-analytics-traffic-and-behaviour-reports` | short, own account | `google analytics api` (`google analytics mcp` 720) | 590 | $33.07 |
| `finance-markets/current-quote-for-a-ticker` | compare, 4, trial pools | `stock price api` (`stock api free` 390) | 480 | $14.76 |
| `connect-your-own-accounts/your-google-business-profile-reviews-and-reply-to-them` | short, own account | `google business profile api` (`google reviews api` 720) | 480 | $58.73 |
| `seo/how-ai-answers-mention-your-brand` | short, metered | `ai visibility tracking` (`ai visibility tool` 1,600) | 480 | $60.31 |
| `local-businesses-reviews/a-business-s-reviews` | platforms, 3 | `tripadvisor api` / `trustpilot api` | 320 / 170 | $36.84 |

## Base ref override

The pre-stage named `origin/seo/pages-2026-08-24` as the tip. It carries 17 pages, the same count as `origin/seo/pages-20260824`, but it is a two-commit variant without the pricing fix (`d7e21c3`), the seo.md update, or the #175 and main merges. `seo/pages-20260824` is #178's actual head, so this branch is cut from it and targets it. The pre-stage's tie-break on page count needs a second key (commit ancestry or the open PR's head).

## Two template fixes, found by reading the rendered page

- **A trial-pool row rendered as "free, your own account".** Finnhub, Tiingo and Twelve Data are served at $0 on treg.to's own free-tier keys with a daily allowance per team; `cost_view` gives `usd == 0`, so they fell into the own-account branch, and with no priced row the hero said "free on the account you already own". The cell, the `.md` table, the hero and `{cheapest}` now state the allowance.
- **The `short` form assumed its one provider was an OAuth connection.** The AI-mentions job has one provider, DataForSEO, and it is metered. The form now branches on `free`: the metered branch states the rate and the $0.000 markup, and the meta description no longer says "never metered".

## Needs a human

- **The Business Profile review endpoints are unverified** (`verified: None` on all four; the v4 paths are hand-transcribed per the catalog's own comment). The page claims what `auth-secrets.md` states, that treg.to holds the approved app, and nothing about a live call. Worth one real call against a listing before this page earns traffic.
- `tests/test_ledger.py::test_n_parallel_reserves_yield_exactly_k_successes` failed once in the full run and passed 3/3 in isolation; `ledger.py` and the test are unchanged from main. Flaky, not this branch.

## What the research changed

- **GA.** No organic post states a Data API quota number, so the page names the quota without one. `google analytics mcp` outsells `google analytics api` 720 to 590; the H1 carries both.
- **Stocks.** "Free forever" is what the forum wants and the allowance cannot honestly give a bot; the page says free to try, own key to run, and names the delay per provider. `yahoo finance api` at 2,900 is the DIY term; the body speaks to it without targeting it.
- **GBP.** The loudest theme is Google's access request and the zero quota, both per Cloud project. The page says the project is treg.to's. Ownership gating is stated plainly rather than worked around.
- **AI visibility.** 10 of 22 relevant posts were vendor content, including a data dump posted twice and a vendor employee asking the question. `ai visibility tool` 1,600 beats the worklist term three to one.
- **Reviews.** ~25 of ~120 posts were scraper vendors. The Trustpilot 200-review unauthenticated cap has one organic source; the page cites it as a self-built scraper's workaround, not a fact.

## Verification

802 tests pass (one flaky, above). 82 in `test_agent_pages.py`. All five pages rendered on a fresh server and read in HTML and `.md`; titles 50 to 64 characters; no empty section. No metered call spent: demand measured on the own-key Google Ads endpoint, research through `opencli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
