### PR TITLE
Top-up redesign: 4 presets + Other, tiered bonus, ladder default, auto top-up on by default

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -184,20 +184,21 @@ built. A 100%-off code collects nothing, so the session credits nothing: `_on_ch
 drops it as `zero amount`. Grant free balance through `ledger.grant`, never through a Stripe coupon.
 
 **The top-up bonus IS that `ledger.grant` on top — tiered, and manual only.** `topup_bonus_tiers`
-(`{10: 0, 50: 5, 100: 10, 200: 15}`, `{min_usd: percent}`) gives a manual top-up a `bonus` block
-worth the highest tier at or below the amount (`bonus_for_topup`: $99 earns the $50 rate, $250 the
-$200 rate; integer `amount * pct // 100`). It is granted inside `_credit`'s `fresh` branch — the one
+(`{10: 0, 50: 500, 100: 750, 200: 1000}`, `{min_usd: basis points}` — 7.5% has to stay an
+integer) gives a manual top-up a `bonus` block worth the highest tier at or below the amount
+(`bonus_for_topup`: $99 earns the $50 rate, $2,000 the $200 rate — the top tier is the ceiling;
+integer `amount * bp // 10_000`). It is granted inside `_credit`'s `fresh` branch — the one
 point that knows money moved for the first time, so a webhook redelivery grants nothing — as a
 **separate block** with `_KIND_ORDER` rank 0: it burns with promo and referral credit, before the
 purchased block, and the purchased block stays exactly what the card paid. That is the whole
 reason it is not folded into `ledger.topup`: purchased credit is a refundable liability, the bonus
 is marketing spend. Automatic refills (`auto=True`) earn nothing — they repeat a chosen amount, and
-a bonus there would be a permanent 9–15% margin cut on every refill rather than a reason to come
+a bonus there would be a permanent 5–10% margin cut on every refill rather than a reason to come
 back and buy bigger. A refund or dispute does **not** reverse it: like an already-granted referral
 bonus it is logged for a human (`_on_payment_reversed` → `bonus_blocks_flagged`), because the ledger
 has no path that drives a balance down and this is not the reason to add one. The grant entry's
-meta carries `payment_intent`, `pct` and `topup_block_id`; `topup_history` joins on it to show
-`bonus_micro` per payment, and the receipt says "$100 + $10 bonus" so a balance that rose $110 on a
+meta carries `payment_intent`, `bp` and `topup_block_id`; `topup_history` joins on it to show
+`bonus_micro` per payment, and the receipt says "$100 + $7.50 bonus" so a balance that rose $107.50 on a
 $100 charge reads as intended rather than as a mistake.
 
 **The preselected amount climbs a ladder, capped.** `next_default_usd` looks at the org's last

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -72,7 +72,7 @@ swallows exceptions, which is right for analytics and fatal for money.
 
 | Op | Effect |
 |---|---|
-| `grant` | new promotional block, balance up (org creation) |
+| `grant` | new promotional block, balance up (org creation, the referral bonus, the top-up bonus) |
 | `topup` | new purchased block, balance up (after Stripe authorized) |
 | `reserve` | balance down by the estimate, `Hold` opened — the hot-path spend gate |
 | `settle` | blocks down by the observed cost, hold closed, difference refunded |
@@ -182,6 +182,34 @@ needs no deploy). Because the webhook credits `amount_total` — what Stripe act
 off means $40 paid and $40 credited. "Pay $40, get $50" would be a `ledger.grant` on top and is not
 built. A 100%-off code collects nothing, so the session credits nothing: `_on_checkout_completed`
 drops it as `zero amount`. Grant free balance through `ledger.grant`, never through a Stripe coupon.
+
+**The top-up bonus IS that `ledger.grant` on top — tiered, and manual only.** `topup_bonus_tiers`
+(`{10: 0, 50: 5, 100: 10, 200: 15}`, `{min_usd: percent}`) gives a manual top-up a `bonus` block
+worth the highest tier at or below the amount (`bonus_for_topup`: $99 earns the $50 rate, $250 the
+$200 rate; integer `amount * pct // 100`). It is granted inside `_credit`'s `fresh` branch — the one
+point that knows money moved for the first time, so a webhook redelivery grants nothing — as a
+**separate block** with `_KIND_ORDER` rank 0: it burns with promo and referral credit, before the
+purchased block, and the purchased block stays exactly what the card paid. That is the whole
+reason it is not folded into `ledger.topup`: purchased credit is a refundable liability, the bonus
+is marketing spend. Automatic refills (`auto=True`) earn nothing — they repeat a chosen amount, and
+a bonus there would be a permanent 9–15% margin cut on every refill rather than a reason to come
+back and buy bigger. A refund or dispute does **not** reverse it: like an already-granted referral
+bonus it is logged for a human (`_on_payment_reversed` → `bonus_blocks_flagged`), because the ledger
+has no path that drives a balance down and this is not the reason to add one. The grant entry's
+meta carries `payment_intent`, `pct` and `topup_block_id`; `topup_history` joins on it to show
+`bonus_micro` per payment, and the receipt says "$100 + $10 bonus" so a balance that rose $110 on a
+$100 charge reads as intended rather than as a mistake.
+
+**The preselected amount climbs a ladder, capped.** `next_default_usd` looks at the org's last
+*manual* top-up and returns the first preset above it, never past `topup_default_cap_usd` ($50):
+$10 → $50, $50 → $50, nothing yet → `topup_default_usd`. Auto refills are skipped so the ladder
+cannot ratchet on its own. The dashboard modal preselects it (`GET /billing` → `topup.default_usd`,
+now per-org) and `POST /billing/topup` with no amount uses it — which is what `treg topup` sends.
+Presets are four (`[10, 50, 100, 200]`) plus "Other": with eight cards from $5 up nobody ever
+picked $100+ and repeat payers stayed flat; the minimum is $10 (fee math, and the referral
+qualifying amount). The threshold for auto top-up is validated separately (`validate_threshold_usd`,
+≥ $1): it is not a charge, so the top-up minimum must not apply to it — raising the minimum
+without that split would have rejected the default $5 threshold on every enable.
 
 Turning `invoice_creation` on makes Stripe emit `invoice.created` / `invoice.paid` for every top-up.
 `handle_webhook_event` drops them, deliberately: crediting on an invoice event as well as on the
@@ -666,10 +694,10 @@ webhook and a page load, and neither may fail over a bonus.
 **The referee is told, on the screen where it changes their behaviour.** `offer_for_org` is the
 mirror of `summary`: a team that arrived through a link has a `pending` row and no idea a bonus
 exists. `GET /billing` carries a `referral_offer` (merged in the api route, not in `billing.py` —
-that module keeps its one job) and the dashboard names the MINIMUM there, because the first top-up
-preset is $5 and the minimum is $10, so the most-clicked button silently forfeits the reward
-otherwise. The qualifying presets say `+$5 bonus` on themselves; a note alone sits above the place
-the decision is actually made. The offer is returned only while `pending` — after qualifying the
+that module keeps its one job) and the dashboard names the MINIMUM there (it equals the smallest preset now that $5
+is gone, but the "Other" input can still go below it, so the note stays). The qualifying presets say `+$5 bonus` on themselves; a note alone sits above the place
+the decision is actually made (the tier bonus and the referral bonus stack on the same card). The
+offer is returned only while `pending` — after qualifying the
 money is already on its way through `sweep`, and still advertising it would read as a second bonus —
 and it names the referrer MASKED (`mask_email`, `j•••@domain`). Not anonymous — "you were invited"
 with nobody attached reads as marketing copy, and someone who clicked a link off a tweet last week

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -211,6 +211,13 @@ qualifying amount). The threshold for auto top-up is validated separately (`vali
 ≥ $1): it is not a charge, so the top-up minimum must not apply to it — raising the minimum
 without that split would have rejected the default $5 threshold on every enable.
 
+**A saved card arms a consented policy from either webhook.** The modal records consent first
+(`set_autotopup` → `no_card`) and relies on the top-up Checkout to save the card, so there is no
+SetupIntent in that flow: `_set_default_pm` — called by both `_on_checkout_completed` and
+`_on_setup_succeeded` — runs `_arm_if_waiting_for_card`, which turns the policy on only from the
+explicit `no_card` state. A decline, 3DS, or a deliberate off (reason `None`, consent still on
+file) stays off; a redelivered payment webhook must not switch a policy back on.
+
 Turning `invoice_creation` on makes Stripe emit `invoice.created` / `invoice.paid` for every top-up.
 `handle_webhook_event` drops them, deliberately: crediting on an invoice event as well as on the
 PaymentIntent would be a second door onto the same money. The invoice is a document; the

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -184,21 +184,20 @@ built. A 100%-off code collects nothing, so the session credits nothing: `_on_ch
 drops it as `zero amount`. Grant free balance through `ledger.grant`, never through a Stripe coupon.
 
 **The top-up bonus IS that `ledger.grant` on top — tiered, and manual only.** `topup_bonus_tiers`
-(`{10: 0, 50: 500, 100: 750, 200: 1000}`, `{min_usd: basis points}` — 7.5% has to stay an
-integer) gives a manual top-up a `bonus` block worth the highest tier at or below the amount
-(`bonus_for_topup`: $99 earns the $50 rate, $2,000 the $200 rate — the top tier is the ceiling;
-integer `amount * bp // 10_000`). It is granted inside `_credit`'s `fresh` branch — the one
+(`{10: 0, 50: 5, 100: 10, 200: 15}`, `{min_usd: percent}`) gives a manual top-up a `bonus` block
+worth the highest tier at or below the amount (`bonus_for_topup`: $99 earns the $50 rate, $250 the
+$200 rate; integer `amount * pct // 100`). It is granted inside `_credit`'s `fresh` branch — the one
 point that knows money moved for the first time, so a webhook redelivery grants nothing — as a
 **separate block** with `_KIND_ORDER` rank 0: it burns with promo and referral credit, before the
 purchased block, and the purchased block stays exactly what the card paid. That is the whole
 reason it is not folded into `ledger.topup`: purchased credit is a refundable liability, the bonus
 is marketing spend. Automatic refills (`auto=True`) earn nothing — they repeat a chosen amount, and
-a bonus there would be a permanent 5–10% margin cut on every refill rather than a reason to come
+a bonus there would be a permanent 9–15% margin cut on every refill rather than a reason to come
 back and buy bigger. A refund or dispute does **not** reverse it: like an already-granted referral
 bonus it is logged for a human (`_on_payment_reversed` → `bonus_blocks_flagged`), because the ledger
 has no path that drives a balance down and this is not the reason to add one. The grant entry's
-meta carries `payment_intent`, `bp` and `topup_block_id`; `topup_history` joins on it to show
-`bonus_micro` per payment, and the receipt says "$100 + $7.50 bonus" so a balance that rose $107.50 on a
+meta carries `payment_intent`, `pct` and `topup_block_id`; `topup_history` joins on it to show
+`bonus_micro` per payment, and the receipt says "$100 + $10 bonus" so a balance that rose $110 on a
 $100 charge reads as intended rather than as a mistake.
 
 **The preselected amount climbs a ladder, capped.** `next_default_usd` looks at the org's last

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -226,8 +226,9 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
     bonus stacks via `refPresetBonus`), a summary box (credit + bonus, total due = the amount — treg
     charges no fee, so there is no fee line), and an **auto top-up toggle that defaults ON** for a
     team with no mandate yet. The toggle's label is the mandate text with the amount being chosen
-    right now, the $5 threshold and a monthly cap of `max(configured cap, 4 × amount)` — never a
-    config default the payer did not see. Pay with the toggle on POSTs `/billing/autotopup`
+    right now and the $5 threshold — never a config default the payer did not see. The monthly cap is
+    not in the copy: it is a server-side runaway guardrail, and the modal sets it to `topup.max_usd`
+    (effectively unlimited) so a big payer is never locked out by a default sized for $10 refills. Pay with the toggle on POSTs `/billing/autotopup`
     (`consent: true`, those numbers, `setup_url: false` because the top-up Checkout saves the card
     itself) **before** `/billing/topup`, so consent exists before the card that will be charged under
     it; the setup webhook then arms the policy. A team that already has a mandate sees a read-only

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -210,16 +210,29 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
     argv deny patterns with their source (skill vs catalog), under a line naming all three deny
     layers — HTTP rules, argv patterns, OS sandbox — so the whole "what is blocked" picture is one
     screen.
