### PR TITLE
fix(mcp): preserve real disconnects after body replay

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -184,6 +184,14 @@ The transport's own DNS-rebinding host check (421) and Origin check (403) sit *b
 middleware, so a credentialed request with a bad host or origin is still refused by them — auth does
 not mask the transport guard.
 
+`RequireAuthForProtectedTools` buffers the POST body only long enough to classify that request. It
+then replays the request body and delegates every later `receive()` call to the original ASGI
+channel; it never manufactures `http.disconnect`. That distinction is load-bearing for MCP
+2026-07-28 `subscriptions/listen`: the SDK keeps that response open and watches `receive()` for the
+client's real disconnect, so a synthetic one cancels the subscription before its 200 response and
+acknowledgment are sent. If the client genuinely disconnects while the middleware is reading the
+body, the observed partial body and real disconnect are replayed without inventing completion.
+
 # treg as an authorization server
 
 Elsewhere treg speaks OAuth as a **client** (`oauth.py` signs in with GitHub, connects a provider

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -185,12 +185,13 @@ middleware, so a credentialed request with a bad host or origin is still refused
 not mask the transport guard.
 
 `RequireAuthForProtectedTools` buffers the POST body only long enough to classify that request. It
-then replays the request body and delegates every later `receive()` call to the original ASGI
+then replays the consumed request messages and delegates every later `receive()` call to the original ASGI
 channel; it never manufactures `http.disconnect`. That distinction is load-bearing for MCP
 2026-07-28 `subscriptions/listen`: the SDK keeps that response open and watches `receive()` for the
 client's real disconnect, so a synthetic one cancels the subscription before its 200 response and
 acknowledgment are sent. If the client genuinely disconnects while the middleware is reading the
-body, the observed partial body and real disconnect are replayed without inventing completion.
+body, every observed partial-body message and the real disconnect are replayed unchanged without
+inventing completion.
 
 # treg as an authorization server
 

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -45,7 +45,11 @@ body past the edge: send it base64/gzip-encoded and set `X-Treg-Body-Encoding: b
 fixes `content-length`, and hands the decoded body to routing — so both the Pydantic JSON endpoints
 (e.g. `POST /skills`) and the `/call` proxy (which relays `request.body()` upstream) see plaintext. A
 malformed encoded body is a clean 400. No header ⇒ untouched. The CLI's `_RegistryClient` uses this
-automatically on a WAF 403 (see [cli](cli.md)), as does the local proxy for an intercepted call.
+automatically on a WAF 403 (see [cli](cli.md)), as does the local proxy for an intercepted call. Body
+replay does not imply connection closure: after delivering the decoded request,
+`_BodyDecodeMiddleware` delegates later `receive()` calls to the original ASGI channel and forwards
+only a real `http.disconnect`. If the client disconnects before the encoded body is complete, the
+middleware skips decoding and replays the partial body followed by that real disconnect.
 
 ## `X-Treg-Error` — whose refusal is this?
 `_mark_treg_own_errors` (an `@app.exception_handler(StarletteHTTPException)`) tags treg's **own**

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -49,7 +49,8 @@ automatically on a WAF 403 (see [cli](cli.md)), as does the local proxy for an i
 replay does not imply connection closure: after delivering the decoded request,
 `_BodyDecodeMiddleware` delegates later `receive()` calls to the original ASGI channel and forwards
 only a real `http.disconnect`. If the client disconnects before the encoded body is complete, the
-middleware skips decoding and replays the partial body followed by that real disconnect.
+middleware skips decoding and replays each consumed partial-body message followed by that real
+disconnect.
 
 ## `X-Treg-Error` — whose refusal is this?
 `_mark_treg_own_errors` (an `@app.exception_handler(StarletteHTTPException)`) tags treg's **own**

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -328,16 +328,41 @@ class _BodyDecodeMiddleware:
         if enc is None:
             return await self.app(scope, receive, send)
         chunks: list[bytes] = []
+        received_request = False
+        body_complete = False
+        trailing_message = None
         while True:
             msg = await receive()
             if msg["type"] == "http.request":
+                received_request = True
                 chunks.append(msg.get("body", b""))
                 if not msg.get("more_body", False):
+                    body_complete = True
                     break
-            elif msg["type"] == "http.disconnect":
+            else:
+                trailing_message = msg
                 break
+        raw = b"".join(chunks)
+
+        # A decoder needs the complete encoded payload. If the client disconnected mid-body, pass
+        # the messages already observed through unchanged so downstream sees the real disconnect.
+        if not body_complete:
+            cached_messages = []
+            if received_request:
+                cached_messages.append(
+                    {"type": "http.request", "body": raw, "more_body": True}
+                )
+            if trailing_message is not None:
+                cached_messages.append(trailing_message)
+
+            async def replay_incomplete():
+                if cached_messages:
+                    return cached_messages.pop(0)
+                return await receive()
+
+            return await self.app(scope, replay_incomplete, send)
         try:
-            decoded = _decode_request_body(b"".join(chunks), enc)
+            decoded = _decode_request_body(raw, enc)
         except Exception:  # noqa: BLE001 -- a malformed encoded body is a client error, not a 500
             return await JSONResponse({"detail": "invalid X-Treg-Body-Encoding body"}, status_code=400)(scope, receive, send)
         # Strip the marker, drop content-encoding, and fix content-length to the decoded size.
@@ -352,7 +377,7 @@ class _BodyDecodeMiddleware:
             if not delivered:
                 delivered = True
                 return {"type": "http.request", "body": decoded, "more_body": False}
-            return {"type": "http.disconnect"}
+            return await receive()
 
         return await self.app(new_scope, receive_decoded, send)
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -328,36 +328,26 @@ class _BodyDecodeMiddleware:
         if enc is None:
             return await self.app(scope, receive, send)
         chunks: list[bytes] = []
-        received_request = False
+        consumed_messages = []
         body_complete = False
-        trailing_message = None
         while True:
             msg = await receive()
+            consumed_messages.append(msg)
             if msg["type"] == "http.request":
-                received_request = True
                 chunks.append(msg.get("body", b""))
                 if not msg.get("more_body", False):
                     body_complete = True
                     break
             else:
-                trailing_message = msg
                 break
         raw = b"".join(chunks)
 
         # A decoder needs the complete encoded payload. If the client disconnected mid-body, pass
         # the messages already observed through unchanged so downstream sees the real disconnect.
         if not body_complete:
-            cached_messages = []
-            if received_request:
-                cached_messages.append(
-                    {"type": "http.request", "body": raw, "more_body": True}
-                )
-            if trailing_message is not None:
-                cached_messages.append(trailing_message)
-
             async def replay_incomplete():
-                if cached_messages:
-                    return cached_messages.pop(0)
+                if consumed_messages:
+                    return consumed_messages.pop(0)
                 return await receive()
 
             return await self.app(scope, replay_incomplete, send)

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -953,15 +953,13 @@ class RequireAuthForProtectedTools:
             return await self.app(scope, receive, send)
 
         chunks: list[bytes] = []
-        received_request = False
+        consumed_messages = []
         body_complete = False
-        trailing_message = None
         while True:
             msg = await receive()
+            consumed_messages.append(msg)
             if msg["type"] != "http.request":
-                trailing_message = msg
                 break
-            received_request = True
             chunks.append(msg.get("body", b""))
             if not msg.get("more_body", False):
                 body_complete = True
@@ -979,17 +977,9 @@ class RequireAuthForProtectedTools:
         # those are exhausted, delegate to the original receive() — only the ASGI server knows when
         # the client disconnected. Fabricating http.disconnect here cancels long-lived requests such
         # as MCP 2026-07-28 subscriptions/listen before they can start their response.
-        cached_messages = []
-        if received_request:
-            cached_messages.append(
-                {"type": "http.request", "body": body, "more_body": not body_complete}
-            )
-        if trailing_message is not None:
-            cached_messages.append(trailing_message)
-
         async def replay():
-            if cached_messages:
-                return cached_messages.pop(0)
+            if consumed_messages:
+                return consumed_messages.pop(0)
             return await receive()
 
         return await self.app(scope, replay, send)

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -952,25 +952,45 @@ class RequireAuthForProtectedTools:
         if scope["type"] != "http" or scope.get("method") != "POST":
             return await self.app(scope, receive, send)
 
-        body, more = b"", True
-        while more:
+        chunks: list[bytes] = []
+        received_request = False
+        body_complete = False
+        trailing_message = None
+        while True:
             msg = await receive()
-            body += msg.get("body", b"")
-            more = msg.get("more_body", False)
+            if msg["type"] != "http.request":
+                trailing_message = msg
+                break
+            received_request = True
+            chunks.append(msg.get("body", b""))
+            if not msg.get("more_body", False):
+                body_complete = True
+                break
+        body = b"".join(chunks)
 
-        verdict = self._auth_verdict(scope, body)
+        # An incomplete request ended by a real disconnect has nothing useful to authenticate, and
+        # challenging it would try to write to a socket that is already gone. Let the transport see
+        # the exact request/disconnect sequence instead.
+        verdict = self._auth_verdict(scope, body) if body_complete else None
         if verdict is not None:
             return await self._challenge(send, invalid=(verdict == "invalid"))
 
-        # The body was consumed to inspect it, so hand the transport a receive() that replays it.
-        replayed = False
+        # The body was consumed to inspect it, so replay the messages we actually received. Once
+        # those are exhausted, delegate to the original receive() — only the ASGI server knows when
+        # the client disconnected. Fabricating http.disconnect here cancels long-lived requests such
+        # as MCP 2026-07-28 subscriptions/listen before they can start their response.
+        cached_messages = []
+        if received_request:
+            cached_messages.append(
+                {"type": "http.request", "body": body, "more_body": not body_complete}
+            )
+        if trailing_message is not None:
+            cached_messages.append(trailing_message)
 
         async def replay():
-            nonlocal replayed
-            if replayed:
-                return {"type": "http.disconnect"}
-            replayed = True
-            return {"type": "http.request", "body": body, "more_body": False}
+            if cached_messages:
+                return cached_messages.pop(0)
+            return await receive()
 
         return await self.app(scope, replay, send)
 

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -109,3 +109,38 @@ async def test_body_decode_delegates_to_the_real_receive_after_replay() -> None:
         {"type": "http.request", "body": b"decoded body", "more_body": False},
         {"type": "http.disconnect", "real": True},
     ]
+
+
+async def test_body_decode_preserves_a_real_mid_body_disconnect() -> None:
+    """An incomplete encoded body cannot be decoded or mistaken for a completed request."""
+    received = []
+
+    async def downstream(scope, receive, send):
+        received.append(await receive())
+        received.append(await receive())
+        received.append(await receive())
+
+    messages = [
+        {"type": "http.request", "body": b"first", "more_body": True},
+        {"type": "http.request", "body": b"second", "more_body": True},
+        {"type": "http.disconnect", "real": True},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "scheme": "http", "path": "/call/example", "raw_path": b"/call/example",
+        "query_string": b"", "root_path": "",
+        "headers": [(b"host", b"localhost"), (b"x-treg-body-encoding", b"base64")],
+        "client": ("127.0.0.1", 50000), "server": ("127.0.0.1", 8000),
+    }
+
+    await _BodyDecodeMiddleware(downstream)(scope, receive, lambda message: None)
+
+    assert received == [
+        {"type": "http.request", "body": b"first", "more_body": True},
+        {"type": "http.request", "body": b"second", "more_body": True},
+        {"type": "http.disconnect", "real": True},
+    ]

--- a/tests/test_asgi_middleware.py
+++ b/tests/test_asgi_middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+
 from httpx import ASGITransport, AsyncClient
 from starlette.responses import PlainTextResponse
 
@@ -72,3 +74,38 @@ async def test_security_headers_are_setdefault_case_insensitively() -> None:
     assert result.headers.get_list("x-content-type-options") == ["strict"]
     assert result.headers["referrer-policy"] == "no-referrer"
     assert result.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
+
+
+async def test_body_decode_delegates_to_the_real_receive_after_replay() -> None:
+    """Finishing the decoded body is not evidence that the client disconnected."""
+    received = []
+
+    async def downstream(scope, receive, send):
+        received.append(await receive())
+        received.append(await receive())
+
+    raw = base64.b64encode(b"decoded body")
+    original_calls = 0
+
+    async def receive():
+        nonlocal original_calls
+        original_calls += 1
+        if original_calls == 1:
+            return {"type": "http.request", "body": raw, "more_body": False}
+        return {"type": "http.disconnect", "real": True}
+
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "POST", "scheme": "http", "path": "/call/example", "raw_path": b"/call/example",
+        "query_string": b"", "root_path": "",
+        "headers": [(b"host", b"localhost"), (b"x-treg-body-encoding", b"base64")],
+        "client": ("127.0.0.1", 50000), "server": ("127.0.0.1", 8000),
+    }
+
+    await _BodyDecodeMiddleware(downstream)(scope, receive, lambda message: None)
+
+    assert original_calls == 2
+    assert received == [
+        {"type": "http.request", "body": b"decoded body", "more_body": False},
+        {"type": "http.disconnect", "real": True},
+    ]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -685,6 +685,36 @@ async def test_subscription_listen_is_acknowledged_before_the_real_disconnect() 
     assert acknowledgment_sent.is_set()
 
 
+async def test_auth_middleware_preserves_a_real_mid_body_disconnect() -> None:
+    """Authentication inspection replays each partial request message and the real disconnect."""
+    from treg.mcp import RequireAuthForProtectedTools
+
+    received = []
+
+    async def downstream(scope, receive, send):
+        received.append(await receive())
+        received.append(await receive())
+        received.append(await receive())
+
+    messages = [
+        {"type": "http.request", "body": b'{"jsonrpc":', "more_body": True},
+        {"type": "http.request", "body": b'"2.0"', "more_body": True},
+        {"type": "http.disconnect", "real": True},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    scope = {"type": "http", "method": "POST", "headers": []}
+    await RequireAuthForProtectedTools(downstream)(scope, receive, lambda message: None)
+
+    assert received == [
+        {"type": "http.request", "body": b'{"jsonrpc":', "more_body": True},
+        {"type": "http.request", "body": b'"2.0"', "more_body": True},
+        {"type": "http.disconnect", "real": True},
+    ]
+
+
 async def test_a_BAD_token_is_the_tool_s_business_not_the_transport_s(clients):
     """The challenge fires only when there is NO credential. Deciding whether a token is valid needs
     the database, and doing that in transport middleware would put a second authentication

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -15,6 +15,7 @@ import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import anyio
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -615,10 +616,73 @@ async def test_a_notification_and_ping_pass_without_a_token(clients):
     async with mcp_session(clients) as c:
         r = await c.post("http://localhost/mcp/", headers=MCP_HEADERS,
                          json={"jsonrpc": "2.0", "method": "notifications/initialized"})
-        assert r.status_code != 401, r.text
+        assert r.status_code == 202, r.text
         r = await c.post("http://localhost/mcp/", headers=MCP_HEADERS,
                          json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
-        assert r.status_code != 401, r.text
+        assert r.status_code == 200, r.text
+
+
+async def test_subscription_listen_is_acknowledged_before_the_real_disconnect() -> None:
+    """Body inspection must not invent a disconnect after replaying the request.
+
+    MCP 2026-07-28's subscriptions/listen watches receive() for the real client disconnect while
+    its response remains open. A synthetic disconnect cancels the handler before it sends even
+    http.response.start, which Uvicorn translates into a 500 on a still-live connection.
+    """
+    from treg import mcp as _mcp
+
+    body = json.dumps({
+        "jsonrpc": "2.0", "id": 7, "method": "subscriptions/listen",
+        "params": {
+            "notifications": {"toolsListChanged": True},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/clientInfo": {"name": "test", "version": "1"},
+            },
+        },
+    }).encode()
+    scope = {
+        "type": "http", "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1", "method": "POST", "scheme": "http",
+        "path": "/", "raw_path": b"/", "query_string": b"", "root_path": "",
+        "client": ("127.0.0.1", 50000), "server": ("localhost", 80),
+        "headers": [
+            (b"host", b"localhost"), (b"content-type", b"application/json"),
+            (b"accept", b"application/json, text/event-stream"),
+            (b"authorization", b"Bearer opaque-test-token"),
+            (b"mcp-protocol-version", b"2026-07-28"),
+            (b"mcp-method", b"subscriptions/listen"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+    }
+    acknowledgment_sent = anyio.Event()
+    receive_calls = 0
+    sent = []
+
+    async def receive():
+        nonlocal receive_calls
+        receive_calls += 1
+        if receive_calls == 1:
+            return {"type": "http.request", "body": body, "more_body": False}
+        await acknowledgment_sent.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        sent.append(message)
+        if (message["type"] == "http.response.body" and
+                b"notifications/subscriptions/acknowledged" in message.get("body", b"")):
+            acknowledgment_sent.set()
+
+    fresh = _mcp.build_mcp_app()
+    async with _mcp.mcp_lifespan(fresh):
+        with anyio.fail_after(2):
+            await fresh(scope, receive, send)
+
+    assert receive_calls == 2
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 200
+    assert acknowledgment_sent.is_set()
 
 
 async def test_a_BAD_token_is_the_tool_s_business_not_the_transport_s(clients):


### PR DESCRIPTION
## Intent

Fix the confirmed MCP 2026-07-28 subscriptions/listen 500: authentication middleware currently buffers and replays the request body, then fabricates http.disconnect, causing the MCP SDK to cancel a live subscription before sending its 200 acknowledgment. Replay consumed request messages and then delegate to the original ASGI receive channel so only real disconnects propagate. Audit and fix the same pattern in _BodyDecodeMiddleware, preserve genuine mid-body disconnect semantics, add end-to-end subscription and middleware regression coverage, strengthen notification/ping status assertions, and update the relevant docs/context fragments. Keep the change minimal and preserve normal MCP tool-call behavior.

## What Changed

- Replay buffered ASGI request messages in MCP auth and body-decoding middleware, then delegate to the original receive channel so only genuine disconnects propagate.
- Preserve partial-body disconnect semantics and allow MCP 2026-07-28 subscriptions to send their 200 acknowledgment before the client disconnects.
- Add middleware and subscription regressions, tighten notification/ping status assertions, and document the receive-replay invariants.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves genuine disconnect semantics across both buffering middleware paths, and adds coverage and documentation for the durable invariant without introducing a substantiated regression.

## Testing

Targeted baseline and final checks exercised subscription/listen, exact multi-chunk replay and genuine disconnects in both middleware layers, notification/ping statuses, authentication, successful balance and team-tool calls, and a live protocol transcript; all passed after the focused replay fix. This is a backend protocol change, so a screenshot was not applicable; the recorded wire transcript is the reviewer-visible evidence.

<details>
<summary>Evidence: MCP subscription protocol transcript</summary>

<code>CLIENT -&gt; request body complete; connection remains open&#10;SERVER &lt;- HTTP 200&#10;SERVER &lt;- notifications/subscriptions/acknowledged&#10;CLIENT -&gt; real http.disconnect (after acknowledgment)&#10;RESULT: acknowledgment_before_disconnect=True receive_calls=2</code>

```text
CLIENT -> request body complete; connection remains open
SERVER <- HTTP 200
SERVER <- event: message
data: {"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged","params":{"_meta":{"io.modelcontextprotocol/subscriptionId":7},"notifications":{"toolsListChanged":true}}}
CLIENT -> real http.disconnect (after acknowledgment)
RESULT: acknowledgment_before_disconnect=True receive_calls=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `d0786e03cfe8480057b1273c30eccf02d3c15dd9..7ad766600d3d2046a5da2397c3795caaf83bcc58` and the mapped MCP/API context fragments.</code>
- `uv run pytest -q tests/test_mcp.py::test_subscription_listen_is_acknowledged_before_the_real_disconnect tests/test_mcp.py::test_a_notification_and_ping_pass_without_a_token tests/test_mcp.py::test_a_BAD_token_is_the_tool_s_business_not_the_transport_s tests/test_asgi_middleware.py::test_body_decode_delegates_to_the_real_receive_after_replay tests/test_asgi_middleware.py::test_disconnected_downstream_may_end_without_a_response`
- `Added focused multi-chunk mid-body disconnect tests; confirmed they failed before the replay fix and passed afterward.`
- `uv run --frozen pytest -q tests/test_asgi_middleware.py tests/test_mcp.py::test_subscription_listen_is_acknowledged_before_the_real_disconnect tests/test_mcp.py::test_a_notification_and_ping_pass_without_a_token tests/test_mcp.py::test_auth_middleware_preserves_a_real_mid_body_disconnect tests/test_mcp.py::test_a_BAD_token_is_the_tool_s_business_not_the_transport_s tests/test_mcp.py::test_a_real_token_reads_its_OWN_balance tests/test_mcp.py::test_call_reaches_the_TEAMS_OWN_tools_too`
- <code>Ran a live MCP ASGI lifespan exchange for protocol version `2026-07-28`, recording the HTTP 200 and subscription acknowledgment before releasing the real disconnect.</code>
- `git diff --check`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
