### PR TITLE
fix(mcp): tolerate client disconnects in ASGI middleware

### DIFF
--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -20,11 +20,29 @@ the Catalog, web, and admin modules define concern-specific `APIRouter` blocks t
 at their legacy registration points. It then calls the factory once at EOF so the deployed and
 documented `treg.api:app` import path remains the default `all` role.
 
-The factory owns concrete assembly: the three middleware registrations, five exception handlers,
+The factory owns concrete assembly: the three pure-ASGI middleware registrations, five exception handlers,
 static mounts, optional MCP mount and lifespan, GET-to-HEAD widening, the OpenAPI wrapper that hides
 implied HEAD operations, shared HTTP client creation, startup work, shutdown drains, and the Ads
 conversion worker. Registration order is compatibility behavior. The four stage-0 snapshots stay
-byte-identical for `role="all"`.
+byte-identical for `role="all"` unless that composition intentionally changes.
+
+The middleware stack is `_BodyDecodeMiddleware` -> `_SecurityHeadersMiddleware` ->
+`_LegacyHostRedirectMiddleware` -> routes/mounts. All three are pure ASGI. The security wrapper adds
+headers at `http.response.start` with case-insensitive setdefault semantics, and the redirect wrapper
+either sends the same 301/302 response as before or calls its child directly. Keeping
+`BaseHTTPMiddleware.call_next()` out of this stack matters for streaming and disconnects: an MCP
+client may close while its stateless transport terminates without sending a response, which is a
+normal end to an already-dead connection rather than a server 500.
+
+Pure ASGI does not make a genuine missing-response defect silent. Uvicorn's
+`RequestResponseCycle.run_asgi` checks an app that returns while the connection is still live, logs
+`ASGI callable returned without starting response.`, and sends a 500. It skips that error only when
+the protocol has already marked the client disconnected, when no response can be delivered. Response
+completion also remains responsible for Starlette background tasks: the `/call` relay's
+`StreamingResponse` runs `BackgroundTask(upstream_resp.aclose)` after its body, and an assertion test
+pins that the shared httpx connection is released exactly once. Removing the two AnyIO memory-stream
+hops changes streaming backpressure and scheduling but not interruption semantics, which the
+callmatrix stream-failure case pins.
 
 ## Role manifests
 

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -556,7 +556,7 @@ helpers `_secret_view` / `_tool_view` / `_bundle_view` never leak secret values 
 surfaced by `GET /tools` / `/bundles/{id}`).
 
 ## Cross-cutting hardening (bug-hunt)
-- **Legacy-host redirect:** `_legacy_host_redirect` 301s GET/HEAD marketing pages (`_REDIRECT_PATHS`)
+- **Legacy-host redirect:** `_LegacyHostRedirectMiddleware` 301s GET/HEAD marketing pages (`_REDIRECT_PATHS`)
   from the legacy hosts (`config.LEGACY_PUBLIC_HOSTS`) to the canonical `public_url` host (`treg.to`)
   — but only for **anonymous** visitors: a `treg_session` cookie is host-scoped, so a signed-in
   browser (e.g. the invite flow landing on `/?invite_org=…`) is served in place. The auth entries
@@ -570,7 +570,7 @@ surfaced by `GET /tools` / `/bundles/{id}`).
   transport allow-lists (`mcp._allowed_hosts`/`_allowed_origins`) and in the OAuth token-audience
   set (`mcp_oauth.mcp_resource_audiences()` — pre-move grants keep their old audience for life,
   and refresh reissues it). Never remove the legacy domain from Render.