-  - **Billing** (admin+) — balance, one-click top-up cards rendered from `billing.topup.presets` (the
-    reference defaults live in [deployment config](../ops/deploy.md#config-configpy)), the auto-top-up
+  - **Billing** (admin+) — balance, a **Top up** button that opens the top-up modal, the auto-top-up
     toggle with its verbatim PSD2/SCA mandate text, and below them **Payment history**: date, amount, an
-    `auto` marker, and one link per row — *Invoice* when Stripe issued one (manual top-ups do; automatic
+    `auto` marker, the `+$X bonus` the payment earned, and one link per row — *Invoice* when Stripe issued one (manual top-ups do; automatic
     ones can't), else
     *Receipt*, else an em dash. Amounts come from our own ledger and the links from Stripe, so when
     Stripe is unreachable the table still renders and a line under it says the links, not the numbers,
     are missing. A **Manage billing** button opens Stripe's hosted portal (card, billing address, tax
     ID, the full invoice archive); it is hidden until `billing.portal` is true, which needs a Stripe
     customer, which a team gets on its first payment — so a new team never sees a button that errors.
+
+    The **top-up modal** (`topupOpen`) is one decision, not three: the four preset cards from
+    `billing.topup.presets` plus **Other** (a whole-dollar input bounded by `topup.min_usd`/`max_usd`),
+    each card naming the tier bonus it earns (`tierBonus`, from `topup.bonus_tiers`; the referral
+    bonus stacks via `refPresetBonus`), a summary box (credit + bonus, total due = the amount — treg
+    charges no fee, so there is no fee line), and an **auto top-up toggle that defaults ON** for a
+    team with no mandate yet. The toggle's label is the mandate text with the amount being chosen
+    right now, the $5 threshold and a monthly cap of `max(configured cap, 4 × amount)` — never a
+    config default the payer did not see. Pay with the toggle on POSTs `/billing/autotopup`
+    (`consent: true`, those numbers, `setup_url: false` because the top-up Checkout saves the card
+    itself) **before** `/billing/topup`, so consent exists before the card that will be charged under
+    it; the setup webhook then arms the policy. A team that already has a mandate sees a read-only
+    "auto top-up is on" line instead. The preselected card is `topup.default_usd`, which is per-org:
+    one preset above the last manual top-up, capped at $50 (see [money](../architecture/money.md)).
   - **Team settings** — deliberately JUST the **Danger zone** (leave / delete), visible to EVERY role
     (leaving is self-service, and `loadOrgAdmin` lands a non-admin here). New team / Join by code /
     Paste token live only in the sidebar picker — cut from this tab on founder review; a personal

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -225,8 +225,11 @@ specific org — token bakes the org in; a session picks it via `X-Treg-Org`), a
     each card naming the tier bonus it earns (`tierBonus`, from `topup.bonus_tiers`; the referral
     bonus stacks via `refPresetBonus`), a summary box (credit + bonus, total due = the amount — treg
     charges no fee, so there is no fee line), and an **auto top-up toggle that defaults ON** for a
-    team with no mandate yet. The toggle's label is the mandate text with the amount being chosen
-    right now and the $5 threshold — never a config default the payer did not see. The monthly cap is
+    team with no mandate yet. The toggle's label is the mandate text with the refill amount and
+    threshold (the server defaults, $20 when below $5 — not the top-up amount: a $200 buyer does
+    not want $200 refills), shown in full so what is agreed is what will be charged; the billing
+    page's **Edit** link on a running policy reopens the same panel to change them (Save re-stamps
+    consent). The monthly cap is
     not in the copy: it is a server-side runaway guardrail, and the modal sets it to `topup.max_usd`
     (effectively unlimited) so a big payer is never locked out by a default sized for $10 refills. Pay with the toggle on POSTs `/billing/autotopup`
     (`consent: true`, those numbers, `setup_url: false` because the top-up Checkout saves the card

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -54,9 +54,12 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
   phase with `scripts/smoke-domain.sh pre|post`. Self-hosters set
   `TREG_PUBLIC_URL`. Used to build the OAuth callback URI.
 - `api_token` — a bootstrap caller token (MVP leftover; per-user tokens are the real auth).
-- `topup_min_usd`, `topup_default_usd`, `topup_presets` — Stripe top-up amounts in whole USD. The
-  reference defaults are a $5 minimum, $10 default, and one-click presets of $5, $10, $25, $50,
-  $100, $200, $300 and $400; `billing_state` publishes the configured preset list to the dashboard.
+- `topup_min_usd`, `topup_default_usd`, `topup_presets`, `topup_bonus_tiers`, `topup_default_cap_usd`
+  — Stripe top-up amounts in whole USD. The reference defaults are a $10 minimum, $10 first default,
+  presets of $10, $50, $100 and $200 (plus "Other"), bonus tiers `{10: 0, 50: 5, 100: 10, 200: 15}`
+  (percent of a MANUAL top-up granted as a separate `bonus` block), and a $50 cap on the preselected
+  amount's climb after each payment; `billing_state` publishes presets, tiers and the per-org default
+  to the dashboard.
 - `admin_token` — the cross-tenant **super-admin** bearer (`TREG_ADMIN_TOKEN`); empty disables the env
   path (only `is_superadmin` users reach `/admin`). Keep it long + secret. See
   [super-admin](../architecture/super-admin.md).

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -56,8 +56,8 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
 - `api_token` — a bootstrap caller token (MVP leftover; per-user tokens are the real auth).
 - `topup_min_usd`, `topup_default_usd`, `topup_presets`, `topup_bonus_tiers`, `topup_default_cap_usd`
   — Stripe top-up amounts in whole USD. The reference defaults are a $10 minimum, $10 first default,
-  presets of $10, $50, $100 and $200 (plus "Other"), bonus tiers `{10: 0, 50: 5, 100: 10, 200: 15}`
-  (percent of a MANUAL top-up granted as a separate `bonus` block), and a $50 cap on the preselected
+  presets of $10, $50, $100 and $200 (plus "Other"), bonus tiers `{10: 0, 50: 500, 100: 750, 200: 1000}`
+  (basis points of a MANUAL top-up granted as a separate `bonus` block; the top tier is the ceiling), and a $50 cap on the preselected
   amount's climb after each payment; `billing_state` publishes presets, tiers and the per-org default
   to the dashboard.
 - `admin_token` — the cross-tenant **super-admin** bearer (`TREG_ADMIN_TOKEN`); empty disables the env

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -56,8 +56,8 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
 - `api_token` — a bootstrap caller token (MVP leftover; per-user tokens are the real auth).
 - `topup_min_usd`, `topup_default_usd`, `topup_presets`, `topup_bonus_tiers`, `topup_default_cap_usd`
   — Stripe top-up amounts in whole USD. The reference defaults are a $10 minimum, $10 first default,
-  presets of $10, $50, $100 and $200 (plus "Other"), bonus tiers `{10: 0, 50: 500, 100: 750, 200: 1000}`
-  (basis points of a MANUAL top-up granted as a separate `bonus` block; the top tier is the ceiling), and a $50 cap on the preselected
+  presets of $10, $50, $100 and $200 (plus "Other"), bonus tiers `{10: 0, 50: 5, 100: 10, 200: 15}`
+  (percent of a MANUAL top-up granted as a separate `bonus` block), and a $50 cap on the preselected
   amount's climb after each payment; `billing_state` publishes presets, tiers and the per-org default
   to the dashboard.
 - `admin_token` — the cross-tenant **super-admin** bearer (`TREG_ADMIN_TOKEN`); empty disables the env

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3776,6 +3776,9 @@ class AutoTopupIn(BaseModel):
     threshold_usd: float | None = None
     amount_usd: float | None = None
     monthly_cap_usd: float | None = None
+    # False when the caller is about to open a top-up Checkout anyway (the dashboard's modal): that
+    # page saves the card too, so a second card-capture session would be a wasted Stripe call.
+    setup_url: bool = True
     # Explicit, per-request agreement to unattended charges — the MIT mandate. Required to ENABLE when
     # there is no timestamp on file; ignored when disabling (nobody consents to stopping).
     consent: bool = False
@@ -3828,7 +3831,7 @@ async def billing_topup(
     redirect by hand — can create balance.
     """
     org = _billing_org(caller)
-    amount = body.amount_usd if body.amount_usd is not None else get_settings().topup_default_usd
+    amount = body.amount_usd if body.amount_usd is not None else await billing.next_default_usd(db, org.id)
     try:
         out = await billing.create_topup_checkout(
             db, org, amount, return_base=_return_base(request), email=caller.email)
@@ -3869,7 +3872,7 @@ async def billing_autotopup(
     except billing.TopupRejected as e:
         raise HTTPException(status_code=422, detail=str(e))
     state = await billing.billing_state(db, org)
-    if body.enabled and not org.stripe_default_pm:
+    if body.enabled and body.setup_url and not org.stripe_default_pm:
         try:
             state["setup_url"] = (await billing.create_setup_checkout(
                 db, org, return_base=_return_base(request), email=caller.email))["url"]

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -96,6 +96,72 @@ def cents_to_micro(amount_cents: int) -> int:
     return int(amount_cents) * MICRO_PER_CENT
 
 
+def bonus_for_topup(amount_micro: int) -> tuple[int, int]:
+    """The promotional bonus a MANUAL top-up of `amount_micro` earns, as `(bonus_micro, percent)`.
+
+    Tiered by size (`topup_bonus_tiers`): the highest tier at or below the amount applies, so $99 gets
+    the $50 rate and $250 the $200 rate. Integer micro-USD throughout — `amount * pct // 100`
+    truncates the sub-micro remainder, which is at most a millionth of a dollar in treg's favour.
+    Callers decide whether the top-up qualifies at all (automatic refills never do).
+    """
+    tiers = get_settings().topup_bonus_tiers or {}
+    usd = int(amount_micro) // MICRO_PER_USD
+    pct = 0
+    for floor_usd in sorted(int(k) for k in tiers):
+        if usd >= floor_usd:
+            pct = int(tiers[floor_usd] if floor_usd in tiers else tiers[str(floor_usd)])
+    if pct <= 0:
+        return 0, 0
+    return int(amount_micro) * pct // 100, pct
+
+
+async def next_default_usd(db: AsyncSession, org_id: int | None) -> int:
+    """The amount to preselect for this org's next MANUAL top-up: one preset above the last manual
+    one, capped at `topup_default_cap_usd`. No history → `topup_default_usd`.
+
+    Automatic refills are ignored on purpose: they repeat the org's own chosen amount, and stepping
+    the default up because of them would ratchet forever. "Above" means the first preset strictly
+    greater than the last amount; an amount at or past the cap stays at the cap.
+    """
+    s = get_settings()
+    if not org_id:
+        return int(s.topup_default_usd)
+    rows = (await db.execute(
+        select(LedgerEntry.amount_micro, LedgerEntry.meta)
+        .where(LedgerEntry.org_id == org_id, LedgerEntry.kind == "topup")
+        .order_by(LedgerEntry.created_at.desc(), LedgerEntry.id.desc()).limit(50)
+    )).all()
+    last_micro = None
+    for amount, meta in rows:
+        if not (meta or {}).get("auto"):
+            last_micro = int(amount)
+            break
+    if last_micro is None:
+        return int(s.topup_default_usd)
+    last_usd = last_micro // MICRO_PER_USD
+    cap = int(s.topup_default_cap_usd)
+    for p in sorted(int(x) for x in s.topup_presets):
+        if p > last_usd:
+            return min(p, cap)
+    return min(max(last_usd, int(s.topup_default_usd)), cap)
+
+
+def validate_threshold_usd(amount_usd) -> int:
+    """The auto-top-up THRESHOLD is not a charge, so it is not held to the top-up minimum (which is
+    card-fee math): any whole dollar amount from $1 up to the single-top-up ceiling."""
+    try:
+        value = float(amount_usd)
+    except (TypeError, ValueError):
+        raise TopupRejected("threshold must be a number of US dollars")
+    if value != int(value):
+        raise TopupRejected("the threshold is whole dollars (e.g. 5, not 5.50)")
+    if value < 1:
+        raise TopupRejected("the threshold must be at least $1")
+    if value > TOPUP_MAX_USD:
+        raise TopupRejected(f"the threshold cannot exceed ${TOPUP_MAX_USD}")
+    return int(value)
+
+
 def validate_topup_usd(amount_usd) -> int:
     """The one gate on "how much". Returns whole dollars; raises `TopupRejected` with a message the
     payer can act on.
@@ -462,6 +528,17 @@ async def list_payments(db: AsyncSession, org: Org, *, limit: int = 24) -> dict:
             )
         )).all()
         auto = {str(bid) for bid, meta in rows if isinstance(meta, dict) and meta.get("auto")}
+    # The bonus each payment earned, keyed by its PaymentIntent (stamped into the grant entry's
+    # meta by `_credit`). Read the same way as `auto`: the org's grant entries, matched in Python.
+    bonus_by_pi: dict[str, int] = {}
+    if blocks:
+        grants = (await db.execute(
+            select(LedgerEntry.amount_micro, LedgerEntry.meta).where(
+                LedgerEntry.org_id == org.id, LedgerEntry.kind == "grant")
+        )).all()
+        for amt, meta in grants:
+            if isinstance(meta, dict) and meta.get("source") == "topup_bonus" and meta.get("payment_intent"):
+                bonus_by_pi[str(meta["payment_intent"])] = bonus_by_pi.get(str(meta["payment_intent"]), 0) + int(amt)
 
     docs, stripe_ok = await _payment_documents(org, len(blocks))
     items = []
@@ -473,6 +550,7 @@ async def list_payments(db: AsyncSession, org: Org, *, limit: int = 24) -> dict:
             "amount_usd": ledger.usd(int(b.amount_micro)),
             "created_at": b.created_at.isoformat() if b.created_at else None,
             "auto": b.id in auto,
+            "bonus_micro": bonus_by_pi.get(b.stripe_payment_intent or "", 0),
             "invoice_number": d.get("number") or "",
             "invoice_pdf": d.get("invoice_pdf") or "",
             "hosted_invoice_url": d.get("hosted_invoice_url") or "",
@@ -819,8 +897,25 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
     block_id = block.id  # captured now: a later rollback (the ad-conversion except below) expires
                         # every object this session is tracking, `block` included, and reading an
                         # expired attribute outside an awaited call raises MissingGreenlet.
-    after = await ledger.balance_of(db, org_id)
     fresh = not already
+    bonus_micro, bonus_pct = 0, 0
+    if fresh and not auto:
+        # The tiered bonus on a MANUAL top-up, as its own promotional block: it burns first and is
+        # never refundable, so it must not inflate the purchased (refundable) block above. `fresh` is
+        # the idempotency guard — a webhook redelivery finds `already` and grants nothing. Swallowed
+        # like the referral qualification below: a failure here must not 500 the handler and make
+        # Stripe retry a payment that has already credited.
+        bonus_micro, bonus_pct = bonus_for_topup(amount_micro)
+        if bonus_micro > 0:
+            try:
+                await ledger.grant(db, org_id, amount_micro=bonus_micro, kind="bonus", once=False,
+                                   meta={"source": "topup_bonus", "payment_intent": pi_id,
+                                         "pct": bonus_pct, "topup_block_id": block_id})
+            except Exception as e:  # noqa: BLE001
+                await db.rollback()
+                bonus_micro, bonus_pct = 0, 0
+                log.warning("billing: bonus grant failed for org %s on %s: %s", org_id, pi_id, e)
+    after = await ledger.balance_of(db, org_id)
     if fresh:
         org = await db.get(Org, org_id)
         if org is not None and (org.autotopup_failures or org.autotopup_disabled_reason):
@@ -832,7 +927,7 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
         to = await owner_email(db, org_id)
         if to:
             await email_mod.send_topup_receipt(to, (org.name or org.slug) if org else "", amount_micro,
-                                              after, auto=auto)
+                                              after, auto=auto, bonus_micro=bonus_micro)
         # Rides `fresh` like the receipt above, so a webhook redelivery re-emits nothing. The webhook
         # is org-scoped, so the owner's email is the best available person (the payer may differ);
         # the `team` group is what makes org-level revenue exact. capture() never raises — an
@@ -841,6 +936,7 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                           {"amount_micro": amount_micro,
                            "amount_usd": amount_micro / 1_000_000,  # display-only, never computed against
                            "auto": auto, "balance_after_micro": after,
+                           "bonus_micro": bonus_micro, "bonus_pct": bonus_pct,
                            "org": org.slug if org else ""},
                           groups={"team": org.slug if org else ""})
         # First top-up only: `fresh` is already the "this delivery moved money" branch, and the
