### PR TITLE
web(getting-started): list Facebook Pages as live

### DIFF
--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4399,8 +4399,8 @@ createApp({
       {k:'soc',  cat:'Scrape linkedin',         logo:'linkedin',prompt:'Use treg to look up linkedin.com/in/jasonzhoudesign'},
     ]; },
     tryOauth(){ return [
-      {label:'Post on social',      items:[{s:'x',n:'X (Twitter)'},{s:'youtube',n:'YouTube'},{s:'tiktok',n:'TikTok'},{s:'linkedin',n:'LinkedIn'}],
-                                    soon:[{s:'instagram',n:'Instagram'},{s:'facebook',n:'Facebook Pages'}]},
+      {label:'Post on social',      items:[{s:'x',n:'X (Twitter)'},{s:'youtube',n:'YouTube'},{s:'tiktok',n:'TikTok'},{s:'linkedin',n:'LinkedIn'},{s:'facebook',n:'Facebook Pages'}],
+                                    soon:[{s:'instagram',n:'Instagram'}]},
       {label:'Manage ad campaigns', items:[{s:'google-ads',n:'Google Ads'},{s:'meta-ads',n:'Meta Ads'}], soon:[]},
       {label:'SEO on your own site',items:[{s:'google-analytics',n:'Google Analytics'},{s:'google-search-console',n:'Search Console'},{s:'google-business-profile',n:'Business Profile'}], soon:[]},
     ]; },


### PR DESCRIPTION
Moves Facebook Pages from the 'coming soon' note into the live chip list under **Post on social** on Getting Started. The `facebook` OAuth provider is registered (`oauth_providers.py`), the logo exists, and the chip routes through the same `openProvider('facebook')` as the connect flow. Instagram remains 'coming soon'.

Note: fully working consent in prod still depends on the pending Meta App Review for `pages_manage_posts` / `business_management`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQBhyRX2BmBWSs9mkHYhQ7