-- **Security headers:** a `@app.middleware` adds `X-Content-Type-Options: nosniff`, `X-Frame-Options:
+- **Security headers:** pure-ASGI `_SecurityHeadersMiddleware` adds `X-Content-Type-Options: nosniff`, `X-Frame-Options:
   DENY`, `Referrer-Policy: no-referrer`, and HSTS to every response (`setdefault`, so the `/call`
   proxy's stricter CSP/nosniff wins).
 - **No 500 on bad ids/URLs:** an `OverflowError` handler turns an oversized all-digit id into a `404`

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from fastapi import APIRouter, Cookie, Depends, Form, Header, HTTPException, Query, Request
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, PlainTextResponse, RedirectResponse, Response, StreamingResponse
+from starlette.datastructures import MutableHeaders
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
@@ -237,38 +238,60 @@ def _login_callback_base(request: Request) -> str:
     return get_settings().public_url.rstrip("/")
 
 
-async def _legacy_host_redirect(request: Request, call_next):
+class _LegacyHostRedirectMiddleware:
     """Redirect marketing pages (301) and auth entries (302) from a legacy host to the canonical
     host. Auth entries get a temporary redirect: their URLs carry one-shot OAuth parameters, and a
     cached permanent answer is exactly the wrong thing to keep."""
-    host = request.headers.get("host", "").split(":")[0].rstrip(".").lower()
-    if request.method in ("GET", "HEAD") and host in _LEGACY_HOSTS:
-        path = request.url.path
-        always = path in _REDIRECT_ALWAYS
-        if always or (path in _REDIRECT_PATHS and sess.COOKIE not in request.cookies):
-            canonical = get_settings().public_url.rstrip("/")
-            # hostname equality, not substring: a self-hoster whose public_url IS a legacy host
-            # must keep serving in place, but "not-treg.superdesign.dev" must not.
-            if host != ((urlsplit(canonical).hostname or "").rstrip(".").lower()):
-                target = canonical + path
-                if request.url.query:
-                    target += "?" + request.url.query
-                return RedirectResponse(target, status_code=302 if always else 301)
-    return await call_next(request)
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+        request = Request(scope)
+        host = request.headers.get("host", "").split(":")[0].rstrip(".").lower()
+        if request.method in ("GET", "HEAD") and host in _LEGACY_HOSTS:
+            path = request.url.path
+            always = path in _REDIRECT_ALWAYS
+            if always or (path in _REDIRECT_PATHS and sess.COOKIE not in request.cookies):
+                canonical = get_settings().public_url.rstrip("/")
+                # hostname equality, not substring: a self-hoster whose public_url IS a legacy host
+                # must keep serving in place, but "not-treg.superdesign.dev" must not.
+                if host != ((urlsplit(canonical).hostname or "").rstrip(".").lower()):
+                    target = canonical + path
+                    if request.url.query:
+                        target += "?" + request.url.query
+                    response = RedirectResponse(target, status_code=302 if always else 301)
+                    return await response(scope, receive, send)
+        return await self.app(scope, receive, send)
 
 
-async def _security_headers(request: Request, call_next):
+class _SecurityHeadersMiddleware:
     """The dashboard is an authenticated app; ship the baseline hardening headers it was missing —
     nosniff, clickjacking protection (X-Frame-Options), and a tight Referrer-Policy. `setdefault`
     so the /call proxy's own stricter CSP/nosniff isn't clobbered."""
-    resp = await call_next(request)
-    resp.headers.setdefault("X-Content-Type-Options", "nosniff")
-    resp.headers.setdefault("X-Frame-Options", "DENY")
-    resp.headers.setdefault("Referrer-Policy", "no-referrer")
-    # HSTS pins the browser to https so a spoofed X-Forwarded-Proto can't downgrade the session
-    # cookie onto cleartext (browsers ignore this header when served over http, so dev is unaffected).
-    resp.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-    return resp
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        async def send_with_security_headers(message):
+            if message["type"] == "http.response.start":
+                message = dict(message, headers=list(message.get("headers", [])))
+                headers = MutableHeaders(scope=message)
+                headers.setdefault("X-Content-Type-Options", "nosniff")
+                headers.setdefault("X-Frame-Options", "DENY")
+                headers.setdefault("Referrer-Policy", "no-referrer")
+                # HSTS pins the browser to https so a spoofed X-Forwarded-Proto can't downgrade the
+                # session cookie onto cleartext (browsers ignore it over http, so dev is unaffected).
+                headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+            await send(message)
+
+        return await self.app(scope, receive, send_with_security_headers)
 
 
 _BODY_ENC_HEADER = b"x-treg-body-encoding"
@@ -343,10 +366,10 @@ async def _id_out_of_range(request: Request, exc: OverflowError) -> JSONResponse
 async def _pool_saturated(request: Request, exc: PoolTimeoutError) -> JSONResponse:
     """The DB pool had no connection to give within `pool_timeout` (db.py). That is treg being
     saturated, not the caller's fault and not the provider's — so say so, typed, and fast. Before this
-    handler the same condition surfaced as a bare `500 Internal Server Error` after a 30 s wait (the
-    exception escaped the router and Starlette's BaseHTTPMiddleware reported "No response returned"),
-    which an agent cannot tell from a provider bug. `treg_saturated` is the key a retrying client
-    should branch on; `Retry-After` is how long to wait before doing so."""
+    handler the same condition escaped request handling and surfaced as a bare
+    `500 Internal Server Error` after a 30 s wait, which an agent cannot tell from a provider bug.
+    `treg_saturated` is the key a retrying client should branch on; `Retry-After` is how long to wait
+    before doing so."""
     resp = JSONResponse(
         {"detail": "treg's database pool is saturated — retry in a moment", "treg_saturated": True},
         status_code=503, headers={"Retry-After": "2"})

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -435,8 +435,8 @@ def create_app(role: AppRole = "all") -> FastAPI:
     )
 
     # Registration order is part of the compatibility surface. add_middleware prepends entries.
-    app.middleware("http")(api_module._legacy_host_redirect)
-    app.middleware("http")(api_module._security_headers)
+    app.add_middleware(api_module._LegacyHostRedirectMiddleware)
+    app.add_middleware(api_module._SecurityHeadersMiddleware)
     app.add_middleware(api_module._BodyDecodeMiddleware)
     app.add_exception_handler(OverflowError, api_module._id_out_of_range)
     app.add_exception_handler(PoolTimeoutError, api_module._pool_saturated)

--- a/tests/snapshots/composition.json
+++ b/tests/snapshots/composition.json
@@ -29,17 +29,13 @@
     },
     {
       "args": [],
-      "class": "starlette.middleware.base.BaseHTTPMiddleware",
-      "kwargs": {
-        "dispatch": "treg.api._security_headers"
-      }
+      "class": "treg.api._SecurityHeadersMiddleware",
+      "kwargs": {}
     },
     {
       "args": [],
-      "class": "starlette.middleware.base.BaseHTTPMiddleware",
-      "kwargs": {
-        "dispatch": "treg.api._legacy_host_redirect"
-      }
+      "class": "treg.api._LegacyHostRedirectMiddleware",
+      "kwargs": {}
     }
   ]
 }

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -1,0 +1,74 @@
+"""Pure-ASGI middleware contracts, especially the no-response disconnect path."""
+
+from __future__ import annotations
+
+from httpx import ASGITransport, AsyncClient
+from starlette.responses import PlainTextResponse
+
+from treg.api import (
+    _BodyDecodeMiddleware,
+    _LegacyHostRedirectMiddleware,
+    _SecurityHeadersMiddleware,
+)
+
+
+def _production_middleware(inner):
+    return _BodyDecodeMiddleware(
+        _SecurityHeadersMiddleware(_LegacyHostRedirectMiddleware(inner))
+    )
+
+
+async def test_disconnected_downstream_may_end_without_a_response() -> None:
+    """A disconnected request is not a server 500 and must not acquire a synthetic response."""
+    received = False
+
+    async def disconnected(scope, receive, send):
+        nonlocal received
+        message = await receive()
+        assert message["type"] == "http.disconnect"
+        received = True
+
+    app = _production_middleware(disconnected)
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/mcp/",
+        "raw_path": b"/mcp/",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"localhost")],
+        "client": ("127.0.0.1", 50000),
+        "server": ("127.0.0.1", 8000),
+    }
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await app(scope, receive, send)
+    assert received is True
+    assert sent == []
+
+
+async def test_security_headers_are_setdefault_case_insensitively() -> None:
+    async def response(scope, receive, send):
+        await PlainTextResponse(
+            "ok",
+            headers={"x-frame-options": "SAMEORIGIN", "x-content-type-options": "strict"},
+        )(scope, receive, send)
+
+    app = _SecurityHeadersMiddleware(response)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        result = await client.get("/")
+
+    assert result.headers.get_list("x-frame-options") == ["SAMEORIGIN"]
+    assert result.headers.get_list("x-content-type-options") == ["strict"]
+    assert result.headers["referrer-policy"] == "no-referrer"
+    assert result.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"

--- a/tests/test_legacy_host_redirect.py
+++ b/tests/test_legacy_host_redirect.py
@@ -45,6 +45,12 @@ async def test_query_string_survives_the_redirect(raw_client):
     assert r.headers["location"] == "https://treg.to/?utm_source=x"
 
 
+async def test_head_uses_the_same_redirect_contract(raw_client):
+    r = await raw_client.head("/support?from=head", headers=LEGACY)
+    assert r.status_code == 301
+    assert r.headers["location"] == "https://treg.to/support?from=head"
+
+
 async def test_a_session_holder_is_never_bounced_off_their_cookies(raw_client):
     # The invite flow sets a legacy-host session then lands on `/?invite_org=…` — a redirect here
     # would strand the browser on the canonical host without the session it just minted.

--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -8,7 +8,38 @@ our control token, and the injected credential.
 
 from __future__ import annotations
 
+import asyncio
+
+import httpx
 from httpx import AsyncClient
+
+from treg.api import app
+
+
+class _CloseTrackingStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.chunks_yielded = 0
+        self.exhausted = False
+
+    async def __aiter__(self):
+        for _ in range(1000):
+            self.chunks_yielded += 1
+            yield b"chunk"
+            await asyncio.sleep(0)
+        self.exhausted = True
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class _CloseTrackingTransport(httpx.AsyncBaseTransport):
+    def __init__(self, stream: _CloseTrackingStream) -> None:
+        self.stream = stream
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"Content-Type": "application/json"},
+                              stream=self.stream, request=request)
 
 
 async def _register(c: AsyncClient, name: str, base_url: str, value: str = "SEK") -> None:
@@ -24,6 +55,65 @@ async def test_passthrough_resolves_by_url_and_injects(clients: AsyncClient):
     d = r.json()
     assert d["auth"] == "Bearer SEK"          # credential injected by treg
     assert d["query"]["per_page"] == "5"      # caller's real query preserved
+
+
+async def test_completed_relay_closes_the_upstream_response(clients: AsyncClient):
+    """A downstream disconnect must run the close task before httpx exhausts its own iterator."""
+    stream = _CloseTrackingStream()
+    tracked = AsyncClient(transport=_CloseTrackingTransport(stream), base_url="http://tracked")
+    original = app.state.http
+    app.state.http = tracked
+    try:
+        await _register(clients, "tracked", "http://tracked")
+        response_started = asyncio.Event()
+        five_chunks_sent = asyncio.Event()
+        body_chunks = 0
+        request_delivered = False
+
+        async def receive():
+            nonlocal request_delivered
+            if not request_delivered:
+                request_delivered = True
+                return {"type": "http.request", "body": b"", "more_body": False}
+            await response_started.wait()
+            await five_chunks_sent.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            nonlocal body_chunks
+            if message["type"] == "http.response.start":
+                assert message["status"] == 200
+                response_started.set()
+            elif message["type"] == "http.response.body" and message.get("body"):
+                body_chunks += 1
+                if body_chunks == 5:
+                    five_chunks_sent.set()
+
+        token = clients.headers["X-Treg-Token"].encode("latin-1")
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/call/tracked/resource",
+            "raw_path": b"/call/tracked/resource",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [(b"host", b"registry"), (b"x-treg-token", token)],
+            "client": ("127.0.0.1", 50000),
+            "server": ("registry", 80),
+        }
+        async with asyncio.timeout(2):
+            await app(scope, receive, send)
+
+        assert body_chunks >= 5
+        assert stream.exhausted is False
+        assert stream.chunks_yielded < 1000
+        assert stream.close_calls == 1
+    finally:
+        app.state.http = original
+        await tracked.aclose()
 
 
 async def test_duplicate_query_params_preserved(clients: AsyncClient):


### PR DESCRIPTION
`POST /mcp/` logged a full traceback and a 500 whenever a client went away mid-request. Found by overnight production monitoring: sustained 6-38 per minute for eight hours, all from a single retry-looping client while 20-28 other clients kept getting 200s. MCP itself was never broken — the errors were misattribution.

```
RuntimeError: No response returned.
  starlette/middleware/base.py:169 in call_next
  treg/api.py in _legacy_host_redirect / _security_headers