@@ -972,7 +1068,26 @@ async def _on_payment_reversed(db: AsyncSession, charge_or_dispute: dict, kind: 
         return {"handled": False, "reason": "clawback failed"}
     if cancelled:
         log.warning("billing: %s on %s cancelled %s pending referral bonus(es)", kind, pi_id, cancelled)
-    return {"handled": True, "type": kind, "referrals_cancelled": cancelled}
+    # The top-up bonus is in the same position as an already-granted referral bonus: it burns first,
+    # so by now it is usually spent, and reversing it would need the balance-reducing path the ledger
+    # deliberately does not have. Logged for a human, with the unspent remainder so they can decide.
+    bonus_rows = (await db.execute(
+        select(CreditBlock.id, CreditBlock.org_id, CreditBlock.amount_micro, CreditBlock.remaining_micro)
+        .join(LedgerEntry, LedgerEntry.block_id == CreditBlock.id)
+        .where(CreditBlock.kind == "bonus", LedgerEntry.kind == "grant")
+    )).all()
+    bonus_flagged = 0
+    for bid, oid, amt, rem in bonus_rows:
+        meta_row = (await db.execute(
+            select(LedgerEntry.meta).where(LedgerEntry.block_id == bid, LedgerEntry.kind == "grant")
+        )).first()
+        meta = (meta_row[0] if meta_row else None) or {}
+        if isinstance(meta, dict) and meta.get("payment_intent") == pi_id:
+            bonus_flagged += 1
+            log.warning("billing: %s on %s — org %s holds top-up bonus block %s (%s micro-USD, %s "
+                        "unspent); not reversed, needs a human", kind, pi_id, oid, bid, amt, rem)
+    return {"handled": True, "type": kind, "referrals_cancelled": cancelled,
+            "bonus_blocks_flagged": bonus_flagged}
 
 
 async def _on_payment_failed(db: AsyncSession, pi: dict) -> dict:
@@ -1036,8 +1151,12 @@ async def billing_state(db: AsyncSession, org: Org) -> dict:
         # Whether the hosted portal can be opened at all. It hangs off the Stripe customer, which only
         # exists once someone has paid — so the button stays hidden rather than 422-ing a new team.
         "portal": configured() and bool(org.stripe_customer_id),
-        "topup": {"min_usd": s.topup_min_usd, "default_usd": s.topup_default_usd,
-                  "presets": list(s.topup_presets)},
+        "topup": {"min_usd": s.topup_min_usd, "max_usd": TOPUP_MAX_USD,
+                  # Per-org: one preset above the last manual top-up, capped (see next_default_usd).
+                  "default_usd": await next_default_usd(db, org.id),
+                  "presets": list(s.topup_presets),
+                  # {usd: percent}; JSON turns the keys into strings — the UI compares numerically.
+                  "bonus_tiers": {int(k): int(v) for k, v in (s.topup_bonus_tiers or {}).items()}},
         "autotopup": {
             "enabled": bool(org.autotopup_enabled),
             "consented_at": org.autotopup_consented_at.isoformat() if org.autotopup_consented_at else None,
@@ -1071,7 +1190,7 @@ async def set_autotopup(
     is on.
     """
     if threshold_usd is not None:
-        org.autotopup_threshold_micro = usd_to_micro(validate_topup_usd(threshold_usd))
+        org.autotopup_threshold_micro = usd_to_micro(validate_threshold_usd(threshold_usd))
     if amount_usd is not None:
         org.autotopup_amount_micro = usd_to_micro(validate_topup_usd(amount_usd))
     if monthly_cap_usd is not None:

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -97,22 +97,23 @@ def cents_to_micro(amount_cents: int) -> int:
 
 
 def bonus_for_topup(amount_micro: int) -> tuple[int, int]:
-    """The promotional bonus a MANUAL top-up of `amount_micro` earns, as `(bonus_micro, percent)`.
+    """The promotional bonus a MANUAL top-up of `amount_micro` earns, as `(bonus_micro, basis_points)`.
 
-    Tiered by size (`topup_bonus_tiers`): the highest tier at or below the amount applies, so $99 gets
-    the $50 rate and $250 the $200 rate. Integer micro-USD throughout — `amount * pct // 100`
-    truncates the sub-micro remainder, which is at most a millionth of a dollar in treg's favour.
-    Callers decide whether the top-up qualifies at all (automatic refills never do).
+    Tiered by size (`topup_bonus_tiers`, values in basis points): the highest tier at or below the
+    amount applies, so $99 gets the $50 rate and $2,000 the $200 rate — the top tier is the ceiling.
+    Integer micro-USD throughout — `amount * bp // 10_000` truncates the sub-micro remainder, which
+    is at most a millionth of a dollar in treg's favour. Callers decide whether the top-up
+    qualifies at all (automatic refills never do).
     """
     tiers = get_settings().topup_bonus_tiers or {}
     usd = int(amount_micro) // MICRO_PER_USD
-    pct = 0
+    bp = 0
     for floor_usd in sorted(int(k) for k in tiers):
         if usd >= floor_usd:
-            pct = int(tiers[floor_usd] if floor_usd in tiers else tiers[str(floor_usd)])
-    if pct <= 0:
+            bp = int(tiers[floor_usd] if floor_usd in tiers else tiers[str(floor_usd)])
+    if bp <= 0:
         return 0, 0
-    return int(amount_micro) * pct // 100, pct
+    return int(amount_micro) * bp // 10_000, bp
 
 
 async def next_default_usd(db: AsyncSession, org_id: int | None) -> int:
@@ -920,22 +921,22 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                         # every object this session is tracking, `block` included, and reading an
                         # expired attribute outside an awaited call raises MissingGreenlet.
     fresh = not already
-    bonus_micro, bonus_pct = 0, 0
+    bonus_micro, bonus_bp = 0, 0
     if fresh and not auto:
         # The tiered bonus on a MANUAL top-up, as its own promotional block: it burns first and is
         # never refundable, so it must not inflate the purchased (refundable) block above. `fresh` is
         # the idempotency guard — a webhook redelivery finds `already` and grants nothing. Swallowed
         # like the referral qualification below: a failure here must not 500 the handler and make
         # Stripe retry a payment that has already credited.
-        bonus_micro, bonus_pct = bonus_for_topup(amount_micro)
+        bonus_micro, bonus_bp = bonus_for_topup(amount_micro)
         if bonus_micro > 0:
             try:
                 await ledger.grant(db, org_id, amount_micro=bonus_micro, kind="bonus", once=False,
                                    meta={"source": "topup_bonus", "payment_intent": pi_id,
-                                         "pct": bonus_pct, "topup_block_id": block_id})
+                                         "bp": bonus_bp, "topup_block_id": block_id})
             except Exception as e:  # noqa: BLE001
                 await db.rollback()
-                bonus_micro, bonus_pct = 0, 0
+                bonus_micro, bonus_bp = 0, 0
                 log.warning("billing: bonus grant failed for org %s on %s: %s", org_id, pi_id, e)
     after = await ledger.balance_of(db, org_id)
     if fresh:
@@ -958,7 +959,7 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                           {"amount_micro": amount_micro,
                            "amount_usd": amount_micro / 1_000_000,  # display-only, never computed against
                            "auto": auto, "balance_after_micro": after,
-                           "bonus_micro": bonus_micro, "bonus_pct": bonus_pct,
+                           "bonus_micro": bonus_micro, "bonus_bp": bonus_bp,
                            "org": org.slug if org else ""},
                           groups={"team": org.slug if org else ""})
         # First top-up only: `fresh` is already the "this delivery moved money" branch, and the
@@ -1169,7 +1170,7 @@ async def billing_state(db: AsyncSession, org: Org) -> dict:
                   # Per-org: one preset above the last manual top-up, capped (see next_default_usd).
                   "default_usd": await next_default_usd(db, org.id),
                   "presets": list(s.topup_presets),
