### PR TITLE
fix(mcp): disable unused change subscriptions

### DIFF
--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -33,6 +33,20 @@ Deliberately not one tool per provider. A catalog of 2,600 endpoints exposed as 
 bury the client's tool list and force a re-connect every time the catalog grew. `catalog_search`
 plus `call` covers all of it and stays the same size.
 
+## Fixed surface — no change subscriptions
+
+The six-tool MCP surface is static. Weekly catalog refreshes change the DATA returned by
+`catalog_search` and `catalog_get`; they do not change `tools/list`. treg also publishes no tool,
+prompt or resource change events. `server/discover` therefore advertises
+`tools.listChanged=false`, `prompts.listChanged=false`, `resources.listChanged=false`, and
+`resources.subscribe=false`, and `subscriptions/listen` is refused with `METHOD_NOT_FOUND`.
+
+MCP SDK 2.0 installs `subscriptions/listen` and derives all four flags from its presence, with no
+public constructor switch to disable it. `_StaticSurfaceCapabilities` corrects both behaviors
+through the SDK's public server-middleware seam: it rewrites the discover result and vetoes listen.
+It deliberately does not mutate the SDK's private handler registry. This keeps clients from opening
+idle SSE streams which can never deliver useful work.
+
 `call` is annotated **destructive + open-world + non-idempotent**, which reads as pessimistic until
 you notice treg does not model the upstream: it relays to somebody else's API and cannot know whether
 that endpoint charges, writes or deletes. Claiming otherwise would be a guess presented as a fact.
@@ -185,13 +199,12 @@ middleware, so a credentialed request with a bad host or origin is still refused
 not mask the transport guard.
 
 `RequireAuthForProtectedTools` buffers the POST body only long enough to classify that request. It
-then replays the consumed request messages and delegates every later `receive()` call to the original ASGI
-channel; it never manufactures `http.disconnect`. That distinction is load-bearing for MCP
-2026-07-28 `subscriptions/listen`: the SDK keeps that response open and watches `receive()` for the
-client's real disconnect, so a synthetic one cancels the subscription before its 200 response and
-acknowledgment are sent. If the client genuinely disconnects while the middleware is reading the
-body, every observed partial-body message and the real disconnect are replayed unchanged without
-inventing completion.
+then replays the consumed request messages and delegates every later `receive()` call to the
+original ASGI channel; it never manufactures `http.disconnect`. That distinction is load-bearing
+for MCP 2026-07-28 `subscriptions/listen`, which exposed the bug before treg stopped advertising
+that unused method, and for any other long response: a synthetic disconnect cancels live downstream
+work. If the client genuinely disconnects while the middleware is reading the body, every observed
+partial-body message and the real disconnect are replayed unchanged without inventing completion.
 
 # treg as an authorization server
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -44,9 +44,11 @@ from urllib.parse import parse_qsl, urlsplit
 
 import httpx
 from mcp.server import MCPServer
+from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
 from mcp.server.mcpserver import Context
 from mcp.server.transport_security import TransportSecuritySettings
-from mcp.types import ToolAnnotations
+from mcp.shared.exceptions import MCPError
+from mcp.types import METHOD_NOT_FOUND, ToolAnnotations
 
 from . import audit, catalog_store
 from .config import PUBLIC_HOST_ALIASES, get_settings
