### PR TITLE
fix(api): use naive UTC for database timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
           tests/test_call_pool_discipline.py
           tests/test_marketplace_call.py
           tests/test_billing.py
+          tests/test_agent_capture.py
+          tests/test_adsconv.py
+          tests/test_health.py
+          tests/test_localrun.py
           tests/test_orgs.py
           tests/test_orgs_isolation.py
           tests/test_orgs_mgmt.py

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -214,7 +214,8 @@ recreate); `get_session()` is the FastAPI dependency. SQLite locally (`aiosqlite
 naive UTC:** `_now()` (the `created_at` default) drops tzinfo because the columns are `TIMESTAMP WITHOUT
 TIME ZONE` and asyncpg rejects tz-aware values on Postgres; the app compares naive UTC throughout.
 Shared request-time conversions live in `timeutil.utcnow_naive` and `timeutil.as_naive`, re-exported
-temporarily as `api._utcnow_naive` and `api._as_naive` during the staged router migration.
+temporarily as `api._utcnow_naive` and `api._as_naive` during the staged router migration. Query
+parameters compared with timestamp columns follow the same constraint as inserted or updated values.
 
 ## Alembic baseline
 

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -17,6 +17,9 @@ Import Linter reads the contracts under `tool.importlinter` in `pyproject.toml`.
 job installs the hand-maintained lock with `uv sync --frozen`, then runs
 `uv run --frozen lint-imports` before the test suite. Keeping the check in that job reuses the
 development environment and avoids a second install for a fast static architecture check.
+The separate `test-postgres` job runs its database-sensitive subset serially against Postgres 16;
+it includes agent attribution, credential health, local-run reporting and ads-conversion coverage so
+naive-UTC assumptions are exercised by asyncpg rather than hidden by SQLite's permissive adapter.
 
 Stage 1 activated the first two contracts:
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -4354,8 +4354,9 @@ async def list_observed_agents(
     plain terminal (`client` in ('', 'cli')): a roster that lists every human twice teaches nothing.
     """
     _require_admin_of(org_id, caller)
-    since = datetime.now(timezone.utc) - timedelta(days=30)
-    today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    now = _utcnow_naive()
+    since = now - timedelta(days=30)
+    today = now.replace(hour=0, minute=0, second=0, microsecond=0)
     # A pair that was PROMOTED — it has its own agent identity now — leaves the detected roster;
     # revoking that agent deletes its membership, which resurfaces the pair automatically.
     promoted = {tuple(m.promoted_from.split("|", 1)) for m in (await db.execute(
@@ -5293,7 +5294,7 @@ async def report_local_run(
         # Mark only the credentials this run actually INJECTED (the ones the CLI used) — not every HTTP
         # binding — and never a `param` (it's config, not a credential; mirrors health.run_all's guard).
         sids = {localrun._resolve_secret_id(e, tool) for e in profile.get("inject") or []}
-        now = datetime.now(timezone.utc)
+        now = _utcnow_naive()
         for sid in [s for s in sids if s is not None]:
             secret = await db.get(Secret, sid)
             if secret is not None and secret.org_id == caller.org_id and secret.kind != "param":

--- a/src/treg/health.py
+++ b/src/treg/health.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import ipaddress
 import socket
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from urllib.parse import urlsplit
 
 import httpx
@@ -20,6 +20,7 @@ from sqlmodel import select
 
 from . import crypto, injectors, oauth
 from .models import Invite, Membership, PendingOAuth, Secret, Tool, User
+from .timeutil import utcnow_naive
 
 OAUTH_PENDING_TTL_MIN = 30  # an in-flight OAuth connect (holds an encrypted client_secret + a CSRF state) expires after this
 
@@ -146,7 +147,7 @@ async def _probe(tool: Tool, smap: dict[int, Secret], client: httpx.AsyncClient)
 async def gc_expired_invites(db: AsyncSession, org_id: int) -> int:
     """Delete expired invites in an org (their codes can never be accepted). Caller commits.
     Runs opportunistically when invites are listed and periodically in the health run."""
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = utcnow_naive()
     rows = (await db.execute(select(Invite).where(Invite.org_id == org_id))).scalars().all()
     n = 0
     for inv in rows:
@@ -160,7 +161,7 @@ async def gc_expired_invites(db: AsyncSession, org_id: int) -> int:
 async def gc_stale_pending_oauth(db: AsyncSession, org_id: int) -> int:
     """Delete in-flight OAuth connects older than the TTL — each holds an encrypted client_secret and
     an otherwise-indefinitely-valid CSRF `state`. Caller commits."""
-    cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=OAUTH_PENDING_TTL_MIN)
+    cutoff = utcnow_naive() - timedelta(minutes=OAUTH_PENDING_TTL_MIN)
     rows = (await db.execute(select(PendingOAuth).where(PendingOAuth.org_id == org_id))).scalars().all()
     n = 0
     for p in rows:
@@ -172,7 +173,7 @@ async def gc_stale_pending_oauth(db: AsyncSession, org_id: int) -> int:
 
 
 async def run_all(db: AsyncSession, client: httpx.AsyncClient, org_id: int | None = None) -> dict:
-    now = datetime.now(timezone.utc)
+    now = utcnow_naive()
     secret_q, tool_q = select(Secret), select(Tool)
     if org_id is not None:  # scope the run to one org (the caller's) — no cross-tenant leakage
         secret_q = secret_q.where(Secret.org_id == org_id)

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -15,6 +15,7 @@ from treg.api import app
 from treg.config import get_settings
 from treg.db import _migrate_to_orgs, reset_db, session_maker
 from treg.models import AdConversion, Org
+from treg.timeutil import utcnow_naive
 
 
 def _h(token: str) -> dict:
@@ -440,14 +441,14 @@ async def test_drain_sends_every_pending_row_in_one_batch(clients, ads_enabled):
 
     async with session_maker() as db:
         org = Org(name="t", slug="t-drain", ad_gclid="C",
-                  ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+                  ad_click_at=utcnow_naive() - timedelta(days=1))
         db.add(org)
         await db.commit()
         await db.refresh(org)
         old = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
-                           created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+                           created_at=utcnow_naive() - timedelta(hours=12))
         fresh = AdConversion(org_id=org.id, action=adsconv.ACTION_PAID,
-                             created_at=datetime.now(timezone.utc))
+                             created_at=utcnow_naive())
         db.add(old); db.add(fresh)
         await db.commit()
 
@@ -469,13 +470,13 @@ async def _seed_upload_rows(db, *, actions, attempts=0):
     anymore — the uploader authenticates with treg's own platform refresh token, not a per-org
     connection (see `ads_enabled`, which sets it)."""
     org = Org(name="t", slug="t-upload-batch", ad_gclid="CLICK_BATCH",
-              ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+              ad_click_at=utcnow_naive() - timedelta(days=1))
     db.add(org)
     await db.commit()
     await db.refresh(org)
     rows = [
         AdConversion(org_id=org.id, action=action, attempts=attempts,
-                     created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+                     created_at=utcnow_naive() - timedelta(hours=12))
         for action in actions
     ]
     db.add_all(rows)
@@ -664,13 +665,13 @@ async def test_access_token_is_cached_and_not_re_exchanged_within_its_lifetime(c
     client = FakeAdsClient(FakeAdsResponse({"requestId": "req-cache-1"}))
     async with session_maker() as db:
         org = Org(name="t", slug="t-token-cache", ad_gclid="C",
-                  ad_click_at=datetime.now(timezone.utc) - timedelta(days=1))
+                  ad_click_at=utcnow_naive() - timedelta(days=1))
         db.add(org)
         await db.commit()
         await db.refresh(org)
 
         row_a = AdConversion(org_id=org.id, action=adsconv.ACTION_SIGNUP,
-                             created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+                             created_at=utcnow_naive() - timedelta(hours=12))
         db.add(row_a)
         await db.commit()
         first = await adsconv.drain_once(db, client)
@@ -678,7 +679,7 @@ async def test_access_token_is_cached_and_not_re_exchanged_within_its_lifetime(c
         assert len(client.token_calls) == 1  # first drain: exchanged once
 
         row_b = AdConversion(org_id=org.id, action=adsconv.ACTION_FIRST_CALL,
-                             created_at=datetime.now(timezone.utc) - timedelta(hours=12))
+                             created_at=utcnow_naive() - timedelta(hours=12))
         db.add(row_b)
         await db.commit()
         second = await adsconv.drain_once(db, client)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -28,6 +28,7 @@ async def test_probe_marks_ok(clients: AsyncClient):
     health = {h["name"]: h for h in (await clients.get("/health")).json()}
     assert health["k"]["status"] == "ok"
     assert "HTTP 200" in health["k"]["detail"]
+    assert "+00:00" not in health["k"]["checked_at"]
 
 
 async def test_probe_failure_marks_invalid(clients: AsyncClient):

--- a/tests/test_localrun.py
+++ b/tests/test_localrun.py
@@ -433,6 +433,7 @@ async def test_run_report_marks_credential_invalid(clients: AsyncClient):
     health = {h["name"]: h for h in (await clients.get("/health")).json()}
     assert health["stripe-key"]["status"] == "invalid"
     assert "local run" in health["stripe-key"]["detail"]
+    assert "+00:00" not in health["stripe-key"]["checked_at"]
     reports = [x for x in (await clients.get("/calls")).json() if x["method"] == "REPORT"]
     assert reports and "credential_invalid" in reports[0]["path"]
 


### PR DESCRIPTION
`GET /orgs/{id}/agents/observed` returned 500 for every team on Postgres. Found by overnight production log monitoring; five distinct orgs hit it (2699, 2125, 3052, 3045, 3060) over ~8 hours.

```
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error)
<class 'asyncpg.exceptions.DataError'>: invalid input for query argument $1:
datetime.datetime(2026, 8, 25, 0, 0, tzi... (can't subtract offset-naive and offset-aware datetimes)
```

## Cause

`list_observed_agents` built its window with tz-aware `datetime.now(timezone.utc)` and compared it against `CallRecord.created_at` / `RunRecord.created_at`, which are `TIMESTAMP WITHOUT TIME ZONE`. asyncpg refuses tz-aware values outright. The repo's convention is naive UTC throughout (`timeutil.utcnow_naive` / `as_naive`, see `docs/context/architecture/data-model.md`); these call sites did not follow it.

## Why CI was green

`tests/test_agent_capture.py` already covered this endpoint — but only ever ran against SQLite, whose adapter accepts aware values silently. On Postgres the same file is 4 failed / 11 passed before this change.

## What changed

- The observed-agents window, the local-run `credential_invalid` write, and the health-runner write now use naive UTC. A repo-wide sweep of `datetime.now(timezone.utc)` / `utcnow()` / `astimezone` / `fromisoformat` confirmed no other value reaches the database aware: `api.py:8011` already passes `tzinfo=None`, `localrun.py:201/206` is epoch arithmetic, `adsconv.py:140` formats an Ads API string, and `oauth._expires_at` returns a float.
- Two already-naive spots in `health.py` were switched to the helper as well, so the next reader copies the right template.
- `tests/test_adsconv.py` fixtures build naive timestamps (they were writing aware values straight into the DB).
- The `test-postgres` CI subset gains `test_agent_capture.py`, `test_adsconv.py`, `test_health.py`, `test_localrun.py` — the point being to let asyncpg expose naive-UTC assumptions instead of letting SQLite's permissive adapter hide them.

## Verification

Postgres 16: the four newly-covered files 139 passed (`test_agent_capture.py` 15/15, was 4 failed); the full `test-postgres` subset plus callmatrix 404 passed. SQLite full suite 1990 passed. Surface snapshots byte-identical; `lint-imports` 3 contracts kept.

Pre-existing bug, not introduced by the recent refactor — the code dates to `bd1097b` (2026-07-28) and was already failing in production before phases 1 and 2 deployed.