-                  # {usd: percent}; JSON turns the keys into strings — the UI compares numerically.
+                  # {usd: basis points}; JSON turns the keys into strings — the UI compares numerically.
                   "bonus_tiers": {int(k): int(v) for k, v in (s.topup_bonus_tiers or {}).items()}},
         "autotopup": {
             "enabled": bool(org.autotopup_enabled),

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -304,11 +304,33 @@ async def _set_default_pm(db: AsyncSession, org_id: int, payment_method: str | N
     if not payment_method:
         return False
     org = await db.get(Org, org_id)
-    if org is None or org.stripe_default_pm == payment_method:
+    if org is None:
         return False
+    changed = org.stripe_default_pm != payment_method
     org.stripe_default_pm = payment_method
-    db.add(org)
-    await db.commit()
+    # A card arriving is what a consented-but-cardless policy was waiting for, whichever door it came
+    # through: the dashboard's top-up modal records consent and then relies on the top-up Checkout to
+    # save the card, so the PAYMENT webhook has to arm it, not only the setup one. Checked even when
+    # the pm is unchanged (a redelivered webhook after a crash between the two commits), and only for
+    # the `no_card` shape — a decline, 3DS, or a deliberate off stays off until a human re-enables it.
+    armed = _arm_if_waiting_for_card(org)
+    if changed or armed:
+        db.add(org)
+        await db.commit()
+    return changed
+
+
+def _arm_if_waiting_for_card(org: Org) -> bool:
+    """Turn a consented policy on once `org.stripe_default_pm` exists. Mutates, does not commit."""
+    if not (org.stripe_default_pm and org.autotopup_consented_at) or org.autotopup_enabled:
+        return False
+    # ONLY the explicit `no_card` state. A deliberate off leaves the reason None with consent still
+    # on file, and a later (or redelivered) payment must not switch it back on.
+    if org.autotopup_disabled_reason != "no_card":
+        return False
+    org.autotopup_enabled = True
+    org.autotopup_disabled_reason = None
+    org.autotopup_failures = 0
     return True
 
 
@@ -1119,17 +1141,9 @@ async def _on_setup_succeeded(db: AsyncSession, si: dict) -> dict:
         return {"handled": False, "reason": "no org in metadata"}
     pm = si.get("payment_method")
     pm_id = pm if isinstance(pm, str) else (pm or {}).get("id")
+    # Arming a consented-and-waiting org happens inside `_set_default_pm` (shared with the payment
+    # path). A disable for any reason other than `no_card` (a decline, 3DS) stays off there too.
     changed = await _set_default_pm(db, org_id, pm_id)
-    org = await db.get(Org, org_id)
-    if org is not None and org.autotopup_consented_at and not org.autotopup_enabled \
-            and org.autotopup_disabled_reason in (None, "no_card"):
-        # The org already consented and was only waiting on a card — arming it now is what they asked
-        # for. A disable for any OTHER reason (a decline, 3DS) stays off until a human re-enables it.
-        org.autotopup_enabled = True
-        org.autotopup_disabled_reason = None
-        org.autotopup_failures = 0
-        db.add(org)
-        await db.commit()
     return {"handled": True, "payment_method_saved": bool(pm_id), "changed": changed}
 
 

--- a/src/treg/billing.py
+++ b/src/treg/billing.py
@@ -97,23 +97,22 @@ def cents_to_micro(amount_cents: int) -> int:
 
 
 def bonus_for_topup(amount_micro: int) -> tuple[int, int]:
-    """The promotional bonus a MANUAL top-up of `amount_micro` earns, as `(bonus_micro, basis_points)`.
+    """The promotional bonus a MANUAL top-up of `amount_micro` earns, as `(bonus_micro, percent)`.
 
-    Tiered by size (`topup_bonus_tiers`, values in basis points): the highest tier at or below the
-    amount applies, so $99 gets the $50 rate and $2,000 the $200 rate — the top tier is the ceiling.
-    Integer micro-USD throughout — `amount * bp // 10_000` truncates the sub-micro remainder, which
-    is at most a millionth of a dollar in treg's favour. Callers decide whether the top-up
-    qualifies at all (automatic refills never do).
+    Tiered by size (`topup_bonus_tiers`): the highest tier at or below the amount applies, so $99 gets
+    the $50 rate and $250 the $200 rate. Integer micro-USD throughout — `amount * pct // 100`
+    truncates the sub-micro remainder, which is at most a millionth of a dollar in treg's favour.
+    Callers decide whether the top-up qualifies at all (automatic refills never do).
     """
     tiers = get_settings().topup_bonus_tiers or {}
     usd = int(amount_micro) // MICRO_PER_USD
-    bp = 0
+    pct = 0
     for floor_usd in sorted(int(k) for k in tiers):
         if usd >= floor_usd:
-            bp = int(tiers[floor_usd] if floor_usd in tiers else tiers[str(floor_usd)])
-    if bp <= 0:
+            pct = int(tiers[floor_usd] if floor_usd in tiers else tiers[str(floor_usd)])
+    if pct <= 0:
         return 0, 0
-    return int(amount_micro) * bp // 10_000, bp
+    return int(amount_micro) * pct // 100, pct
 
 
 async def next_default_usd(db: AsyncSession, org_id: int | None) -> int:
@@ -921,22 +920,22 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                         # every object this session is tracking, `block` included, and reading an
                         # expired attribute outside an awaited call raises MissingGreenlet.
     fresh = not already
-    bonus_micro, bonus_bp = 0, 0
+    bonus_micro, bonus_pct = 0, 0
     if fresh and not auto:
         # The tiered bonus on a MANUAL top-up, as its own promotional block: it burns first and is
         # never refundable, so it must not inflate the purchased (refundable) block above. `fresh` is
         # the idempotency guard — a webhook redelivery finds `already` and grants nothing. Swallowed
         # like the referral qualification below: a failure here must not 500 the handler and make
         # Stripe retry a payment that has already credited.
-        bonus_micro, bonus_bp = bonus_for_topup(amount_micro)
+        bonus_micro, bonus_pct = bonus_for_topup(amount_micro)
         if bonus_micro > 0:
             try:
                 await ledger.grant(db, org_id, amount_micro=bonus_micro, kind="bonus", once=False,
                                    meta={"source": "topup_bonus", "payment_intent": pi_id,
-                                         "bp": bonus_bp, "topup_block_id": block_id})
+                                         "pct": bonus_pct, "topup_block_id": block_id})
             except Exception as e:  # noqa: BLE001
                 await db.rollback()
-                bonus_micro, bonus_bp = 0, 0
+                bonus_micro, bonus_pct = 0, 0
                 log.warning("billing: bonus grant failed for org %s on %s: %s", org_id, pi_id, e)
     after = await ledger.balance_of(db, org_id)
     if fresh:
@@ -959,7 +958,7 @@ async def _credit(db: AsyncSession, org_id: int, amount_micro: int, pi_id: str, 
                           {"amount_micro": amount_micro,
                            "amount_usd": amount_micro / 1_000_000,  # display-only, never computed against
                            "auto": auto, "balance_after_micro": after,
-                           "bonus_micro": bonus_micro, "bonus_bp": bonus_bp,
+                           "bonus_micro": bonus_micro, "bonus_pct": bonus_pct,
                            "org": org.slug if org else ""},
                           groups={"team": org.slug if org else ""})
         # First top-up only: `fresh` is already the "this delivery moved money" branch, and the
@@ -1170,7 +1169,7 @@ async def billing_state(db: AsyncSession, org: Org) -> dict:
                   # Per-org: one preset above the last manual top-up, capped (see next_default_usd).
                   "default_usd": await next_default_usd(db, org.id),
                   "presets": list(s.topup_presets),
-                  # {usd: basis points}; JSON turns the keys into strings — the UI compares numerically.
+                  # {usd: percent}; JSON turns the keys into strings — the UI compares numerically.
                   "bonus_tiers": {int(k): int(v) for k, v in (s.topup_bonus_tiers or {}).items()}},
         "autotopup": {
             "enabled": bool(org.autotopup_enabled),

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3685,13 +3685,8 @@ def _billing_autotopup(cfg: dict) -> dict | None:
         return None
 
 
-def _pct(bp: int) -> str:
-    """Basis points as a human percent: 750 → '7.5%', 1000 → '10%'."""
-    return f"{bp / 100:g}%"
-
-
 def _billing_bonus_tiers(cfg: dict) -> dict[int, int]:
-    """`{min_usd: basis points}` from GET /billing, or {} when unavailable. Same never-raises posture as
+    """`{min_usd: percent}` from GET /billing, or {} when unavailable. Same never-raises posture as
     `_billing_autotopup`: this decorates the top-up output."""
     try:
         with _client(cfg) as c:
@@ -3727,12 +3722,12 @@ def cmd_topup(args, cfg) -> None:
     tiers = _billing_bonus_tiers(cfg)
     if tiers:
         usd = out["amount_micro"] // 1_000_000
-        bp = max([v for k, v in tiers.items() if usd >= k], default=0)
-        if bp:
-            print(f"  {_G}+{_pct(bp)} bonus credit{_R} ({_usd(out['amount_micro'] * bp // 10_000)}) added when it lands")
-        nxt = [(k, v) for k, v in sorted(tiers.items()) if k > usd and v > bp]
+        pct = max([v for k, v in tiers.items() if usd >= k], default=0)
+        if pct:
+            print(f"  {_G}+{pct}% bonus credit{_R} ({_usd(out['amount_micro'] * pct // 100)}) added when it lands")
+        nxt = [(k, v) for k, v in sorted(tiers.items()) if k > usd and v > pct]
         if nxt:
-            print(f"  {_M}top up ${nxt[0][0]} or more for +{_pct(nxt[0][1])} bonus credit{_R}")
+            print(f"  {_M}top up ${nxt[0][0]} or more for +{nxt[0][1]}% bonus credit{_R}")
     print(f"\n  Pay on Stripe's secure page:\n\n    {_TEAL}{out['url']}{_R}")
     print(f"\n  {_M}Your balance updates as soon as Stripe confirms the payment "
           f"(seconds). Check it with `treg balance`.{_R}\n")
@@ -5505,7 +5500,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     tu = mk(sub, "topup", "Add funds to your team's balance, or set up automatic top-ups.",
             "treg topup                                     # a Checkout link for the default amount",
-            "treg topup 100                                 # …for $100 (+7.5% bonus credit)",
+            "treg topup 100                                 # …for $100 (+10% bonus credit)",
             "treg topup --auto on --threshold 5 --amount 20 # refill $20 whenever it drops below $5",
             "treg topup --auto off")
     tu.add_argument("amount", nargs="?", type=float, default=None,

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -5501,7 +5501,7 @@ def build_parser() -> argparse.ArgumentParser:
     tu = mk(sub, "topup", "Add funds to your team's balance, or set up automatic top-ups.",
             "treg topup                                     # a Checkout link for the default amount",
             "treg topup 100                                 # …for $100 (+10% bonus credit)",
-            "treg topup --auto on --threshold 5 --amount 10 # refill $10 whenever it drops below $5",
+            "treg topup --auto on --threshold 5 --amount 20 # refill $20 whenever it drops below $5",
             "treg topup --auto off")
     tu.add_argument("amount", nargs="?", type=float, default=None,
                     help="how many US dollars to add (whole dollars; default from the server)")

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3685,6 +3685,20 @@ def _billing_autotopup(cfg: dict) -> dict | None:
         return None
 
 
+def _billing_bonus_tiers(cfg: dict) -> dict[int, int]:
+    """`{min_usd: percent}` from GET /billing, or {} when unavailable. Same never-raises posture as
+    `_billing_autotopup`: this decorates the top-up output."""
+    try:
+        with _client(cfg) as c:
+            r = c.get("/billing")
+        if r.status_code >= 400:
+            return {}
+        tiers = ((r.json().get("topup") or {}).get("bonus_tiers")) or {}
+        return {int(k): int(v) for k, v in tiers.items()}
+    except Exception:
+        return {}
+
+
 def cmd_topup(args, cfg) -> None:
     """Add funds (prints a Stripe Checkout URL), or configure auto top-up.
 
@@ -3703,6 +3717,17 @@ def cmd_topup(args, cfg) -> None:
         return
     out = r.json()
     print(f"\n  {_A}Add {_usd(out['amount_micro'])} to your balance{_R}")
+    # The bonus this size earns, and the next tier up if it earns more — the one nudge that changes
+    # what people pay. Comes from GET /billing; silence when it can't be fetched.
+    tiers = _billing_bonus_tiers(cfg)
+    if tiers:
+        usd = out["amount_micro"] // 1_000_000
+        pct = max([v for k, v in tiers.items() if usd >= k], default=0)
+        if pct:
+            print(f"  {_G}+{pct}% bonus credit{_R} ({_usd(out['amount_micro'] * pct // 100)}) added when it lands")
+        nxt = [(k, v) for k, v in sorted(tiers.items()) if k > usd and v > pct]
+        if nxt:
+            print(f"  {_M}top up ${nxt[0][0]} or more for +{nxt[0][1]}% bonus credit{_R}")
     print(f"\n  Pay on Stripe's secure page:\n\n    {_TEAL}{out['url']}{_R}")
     print(f"\n  {_M}Your balance updates as soon as Stripe confirms the payment "
           f"(seconds). Check it with `treg balance`.{_R}\n")
@@ -5475,7 +5500,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     tu = mk(sub, "topup", "Add funds to your team's balance, or set up automatic top-ups.",
             "treg topup                                     # a Checkout link for the default amount",
-            "treg topup 25                                  # …for $25",
+            "treg topup 100                                 # …for $100 (+10% bonus credit)",
             "treg topup --auto on --threshold 5 --amount 10 # refill $10 whenever it drops below $5",
             "treg topup --auto off")
     tu.add_argument("amount", nargs="?", type=float, default=None,

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3685,8 +3685,13 @@ def _billing_autotopup(cfg: dict) -> dict | None:
         return None
 
 
+def _pct(bp: int) -> str:
+    """Basis points as a human percent: 750 → '7.5%', 1000 → '10%'."""
+    return f"{bp / 100:g}%"
+
+
 def _billing_bonus_tiers(cfg: dict) -> dict[int, int]:
-    """`{min_usd: percent}` from GET /billing, or {} when unavailable. Same never-raises posture as
+    """`{min_usd: basis points}` from GET /billing, or {} when unavailable. Same never-raises posture as
     `_billing_autotopup`: this decorates the top-up output."""
     try:
         with _client(cfg) as c:
@@ -3722,12 +3727,12 @@ def cmd_topup(args, cfg) -> None:
     tiers = _billing_bonus_tiers(cfg)
     if tiers:
         usd = out["amount_micro"] // 1_000_000
-        pct = max([v for k, v in tiers.items() if usd >= k], default=0)
-        if pct:
-            print(f"  {_G}+{pct}% bonus credit{_R} ({_usd(out['amount_micro'] * pct // 100)}) added when it lands")
-        nxt = [(k, v) for k, v in sorted(tiers.items()) if k > usd and v > pct]
+        bp = max([v for k, v in tiers.items() if usd >= k], default=0)
+        if bp:
+            print(f"  {_G}+{_pct(bp)} bonus credit{_R} ({_usd(out['amount_micro'] * bp // 10_000)}) added when it lands")
+        nxt = [(k, v) for k, v in sorted(tiers.items()) if k > usd and v > bp]
         if nxt:
-            print(f"  {_M}top up ${nxt[0][0]} or more for +{nxt[0][1]}% bonus credit{_R}")
+            print(f"  {_M}top up ${nxt[0][0]} or more for +{_pct(nxt[0][1])} bonus credit{_R}")
     print(f"\n  Pay on Stripe's secure page:\n\n    {_TEAL}{out['url']}{_R}")
     print(f"\n  {_M}Your balance updates as soon as Stripe confirms the payment "
           f"(seconds). Check it with `treg balance`.{_R}\n")
@@ -5500,7 +5505,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     tu = mk(sub, "topup", "Add funds to your team's balance, or set up automatic top-ups.",
             "treg topup                                     # a Checkout link for the default amount",
-            "treg topup 100                                 # …for $100 (+10% bonus credit)",
+            "treg topup 100                                 # …for $100 (+7.5% bonus credit)",
             "treg topup --auto on --threshold 5 --amount 20 # refill $20 whenever it drops below $5",
             "treg topup --auto off")
     tu.add_argument("amount", nargs="?", type=float, default=None,

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -3685,7 +3685,7 @@ def _billing_autotopup(cfg: dict) -> dict | None:
         return None
 
 
-def _billing_bonus_tiers(cfg: dict) -> dict[int, int]:
+def _bonus_tiers_from_server(cfg: dict) -> dict[int, int]:
     """`{min_usd: percent}` from GET /billing, or {} when unavailable. Same never-raises posture as
     `_billing_autotopup`: this decorates the top-up output."""
     try:
@@ -3719,7 +3719,7 @@ def cmd_topup(args, cfg) -> None:
     print(f"\n  {_A}Add {_usd(out['amount_micro'])} to your balance{_R}")
     # The bonus this size earns, and the next tier up if it earns more — the one nudge that changes
     # what people pay. Comes from GET /billing; silence when it can't be fetched.
-    tiers = _billing_bonus_tiers(cfg)
+    tiers = _bonus_tiers_from_server(cfg)
     if tiers:
         usd = out["amount_micro"] // 1_000_000
         pct = max([v for k, v in tiers.items() if usd >= k], default=0)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -231,7 +231,7 @@ class Settings(BaseSettings):
     # threshold is deliberately above the $1 promo grant's tail: at agent call rates a $2 floor is one
     # burst away from empty, and an off-session charge takes seconds to land.
     autotopup_default_threshold_usd: int = 5
-    autotopup_default_amount_usd: int = 10
+    autotopup_default_amount_usd: int = 20
     # Hard guardrails on the off-session charge — the difference between "convenient" and "a runaway
     # agent bills a card all night". Cap is per calendar month, cooldown is between attempts, and
     # max_attempts counts CONSECUTIVE failures before auto-top-up disables itself.

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -220,12 +220,10 @@ class Settings(BaseSettings):
     # Four presets plus "Other" (any whole amount ≥ min). Deliberately few and skewed big: with eight
     # cards from $5 up nobody ever picked $100+, and repeat payers stayed flat ($10 → $10).
     topup_presets: list[int] = [10, 50, 100, 200]
-    # Bonus credit on a MANUAL top-up, as {min_usd: basis points} (100 bp = 1%): the highest key ≤
-    # the amount applies, and the last tier is the ceiling — $2,000 earns the $200 rate. Basis points
-    # because 7.5% has to stay an integer (money code never sees a float). It is promotional credit
-    # (a separate block that burns first and is never refundable), never purchased balance — see
-    # billing.bonus_for_topup. Automatic refills get no bonus.
-    topup_bonus_tiers: dict[int, int] = {10: 0, 50: 500, 100: 750, 200: 1000}
+    # Bonus credit on a MANUAL top-up, as {min_usd: percent}: the highest key ≤ the amount applies.
+    # It is promotional credit (a separate block that burns first and is never refundable), never
+    # purchased balance — see billing.bonus_for_topup. Automatic refills get no bonus.
+    topup_bonus_tiers: dict[int, int] = {10: 0, 50: 5, 100: 10, 200: 15}
     # After each manual top-up the dashboard's preselected amount steps one preset up, but never past
     # this — the ladder nudges $10 payers toward $50 without preselecting $200 at anyone.
     topup_default_cap_usd: int = 50

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -220,10 +220,12 @@ class Settings(BaseSettings):
     # Four presets plus "Other" (any whole amount ≥ min). Deliberately few and skewed big: with eight
     # cards from $5 up nobody ever picked $100+, and repeat payers stayed flat ($10 → $10).
     topup_presets: list[int] = [10, 50, 100, 200]
-    # Bonus credit on a MANUAL top-up, as {min_usd: percent}: the highest key ≤ the amount applies.
-    # It is promotional credit (a separate block that burns first and is never refundable), never
-    # purchased balance — see billing.bonus_for_topup. Automatic refills get no bonus.
-    topup_bonus_tiers: dict[int, int] = {10: 0, 50: 5, 100: 10, 200: 15}
+    # Bonus credit on a MANUAL top-up, as {min_usd: basis points} (100 bp = 1%): the highest key ≤
+    # the amount applies, and the last tier is the ceiling — $2,000 earns the $200 rate. Basis points
+    # because 7.5% has to stay an integer (money code never sees a float). It is promotional credit
+    # (a separate block that burns first and is never refundable), never purchased balance — see
+    # billing.bonus_for_topup. Automatic refills get no bonus.
+    topup_bonus_tiers: dict[int, int] = {10: 0, 50: 500, 100: 750, 200: 1000}
     # After each manual top-up the dashboard's preselected amount steps one preset up, but never past
     # this — the ladder nudges $10 payers toward $50 without preselecting $200 at anyone.
     topup_default_cap_usd: int = 50

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -213,10 +213,20 @@ class Settings(BaseSettings):
     stripe_webhook_secret: str = ""
     # Top-up amounts, in whole USD (the ONLY place dollars appear — billing.py converts to micro-USD
     # for the ledger and to integer cents for Stripe at the boundaries, and nothing in between sees a
-    # float). $5 minimum is fee math, not policy: at 2.9% + $0.30 a $1 top-up loses 33% to fees.
-    topup_min_usd: int = 5
+    # float). The $10 minimum is fee math, not policy: at 2.9% + $0.30 a $5 top-up loses 9% to fees,
+    # and the referral offer's qualifying amount is $10 already.
+    topup_min_usd: int = 10
     topup_default_usd: int = 10
-    topup_presets: list[int] = [5, 10, 25, 50, 100, 200, 300, 400]
+    # Four presets plus "Other" (any whole amount ≥ min). Deliberately few and skewed big: with eight
+    # cards from $5 up nobody ever picked $100+, and repeat payers stayed flat ($10 → $10).
+    topup_presets: list[int] = [10, 50, 100, 200]
+    # Bonus credit on a MANUAL top-up, as {min_usd: percent}: the highest key ≤ the amount applies.
+    # It is promotional credit (a separate block that burns first and is never refundable), never
+    # purchased balance — see billing.bonus_for_topup. Automatic refills get no bonus.
+    topup_bonus_tiers: dict[int, int] = {10: 0, 50: 5, 100: 10, 200: 15}
+    # After each manual top-up the dashboard's preselected amount steps one preset up, but never past
+    # this — the ladder nudges $10 payers toward $50 without preselecting $200 at anyone.
+    topup_default_cap_usd: int = 50
     # Auto-top-up defaults, applied when an org enables it without naming its own numbers. The
     # threshold is deliberately above the $1 promo grant's tail: at agent call rates a $2 floor is one
     # burst away from empty, and an off-session charge takes seconds to land.

--- a/src/treg/email.py
+++ b/src/treg/email.py
@@ -105,16 +105,19 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
 
 
 async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balance_micro: int,
-                             *, auto: bool = False) -> bool:
+                             *, auto: bool = False, bonus_micro: int = 0) -> bool:
     """Balance was added. Stripe emails its own payment receipt (the tax document); THIS email is the
     one that says what the money became — how much call balance the team now has — which Stripe cannot
     know. An automatic top-up says so plainly: an unattended charge nobody was told about is how a
     chargeback starts."""
     added, left = _money(amount_micro), _money(balance_micro)
     how = "Auto top-up" if auto else "Top-up"
+    # The bonus is named next to the charge so the receipt and the balance agree: "$100 + $10 bonus"
+    # explains a balance that went up $110 on a $100 card charge, which otherwise reads as a mistake.
+    bonus = f' <span style="color:#19D0E8">+ {_money(bonus_micro)} bonus</span>' if bonus_micro else ""
     lead = (f'Your balance dropped below your auto top-up threshold, so we charged your saved card '
             f'<b style="color:#f2efe8">{added}</b>.' if auto
-            else f'Thanks — <b style="color:#f2efe8">{added}</b> has been added to your balance.')
+            else f'Thanks — <b style="color:#f2efe8">{added}</b>{bonus} has been added to your balance.')
     body = (
         f'<p style="margin:0 0 6px;color:#f2efe8;font-size:16px;font-weight:600">{how} confirmed</p>'
         f'<p style="margin:0 0 18px;color:#8e8c86;font-size:13px;line-height:1.6">{lead}</p>'
@@ -126,7 +129,8 @@ async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balan
         '<p style="margin:18px 0 0;color:#8e8c86;font-size:12px;line-height:1.6">Run <span style="color:#19D0E8">treg balance</span> to see what it\'s made of and where it goes.</p>'
     )
     subject = f"{added} added to your tools-registry balance"
-    text = (f"{how} confirmed: {added} added to {org_name}'s tools-registry balance.\n"
+    bonus_txt = f" (+ {_money(bonus_micro)} bonus)" if bonus_micro else ""
+    text = (f"{how} confirmed: {added}{bonus_txt} added to {org_name}'s tools-registry balance.\n"
             f"Balance now: {left}. Run `treg balance` for the detail.")
     return await _send(email, subject, _WRAP.format(body=body), text)
 

--- a/src/treg/ledger.py
+++ b/src/treg/ledger.py
@@ -63,7 +63,9 @@ from .models import CreditBlock, Hold, LedgerEntry, Org, TagSpend
 # It is a separate kind ONLY so reporting can tell the two apart. Note that an unrecognised kind
 # sorts LAST (`.get(kind, 99)` in `_consume_blocks`), i.e. after purchased: any new non-refundable
 # kind must be added here or it silently gets the most expensive treatment available.
-_KIND_ORDER = {"promotional": 0, "referral": 0, "purchased": 1}
+# `bonus` (the tiered extra on a manual top-up, `billing.bonus_for_topup`) is the same kind of thing:
+# marketing spend keyed to a payment, never refundable, so it burns first too.
+_KIND_ORDER = {"promotional": 0, "referral": 0, "bonus": 0, "purchased": 1}
 
 
 class InsufficientBalance(Exception):

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4021,7 +4021,7 @@ createApp({
     topupUsd(){ if(!this.billing) return 0; if(this.topupPick==='other'){ const v=Number(this.topupOther); return Number.isInteger(v)&&v>0?v:0; } return this.topupPick; },
     topupValid(){ if(!this.billing||!this.topupUsd) return false; const t=this.billing.topup; return this.topupUsd>=t.min_usd&&this.topupUsd<=t.max_usd; },
     topupBonusMicro(){ return this.tierBonus(this.topupUsd)+this.refPresetBonus(this.topupUsd); },
-    maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t)):0; },
+    maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t))/100:0; },
     // The monthly cap is a server-side runaway guardrail, not something the payer is asked to pick:
     // the modal sets it to the single-top-up ceiling (effectively unlimited) so a big payer is never
     // locked out mid-month by a default sized for $10 refills. The manage panel below can lower it.