anyio.EndOfStream (anyio/streams/memory.py:133 in receive)
```

## Cause

treg's MCP transport is stateless streamable HTTP. When the client disconnects, the transport terminates and closes its streams without sending `http.response.start`. `BaseHTTPMiddleware.call_next()` receives the response over an anyio memory stream, sees `EndOfStream`, and translates a vanished client into a server fault.

## What changed

`_legacy_host_redirect` and `_security_headers` become pure ASGI middleware classes, keeping the nesting order `BodyDecode -> Security -> Legacy`. A downstream that ends without responding now simply ends; real exceptions still propagate. The rejected alternatives were routing `/mcp` around the middleware stack (duplicates the mount and drops security headers) and catching `RuntimeError("No response returned.")` by string (depends on Starlette internals, and a disconnected client cannot receive a 499 anyway).

## Verification

The load-bearing guard is deterministic, not timing-dependent: `tests/test_asgi_middleware.py` assembles the three real middleware around a downstream that ends after `http.disconnect` without responding, and asserts the call returns with no synthetic response. Under `BaseHTTPMiddleware` the same arrangement raises.

`tests/test_passthrough.py` covers the cleanup path this change could have broken silently: the relay attaches `BackgroundTask(upstream_resp.aclose)`, which is the shared httpx pool's only release point when a stream is abandoned. The test drives the full `/call` ASGI path, disconnects after five chunks with the upstream stream demonstrably unexhausted, and asserts `aclose` ran exactly once. Removing the background task turns the test red.

Also: security headers keep case-insensitive `setdefault` (no duplicates, `/call`'s stricter values win); `tests/test_legacy_host_redirect.py` covers 301/302, query preservation and HEAD; `_BodyDecodeMiddleware` is unchanged and still outermost; full suite 1996 passed; `lint-imports` 3 contracts kept.

Snapshots: `composition.json` changes by exactly two entries — the intended replacement of the BaseHTTP wrappers by their pure-ASGI classes, order preserved. `routes.json`, `openapi.json` and `lifespan.json` are byte-identical.

Raw-socket RST testing against a live uvicorn showed no tracebacks after the change — but the same test produces none against the pre-fix code either, so it is reported as a smoke check, not as evidence. The production race depends on uvicorn/anyio/MCP scheduling and does not reproduce reliably in-process.

Pre-existing bug, not introduced by the recent refactor.