@@ -70,6 +72,40 @@ _CALLS = ToolAnnotations(read_only_hint=False, destructive_hint=True, open_world
 _INTERNAL_BASE = "http://treg.internal"
 _TIMEOUT = httpx.Timeout(120.0, connect=5.0)
 
+
+class _StaticSurfaceCapabilities:
+    """Do not advertise or serve change subscriptions for treg's fixed MCP surface.
+
+    MCP SDK 2.0 currently installs subscriptions/listen unconditionally, then derives every
+    listChanged/resource-subscribe capability from that handler. treg never changes its six-tool
+    surface or publishes prompt/resource/tool events; weekly catalog changes are tool DATA, not a
+    tools/list change. Use the SDK's public middleware seam until it exposes a constructor switch —
+    never reach into its private handler registry.
+    """
+
+    async def __call__(
+        self, ctx: ServerRequestContext[Any, Any], call_next: CallNext
+    ) -> HandlerResult:
+        if ctx.method == "subscriptions/listen":
+            raise MCPError(code=METHOD_NOT_FOUND, message="Method not found", data=ctx.method)
+
+        result = await call_next(ctx)
+        if ctx.method != "server/discover" or not isinstance(result, dict):
+            return result
+
+        result = dict(result)
+        capabilities = dict(result.get("capabilities") or {})
+        for name in ("tools", "prompts"):
+            capability = dict(capabilities.get(name) or {})
+            capability["listChanged"] = False
+            capabilities[name] = capability
+        resources = dict(capabilities.get("resources") or {})
+        resources.update({"listChanged": False, "subscribe": False})
+        capabilities["resources"] = resources
+        result["capabilities"] = capabilities
+        return result
+
+
 mcp = MCPServer(
     name="treg",
     title="treg — the tool catalog for your agent",
@@ -85,6 +121,7 @@ mcp = MCPServer(
         "catalog_get (params) → call. Multiple providers for one job? catalog_get ranks them by "
         "measured success, speed and price — you pick."
     ),
+    middleware=[_StaticSurfaceCapabilities()],
 )
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -15,7 +15,6 @@ import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-import anyio
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -38,6 +37,23 @@ async def _rpc(client: AsyncClient, method: str, params=None, token: str | None 
     # allow-list — see test_an_unknown_host_is_refused.
     r = await client.post("http://localhost/mcp/", json=body, headers=headers)
     return r
+
+
+async def _modern_rpc(client: AsyncClient, method: str, params=None, token: str = "opaque-test-token"):
+    body_params = dict(params or {})
+    body_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {"name": "test", "version": "1"},
+    }
+    return await client.post("http://localhost/mcp/", json={
+        "jsonrpc": "2.0", "id": 1, "method": method, "params": body_params,
+    }, headers={
+        **MCP_HEADERS,
+        "Authorization": f"Bearer {token}",
+        "MCP-Protocol-Version": "2026-07-28",
+        "MCP-Method": method,
+    })
 
 
 async def _call_tool(client: AsyncClient, name: str, args: dict, token: str | None = None) -> dict:
@@ -622,67 +638,66 @@ async def test_a_notification_and_ping_pass_without_a_token(clients):
         assert r.status_code == 200, r.text
 
 
-async def test_subscription_listen_is_acknowledged_before_the_real_disconnect() -> None:
-    """Body inspection must not invent a disconnect after replaying the request.
+async def test_auth_body_replay_waits_for_the_real_disconnect_on_a_long_response() -> None:
+    """A completed request body is not a disconnect; long responses keep the live receive channel."""
+    from treg.mcp import RequireAuthForProtectedTools
 
-    MCP 2026-07-28's subscriptions/listen watches receive() for the real client disconnect while
-    its response remains open. A synthetic disconnect cancels the handler before it sends even
-    http.response.start, which Uvicorn translates into a 500 on a still-live connection.
-    """
-    from treg import mcp as _mcp
-
-    body = json.dumps({
-        "jsonrpc": "2.0", "id": 7, "method": "subscriptions/listen",
-        "params": {
-            "notifications": {"toolsListChanged": True},
-            "_meta": {
-                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
-                "io.modelcontextprotocol/clientCapabilities": {},
-                "io.modelcontextprotocol/clientInfo": {"name": "test", "version": "1"},
-            },
-        },
-    }).encode()
-    scope = {
-        "type": "http", "asgi": {"version": "3.0", "spec_version": "2.3"},
-        "http_version": "1.1", "method": "POST", "scheme": "http",
-        "path": "/", "raw_path": b"/", "query_string": b"", "root_path": "",
-        "client": ("127.0.0.1", 50000), "server": ("localhost", 80),
-        "headers": [
-            (b"host", b"localhost"), (b"content-type", b"application/json"),
-            (b"accept", b"application/json, text/event-stream"),
-            (b"authorization", b"Bearer opaque-test-token"),
-            (b"mcp-protocol-version", b"2026-07-28"),
-            (b"mcp-method", b"subscriptions/listen"),
-            (b"content-length", str(len(body)).encode()),
-        ],
-    }
-    acknowledgment_sent = anyio.Event()
-    receive_calls = 0
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "ping"}).encode()
+    original_calls = 0
+    downstream_received = []
     sent = []
 
     async def receive():
-        nonlocal receive_calls
-        receive_calls += 1
-        if receive_calls == 1:
+        nonlocal original_calls
+        original_calls += 1
+        if original_calls == 1:
             return {"type": "http.request", "body": body, "more_body": False}
-        await acknowledgment_sent.wait()
-        return {"type": "http.disconnect"}
+        return {"type": "http.disconnect", "real": True}
 
     async def send(message):
         sent.append(message)
-        if (message["type"] == "http.response.body" and
-                b"notifications/subscriptions/acknowledged" in message.get("body", b"")):
-            acknowledgment_sent.set()
 
-    fresh = _mcp.build_mcp_app()
-    async with _mcp.mcp_lifespan(fresh):
-        with anyio.fail_after(2):
-            await fresh(scope, receive, send)
+    async def long_response(scope, receive, send):
+        downstream_received.append(await receive())
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"still open", "more_body": True})
+        downstream_received.append(await receive())
 