@@ -5013,9 +5013,10 @@ createApp({
     // away from theirs. Only on first pick - a value they typed survives re-selecting the card.
     pickOther(){ if(this.topupPick!=='other'&&!this.topupOther){ const top=Math.max(...this.billing.topup.presets); this.topupOther=Math.min(this.billing.topup.max_usd, top>=200?500:top*2); } this.topupPick='other'; },
     tierBonus(usd){ const t=this.billing&&this.billing.topup.bonus_tiers; if(!t||!usd) return 0;
-      // Keys arrive as strings from JSON; the highest floor at or below the amount applies.
-      let pct=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) pct=t[k]; });
-      return Math.floor(usd*1e6*pct/100); },
+      // Keys arrive as strings from JSON; values are basis points; the highest floor at or below the
+      // amount applies (and the top tier is the ceiling). Integer micro-USD, same as the server.
+      let bp=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) bp=t[k]; });
+      return Math.floor(usd*1e6*bp/10000); },
     async payTopup(){ const usd=this.topupUsd; if(!this.topupValid) return;
       this.billingBusy=true; this.topupErr=''; this.topupAmount=usd;
       this.track('topup_checkout_opened',{amount_usd:usd, auto_opt_in:this.topupAuto, bonus_micro:this.topupBonusMicro});

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2382,7 +2382,6 @@ a:hover{text-decoration-color:var(--muted)}
                     <div style="flex:1;min-width:220px">
                       <div class="lbl">Balance</div>
                       <div style="font-size:28px;font-weight:700;color:var(--accent);font-family:var(--mono)">{{money(billing.balance_micro)}}</div>
-                      <p class="sub" style="margin:4px 0 0">Prepaid credit. Calls draw from it - <code>treg balance</code> shows the ledger.</p>
                     </div>
                     <!-- Stripe's hosted portal: card, billing address, tax ID and the invoice archive.
                          Hidden until the team has a Stripe customer, which its first payment creates. -->
@@ -2394,8 +2393,7 @@ a:hover{text-decoration-color:var(--muted)}
                   <p v-if="!billing.configured" class="sub" style="margin:12px 0 0">Top-ups aren't configured on this deployment.</p>
 
                   <template v-if="billing.configured">
-                    <div style="margin-top:16px;border-top:1px solid var(--line);padding-top:14px">
-                      <div class="lbl">Add funds</div>
+                    <div style="margin-top:12px">
                       <!-- A team that arrived through someone's link does not know a bonus exists.
                            This is the one screen where saying so changes what they do, and the
                            MINIMUM is the part that matters: the first preset ($5) is below it, so
@@ -2429,10 +2427,7 @@ a:hover{text-decoration-color:var(--muted)}
                       <!-- The amounts live in a modal (openTopup), not inline: choosing a size,
                            seeing the bonus it earns and deciding on auto top-up are one decision,
                            and the mandate text has to sit next to the Pay button it authorizes. -->
-                      <div style="margin-top:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
-                        <button class="btn primary" :disabled="billingBusy" @click="openTopup()">Top up</button>
-                        <span class="sub" style="margin:0">Bigger top-ups earn bonus credit — up to {{maxBonusPct}}% extra.</span>
-                      </div>
+                      <button class="btn primary" :disabled="billingBusy" @click="openTopup()">Top up</button>
                     </div>
 
                     <!-- `no_card` is not a failure: consent was recorded (usually from the top-up
@@ -3249,16 +3244,18 @@ product, including per-customer usage tracking and billing.</pre>
                  The referral bonus (refPresetBonus) stacks on the tier bonus. -->
             <span v-if="tierBonus(p)" style="color:var(--green)">+{{money(tierBonus(p))}} bonus</span>
             <span v-else-if="refPresetBonus(p)" style="color:var(--green)">+{{money(refPresetBonus(p))}} bonus</span>
-            <span v-else>one-time</span>
           </button>
           <button class="fundcard" :class="{sel:topupPick==='other'}" :disabled="billingBusy" @click="topupPick='other'">
-            <b>Other</b><span>${{billing.topup.min_usd}}+</span>
+            <b>Other</b>
           </button>
         </div>
-        <div v-if="topupPick==='other'" style="margin-top:10px;display:flex;gap:8px;align-items:center">
-          <span class="sub" style="margin:0">Amount $</span>
-          <input class="msel" style="width:110px" type="number" :min="billing.topup.min_usd" :max="billing.topup.max_usd" step="1" v-model.number="topupOther" placeholder="e.g. 75"/>
-          <span class="sub" style="margin:0">whole dollars, ${{billing.topup.min_usd}}–${{billing.topup.max_usd.toLocaleString()}}</span>
+        <div v-if="topupPick==='other'" style="margin-top:12px">
+          <div style="display:flex;align-items:center;border:1px solid var(--line);border-radius:var(--rb);background:var(--bg);padding:0 14px">
+            <span style="font-family:var(--mono);font-size:22px;color:var(--muted)">$</span>
+            <input type="number" :min="billing.topup.min_usd" :max="billing.topup.max_usd" step="1" v-model.number="topupOther" placeholder="0" autocomplete="off" data-lpignore="true"
+                   style="flex:1;border:0;background:transparent;color:var(--ink);font-family:var(--mono);font-size:22px;font-weight:700;padding:12px 8px;outline:none;min-width:0"/>
+          </div>
+          <p class="sub" style="margin:6px 0 0">Whole dollars, ${{billing.topup.min_usd}}–${{billing.topup.max_usd.toLocaleString()}}.</p>
         </div>
 
         <!-- Auto top-up. Read-only line when the team already has a mandate; otherwise the toggle. -->
@@ -3276,7 +3273,7 @@ product, including per-customer usage tracking and billing.</pre>
                      THESE numbers is an unauthorized charge under PSD2/SCA. The amount is the one
                      being chosen right now, never a config default the payer didn't see. -->
                 <span class="sub" style="display:block;margin:2px 0 0">
-                  <template v-if="topupAuto">I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b> automatically whenever my balance drops below <b>${{autoThreshold}}</b>, up to <b>${{autoCapUsd}}</b> per month. Cancel any time from the billing page.</template>
+                  <template v-if="topupAuto">I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b> automatically whenever my balance drops below <b>${{autoThreshold}}</b>. Cancel any time from the billing page.</template>
                   <template v-else>Calls fail with a 402 once the balance runs out. Turn this on to keep agents running without watching it.</template>
                 </span>
               </span>
@@ -3285,7 +3282,7 @@ product, including per-customer usage tracking and billing.</pre>
         </div>
 
         <div style="margin-top:14px;border:1px solid var(--line);border-radius:var(--rb);padding:10px 12px;font-family:var(--mono);font-size:12.5px">
-          <div style="display:flex;justify-content:space-between"><span>Top-up credit</span><span>{{topupUsd?money(topupUsd*1e6):'—'}}<span v-if="topupBonusMicro" style="color:var(--green)"> (+{{money(topupBonusMicro)}} bonus)</span></span></div>
+          <div style="display:flex;justify-content:space-between"><span>Credit added</span><span v-if="!topupUsd">—</span><span v-else><b>{{money(topupUsd*1e6+topupBonusMicro)}}</b><span v-if="topupBonusMicro" class="sub" style="margin:0"> ({{money(topupUsd*1e6)}} + <span style="color:var(--green)">{{money(topupBonusMicro)}} bonus</span>)</span></span></div>
           <div style="display:flex;justify-content:space-between;border-top:1px solid var(--line);margin-top:8px;padding-top:8px;font-weight:700"><span>Total due</span><span>{{topupUsd?money(topupUsd*1e6):'—'}}</span></div>
         </div>
         <p v-if="topupErr" class="sub" style="color:var(--red);margin:10px 0 0">{{topupErr}}</p>
@@ -4020,9 +4017,10 @@ createApp({
     topupValid(){ if(!this.billing||!this.topupUsd) return false; const t=this.billing.topup; return this.topupUsd>=t.min_usd&&this.topupUsd<=t.max_usd; },
     topupBonusMicro(){ return this.tierBonus(this.topupUsd)+this.refPresetBonus(this.topupUsd); },
     maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t)):0; },
-    // The monthly cap the mandate names: the configured default, or four refills of the chosen
-    // amount, whichever is larger - a $200 payer under a $100 cap would be locked out after one.
-    autoCapUsd(){ if(!this.billing) return 0; return Math.max(Math.round(this.billing.autotopup.monthly_cap_usd), 4*(this.topupUsd||0)); },
+    // The monthly cap is a server-side runaway guardrail, not something the payer is asked to pick:
+    // the modal sets it to the single-top-up ceiling (effectively unlimited) so a big payer is never
+    // locked out mid-month by a default sized for $10 refills. The manage panel below can lower it.
+    autoCapUsd(){ return this.billing?this.billing.topup.max_usd:0; },
     // Marketplace shelves. /oauth/providers already returns providers grouped-then-alphabetical, so
     // this walks the list once and starts a shelf whenever the category changes — re-sorting here
     // would just be a second place to keep the order in step with the registry.

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2446,10 +2446,13 @@ a:hover{text-decoration-color:var(--muted)}
                         <span v-if="billing.card_on_file" class="sub" style="margin-left:auto">Card on file ✓</span>
                       </label>
                       <p class="sub" style="margin:8px 0 0">
-                        <template v-if="billing.autotopup.enabled">On - we add {{money(billing.autotopup.amount_micro)}} whenever the balance drops below {{money(billing.autotopup.threshold_micro)}}. This month: {{money(billing.autotopup.month_spend_micro)}} of {{money(billing.autotopup.monthly_cap_micro)}}.</template>
-                        <template v-else>Keep agents running without watching the balance. We charge your saved card only when it dips below your threshold, never more than your monthly cap.</template>
+                        <template v-if="billing.autotopup.enabled">On - we add {{money(billing.autotopup.amount_micro)}} whenever the balance drops below {{money(billing.autotopup.threshold_micro)}}. This month: {{money(billing.autotopup.month_spend_micro)}}.
+                          <a href="#" @click.prevent="autoOpen=!autoOpen;autoConsent=false">{{autoOpen?'Cancel':'Edit'}}</a></template>
+                        <template v-else>Keep agents running without watching the balance. We charge your saved card only when it dips below your threshold.</template>
                       </p>
-                      <div v-if="!billing.autotopup.enabled && autoOpen" style="margin-top:12px;background:var(--panel2);border:1px solid var(--line);border-radius:var(--rb);padding:12px 14px;max-width:560px">
+                      <!-- The same panel edits a running policy (Edit link above) and arms a new one:
+                           either way the numbers change, so the mandate is re-agreed and re-stamped. -->
+                      <div v-if="autoOpen" style="margin-top:12px;background:var(--panel2);border:1px solid var(--line);border-radius:var(--rb);padding:12px 14px;max-width:560px">
                         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
                           <span class="sub" style="margin:0">Add $</span>
                           <input class="msel" style="width:70px" type="number" min="5" v-model.number="autoAmount"/>
@@ -2460,10 +2463,10 @@ a:hover{text-decoration-color:var(--muted)}
                           <input type="checkbox" v-model="autoConsent" style="margin-top:3px"/>
                           <!-- The mandate text. Not decoration: an off-session charge with no recorded
                                agreement to THESE numbers is an unauthorized charge under PSD2/SCA. -->
-                          <span class="sub" style="margin:0">I authorize treg to charge my saved card ${{autoAmount}} automatically whenever my balance drops below ${{autoThreshold}}, up to {{money(billing.autotopup.monthly_cap_micro)}} per month. Cancel any time.</span>
+                          <span class="sub" style="margin:0">I authorize treg to charge my saved card ${{autoAmount}} automatically whenever my balance drops below ${{autoThreshold}}. Cancel any time.</span>
                         </label>
                         <div style="margin-top:12px">
-                          <button class="btn primary" :disabled="!autoConsent||billingBusy" @click="setAuto(true)">{{billingBusy?'…':'Turn on auto top-up'}}</button>
+                          <button class="btn primary" :disabled="!autoConsent||billingBusy" @click="setAuto(true)">{{billingBusy?'…':(billing.autotopup.enabled?'Save':'Turn on auto top-up')}}</button>
                         </div>
                       </div>
                     </div>
@@ -3226,7 +3229,7 @@ product, including per-customer usage tracking and billing.</pre>
 
     <!-- TOP UP. Four presets + Other, the bonus each earns, and auto top-up as a toggle that is
          ON by default for a team with no mandate yet. The toggle IS the consent control: its label
-         is the PSD2/SCA mandate text (amount, threshold, monthly cap), and Pay records it through
+         is the PSD2/SCA mandate text (amount, threshold), and Pay records it through
          /billing/autotopup BEFORE opening Checkout — so the card Checkout saves arms auto top-up
          from the setup webhook with numbers a human agreed to. Off = plain one-off top-up. -->
     <div v-if="topupOpen&&billing" class="scrim" role="dialog" aria-modal="true" @click.self="topupOpen=false">
@@ -3270,10 +3273,12 @@ product, including per-customer usage tracking and billing.</pre>
               <span>
                 <b style="font-size:12.5px">Auto top-up {{topupAuto?'on':'off'}}</b>
                 <!-- The mandate. Not decoration: an off-session charge with no recorded agreement to
-                     THESE numbers is an unauthorized charge under PSD2/SCA. The amount is the one
-                     being chosen right now, never a config default the payer didn't see. -->
+                     THESE numbers is an unauthorized charge under PSD2/SCA. The numbers are the
+                     server defaults ($20 when below $5), shown here in full; the billing page's
+                     Edit panel changes them. Not the top-up amount: a $200 buyer does not want
+                     $200 refills. -->
                 <span class="sub" style="display:block;margin:2px 0 0">
-                  <template v-if="topupAuto">I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b> automatically whenever my balance drops below <b>${{autoThreshold}}</b>. Cancel any time from the billing page.</template>
+                  <template v-if="topupAuto">I authorize treg to charge my saved card <b>${{autoAmount}}</b> automatically whenever my balance drops below <b>${{autoThreshold}}</b>. Cancel any time from the billing page.</template>
                   <template v-else>Calls fail with a 402 once the balance runs out. Turn this on to keep agents running without watching it.</template>
                 </span>
               </span>
@@ -5022,14 +5027,14 @@ createApp({
           // saved card then arms it from the setup webhook. A failure here stops the payment too -
           // paying without the auto top-up the user just agreed to would be a silent downgrade.
           this.billing=await this.api('/billing/autotopup',{method:'POST',headers:{'content-type':'application/json'},
-            body:JSON.stringify({enabled:true, consent:true, amount_usd:usd, threshold_usd:this.autoThreshold, monthly_cap_usd:this.autoCapUsd, setup_url:false})});
+            body:JSON.stringify({enabled:true, consent:true, amount_usd:this.autoAmount, threshold_usd:this.autoThreshold, monthly_cap_usd:this.autoCapUsd, setup_url:false})});
         }
         const out=await this.api('/billing/topup',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({amount_usd:usd})});
         window.location.href=out.url; }
       catch(e){ this.topupErr='Could not start the payment: '+(e.detail||e.status); this.billingBusy=false; } },
     // The toggle itself never arms auto top-up - it can only DISARM (off is safe) or open the
     // settings panel; arming still goes through the consent checkbox + confirm button below.
