### PR TITLE
fix(dashboard): preserve marketplace request method

### DIFF
--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -656,8 +656,11 @@ and in a merged row's provider sub-row, because both paths share the one `.lep` 
 one-line setup (`epTrySetupLine`, with team + token embedded **here only**, a copy-and-run-now context;
 the setup line everywhere else stays clean) plus a ready "Use treg to call `<id>` — `<summary>`" prompt
 (`epTryAgentUse`); **CLI** — install/login, `treg catalog get <id>`, and the filled `treg call <id>
---query …` (`epTryCliCall`); **API** — the `curl {BASE}/call/<id>?<query>` passthrough with the token
-header (`epTryCurl`, adding `X-Treg-Org` in session mode since the minted token is an identity token);
+--query …` (`epTryCliCall`), with `--method` and a shell-quoted `--data` JSON body for non-GET
+requests; **API** — the `curl -X <method> {BASE}/call/<id>?<query>` passthrough with the token header
+(`epTryCurl`, adding `X-Treg-Org` in session mode since the minted token is an identity token), plus
+`Content-Type: application/json` and the same shell-quoted, editable `epTryBody` for a non-GET request
+that has a body;
 and **Manual** — the live test form (params + `❯ Run`, disabled with a reason when the access dry-run
 says this org can't call it) that the drawer used to be by itself.
 

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4288,15 +4288,21 @@ createApp({
     // Try-it drawer: the filled query string + the three "how to run it" recipes (agent / CLI / API)
     epTryQuery(){ return (this.epTryParams||[]).filter(p=>p.value!=='' && p.value!=null)
       .map(p=>encodeURIComponent(p.name)+'='+encodeURIComponent(p.value)).join('&'); },
+    epTryShellBody(){ return "'"+String(this.epTryBody).replace(/'/g,"'\"'\"'")+"'"; },
     epTryCliCall(){ if(!this.epTry) return '';
       const args=(this.epTryParams||[]).filter(p=>p.value!=='' && p.value!=null)
         .map(p=>`--query ${p.name}=${/\s/.test(String(p.value))?JSON.stringify(String(p.value)):p.value}`).join(' ');
-      return `treg call ${this.epTry.id}${args?' '+args:''}`; },
+      const method=(this.epTry.method||'GET').toUpperCase();
+      let s=`treg call ${this.epTry.id}${args?' '+args:''}`;
+      if(method!=='GET') s+=` --method ${method}`;
+      if(method!=='GET' && this.epTryBody.trim()) s+=` --data ${this.epTryShellBody}`;
+      return s; },
     epTryCurl(){ if(!this.epTry) return '';
       const q=this.epTryQuery; const url=`${this.proxy}/call/${this.epTry.id}${q?'?'+q:''}`;
-      const tok=this.myToken||'$TREG_TOKEN';
-      let s=`curl "${url}" \\\n  -H "X-Treg-Token: ${tok}"`;
+      const tok=this.myToken||'$TREG_TOKEN', method=(this.epTry.method||'GET').toUpperCase();
+      let s=`curl -X ${method} "${url}" \\\n  -H "X-Treg-Token: ${tok}"`;
       if(this.sessionMode && this.activeSlugNow) s+=` \\\n  -H "X-Treg-Org: ${this.activeSlugNow}"`;  // minted identity token needs the org header
+      if(method!=='GET' && this.epTryBody.trim()) s+=` \\\n  -H "Content-Type: application/json" \\\n  --data ${this.epTryShellBody}`;
       return s; },
     // token + team embedded HERE ONLY (a copy-and-run-now context) — the setup line elsewhere stays clean
     epTrySetupLine(){ const S=this.activeSlugNow||'<team-slug>', T=this.myToken||'<YOUR_TOKEN>';

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -818,6 +818,25 @@ def test_the_run_actions_lead_the_expansion_tab_bar():
     assert ".ltabs-r .btn.primary{background:var(--inverse)" in INDEX
 
 
+def test_try_it_post_snippets_carry_the_method_and_shell_safe_body():
+    """The drawer must copy the request shown in Manual, not silently turn every endpoint into GET."""
+    block = INDEX[INDEX.index("epTryShellBody(){") : INDEX.index("epTrySetupLine(){")]
+    assert "replace(/'/g,\"'\\\"'\\\"'\")" in block
+    assert "if(method!=='GET') s+=` --method ${method}`" in block
+    assert "--data ${this.epTryShellBody}" in block
+    assert "curl -X ${method}" in block
+    assert '-H "Content-Type: application/json"' in block
+
+
+def test_try_it_get_snippets_keep_query_and_auth_without_a_body():
+    """GET stays explicit in curl, keeps query and org selection, and does not gain body options."""
+    block = INDEX[INDEX.index("epTryQuery(){") : INDEX.index("epTrySetupLine(){")]
+    assert "const q=this.epTryQuery" in block and "${q?'?'+q:''}" in block
+    assert "curl -X ${method}" in block
+    assert "if(this.sessionMode && this.activeSlugNow)" in block
+    assert block.count("method!=='GET' && this.epTryBody.trim()") == 2
+
+
 def test_provider_page_links_into_the_catalog():
     """Navigation runs both ways: an integration page names the platforms its catalog covers."""
     assert _enclosing_views('v-for="pl in mkPlatforms"') == ["provider"]


### PR DESCRIPTION
Fix Marketplace Try-it snippets so non-GET endpoints keep their HTTP method and editable JSON body in both CLI and cURL copies. Query parameters, GET behavior, and session organization headers remain unchanged.

Test: uv run --frozen pytest -q tests/test_dashboard_markup.py (92 passed)