-    assert receive_calls == 2
-    assert sent[0]["type"] == "http.response.start"
-    assert sent[0]["status"] == 200
-    assert acknowledgment_sent.is_set()
+    scope = {"type": "http", "method": "POST", "headers": []}
+    await RequireAuthForProtectedTools(long_response)(scope, receive, send)
+
+    assert original_calls == 2
+    assert downstream_received == [
+        {"type": "http.request", "body": body, "more_body": False},
+        {"type": "http.disconnect", "real": True},
+    ]
+    assert sent[0] == {"type": "http.response.start", "status": 200, "headers": []}
+
+
+async def test_discover_disables_unused_change_capabilities(clients) -> None:
+    """A fixed tool surface must not make clients open an idle subscription stream."""
+    async with mcp_session(clients) as c:
+        r = await _modern_rpc(c, "server/discover")
+
+    assert r.status_code == 200, r.text
+    capabilities = r.json()["result"]["capabilities"]
+    assert capabilities["tools"]["listChanged"] is False
+    assert capabilities["prompts"]["listChanged"] is False
+    assert capabilities["resources"]["listChanged"] is False
+    assert capabilities["resources"]["subscribe"] is False
+
+
+async def test_subscription_listen_is_not_served(clients) -> None:
+    """SDK 2.0 registers listen by default; treg refuses it through the public middleware seam."""
+    async with mcp_session(clients) as c:
+        r = await _modern_rpc(c, "subscriptions/listen", {
+            "notifications": {"toolsListChanged": True},
+        })
+
+    assert r.status_code == 404, r.text
+    assert r.json()["error"] == {
+        "code": -32601, "message": "Method not found", "data": "subscriptions/listen",
+    }
 
 
 async def test_auth_middleware_preserves_a_real_mid_body_disconnect() -> None:


### PR DESCRIPTION
## Intent

After admin-merging PR #206, create a separate follow-up PR that closes treg's unused MCP change-subscription capabilities. treg has a fixed six-tool surface; weekly catalog updates change catalog_search/catalog_get data rather than tools/list, and treg publishes no tool, prompt, or resource change events. Make server/discover advertise tools.listChanged=false, prompts.listChanged=false, resources.listChanged=false, and resources.subscribe=false; do not serve subscriptions/listen. MCP SDK 2.0 registers listen automatically and has no public stable off switch, so use a public SDK integration seam and do not mutate private _request_handlers or similar internals. Add end-to-end discovery and refusal coverage while preserving PR #206's generic real-http.disconnect replay regression, update the MCP context fragment, keep the change isolated from #206, and validate the PR through CI.

## What Changed

- Advertise the fixed MCP surface with tool, prompt, and resource change capabilities disabled.
- Refuse `subscriptions/listen` through the SDK’s public middleware seam without mutating private handlers.
- Add end-to-end discovery/refusal coverage, preserve generic disconnect-replay regression coverage, and update the MCP architecture context.

## Risk Assessment

✅ Low: The change is narrowly scoped, uses the SDK’s public middleware seam, satisfies all capability and refusal requirements, preserves the generic disconnect replay regression, and updates the relevant context documentation.

## Testing

Focused MCP tests and mounted-transport API requests confirmed the fixed six-tool surface, all four disabled discovery capabilities, method-not-found refusal for subscriptions/listen, and preservation of PR #206’s generic real-disconnect replay behavior. The API transcript is the reviewer-visible artifact; no screenshot was applicable because this change has no UI surface.

<details>
<summary>Evidence: Mounted MCP API evidence</summary>

`Discovery: HTTP 200; all four change/subscription capabilities false. Listen: HTTP 404, JSON-RPC -32601. Tools: fixed six-tool surface.`

```text
{
  "request_surface": "POST /mcp/ (mounted streamable HTTP transport)",
  "server_discover": {
    "http_status": 200,
    "advertised_change_capabilities": {
      "tools.listChanged": false,
      "prompts.listChanged": false,
      "resources.listChanged": false,
      "resources.subscribe": false
    }
  },
  "subscriptions_listen": {
    "http_status": 404,
    "jsonrpc_error": {
      "code": -32601,
      "message": "Method not found",
      "data": "subscriptions/listen"
    }
  },
  "tools_list": {
    "count": 6,
    "names": [
      "catalog_search",
      "catalog_request",
      "catalog_get",
      "call",
      "balance",
      "my_tools"
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest -q tests/test_mcp.py::test_the_server_lists_exactly_the_six_tools tests/test_mcp.py::test_discover_disables_unused_change_capabilities tests/test_mcp.py::test_subscription_listen_is_not_served tests/test_mcp.py::test_auth_body_replay_waits_for_the_real_disconnect_on_a_long_response tests/test_mcp.py::test_auth_middleware_preserves_a_real_mid_body_disconnect`
- <code>Mounted-ASGI manual JSON-RPC requests to `server/discover`, `subscriptions/listen`, and `tools/list` through `POST /mcp/`</code>
- <code>Verified the evidence file checksum and confirmed the worktree was clean after removing the test runner’s incidental `uv.lock` rewrite</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