-    autoToggled(){ if(this.billing.autotopup.enabled){ this.setAuto(false); return; }
+    autoToggled(){ if(this.billing.autotopup.enabled){ this.autoOpen=false; this.setAuto(false); return; }
       this.autoOpen=!this.autoOpen; if(!this.autoOpen) this.autoConsent=false; },
     async setAuto(on){ this.billingBusy=true; this.err='';
       try{ const out=await this.api('/billing/autotopup',{method:'POST',headers:{'content-type':'application/json'},

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4021,7 +4021,7 @@ createApp({
     topupUsd(){ if(!this.billing) return 0; if(this.topupPick==='other'){ const v=Number(this.topupOther); return Number.isInteger(v)&&v>0?v:0; } return this.topupPick; },
     topupValid(){ if(!this.billing||!this.topupUsd) return false; const t=this.billing.topup; return this.topupUsd>=t.min_usd&&this.topupUsd<=t.max_usd; },
     topupBonusMicro(){ return this.tierBonus(this.topupUsd)+this.refPresetBonus(this.topupUsd); },
-    maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t))/100:0; },
+    maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t)):0; },
     // The monthly cap is a server-side runaway guardrail, not something the payer is asked to pick:
     // the modal sets it to the single-top-up ceiling (effectively unlimited) so a big payer is never
     // locked out mid-month by a default sized for $10 refills. The manage panel below can lower it.
@@ -5013,10 +5013,9 @@ createApp({
     // away from theirs. Only on first pick - a value they typed survives re-selecting the card.
     pickOther(){ if(this.topupPick!=='other'&&!this.topupOther){ const top=Math.max(...this.billing.topup.presets); this.topupOther=Math.min(this.billing.topup.max_usd, top>=200?500:top*2); } this.topupPick='other'; },
     tierBonus(usd){ const t=this.billing&&this.billing.topup.bonus_tiers; if(!t||!usd) return 0;
-      // Keys arrive as strings from JSON; values are basis points; the highest floor at or below the
-      // amount applies (and the top tier is the ceiling). Integer micro-USD, same as the server.
-      let bp=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) bp=t[k]; });
-      return Math.floor(usd*1e6*bp/10000); },
+      // Keys arrive as strings from JSON; the highest floor at or below the amount applies.
+      let pct=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) pct=t[k]; });
+      return Math.floor(usd*1e6*pct/100); },
     async payTopup(){ const usd=this.topupUsd; if(!this.topupValid) return;
       this.billingBusy=true; this.topupErr=''; this.topupAmount=usd;
       this.track('topup_checkout_opened',{amount_usd:usd, auto_opt_in:this.topupAuto, bonus_micro:this.topupBonusMicro});

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -3245,7 +3245,7 @@ product, including per-customer usage tracking and billing.</pre>
             <span v-if="tierBonus(p)" style="color:var(--green)">+{{money(tierBonus(p))}} bonus</span>
             <span v-else-if="refPresetBonus(p)" style="color:var(--green)">+{{money(refPresetBonus(p))}} bonus</span>
           </button>
-          <button class="fundcard" :class="{sel:topupPick==='other'}" :disabled="billingBusy" @click="topupPick='other'">
+          <button class="fundcard" :class="{sel:topupPick==='other'}" :disabled="billingBusy" @click="pickOther()">
             <b>Other</b>
           </button>
         </div>
@@ -5003,6 +5003,10 @@ createApp({
       // Default ON only for a team with no mandate; a team that already decided is not re-asked.
       this.topupAuto=!(this.billing.autotopup.enabled||this.billing.autotopup.consented_at);
       this.topupOpen=true; },
+    // "Other" starts one rung above the biggest card, not blank: the card row ends at $200, so the
+    // amount a payer reaches for here is larger than that, and a prefilled number is one keystroke
+    // away from theirs. Only on first pick - a value they typed survives re-selecting the card.
+    pickOther(){ if(this.topupPick!=='other'&&!this.topupOther){ const top=Math.max(...this.billing.topup.presets); this.topupOther=Math.min(this.billing.topup.max_usd, top>=200?500:top*2); } this.topupPick='other'; },
     tierBonus(usd){ const t=this.billing&&this.billing.topup.bonus_tiers; if(!t||!usd) return 0;
       // Keys arrive as strings from JSON; the highest floor at or below the amount applies.
       let pct=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) pct=t[k]; });

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -368,6 +368,7 @@ addEventListener('load', function(){
   .fundcard{background:var(--panel2);border:1px solid var(--line);border-radius:var(--rb);padding:13px 8px 11px;text-align:center;cursor:pointer;color:var(--ink);font-family:var(--mono);transition:border-color .12s,transform .12s}
   .fundcard:hover:not(:disabled){border-color:var(--accent);transform:translateY(-1px)}
   .fundcard:disabled{opacity:.55;cursor:default}
+  .fundcard.sel{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent) inset}
   .fundcard b{display:block;font-size:17px;letter-spacing:-.3px}
   .fundcard span{display:block;font-size:10.5px;color:var(--muted);margin-top:3px}
   @media(max-width:520px){.fundgrid{grid-template-columns:repeat(2,1fr)}}
@@ -2425,20 +2426,22 @@ a:hover{text-decoration-color:var(--muted)}
                         {{money(billing.referral_offer.referrer_micro)}} after
                         {{billing.referral_offer.hold_days}} days.
                       </div>
-                      <div class="fundgrid" style="margin-top:8px">
-                        <button v-for="p in billing.topup.presets" :key="p" class="fundcard" :disabled="billingBusy" @click="addFunds(p)">
-                          <b>${{p}}</b>
-                          <!-- The bonus is named ON the qualifying buttons, not only in the note
-                               above: the amount is chosen here, and a preset that quietly forfeits
-                               it is the whole failure this is meant to prevent. -->
-                          <span v-if="billingBusy&&topupAmount===p">Opening Stripe…</span>
-                          <span v-else-if="refPresetBonus(p)" style="color:var(--green)">+{{money(refPresetBonus(p))}} bonus</span>
-                          <span v-else>one-time</span>
-                        </button>
+                      <!-- The amounts live in a modal (openTopup), not inline: choosing a size,
+                           seeing the bonus it earns and deciding on auto top-up are one decision,
+                           and the mandate text has to sit next to the Pay button it authorizes. -->
+                      <div style="margin-top:10px;display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+                        <button class="btn primary" :disabled="billingBusy" @click="openTopup()">Top up</button>
+                        <span class="sub" style="margin:0">Bigger top-ups earn bonus credit — up to {{maxBonusPct}}% extra.</span>
                       </div>
                     </div>
 
-                    <div v-if="billing.autotopup.disabled_reason" class="banner" style="margin:14px 0 0">
+                    <!-- `no_card` is not a failure: consent was recorded (usually from the top-up
+                         modal) and the policy arms itself when a payment saves a card. Showing it in
+                         the red "switched itself off" banner made an abandoned Checkout look broken. -->
+                    <p v-if="billing.autotopup.disabled_reason==='no_card'" class="sub" style="margin:14px 0 0">
+                      Auto top-up is set up and will switch on as soon as a top-up saves your card.
+                    </p>
+                    <div v-else-if="billing.autotopup.disabled_reason" class="banner" style="margin:14px 0 0">
                       Auto top-up switched itself off ({{billing.autotopup.disabled_reason}}). Once the balance runs out, calls will fail until it's funded.
                     </div>
                     <div style="margin-top:16px;border-top:1px solid var(--line);padding-top:14px">
@@ -2481,7 +2484,7 @@ a:hover{text-decoration-color:var(--muted)}
                           <tr v-for="i in bhist.items" :key="i.payment_intent" style="border-top:1px solid var(--line)">
                             <td style="padding:8px 10px 8px 0;white-space:nowrap">{{bhistDate(i.created_at)}}</td>
                             <td style="padding:8px 10px 8px 0;font-family:var(--mono);white-space:nowrap">{{money(i.amount_micro)}}</td>
-                            <td style="padding:8px 10px 8px 0" class="sub">{{i.auto?'auto':''}}</td>
+                            <td style="padding:8px 10px 8px 0" class="sub">{{i.auto?'auto':''}}<span v-if="i.bonus_micro" style="color:var(--green)">+{{money(i.bonus_micro)}} bonus</span></td>
                             <td style="padding:8px 0;text-align:right;white-space:nowrap">
                               <a v-if="bhistLink(i)" :href="bhistLink(i)" target="_blank" rel="noopener">{{bhistLabel(i)}}</a>
                               <span v-else class="muted">—</span>
@@ -3226,6 +3229,74 @@ product, including per-customer usage tracking and billing.</pre>
       </div>
     </div>
 
+    <!-- TOP UP. Four presets + Other, the bonus each earns, and auto top-up as a toggle that is
+         ON by default for a team with no mandate yet. The toggle IS the consent control: its label
+         is the PSD2/SCA mandate text (amount, threshold, monthly cap), and Pay records it through
+         /billing/autotopup BEFORE opening Checkout — so the card Checkout saves arms auto top-up
+         from the setup webhook with numbers a human agreed to. Off = plain one-off top-up. -->
+    <div v-if="topupOpen&&billing" class="scrim" role="dialog" aria-modal="true" @click.self="topupOpen=false">
+      <div class="modal" style="padding:18px 20px;width:min(620px,94vw)">
+        <div style="display:flex;justify-content:space-between;align-items:center">
+          <h3 style="margin:0">Top up credits</h3>
+          <button class="btn sm" @click="topupOpen=false" aria-label="Close">✕</button>
+        </div>
+        <p class="sub" style="margin:6px 0 14px">Choose an amount. Bigger top-ups earn bonus credit; you can always add more later.</p>
+        <div class="fundgrid" style="max-width:none;grid-template-columns:repeat(5,minmax(80px,1fr))">
+          <button v-for="p in billing.topup.presets" :key="p" class="fundcard" :class="{sel:topupPick===p}" :disabled="billingBusy" @click="topupPick=p">
+            <b>${{p}}</b>
+            <!-- The bonus is named ON the qualifying buttons: the amount is chosen here, and a
+                 preset that quietly forfeits a bonus is the whole failure this is meant to prevent.
+                 The referral bonus (refPresetBonus) stacks on the tier bonus. -->
+            <span v-if="tierBonus(p)" style="color:var(--green)">+{{money(tierBonus(p))}} bonus</span>
+            <span v-else-if="refPresetBonus(p)" style="color:var(--green)">+{{money(refPresetBonus(p))}} bonus</span>
+            <span v-else>one-time</span>
+          </button>
+          <button class="fundcard" :class="{sel:topupPick==='other'}" :disabled="billingBusy" @click="topupPick='other'">
+            <b>Other</b><span>${{billing.topup.min_usd}}+</span>
+          </button>
+        </div>
+        <div v-if="topupPick==='other'" style="margin-top:10px;display:flex;gap:8px;align-items:center">
+          <span class="sub" style="margin:0">Amount $</span>
+          <input class="msel" style="width:110px" type="number" :min="billing.topup.min_usd" :max="billing.topup.max_usd" step="1" v-model.number="topupOther" placeholder="e.g. 75"/>
+          <span class="sub" style="margin:0">whole dollars, ${{billing.topup.min_usd}}–${{billing.topup.max_usd.toLocaleString()}}</span>
+        </div>
+
+        <!-- Auto top-up. Read-only line when the team already has a mandate; otherwise the toggle. -->
+        <div style="margin-top:14px;border:1px solid var(--line);border-radius:var(--rb);padding:10px 12px;background:var(--panel2)">
+          <template v-if="billing.autotopup.enabled||billing.autotopup.consented_at">
+            <b style="font-size:12.5px">Auto top-up is {{billing.autotopup.enabled?'on':'set up'}}.</b>
+            <span class="sub" style="margin:0"> Manage or turn it off from the billing page.</span>
+          </template>
+          <template v-else>
+            <label style="display:flex;gap:10px;align-items:flex-start;cursor:pointer">
+              <span class="tswitch" style="margin-top:2px"><input type="checkbox" v-model="topupAuto"/><span class="knob"></span></span>
+              <span>
+                <b style="font-size:12.5px">Auto top-up {{topupAuto?'on':'off'}}</b>
+                <!-- The mandate. Not decoration: an off-session charge with no recorded agreement to
+                     THESE numbers is an unauthorized charge under PSD2/SCA. The amount is the one
+                     being chosen right now, never a config default the payer didn't see. -->
+                <span class="sub" style="display:block;margin:2px 0 0">
+                  <template v-if="topupAuto">I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b> automatically whenever my balance drops below <b>${{autoThreshold}}</b>, up to <b>${{autoCapUsd}}</b> per month. Cancel any time from the billing page.</template>
+                  <template v-else>Calls fail with a 402 once the balance runs out. Turn this on to keep agents running without watching it.</template>
+                </span>
+              </span>
+            </label>
+          </template>
+        </div>
+
+        <div style="margin-top:14px;border:1px solid var(--line);border-radius:var(--rb);padding:10px 12px;font-family:var(--mono);font-size:12.5px">
+          <div style="display:flex;justify-content:space-between"><span>Top-up credit</span><span>{{topupUsd?money(topupUsd*1e6):'—'}}<span v-if="topupBonusMicro" style="color:var(--green)"> (+{{money(topupBonusMicro)}} bonus)</span></span></div>
+          <div style="display:flex;justify-content:space-between;border-top:1px solid var(--line);margin-top:8px;padding-top:8px;font-weight:700"><span>Total due</span><span>{{topupUsd?money(topupUsd*1e6):'—'}}</span></div>
+        </div>
+        <p v-if="topupErr" class="sub" style="color:var(--red);margin:10px 0 0">{{topupErr}}</p>
+        <p class="sub" style="margin:10px 0 0">You'll pay on Stripe's secure page. The balance updates the moment the payment lands.</p>
+        <div style="margin-top:14px;display:flex;justify-content:flex-end;gap:8px">
+          <button class="btn" @click="topupOpen=false" :disabled="billingBusy">Cancel</button>
+          <button class="btn primary" :disabled="billingBusy||!topupValid" @click="payTopup()">{{billingBusy?'Opening Stripe…':(topupUsd?'Pay $'+topupUsd+' now':'Pay now')}}</button>
+        </div>
+      </div>
+    </div>
+
     <div v-if="capAsk" class="scrim" role="dialog" aria-modal="true" @click.self="capAsk=null">
       <div class="modal" style="padding:16px">
         <h3 style="margin:0 0 6px">Connect {{capAsk.provider.display_name}}</h3>
@@ -3861,6 +3932,7 @@ createApp({
       // Billing (Stripe top-ups). `billing` null = not loaded / not an admin; billing.configured
       // false = this deployment sells no balance, so the whole block stays hidden.
       billing:null, billingBusy:false, topupAmount:10, autoAmount:10, autoThreshold:5, autoConsent:false, autoOpen:false,
+      topupOpen:false, topupPick:10, topupOther:null, topupAuto:true, topupErr:'',
       capCfg:null, capUsd:0, capBusy:false, capErr:'',
       budgets:[], budDims:[], budDim:'', budVal:'', budDaily:'', budBusy:false, budErr:'',
       bhist:{items:[],loading:false,ok:true},   // past top-ups + their invoice/receipt links; ok=false means Stripe was unreachable, amounts are still right
@@ -3944,6 +4016,13 @@ createApp({
     };
   },
   computed:{
+    topupUsd(){ if(!this.billing) return 0; if(this.topupPick==='other'){ const v=Number(this.topupOther); return Number.isInteger(v)&&v>0?v:0; } return this.topupPick; },
+    topupValid(){ if(!this.billing||!this.topupUsd) return false; const t=this.billing.topup; return this.topupUsd>=t.min_usd&&this.topupUsd<=t.max_usd; },
+    topupBonusMicro(){ return this.tierBonus(this.topupUsd)+this.refPresetBonus(this.topupUsd); },
+    maxBonusPct(){ const t=this.billing&&this.billing.topup.bonus_tiers; return t?Math.max(0,...Object.values(t)):0; },
+    // The monthly cap the mandate names: the configured default, or four refills of the chosen
+    // amount, whichever is larger - a $200 payer under a $100 cap would be locked out after one.
+    autoCapUsd(){ if(!this.billing) return 0; return Math.max(Math.round(this.billing.autotopup.monthly_cap_usd), 4*(this.topupUsd||0)); },
     // Marketplace shelves. /oauth/providers already returns providers grouped-then-alphabetical, so
     // this walks the list once and starts a shelf whenever the category changes — re-sorting here
     // would just be a second place to keep the order in step with the registry.
@@ -4921,6 +5000,31 @@ createApp({
         // on the return redirect (which a payer could simply type). Same tab, so the return lands here.
         window.location.href=out.url; }
       catch(e){ this.err='Could not start the payment: '+(e.detail||e.status); this.billingBusy=false; } },
+    // ---- top-up modal ----
+    openTopup(){ this.topupPick=this.billing.topup.default_usd; this.topupOther=null; this.topupErr='';
+      // Default ON only for a team with no mandate; a team that already decided is not re-asked.
+      this.topupAuto=!(this.billing.autotopup.enabled||this.billing.autotopup.consented_at);
+      this.topupOpen=true; },
+    tierBonus(usd){ const t=this.billing&&this.billing.topup.bonus_tiers; if(!t||!usd) return 0;
+      // Keys arrive as strings from JSON; the highest floor at or below the amount applies.
+      let pct=0; Object.keys(t).map(Number).sort((a,b)=>a-b).forEach(k=>{ if(usd>=k) pct=t[k]; });
+      return Math.floor(usd*1e6*pct/100); },
+    async payTopup(){ const usd=this.topupUsd; if(!this.topupValid) return;
+      this.billingBusy=true; this.topupErr=''; this.topupAmount=usd;
+      this.track('topup_checkout_opened',{amount_usd:usd, auto_opt_in:this.topupAuto, bonus_micro:this.topupBonusMicro});
+      try{
+        const fresh=!(this.billing.autotopup.enabled||this.billing.autotopup.consented_at);
+        if(fresh&&this.topupAuto){
+          // Consent first, Checkout second: the mandate has to exist before the card that will be
+          // charged under it. The server stores the numbers and marks it "no_card"; Checkout's
+          // saved card then arms it from the setup webhook. A failure here stops the payment too -
+          // paying without the auto top-up the user just agreed to would be a silent downgrade.
+          this.billing=await this.api('/billing/autotopup',{method:'POST',headers:{'content-type':'application/json'},
+            body:JSON.stringify({enabled:true, consent:true, amount_usd:usd, threshold_usd:this.autoThreshold, monthly_cap_usd:this.autoCapUsd, setup_url:false})});
+        }
+        const out=await this.api('/billing/topup',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({amount_usd:usd})});
+        window.location.href=out.url; }
+      catch(e){ this.topupErr='Could not start the payment: '+(e.detail||e.status); this.billingBusy=false; } },
     // The toggle itself never arms auto top-up - it can only DISARM (off is safe) or open the
     // settings panel; arming still goes through the consent checkbox + confirm button below.
     autoToggled(){ if(this.billing.autotopup.enabled){ this.setAuto(false); return; }

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -186,6 +186,11 @@
             ],
             "title": "Monthly Cap Usd"
           },
+          "setup_url": {
+            "default": true,
+            "title": "Setup Url",
+            "type": "boolean"
+          },
           "threshold_usd": {
             "anyOf": [
               {

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -126,7 +126,7 @@ def test_amount_validation_rejects_what_we_will_not_charge(amount):
         billing.validate_topup_usd(amount)
 
 
-@pytest.mark.parametrize("amount", [5, 10, 25, 50, 37, 2_000])
+@pytest.mark.parametrize("amount", [10, 25, 50, 37, 2_000])
 def test_amount_validation_accepts_the_minimum_and_above(amount):
     assert billing.validate_topup_usd(amount) == amount
 
@@ -152,8 +152,10 @@ async def test_billing_get_reports_state_for_an_admin(c: AsyncClient, monkeypatc
     assert body["configured"] is True and body["customer"] is False and body["card_on_file"] is False
     assert body["balance_micro"] == get_settings().promo_grant_micro
     assert body["autotopup"]["enabled"] is False and body["autotopup"]["consented_at"] is None
-    assert body["topup"]["min_usd"] == 5
-    assert body["topup"]["presets"] == [5, 10, 25, 50, 100, 200, 300, 400]
+    assert body["topup"]["min_usd"] == 10
+    assert body["topup"]["presets"] == [10, 50, 100, 200]
+    assert body["topup"]["default_usd"] == 10  # no history yet
+    assert body["topup"]["bonus_tiers"] == {"10": 0, "50": 5, "100": 10, "200": 15}
 
 
 async def test_billing_is_503_when_stripe_is_not_configured(c: AsyncClient, monkeypatch):
@@ -1017,3 +1019,95 @@ async def test_pm_and_fingerprint_survives_sdk_objects(monkeypatch):
     monkeypatch.setattr(stripe.PaymentIntent, "retrieve", staticmethod(fake_retrieve))
     pm_id, fingerprint = await billing._pm_and_fingerprint("pi_real")
     assert (pm_id, fingerprint) == ("pm_real", "fp_real")
+
+
+# ---- tiered bonus + the ladder default ---------------------------------------------------------
+@pytest.mark.parametrize("usd,bonus,pct", [
+    (10, 0, 0), (49, 0, 0), (50, 2_500_000, 5), (99, 4_950_000, 5), (100, 10_000_000, 10),
+    (250, 37_500_000, 15), (2_000, 300_000_000, 15),
+])
+def test_bonus_tiers_apply_the_highest_floor_at_or_below_the_amount(usd, bonus, pct):
+    assert billing.bonus_for_topup(usd * 1_000_000) == (bonus, pct)
+
+
+@pytest.mark.parametrize("amount", [1, 5, 0.5, 2.5, 99_999, "x"])
+def test_threshold_validation_is_not_the_topup_minimum(amount):
+    """A $5 threshold is fine even though a $5 top-up is not: the threshold is not a charge."""
+    if amount in (1, 5):
+        assert billing.validate_threshold_usd(amount) == amount
+    else:
+        with pytest.raises(billing.TopupRejected):
+            billing.validate_threshold_usd(amount)
+
+
+async def test_manual_topup_grants_a_bonus_block_once_and_auto_never_does(c: AsyncClient, monkeypatch):
+    """$100 by hand → $100 purchased + $10 bonus, and a redelivery adds nothing. The bonus is its own
+    promotional-rank block: the purchased (refundable) block stays exactly what the card paid."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    promo = get_settings().promo_grant_micro
+    event = _pi_event(org_id, pi="pi_bonus", cents=10_000)
+    assert (await _deliver(c, event)).json()["credited"] is True
+    assert (await _deliver(c, event)).json()["credited"] is False
+    body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
+    assert body["balance_micro"] == promo + 100_000_000 + 10_000_000
+    kinds = [b["kind"] for b in body["blocks"]]
+    assert kinds.count("purchased") == 1 and kinds.count("bonus") == 1
+    purchased = [b for b in body["blocks"] if b["kind"] == "purchased"][0]
+    assert purchased["amount_micro"] == 100_000_000
+    grants = [e for e in body["entries"]["items"] if e["kind"] == "grant" and e["meta"].get("source") == "topup_bonus"]
+    assert len(grants) == 1 and grants[0]["meta"]["payment_intent"] == "pi_bonus" and grants[0]["meta"]["pct"] == 10
+
+    # An automatic refill of the same size earns nothing.
+    r = await _deliver(c, _pi_event(org_id, pi="pi_bonus_auto", cents=10_000, auto="1"))
+    assert r.json()["credited"] is True
+    body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
+    assert [b["kind"] for b in body["blocks"]].count("bonus") == 1
+    assert body["balance_micro"] == promo + 210_000_000
+
+
+async def test_bonus_burns_before_purchased_credit(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    await _deliver(c, _pi_event(org_id, pi="pi_burn", cents=5_000))  # $50 + $2.50 bonus
+    spend = get_settings().promo_grant_micro + 1_000_000  # the whole promo grant plus $1 of bonus
+    async with session_maker() as db:
+        call_id = await ledger.reserve(db, org_id, "ep_burn", spend)
+        await ledger.settle(db, call_id, spend)
+    body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
+    by_kind = {b["kind"]: b for b in body["blocks"]}
+    assert by_kind["purchased"]["remaining_micro"] == 50_000_000, "purchased credit was touched first"
+    assert by_kind["bonus"]["remaining_micro"] == 1_500_000
+
+
+async def test_the_next_default_steps_one_preset_up_and_caps_at_fifty(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    state = lambda: c.get("/billing", headers=_h(owner))  # noqa: E731
+    assert (await state()).json()["topup"]["default_usd"] == 10
+    await _deliver(c, _pi_event(org_id, pi="pi_l1", cents=1_000))            # $10 → next is $50
+    assert (await state()).json()["topup"]["default_usd"] == 50
+    await _deliver(c, _pi_event(org_id, pi="pi_l2", cents=20_000, auto="1"))  # auto refills don't count
+    assert (await state()).json()["topup"]["default_usd"] == 50
+    await _deliver(c, _pi_event(org_id, pi="pi_l3", cents=5_000))            # $50 → would be $100, capped
+    assert (await state()).json()["topup"]["default_usd"] == 50
+    await _deliver(c, _pi_event(org_id, pi="pi_l4", cents=20_000))           # $200 → stays at the cap
+    assert (await state()).json()["topup"]["default_usd"] == 50
+
+
+async def test_topup_without_an_amount_uses_the_ladder_default(c: AsyncClient, monkeypatch):
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    await _deliver(c, _pi_event(org_id, pi="pi_ld", cents=1_000))
+    seen = {}
+
+    async def fake_sdk(fn, /, **kw):
+        if "Customer" in str(fn):
+            return {"id": "cus_ld"}
+        seen.update(kw)
+        return {"id": "cs_ld", "url": "https://checkout.stripe.com/c/pay/cs_ld"}
+
+    monkeypatch.setattr(billing, "_sdk", fake_sdk)
+    r = await c.post("/billing/topup", json={}, headers=_h(owner))
+    assert r.status_code == 200, r.text
+    assert r.json()["amount_usd"] == 50

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -155,7 +155,7 @@ async def test_billing_get_reports_state_for_an_admin(c: AsyncClient, monkeypatc
     assert body["topup"]["min_usd"] == 10
     assert body["topup"]["presets"] == [10, 50, 100, 200]
     assert body["topup"]["default_usd"] == 10  # no history yet
-    assert body["topup"]["bonus_tiers"] == {"10": 0, "50": 500, "100": 750, "200": 1000}
+    assert body["topup"]["bonus_tiers"] == {"10": 0, "50": 5, "100": 10, "200": 15}
 
 
 async def test_billing_is_503_when_stripe_is_not_configured(c: AsyncClient, monkeypatch):
@@ -1022,13 +1022,12 @@ async def test_pm_and_fingerprint_survives_sdk_objects(monkeypatch):
 
 
 # ---- tiered bonus + the ladder default ---------------------------------------------------------
-@pytest.mark.parametrize("usd,bonus,bp", [
-    (10, 0, 0), (49, 0, 0), (50, 2_500_000, 500), (99, 4_950_000, 500), (100, 7_500_000, 750),
-    (199, 14_925_000, 750), (200, 20_000_000, 1000), (250, 25_000_000, 1000),
-    (2_000, 200_000_000, 1000),  # the top tier is the ceiling
+@pytest.mark.parametrize("usd,bonus,pct", [
+    (10, 0, 0), (49, 0, 0), (50, 2_500_000, 5), (99, 4_950_000, 5), (100, 10_000_000, 10),
+    (250, 37_500_000, 15), (2_000, 300_000_000, 15),
 ])
-def test_bonus_tiers_apply_the_highest_floor_at_or_below_the_amount_and_cap_at_the_top(usd, bonus, bp):
-    assert billing.bonus_for_topup(usd * 1_000_000) == (bonus, bp)
+def test_bonus_tiers_apply_the_highest_floor_at_or_below_the_amount(usd, bonus, pct):
+    assert billing.bonus_for_topup(usd * 1_000_000) == (bonus, pct)
 
 
 @pytest.mark.parametrize("amount", [1, 5, 0.5, 2.5, 99_999, "x"])
@@ -1042,7 +1041,7 @@ def test_threshold_validation_is_not_the_topup_minimum(amount):
 
 
 async def test_manual_topup_grants_a_bonus_block_once_and_auto_never_does(c: AsyncClient, monkeypatch):
-    """$100 by hand → $100 purchased + $7.50 bonus, and a redelivery adds nothing. The bonus is its own
+    """$100 by hand → $100 purchased + $10 bonus, and a redelivery adds nothing. The bonus is its own
     promotional-rank block: the purchased (refundable) block stays exactly what the card paid."""
     org_id, owner = await _org(c)
     monkeypatch.setattr(billing, "_sdk", _no_sdk)
@@ -1051,20 +1050,20 @@ async def test_manual_topup_grants_a_bonus_block_once_and_auto_never_does(c: Asy
     assert (await _deliver(c, event)).json()["credited"] is True
     assert (await _deliver(c, event)).json()["credited"] is False
     body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
-    assert body["balance_micro"] == promo + 100_000_000 + 7_500_000
+    assert body["balance_micro"] == promo + 100_000_000 + 10_000_000
     kinds = [b["kind"] for b in body["blocks"]]
     assert kinds.count("purchased") == 1 and kinds.count("bonus") == 1
     purchased = [b for b in body["blocks"] if b["kind"] == "purchased"][0]
     assert purchased["amount_micro"] == 100_000_000
     grants = [e for e in body["entries"]["items"] if e["kind"] == "grant" and e["meta"].get("source") == "topup_bonus"]
-    assert len(grants) == 1 and grants[0]["meta"]["payment_intent"] == "pi_bonus" and grants[0]["meta"]["bp"] == 750
+    assert len(grants) == 1 and grants[0]["meta"]["payment_intent"] == "pi_bonus" and grants[0]["meta"]["pct"] == 10
 
     # An automatic refill of the same size earns nothing.
     r = await _deliver(c, _pi_event(org_id, pi="pi_bonus_auto", cents=10_000, auto="1"))
     assert r.json()["credited"] is True
     body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
     assert [b["kind"] for b in body["blocks"]].count("bonus") == 1
-    assert body["balance_micro"] == promo + 207_500_000
+    assert body["balance_micro"] == promo + 210_000_000
 
 
 async def test_bonus_burns_before_purchased_credit(c: AsyncClient, monkeypatch):

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -155,7 +155,7 @@ async def test_billing_get_reports_state_for_an_admin(c: AsyncClient, monkeypatc
     assert body["topup"]["min_usd"] == 10
     assert body["topup"]["presets"] == [10, 50, 100, 200]
     assert body["topup"]["default_usd"] == 10  # no history yet
-    assert body["topup"]["bonus_tiers"] == {"10": 0, "50": 5, "100": 10, "200": 15}
+    assert body["topup"]["bonus_tiers"] == {"10": 0, "50": 500, "100": 750, "200": 1000}
 
 
 async def test_billing_is_503_when_stripe_is_not_configured(c: AsyncClient, monkeypatch):
@@ -1022,12 +1022,13 @@ async def test_pm_and_fingerprint_survives_sdk_objects(monkeypatch):
 
 
 # ---- tiered bonus + the ladder default ---------------------------------------------------------
-@pytest.mark.parametrize("usd,bonus,pct", [
-    (10, 0, 0), (49, 0, 0), (50, 2_500_000, 5), (99, 4_950_000, 5), (100, 10_000_000, 10),
-    (250, 37_500_000, 15), (2_000, 300_000_000, 15),
+@pytest.mark.parametrize("usd,bonus,bp", [
+    (10, 0, 0), (49, 0, 0), (50, 2_500_000, 500), (99, 4_950_000, 500), (100, 7_500_000, 750),
+    (199, 14_925_000, 750), (200, 20_000_000, 1000), (250, 25_000_000, 1000),
+    (2_000, 200_000_000, 1000),  # the top tier is the ceiling
 ])
-def test_bonus_tiers_apply_the_highest_floor_at_or_below_the_amount(usd, bonus, pct):
-    assert billing.bonus_for_topup(usd * 1_000_000) == (bonus, pct)
+def test_bonus_tiers_apply_the_highest_floor_at_or_below_the_amount_and_cap_at_the_top(usd, bonus, bp):
+    assert billing.bonus_for_topup(usd * 1_000_000) == (bonus, bp)
 
 
 @pytest.mark.parametrize("amount", [1, 5, 0.5, 2.5, 99_999, "x"])
@@ -1041,7 +1042,7 @@ def test_threshold_validation_is_not_the_topup_minimum(amount):
 
 
 async def test_manual_topup_grants_a_bonus_block_once_and_auto_never_does(c: AsyncClient, monkeypatch):
-    """$100 by hand → $100 purchased + $10 bonus, and a redelivery adds nothing. The bonus is its own
+    """$100 by hand → $100 purchased + $7.50 bonus, and a redelivery adds nothing. The bonus is its own
     promotional-rank block: the purchased (refundable) block stays exactly what the card paid."""
     org_id, owner = await _org(c)
     monkeypatch.setattr(billing, "_sdk", _no_sdk)
@@ -1050,20 +1051,20 @@ async def test_manual_topup_grants_a_bonus_block_once_and_auto_never_does(c: Asy
     assert (await _deliver(c, event)).json()["credited"] is True
     assert (await _deliver(c, event)).json()["credited"] is False
     body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
-    assert body["balance_micro"] == promo + 100_000_000 + 10_000_000
+    assert body["balance_micro"] == promo + 100_000_000 + 7_500_000
     kinds = [b["kind"] for b in body["blocks"]]
     assert kinds.count("purchased") == 1 and kinds.count("bonus") == 1
     purchased = [b for b in body["blocks"] if b["kind"] == "purchased"][0]
     assert purchased["amount_micro"] == 100_000_000
     grants = [e for e in body["entries"]["items"] if e["kind"] == "grant" and e["meta"].get("source") == "topup_bonus"]
-    assert len(grants) == 1 and grants[0]["meta"]["payment_intent"] == "pi_bonus" and grants[0]["meta"]["pct"] == 10
+    assert len(grants) == 1 and grants[0]["meta"]["payment_intent"] == "pi_bonus" and grants[0]["meta"]["bp"] == 750
 
     # An automatic refill of the same size earns nothing.
     r = await _deliver(c, _pi_event(org_id, pi="pi_bonus_auto", cents=10_000, auto="1"))
     assert r.json()["credited"] is True
     body = (await c.get(f"/orgs/{org_id}/balance", headers=_h(owner))).json()
     assert [b["kind"] for b in body["blocks"]].count("bonus") == 1
-    assert body["balance_micro"] == promo + 210_000_000
+    assert body["balance_micro"] == promo + 207_500_000
 
 
 async def test_bonus_burns_before_purchased_credit(c: AsyncClient, monkeypatch):

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1111,3 +1111,33 @@ async def test_topup_without_an_amount_uses_the_ladder_default(c: AsyncClient, m
     r = await c.post("/billing/topup", json={}, headers=_h(owner))
     assert r.status_code == 200, r.text
     assert r.json()["amount_usd"] == 50
+
+
+async def test_a_topup_checkout_arms_a_consented_policy_that_was_waiting_for_a_card(c: AsyncClient, monkeypatch):
+    """The modal flow: consent is stored first (no card → `no_card`), then the top-up Checkout saves
+    the card. The PAYMENT webhook must arm the policy — there is no setup_intent in this flow."""
+    org_id, owner = await _org(c)
+    monkeypatch.setattr(billing, "_sdk", _no_sdk)
+    r = await c.post("/billing/autotopup", headers=_h(owner),
+                     json={"enabled": True, "consent": True, "threshold_usd": 5, "amount_usd": 100,
+                           "monthly_cap_usd": 2000, "setup_url": False})
+    assert r.status_code == 200, r.text
+    assert r.json()["autotopup"]["enabled"] is False
+    assert r.json()["autotopup"]["disabled_reason"] == "no_card" and "setup_url" not in r.json()
+
+    async def pm(pi_id):
+        return "pm_saved_by_checkout", "fp_1"
+    monkeypatch.setattr(billing, "_pm_and_fingerprint", pm)
+    session_event = {"id": "evt_cs_arm", "type": "checkout.session.completed", "data": {"object": {
+        "id": "cs_arm", "object": "checkout.session", "mode": "payment", "payment_status": "paid",
+        "amount_total": 10_000, "currency": "usd", "payment_intent": "pi_arm",
+        "metadata": {"treg_org_id": str(org_id), "treg_kind": "topup"}}}}
+    assert (await _deliver(c, session_event)).json()["credited"] is True
+    body = (await c.get("/billing", headers=_h(owner))).json()
+    assert body["card_on_file"] is True
+    assert body["autotopup"]["enabled"] is True and body["autotopup"]["disabled_reason"] is None
+    assert body["autotopup"]["amount_usd"] == 100 and body["autotopup"]["monthly_cap_usd"] == 2000
+    # A redelivery (same card, already armed) is a no-op, and a deliberate OFF is not re-armed by it.
+    await c.post("/billing/autotopup", json={"enabled": False, "consent": False}, headers=_h(owner))
+    await _deliver(c, session_event)
+    assert (await c.get("/billing", headers=_h(owner))).json()["autotopup"]["enabled"] is False

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -998,3 +998,26 @@ def test_the_referral_preset_helper_null_guards_before_reading_the_offer():
     body = INDEX[at : INDEX.index("},", at)]
     assert "if(!o) return 0;" in body
     assert body.index("if(!o) return 0;") < body.index("o.remaining_micro")
+
+
+def test_the_topup_modal_offers_four_presets_plus_other_and_an_auto_toggle():
+    """The amount, its bonus and auto top-up are one decision in one modal. The toggle's label is the
+    mandate text and names the amount being chosen (`topupUsd`), never a config default the payer
+    did not see; consent is posted BEFORE the Checkout that saves the card."""
+    at = INDEX.index('v-if="topupOpen&&billing"')
+    modal = INDEX[at : INDEX.index('v-if="capAsk"', at)]
+    assert 'v-for="p in billing.topup.presets"' in modal
+    assert "topupPick='other'" in modal and 'topupPick===\'other\'' in modal
+    assert 'v-model="topupAuto"' in modal
+    assert "I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b>" in modal
+    assert "Processing fee" not in modal, "treg charges no fee; do not copy one from elsewhere"
+    js = INDEX[INDEX.index("async payTopup("):]
+    js = js[: js.index("autoToggled(")]
+    assert js.index("/billing/autotopup") < js.index("/billing/topup"), "consent must precede Checkout"
+    assert "consent:true" in js and "setup_url:false" in js
+
+
+def test_the_topup_modal_defaults_auto_on_only_without_a_mandate():
+    js = INDEX[INDEX.index("openTopup(){"):]
+    js = js[: js.index("tierBonus(")]
+    assert "this.topupAuto=!(this.billing.autotopup.enabled||this.billing.autotopup.consented_at)" in js

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -1009,7 +1009,7 @@ def test_the_topup_modal_offers_four_presets_plus_other_and_an_auto_toggle():
     assert 'v-for="p in billing.topup.presets"' in modal
     assert "pickOther()" in modal and 'topupPick===\'other\'' in modal
     assert 'v-model="topupAuto"' in modal
-    assert "I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b>" in modal
+    assert "I authorize treg to charge my saved card <b>${{autoAmount}}</b>" in modal
     assert "Processing fee" not in modal, "treg charges no fee; do not copy one from elsewhere"
     js = INDEX[INDEX.index("async payTopup("):]
     js = js[: js.index("autoToggled(")]

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -1007,7 +1007,7 @@ def test_the_topup_modal_offers_four_presets_plus_other_and_an_auto_toggle():
     at = INDEX.index('v-if="topupOpen&&billing"')
     modal = INDEX[at : INDEX.index('v-if="capAsk"', at)]
     assert 'v-for="p in billing.topup.presets"' in modal
-    assert "topupPick='other'" in modal and 'topupPick===\'other\'' in modal
+    assert "pickOther()" in modal and 'topupPick===\'other\'' in modal
     assert 'v-model="topupAuto"' in modal
     assert "I authorize treg to charge my saved card <b>${{topupUsd||'…'}}</b>" in modal
     assert "Processing fee" not in modal, "treg charges no fee; do not copy one from elsewhere"


### PR DESCRIPTION
## What

The billing tab's eight one-click cards ($5…$400) become a top-up modal:

- **Presets $10 / $50 / $100 / $200 + Other** (minimum now $10 — fee math, and the referral qualifying amount). Other prefills $500.
- **Tiered bonus on manual top-ups**: $50 → 5%, $100 → 10%, $200+ → 15%. Granted as a separate `bonus` credit block (burns first, never inflates refundable purchased balance). Auto refills earn nothing. Shown on the cards, in the summary (`$52.50 ($50.00 + $2.50 bonus)`), the receipt email, payment history and PostHog.
- **Ladder default**: the preselected amount is one preset above the last manual top-up, capped at $50. `POST /billing/topup` with no amount (and `treg topup`) use it.
- **Auto top-up toggle in the modal, on by default** for teams with no mandate. Its label is the PSD2/SCA mandate ($20 when below $5 — the new server defaults). Pay records consent via `/billing/autotopup` *before* opening Checkout; the card Checkout saves then arms the policy.
- Running policies get an **Edit** link (amount / threshold; Save re-stamps consent). Monthly-cap wording removed from all copy; the server guardrail stays (the modal sets it to the $2,000 ceiling).
- Balance card simplified to balance + **Top up**.

## Verification

- Money suites + markup + surface snapshot green; the 49 `test_agent_pages` failures are pre-existing on `main`.
- Live against Stripe test mode via `stripe listen`: $50 top-up credited $50 purchased + $2.50 bonus, auto top-up armed from the payment webhook, Edit → Save persisted a new threshold, redelivery did not double-credit.
- Docs updated in the same commits: `money.md`, `dashboard.md`, `deploy.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbpCR9EWEKVTXRqVBMeszZ