### PR TITLE
feat(catalog): add Exa — web/people/company search, contents, similar, answer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ job — without owning the API keys.
 
 Two halves answer the same token, through the same `/call/`:
 
-- **The catalog** — 2,835 curated external endpoints across 59 providers (SEO and backlinks, social
+- **The catalog** — 2,895 curated external endpoints across 60 providers (SEO and backlinks, social
   and trends, people and company enrichment, ads, scraping). treg can serve eligible ones **on its own
   key**, metered per call from the team's prepaid balance ($1.00 free per new team). No provider signup.
 - **Your own tools** — what a teammate registered: a paid API account, an OAuth connection, a vendor

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![treg — the tool catalog for your agent](docs/assets/treg-hero.png)
 
 **OpenRouter, but for agent tools instead of models.** Point an agent at one base URL with one token
-and it can do the job: **2,835 catalogued endpoints across 59 providers** — SEO and backlinks,
+and it can do the job: **2,895 catalogued endpoints across 60 providers** — SEO and backlinks,
 social and trends, people and company enrichment, ads, scraping — **priced per call, from a cent**,
 with no provider signup. Plus your own team's keys, skills and CLIs, callable by every teammate's
 agent without the credential ever leaving the server.

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1064,6 +1064,7 @@ long strings clipped, ~10 KB cap) by the verifier, then human-reviewed for PII b
 | service | platform focus | auth (from oauth_providers.py) | overlap group |
 |---|---|---|---|
 | dataforseo | google, web | Basic (login:password base64) | SEO: web.backlinks.*, web.url.metrics |
+| exa (2026-08-27) | web, people, companies | `x-api-key` header; dollar-priced, settles from `costDollars.total` | Search: web.search*, web.contents.get, web.similar, web.answer; Enrichment: people.search, companies.search |
 | moz | web | Basic (AccessID:SecretKey base64), POST JSON API | SEO: web.backlinks.*, web.url.metrics |
 | tikhub | tiktok (+instagram, youtube, x) | Bearer key | Social: tiktok.* |
 | justoneapi | tiktok (+instagram, xiaohongshu, weibo) | `?token=` query param | Social: tiktok.* |

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -306,7 +306,9 @@ are admin-scale windows over a bounded number of metered calls, the same tradeof
               (dataforseo `cost`, scrapecreators `credits_charged`, akta `credits_consumed` —
               the last is what makes akta's per-section enrich billable: the estimate is an
               upper bound, the settle is the real charge; Crustdata reports `X-Credits-Used` in
-              a response header), else at the estimate;
+              a response header; Exa reports dollars as `costDollars.total` on every body —
+              the per-result rider beyond 10 and each contents type live only there), else at
+              the estimate;
               release instead when the call was not billable
 
 Two providers do not report a charge but have a rule the RESPONSE decides, so `_observed_cost_micro`

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -69,6 +69,7 @@ this fragment is the *process*, not the mechanics reference.
 | HTTP Basic with a RAW token after `Basic ` | `token_format="Basic {secret}"`, **no** `token_encode` | The Companies API |
 | Cheapest check on a DIFFERENT host | `probe_url` (absolute) | Semrush (balance host), Diffbot (account host) |
 | Probe needs a POST body | `probe_method="POST"` + `probe_json` | Serpstat, Moz, Coresignal |
+| No free route at all — the cheapest PAID call is the probe | `probe_method="POST"` + `probe_json` on the cheapest cached call; say the price in `setup_note` | Exa `/contents` on example.com, $0.001; `/v0/teams/me` 404s on every key (2026-08-27) |
 | 200 on a bad key; a truthy field = valid | `token_verify_field` | Slack `ok`, Apollo `is_logged_in` |
 | 200 on a bad key; a field == a value = valid | `token_ok_field` + `token_ok_value` | Majestic `Code=="OK"` |
 | 200 on a bad key; an error object present = invalid | `token_reject_field` | Serpstat `error` |

--- a/docs/context/interface/env-import.md
+++ b/docs/context/interface/env-import.md
@@ -23,7 +23,7 @@ Bare `treg upload` does **both** sides of the dir; `treg upload env` / `treg upl
   each as a tool (+ recipe) or a recipe-only bundle — see "Skill directories" below.
 
 ## The provider catalog (`CATALOG`)
-~80 curated providers (`CATALOG_VERSION`, now **11** — Crustdata and Aviato are included, and
+~80 curated providers (`CATALOG_VERSION`, now **12** — Exa (`x-api-key`) joined on 2026-08-27; Crustdata and Aviato are included, and
 `required_headers` can describe a fixed protocol header such as Crustdata's API-version pin; `probe`
 remains the cheap authenticated GET path per provider so an imported tool self-validates, followed by
 a wave of `cli` local-run blocks plus the CLI-only
@@ -57,7 +57,7 @@ real machine test (docs lie — Vercel ships an env var it ignores, so it inject
 verified); `beta` marks an unverified entry. Several entries now carry **`deny`** patterns for subcommands
 that would print the injected key or run member code as the isolated runner (`gh extension`/`alias`/`auth
 token`/`--show-token`, `flyctl|turso auth token`, `doppler|infisical run`, …) — enforced by `check_deny` at
-grant (see [local-run](../architecture/local-run.md)). `CATALOG_VERSION` is now **11**. An `unsupported:true` block is first-class: it tells the analyzer
+grant (see [local-run](../architecture/local-run.md)). `CATALOG_VERSION` is now **12**. An `unsupported:true` block is first-class: it tells the analyzer
 WHY and what to do instead (e.g. **Azure** — device-login only → register a service principal as an HTTP tool).
 The catalog can never ENABLE a local run — only the owner's `tool.cli.enabled` does.
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -296,6 +296,15 @@ The `fx.yaml` rates are the replacement costs configured on the accounts: Crustd
 ($0.30), Aviato $10/1,000 credits ($0.01). Crustdata settles from `X-Credits-Used`; Aviato fixed and
 conditional prices are derived from the authenticated rate card plus request/response shape.
 
+## Exa platform key (2026-08-27)
+
+`TREG_PLATFORM_KEY_EXA` is Jason's own Exa API key (dollar-metered, $20 signup credit + $10/month
+free tier; top up on the Exa dashboard). Add `exa` to `TREG_PLATFORM_PROVIDERS` to serve its nine
+routes on tier 4. Binding is the plain `x-api-key` header; no `fx.yaml` row because Exa prices in
+USD. Platform billing settles every call from the response's `costDollars.total`, so a 20-result
+search or a contents call with three content types bills exactly what Exa charged, not the catalog
+base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 on a 12-result search.
+
 ## A db.py change needs a Postgres-shaped deploy plan
 
 SQLite cannot catch this class: it has no connection pool and no lock queue. Two rules, both from the

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 ---
 
 ## First, check which treg you have
@@ -94,7 +94,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 ---
 
 ## First, check which treg you have
@@ -97,7 +97,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 version: 0.12.1
 ---
 
@@ -78,7 +78,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 version: 0.12.1
 ---
 
@@ -76,7 +76,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/render.yaml
+++ b/render.yaml
@@ -136,6 +136,8 @@ services:
         sync: false
       - key: TREG_PLATFORM_KEY_AVIATO             # Aviato API key (Authorization: Bearer)
         sync: false
+      - key: TREG_PLATFORM_KEY_EXA                # Exa API key (x-api-key); every response reports costDollars
+        sync: false
       - key: TREG_PLATFORM_KEY_FIBER_AI           # Fiber AI key (x-api-key)
         sync: false
       - key: TREG_PLATFORM_KEY_TOMBA              # Tomba API key ta_… (X-Tomba-Key)

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 version: 0.12.1
 ---
 
@@ -76,7 +76,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -8661,6 +8661,9 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
         charge for a 2xx whose payload is an embedded error (verified live 2026-07-30 — see
         docs/context/architecture/catalog.md, "the provider decides what counts as success").
 
+      - exa: REPORTED in dollars, `costDollars.total` on every 2xx body (same contract as
+        dataforseo's `cost`) — the only place the per-result and per-content riders exist.
+
     Everyone else settles at the estimate. This is the same signal the catalog's `observed_cost`
     harvests, which is what lets phase 5's drift detector compare the two numbers directly."""
     provider = mk.provider
@@ -8715,6 +8718,16 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
         cost = doc.get("cost")
         if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
             return int(cost * 1_000_000 + 0.5)
+        return None
+    if provider == "exa":
+        # REPORTED in dollars: every Exa response carries `costDollars.total` — the search base,
+        # the per-result rider beyond 10, deep-mode uplifts and each contents type summed (verified
+        # live 2026-08-27: 20 results → 0.016, highlights+summary → 0.002). The catalog holds the
+        # base price; this is what makes a 20-result search settle at what Exa actually charged.
+        cost = doc.get("costDollars")
+        total = cost.get("total") if isinstance(cost, dict) else None
+        if isinstance(total, (int, float)) and not isinstance(total, bool) and total >= 0:
+            return int(total * 1_000_000 + 0.5)
         return None
     if provider in ("scrapecreators", "akta", "leadmagic"):
         credits = doc.get("credits_charged" if provider == "scrapecreators" else "credits_consumed")

--- a/src/treg/catalog/exa.yaml
+++ b/src/treg/catalog/exa.yaml
@@ -1,0 +1,362 @@
+provider: exa
+source:
+  docs: https://docs.exa.ai/reference/getting-started
+  openapi: https://api.exa.ai/openapi.json
+  curated: '2026-08-27'
+limits: "Per-key concurrency limits are enforced server-side (x-exa-queued / x-exa-queue-ms response headers show when a call waited); no public numeric QPS is published. numResults is capped at 100 per call."
+pricing_url: https://exa.ai/pricing
+
+# Exa is a semantic web-search index with typed sub-indexes (people, companies, news, publications),
+# page-contents extraction, similar-link discovery and cited answers. Available through BYOK and
+# treg's platform key. Prices are in DOLLARS, not credits — no fx.yaml row — and every response
+# carries `costDollars.total`, which platform billing settles from (api.py `_observed_cost_micro`),
+# so the catalog holds the BASE price and riders (results beyond 10 at $1/1k, each extra contents
+# type at $1/1k page, deep-mode uplifts) are billed exactly as Exa reports them. All nine routes
+# were live verified on 2026-08-27 against that meter; the rate-card figures matched to the cent.
+# Observed that day and worth knowing: `type: fast` / `instant` and every `category` bill the same
+# $0.007 base as `auto`; highlights requested INSIDE a /search call were NOT billed on top.
+#
+# There is no free account route (/v0/teams/me answers 404 on every key), so the connect probe is
+# a cached /contents call on example.com at $0.001; a bad key gets 401 INVALID_API_KEY.
+
+proposed_capabilities:
+  web.search: "Search the web by meaning or keyword"
+  web.search.deep: "Deep multi-query web search with reasoning"
+  web.search.news: "Search recent news articles by topic"
+  web.search.publications: "Search research papers and publications"
+  web.contents.get: "Get a page's text, highlights or summary by URL"
+  web.similar: "Find pages similar to a URL"
+  web.answer: "Get a cited answer to a question from the web"
+
+endpoints:
+  - id: exa.web.search
+    domain: search
+    capability: web.search
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search the web"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, note: "natural-language or keyword query; Exa's neural index understands meaning, so phrase it as a description of the page you want", example: "open source vector database written in rust"}
+        numResults: {type: integer, required: false, note: "1-100, default 10. The first 10 are covered by the base price; each result beyond 10 adds $0.001", example: 5}
+        type: {type: string, required: false, note: "auto (default) | instant | fast | deep-lite | deep | deep-reasoning. auto/instant/fast bill the base; use exa.web.search.deep for the deep modes", example: "auto"}
+        category: {type: string, required: false, note: "focus on one sub-index: company | people | news | publication | personal site | financial report. The people/company/news/publication categories have their own curated routes below"}
+        includeDomains: {type: "array[string]", required: false, note: "only these hosts or host paths"}
+        excludeDomains: {type: "array[string]", required: false}
+        startPublishedDate: {type: string, required: false, note: "ISO 8601; only pages published after this"}
+        endPublishedDate: {type: string, required: false, note: "ISO 8601"}
+        userLocation: {type: string, required: false, note: "two-letter ISO country code to localise results, e.g. US"}
+        contents: {type: object, required: false, note: "attach page content to each result: {text: true|{maxCharacters}, highlights: true|{query, maxCharacters}, summary: {query}}. Observed 2026-08-27: highlights on a search were not billed on top of the base; text/summary follow the $1/1k-page contents rate"}
+      note: "results carry url, title, publishedDate, author, score and any requested contents. Keep numResults at 10 or below to stay at the base price."
+    test_request:
+      body: {query: "open source vector database written in rust", numResults: 3}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.search.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results, plus $0.001 per result beyond 10 (OBSERVED 2026-08-27: numResults 10 → costDollars.total 0.007; numResults 20 → 0.016, i.e. 19 returned = base + 9 riders). type fast and instant billed the same 0.007. Platform billing settles the exact costDollars.total the response reports, so the rider is charged as Exa charges it."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.web.search.deep
+    domain: search
+    capability: web.search.deep
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Deep web search"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, example: "what changed in the EU AI Act implementing guidance this summer"}
+        type: {type: string, required: true, note: "deep-lite ($12/1k) | deep ($12/1k) | deep-reasoning ($15/1k). This route exists so the deep modes carry their own price; the base route is exa.web.search", example: "deep-lite"}
+        numResults: {type: integer, required: false, note: "1-100, default 10; results beyond 10 add $0.001 each", example: 5}
+        additionalQueries: {type: "array[string]", required: false, note: "extra query variations the deep search fans out over"}
+        includeDomains: {type: "array[string]", required: false}
+        excludeDomains: {type: "array[string]", required: false}
+        startPublishedDate: {type: string, required: false}
+        endPublishedDate: {type: string, required: false}
+        contents: {type: object, required: false, note: "same shape as exa.web.search"}
+      note: "the same /search route with a deep `type`; same result shape as exa.web.search"
+    test_request:
+      body: {query: "open source vector database written in rust", numResults: 3, type: "deep-lite"}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.search.deep.json
+    cost:
+      type: per_call
+      value: 12
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.012 per deep-lite or deep call (OBSERVED 2026-08-27: deep-lite, 5 results → costDollars.total 0.012); deep-reasoning is documented at $0.015 and unobserved. Results beyond 10 add $0.001 each. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.people.search
+    domain: people
+    capability: people.search
+    platform: people
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search people by description"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, note: "describe the person in words — role, seniority, location, industry, anything a profile page would say. Free text, not filters: 'head of security at a fintech in berlin' works, so does 'ai safety researchers in greater phoenix'", example: "head of security at a fintech in berlin"}
+        category: {type: string, required: true, note: "must be `people`", example: "people"}
+        numResults: {type: integer, required: false, note: "1-100, default 10; beyond 10 adds $0.001 each", example: 5}
+        includeDomains: {type: "array[string]", required: false, note: "e.g. [\"linkedin.com\"] to keep to one profile host"}
+        contents: {type: object, required: false, note: "{highlights: true} returns the profile lines that matched the query"}
+      note: "each result is a profile page: url (mostly linkedin.com/in/…), title (the person's name), publishedDate, and an `entities` block with the structured person record Exa extracted (name, current title, company, location). No contact data — pair with a people.enrich or people.email.find provider for that. Scored 72% R@1 / 94.5% R@10 on Exa's open people-search benchmark; the structured providers under this capability need role+location filters instead of free text."
+    test_request:
+      body: {query: "head of security at a fintech in berlin", category: "people", numResults: 3}
+    verified: '2026-08-27'
+    example_response: examples/exa.people.search.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results (OBSERVED 2026-08-27: category people, 5 results → costDollars.total 0.007), plus $0.001 per result beyond 10. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.companies.search
+    domain: companies
+    capability: companies.search
+    platform: companies
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search companies by description"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, note: "describe the company in words — what it does, stage, geography", example: "vector database startups"}
+        category: {type: string, required: true, note: "must be `company`", example: "company"}
+        numResults: {type: integer, required: false, example: 5}
+        includeDomains: {type: "array[string]", required: false}
+        startPublishedDate: {type: string, required: false}
+        contents: {type: object, required: false, note: "{summary: {query: \"what does this company sell\"}} adds a $0.001/page summary"}
+      note: "each result is the company's own site or profile page: url, title, and an `entities` block with the structured company record (name, description, location, industry, headcount range, founding year where known). Firmographic FILTERS (headcount, funding) belong to the structured providers under this capability; this one takes a description."
+    test_request:
+      body: {query: "vector database startups", category: "company", numResults: 3}
+    verified: '2026-08-27'
+    example_response: examples/exa.companies.search.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results (OBSERVED 2026-08-27: category company, 5 results → costDollars.total 0.007), plus $0.001 per result beyond 10. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.web.search.news
+    domain: search
+    capability: web.search.news
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search news by topic"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, example: "vector database funding round"}
+        category: {type: string, required: true, note: "must be `news`", example: "news"}
+        startPublishedDate: {type: string, required: false, note: "ISO 8601 — the usual way to mean 'recent'", example: "2026-07-01"}
+        endPublishedDate: {type: string, required: false}
+        numResults: {type: integer, required: false, example: 5}
+        includeDomains: {type: "array[string]", required: false}
+        contents: {type: object, required: false, note: "{highlights: true} or {summary: {query}}"}
+      note: "results are articles: url, title, publishedDate, author"
+    test_request:
+      body: {query: "vector database funding round", category: "news", numResults: 3, startPublishedDate: "2026-07-01"}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.search.news.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results (OBSERVED 2026-08-27: category news, 5 results → costDollars.total 0.007), plus $0.001 per result beyond 10. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.web.search.publications
+    domain: search
+    capability: web.search.publications
+    platform: web
+    scope: any_account
+    method: POST
+    path: /search
+    name: "Search research publications"
+    summary: "The search endpoint lets you intelligently search the web and extract contents from the results."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, note: "a research question, method, or a vague recollection of the paper", example: "approximate nearest neighbor search HNSW"}
+        category: {type: string, required: true, note: "must be `publication`", example: "publication"}
+        numResults: {type: integer, required: false, example: 5}
+        startPublishedDate: {type: string, required: false}
+        includeDomains: {type: "array[string]", required: false, note: "e.g. [\"arxiv.org\"]"}
+        contents: {type: object, required: false, note: "{highlights: {query}} pulls the matching passage"}
+      note: "results are paper pages (arxiv, publisher, DOI landing pages): url, title, publishedDate, author"
+    test_request:
+      body: {query: "approximate nearest neighbor search HNSW", category: "publication", numResults: 3}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.search.publications.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results (OBSERVED 2026-08-27: category publication, 5 results → costDollars.total 0.007), plus $0.001 per result beyond 10. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/search
+
+  - id: exa.web.contents.get
+    domain: contents
+    capability: web.contents.get
+    platform: web
+    scope: any_account
+    method: POST
+    path: /contents
+    name: "Get page contents by URL"
+    summary: "Get the full page contents, summaries, and metadata for a list of URLs."
+    input:
+      bodyType: json
+      body:
+        urls: {type: "array[string]", required: true, note: "one or more page URLs; each page is billed per content type requested", example: ["https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world"]}
+        text: {type: "boolean|object", required: false, note: "true, or {maxCharacters: N} — the page as clean text. $0.001 per page", example: {maxCharacters: 2000}}
+        highlights: {type: object, required: false, note: "{query, maxCharacters, numSentences} — the passages most relevant to `query`. $0.001 per page"}
+        summary: {type: object, required: false, note: "{query} — an AI summary of the page focused on `query`. $0.001 per page"}
+        maxAgeHours: {type: integer, required: false, note: "serve cache if younger than this, else live-crawl; omit for Exa's default freshness"}
+        livecrawlTimeout: {type: integer, required: false, note: "ms, default 10000"}
+        subpages: {type: integer, required: false, note: "also crawl N linked subpages (each billed as a page)"}
+      note: "each result carries url, title, author, publishedDate and whichever of text / highlights / summary was asked for; `statuses` says per URL whether it came from cache or a live crawl, or failed. Request only the content types you need — each one is a separate $0.001 per page."
+    test_request:
+      body: {urls: ["https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world"], text: {maxCharacters: 2000}}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.contents.get.json
+    cost:
+      type: per_result
+      value: 1
+      currency: USD
+      per: 1000
+      unit: page
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.001 per page PER CONTENT TYPE: text, highlights and summary are each billed separately (OBSERVED 2026-08-27: text on one page → costDollars.total 0.001; highlights+summary on one page → 0.002 as {highlights: 0.001, summary: 0.001}). A failed URL is not billed. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/get-contents
+
+  - id: exa.web.similar
+    domain: search
+    capability: web.similar
+    platform: web
+    scope: any_account
+    method: POST
+    path: /findSimilar
+    name: "Find pages similar to a URL"
+    summary: "Find similar links to the link provided and optionally return the contents of the pages."
+    input:
+      bodyType: json
+      body:
+        url: {type: string, required: true, note: "the page to find neighbours of — a product site to find competitors, an article to find coverage of the same story", example: "https://qdrant.tech"}
+        numResults: {type: integer, required: false, note: "1-100, default 10; beyond 10 adds $0.001 each", example: 5}
+        excludeSourceDomain: {type: boolean, required: false, note: "drop results from the input URL's own domain — usually what you want", example: true}
+        category: {type: string, required: false, note: "company | people | news | publication | personal site | financial report"}
+        includeDomains: {type: "array[string]", required: false}
+        excludeDomains: {type: "array[string]", required: false}
+        startPublishedDate: {type: string, required: false}
+        contents: {type: object, required: false, note: "same shape as exa.web.search"}
+      note: "results carry url, title, publishedDate, author and a similarity `score`"
+    test_request:
+      body: {url: "https://qdrant.tech", numResults: 3, excludeSourceDomain: true}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.similar.json
+    cost:
+      type: per_call
+      value: 7
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.007 per call for up to 10 results (OBSERVED 2026-08-27: 5 results → costDollars.total 0.007), plus $0.001 per result beyond 10. Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/find-similar-links
+
+  - id: exa.web.answer
+    domain: answer
+    capability: web.answer
+    platform: web
+    scope: any_account
+    method: POST
+    path: /answer
+    name: "Answer a question with citations"
+    summary: "Get an LLM answer to a question informed by Exa search results. Fully compatible with OpenAI's chat completions endpoint."
+    input:
+      bodyType: json
+      body:
+        query: {type: string, required: true, note: "a question or instruction; Exa searches, reads, and writes an answer with citations", example: "What year was the HNSW algorithm paper published and by whom?"}
+        text: {type: boolean, required: false, note: "true also returns the full text of each cited page"}
+        outputSchema: {type: object, required: false, note: "JSON Schema draft-7; when set, `answer` is a JSON object in that shape instead of prose"}
+        stream: {type: boolean, required: false, note: "server-sent events; leave false through the proxy"}
+      note: "response is {answer, citations: [{url, title, publishedDate, author, text?}], costDollars}. This is the one Exa route that runs a model over the results; for raw results use exa.web.search."
+    test_request:
+      body: {query: "What year was the HNSW algorithm paper published and by whom?"}
+    verified: '2026-08-27'
+    example_response: examples/exa.web.answer.json
+    cost:
+      type: per_call
+      value: 5
+      currency: USD
+      per: 1000
+      unit: call
+      source: observed
+      source_url: https://exa.ai/pricing
+      checked: '2026-08-27'
+      confidence: verified
+      note: "$0.005 per answer (OBSERVED 2026-08-27: costDollars.total 0.005). Platform billing settles the exact costDollars.total."
+    docs_url: https://docs.exa.ai/reference/answer

--- a/src/treg/catalog/examples/exa.companies.search.json
+++ b/src/treg/catalog/examples/exa.companies.search.json
@@ -1,0 +1,118 @@
+{
+  "requestId": "284f8a5f9f2c61b86eaebdb33e1f4f9f",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://exa.ai/library/organization/64hnz3g3vgf",
+      "title": "Pinecone",
+      "url": "https://pinecone.io/",
+      "publishedDate": "2026-06-27T00:00:00.000Z",
+      "author": "Exa",
+      "image": "https://media.licdn.com/dms/image/v2/C4E0BAQHYjma_4kJHhw/company-logo_200_200/company-logo_200_200/0/1630629175187/hypercube_systems_logo?e=2147483647&v=beta&t=qvV03plHu-LpeSPOf2CYWLrAVFaYKzYofLUmpuifLuo",
+      "entities": [
+        {
+          "id": "https://exa.ai/library/organization/64hnz3g3vgf",
+          "type": "company",
+          "version": 1,
+          "properties": {
+            "name": "Pinecone",
+            "foundedYear": 2019,
+            "description": "Pinecone is the knowledge infrastructure for AI at scale. Its leading vector database and knowledge engine, Pinecone Nexus, power accurate, performant AI applications for more than 9,000 customers and 800,000 developers worldwide. Pinecone's mission is to make AI knowledgeable.",
+            "workforce": {
+              "total": 88
+            },
+            "headquarters": {
+              "address": "New York, NY 10001, US",
+              "city": "New York",
+              "postalCode": null,
+              "country": "United States"
+            },
+            "financials": {
+              "revenueAnnual": 18500000,
+              "fundingTotal": 138000000,
+              "fundingLatestRound": null
+            },
+            "webTraffic": {
+              "visitsMonthly": 648024,
+              "countryRank": 37853,
+              "avgDurationSeconds": 154,
+              "history": [
+                {
+                  "value": 627693,
+                  "dateFrom": "2026-03",
+                  "dateTo": "2026-03"
+                },
+                {
+                  "value": 536597,
+                  "dateFrom": "2026-04",
+                  "dateTo": "2026-04"
+                },
+                "… 4 more item(s) truncated"
+              ]
+            },
+            "research": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "https://exa.ai/library/organization/wcftrdxc39q",
+      "title": "Qdrant",
+      "url": "https://qdrant.tech/",
+      "image": "https://media.licdn.com/dms/image/v2/D4D0BAQGJgSgWmgTCIQ/company-logo_200_200/B4DZgABCBEH8AM-/0/1752346928000/qdrant_logo?e=2147483647&v=beta&t=WruBXkp9lSqEt3ETIg7GqoH2S8lOMoJZ7RL56x5ELzc",
+      "entities": [
+        {
+          "id": "https://exa.ai/library/organization/wcftrdxc39q",
+          "type": "company",
+          "version": 1,
+          "properties": {
+            "name": "Qdrant",
+            "foundedYear": 2021,
+            "description": "Powering the next generation of AI applications\nwith advanced and high-performant vector similarity search technology.\n\nQdrant is an open-source vector search engine. It deploys as an API service providing a search for the nearest high-dimensional vectors. With Qdrant, embeddings or neural network encoders can be turned into full-fledged applications for matching, searching, recommending, and much more. \n\nMake the most of your Unstructured Data!",
+            "workforce": {
+              "total": 102
+            },
+            "headquarters": {
+              "address": "Berlin, Berlin 10115, DE",
+              "city": "Berlin",
+              "postalCode": null,
+              "country": "Germany"
+            },
+            "financials": {
+              "revenueAnnual": 1000000,
+              "fundingTotal": 88268073,
+              "fundingLatestRound": null
+            },
+            "webTraffic": {
+              "visitsMonthly": 300240,
+              "countryRank": 58647,
+              "avgDurationSeconds": 60,
+              "history": [
+                {
+                  "value": 319234,
+                  "dateFrom": "2026-02",
+                  "dateTo": "2026-02"
+                },
+                {
+                  "value": 363418,
+                  "dateFrom": "2026-03",
+                  "dateTo": "2026-03"
+                },
+                "… 4 more item(s) truncated"
+              ]
+            },
+            "research": null
+          }
+        }
+      ]
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 890.5,
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  }
+}

--- a/src/treg/catalog/examples/exa.people.search.json
+++ b/src/treg/catalog/examples/exa.people.search.json
@@ -1,0 +1,136 @@
+{
+  "requestId": "00000000000000000000000000000000",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://exa.ai/library/person/example1",
+      "title": "Jane Doe",
+      "url": "https://www.linkedin.com/in/jane-doe-example",
+      "author": "Exa",
+      "image": "https://static.licdn.com/example.jpg",
+      "entities": [
+        {
+          "id": "https://exa.ai/library/person/example1",
+          "type": "person",
+          "version": 1,
+          "properties": {
+            "name": "Jane Doe",
+            "firstName": "Jane",
+            "lastName": "Doe",
+            "location": "Berlin, Berlin, Germany",
+            "workHistory": [
+              {
+                "title": "Head of Information Security",
+                "location": "Berlin, Germany",
+                "dates": {
+                  "from": "2025-04-01",
+                  "to": null
+                },
+                "company": {
+                  "id": "https://exa.ai/library/organization/example",
+                  "name": "Example Fintech GmbH"
+                }
+              },
+              {
+                "title": "Chief Information Security Officer",
+                "location": "Berlin, Germany",
+                "dates": {
+                  "from": "2022-12-01",
+                  "to": "2025-04-01"
+                },
+                "company": {
+                  "id": "https://exa.ai/library/organization/example",
+                  "name": "Example Fintech GmbH"
+                }
+              },
+              "… 5 more item(s) truncated"
+            ],
+            "educationHistory": [
+              {
+                "degree": "MSc Computer Science",
+                "dates": {
+                  "from": "2007",
+                  "to": "2012"
+                },
+                "institution": {
+                  "id": "https://exa.ai/library/organization/example-university",
+                  "name": "Example University"
+                }
+              }
+            ],
+            "research": null
+          }
+        }
+      ]
+    },
+    {
+      "id": "https://exa.ai/library/person/example2",
+      "title": "John Smith",
+      "url": "https://www.linkedin.com/in/john-smith-example",
+      "author": "Exa",
+      "image": "https://static.licdn.com/example.jpg",
+      "entities": [
+        {
+          "id": "https://exa.ai/library/person/example2",
+          "type": "person",
+          "version": 1,
+          "properties": {
+            "name": "John Smith",
+            "firstName": "John",
+            "lastName": "Smith",
+            "location": "Berlin, Berlin, Germany",
+            "workHistory": [
+              {
+                "title": "Head of Security & IT",
+                "location": "Berlin, Germany",
+                "dates": {
+                  "from": "2026-01-01",
+                  "to": null
+                },
+                "company": {
+                  "id": "https://exa.ai/library/organization/example",
+                  "name": "Example Fintech GmbH"
+                }
+              },
+              {
+                "title": "Security Engineering Lead",
+                "location": null,
+                "dates": {
+                  "from": "2024-01-01",
+                  "to": "2025-12-01"
+                },
+                "company": {
+                  "id": "https://exa.ai/library/organization/example",
+                  "name": "Example Fintech GmbH"
+                }
+              },
+              "… 10 more item(s) truncated"
+            ],
+            "educationHistory": [
+              {
+                "degree": "MSc Computer Science",
+                "dates": {
+                  "from": "2012",
+                  "to": "2014"
+                },
+                "institution": {
+                  "id": "https://exa.ai/library/organization/example-university",
+                  "name": "Example University"
+                }
+              }
+            ],
+            "research": null
+          }
+        }
+      ]
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 1530.2,
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  }
+}

--- a/src/treg/catalog/examples/exa.web.answer.json
+++ b/src/treg/catalog/examples/exa.web.answer.json
@@ -1,0 +1,21 @@
+{
+  "requestId": "f6dfa04f1e1766b5127dd1f54dfb7083",
+  "answer": "The HNSW algorithm paper, titled Efficient and Robust Approximate Nearest Neighbor Search Using Hierarchical Navigable Small World Graphs, was authored by Yu. A. Malkov and D. A. Yashunin [1][2][3]. It was first published as a preprint in 2016 [4][5][6], with the peer-reviewed journal version appearing in IEEE Transactions on Pattern Analysis and Machine Intelligence in 2018 [1][7][8].",
+  "citations": [
+    {
+      "id": "https://users.cs.utah.edu/~pandey/courses/cs6530/fall24/papers/vectordb/HNSW.pdf",
+      "title": "Efficient and Robust Approximate Nearest Neighbor Search Using Hierarchical Navigable Small World Graphs",
+      "url": "https://users.cs.utah.edu/~pandey/courses/cs6530/fall24/papers/vectordb/HNSW.pdf"
+    },
+    {
+      "id": "https://arxiv.gg/abs/1603.09320",
+      "title": "Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs - arXiv.gg",
+      "url": "https://arxiv.gg/abs/1603.09320",
+      "publishedDate": "2018-08-14T11:38:29.000Z"
+    },
+    "… 6 more item(s) truncated"
+  ],
+  "costDollars": {
+    "total": 0.005
+  }
+}

--- a/src/treg/catalog/examples/exa.web.contents.get.json
+++ b/src/treg/catalog/examples/exa.web.contents.get.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "6ffe69aeb1fade605821e70c9c627ceb",
+  "results": [
+    {
+      "id": "https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world",
+      "title": "Hierarchical navigable small world",
+      "url": "https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world",
+      "author": null,
+      "text": "Hierarchical navigable small world\n\nHierarchical navigable small world (HNSW) is an algorithm for approximate nearest neighbor search. It is used to find items that are similar to a query item in a large collection, without comparing the query with every item one by one.\n\nThe algorithm is commonly used for searching vector data. In these systems, an item such as a document, image, song, or user profile is represented by a list of numbers called a vector. Items with similar vectors are treated as… [2000 chars total]",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Internet_map_1024.jpg/250px-Internet_map_1024.jpg?utm_source=en.wikipedia.org&utm_campaign=parser&utm_content=thumbnail"
+    }
+  ],
+  "statuses": [
+    {
+      "id": "https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world",
+      "status": "success",
+      "source": "cached"
+    }
+  ],
+  "costDollars": {
+    "total": 0.001,
+    "contents": {
+      "text": 0.001
+    }
+  },
+  "searchTime": 11.709653999656439
+}

--- a/src/treg/catalog/examples/exa.web.search.deep.json
+++ b/src/treg/catalog/examples/exa.web.search.deep.json
@@ -1,0 +1,21 @@
+{
+  "requestId": "f09b9cd09341dd73f73e2f293029c0a8",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://github.com/qdrant/qdrant",
+      "title": "qdrant/qdrant",
+      "url": "https://github.com/qdrant/qdrant"
+    },
+    {
+      "id": "https://qdrant.tech/",
+      "title": "Qdrant - Vector Search Engine",
+      "url": "https://qdrant.tech/"
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 5566.6,
+  "costDollars": {
+    "total": 0.012
+  }
+}

--- a/src/treg/catalog/examples/exa.web.search.json
+++ b/src/treg/catalog/examples/exa.web.search.json
@@ -1,0 +1,24 @@
+{
+  "requestId": "b959ac906bdcd6aef3e1ec423a4d2544",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://github.com/qdrant/qdrant",
+      "title": "GitHub - qdrant/qdrant: Qdrant - High-performance ...",
+      "url": "https://github.com/qdrant/qdrant"
+    },
+    {
+      "id": "https://qdrant.tech/",
+      "title": "Qdrant - Vector Search Engine",
+      "url": "https://qdrant.tech/"
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 1464,
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  }
+}

--- a/src/treg/catalog/examples/exa.web.search.news.json
+++ b/src/treg/catalog/examples/exa.web.search.news.json
@@ -1,0 +1,26 @@
+{
+  "requestId": "d7400ad58aee7ef287bd5bb4ddbf59a1",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://www.venturesquare.net/en/1105652/",
+      "title": "Graph, Vector, and Relational DB in One Engine… Graphi, 17 Billion Won Series A - 벤처스퀘어",
+      "url": "https://www.venturesquare.net/en/1105652/",
+      "publishedDate": "2026-08-13T00:00:00.000Z"
+    },
+    {
+      "id": "https://en.wowtale.net/2026/08/14/234729/",
+      "title": "Algorix Raises $11.5M Series A Led by K2 Investment Partners, Bringing Total Funding to $14M - WOWTALE",
+      "url": "https://en.wowtale.net/2026/08/14/234729/",
+      "publishedDate": "2026-08-14T00:00:00.000Z"
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 572.2,
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  }
+}

--- a/src/treg/catalog/examples/exa.web.search.publications.json
+++ b/src/treg/catalog/examples/exa.web.search.publications.json
@@ -1,0 +1,26 @@
+{
+  "requestId": "ebb125edce6185c3967a7767aeb0a7ed",
+  "resolvedSearchType": "",
+  "results": [
+    {
+      "id": "https://exa.ai/library/publication/v0rzqcj5p6t",
+      "title": "A Comparative Study of HNSW Implementations for Scalable Approximate Nearest Neighbor Search",
+      "url": "https://exa.ai/library/publication/v0rzqcj5p6t",
+      "author": "Exa"
+    },
+    {
+      "id": "https://exa.ai/library/publication/zbmp4bqptgm",
+      "title": "AQR-HNSW: Accelerating Approximate Nearest Neighbor Search via Density-aware Quantization and Multi-stage Re-ranking",
+      "url": "https://exa.ai/library/publication/zbmp4bqptgm",
+      "author": "Exa"
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "searchTime": 353.1,
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  }
+}

--- a/src/treg/catalog/examples/exa.web.similar.json
+++ b/src/treg/catalog/examples/exa.web.similar.json
@@ -1,0 +1,27 @@
+{
+  "requestId": "cc211990a15bdf64040b26d28c0ece52",
+  "results": [
+    {
+      "id": "http://github.com/qdrant/qdrant",
+      "title": "qdrant/qdrant",
+      "url": "http://github.com/qdrant/qdrant",
+      "author": null,
+      "score": 0.8847360610961914
+    },
+    {
+      "id": "https://raw.githubusercontent.com/qdrant/qdrant/master/README.md",
+      "title": "",
+      "url": "https://raw.githubusercontent.com/qdrant/qdrant/master/README.md",
+      "author": null,
+      "score": 0.8817116022109985
+    },
+    "… 1 more item(s) truncated"
+  ],
+  "costDollars": {
+    "total": 0.007,
+    "search": {
+      "neural": 0.007
+    }
+  },
+  "searchTime": 279.36948199989274
+}

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -183,6 +183,7 @@ class Settings(BaseSettings):
     platform_key_influencersclub: str = ""  # Bearer key (dashboard JWT); creator discovery + enrichment, fx.yaml $0.598/credit (our $299/500 plan)
     platform_key_crustdata: str = ""  # Bearer key; every call also needs the pinned x-api-version header
     platform_key_aviato: str = ""     # Bearer key; $10 auto-top-up buys 1,000 credits
+    platform_key_exa: str = ""        # x-api-key; dollar-metered ($7/1k searches, $1/1k pages); settles from costDollars.total
     # The KILL SWITCH, and the reason a key alone isn't enough: a provider serves tier 4 only if it is
     # named here AND its key is set. Empty (the default) = tier 4 is entirely off, so a deploy that
     # happens to hold a key can't start spending it by accident. `TREG_PLATFORM_PROVIDERS=""` in the

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1511,6 +1511,43 @@ AVIATO = OAuthProvider(
     probe_path="/billing/balance",
 )
 
+EXA = OAuthProvider(
+    service="exa",
+    display_name="Exa",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Exa API key",
+    # Exa takes the key as an x-api-key header (or Authorization: Bearer). Header, so the key never
+    # lands in a logged URL.
+    token_header="x-api-key",
+    token_format="{secret}",
+    setup_url="https://dashboard.exa.ai/api-keys",
+    setup_action_label="Get your Exa API key",
+    setup_steps=(
+        "Sign in to the Exa dashboard and open API Keys.",
+        "Create a key and copy it.",
+    ),
+    setup_note=(
+        "Every call is metered in dollars from your Exa balance (search $7/1k, page contents $1/1k, "
+        "answer $5/1k). Connecting spends one cached contents call, $0.001."
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="SEO",
+    summary=(
+        "Semantic web search, people/company/news/publication search, page contents, similar links "
+        "and cited answers over Exa's own web index."
+    ),
+    base_url="https://api.exa.ai",
+    docs_url="https://docs.exa.ai/reference/getting-started",
+    # Exa has no free account route (/v0/teams/me answers 404 on every key, 2026-08-27). The cheapest
+    # authenticated call is /contents on a cached public page: $0.001, 401 INVALID_API_KEY on a bad key.
+    probe_path="/contents",
+    probe_method="POST",
+    probe_json={"urls": ["https://example.com"], "text": {"maxCharacters": 1}},
+)
+
 
 # ---- more Enrichment API-key providers (2026-08 category expansion) ---------------------------
 # Eight providers added together to deepen Enrichment: company/people enrichment with prospecting
@@ -2313,7 +2350,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers
-        DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT,
+        DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT, EXA,
         # more Enrichment API-key providers
         LUSHA, CORESIGNAL, DIFFBOT, THECOMPANIESAPI, LEADMAGIC, FIBER_AI, CRUSTDATA, AVIATO,
         COMPANYENRICH, OCEANIO, TOMBA, PREDICTLEADS, FINDYMAIL, BRANDDEV, ICYPEAS, LEADSFORGE,

--- a/src/treg/providers.py
+++ b/src/treg/providers.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 # `auth` is the provider's DEFAULT shape; a per-variable form (CLIENT_ID/SECRET → oauth2) can override
 # it. Served at GET /providers.json so the CLI can refresh centrally (bundled copy = offline fallback);
 # bump CATALOG_VERSION whenever entries change so a cache can tell it's stale.
-CATALOG_VERSION = 11  # v11 2026-08-24: Crustdata + Aviato; provider-required static headers
+CATALOG_VERSION = 12  # v12 2026-08-27: Exa (x-api-key)
 # `skills` (optional) matches a SKILL FOLDER name for file-credential skills that have no env var to
 # key on (OAuth token files etc.) — see `match_skill`. Such providers carry `tokens: []` so the env
 # scanner never mis-detects them as a simple bearer key (their real auth is OAuth + extra headers).

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -1,7 +1,7 @@
 # treg — the tool catalog for your agent
 
 > **OpenRouter, but for agent tools instead of models.** Point an agent at ONE base URL with ONE
-> token and it can do the *job*: 2,835 catalogued endpoints across 59 providers (SEO and SERP
+> token and it can do the *job*: 2,895 catalogued endpoints across 60 providers (SEO and SERP
 > data, backlinks, social and trends, people and company enrichment, ads, scraping) — plus your
 > own team's keys, skills and CLIs. Every credential is injected **server-side**; nothing
 > sensitive lands on the agent's machine, and every call is audited.
@@ -125,7 +125,7 @@ ledger.
 
 ## The catalog — tools you do not have a key for
 
-Curated endpoints across 47 providers, grouped by what they DO: keyword and rank tracking,
+Curated endpoints across 60 providers, grouped by what they DO: keyword and rank tracking,
 backlinks and authority, AI visibility, trending and discovery, publishing to socials, people and
 company enrichment, ads management and creative, measurement. Ask for the task; the catalog tells
 you which endpoints serve it, what each costs, and how you would be served. Exact live counts:
@@ -491,7 +491,7 @@ skills` restrict it (`--dir` sets the location).
 8. **Report the outcome as a doorway, not an install log.** Nobody signed up to read which
    Python version uv picked. Open with ONE line about what they just gained, e.g.:
 
-       treg is live — your agent can now call 2,800+ tools across 59 providers (market data, SEO &
+       treg is live — your agent can now call 2,800+ tools across 60 providers (market data, SEO &
        keywords, social & trends, people/company enrichment, ads, scraping), with $1.00
        of free credit to spend.
 

--- a/src/treg/web/logos/exa.svg
+++ b/src/treg/web/logos/exa.svg
@@ -1,0 +1,5 @@
+<svg width="65" height="65" viewBox="0 0 65 65" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="exa">
+  <rect x="0.75" y="0.988281" width="64" height="64" rx="12.8" fill="#1A1A1A"/>
+  <text x="32.75" y="43" text-anchor="middle" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="30" font-weight="700" fill="#FFFFFF">E</text>
+  <rect x="1.25" y="1.48828" width="63" height="63" rx="12.3" stroke="#ECECEC"/>
+</svg>

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,835 endpoints across 59 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
+description: Reach for this first for external or live data. 2,895 endpoints across 60 providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
 ---
 
 # treg — the tool catalog for your agent
@@ -55,7 +55,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,835 catalogued endpoints across 59 providers, grouped by what they DO: keyword & rank tracking,
+2,895 catalogued endpoints across 60 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement.
 

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -19,7 +19,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
-                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat",
+                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
                 "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",
                 "icypeas", "leadsforge", "influencersclub", "crustdata", "aviato",

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -457,6 +457,12 @@ def test_observed_cost_only_trusts_a_real_number():
     assert A._observed_cost_micro(_mk("dataforseo"), b"not json") is None
     assert A._observed_cost_micro(_mk("dataforseo"), b"[1,2,3]") is None
     assert A._observed_cost_micro(_mk("tikhub"), b'{"cost": 0.5}') is None, "tikhub doesn't report a charge"
+    # exa reports dollars one level down; a 20-result search is the base plus ten $0.001 riders
+    assert A._observed_cost_micro(_mk("exa"), b'{"costDollars": {"total": 0.016, "search": {"neural": 0.016}}}') == 16_000
+    assert A._observed_cost_micro(_mk("exa"), b'{"costDollars": {"total": 0}}') == 0
+    assert A._observed_cost_micro(_mk("exa"), b'{"costDollars": {"total": "0.007"}}') is None
+    assert A._observed_cost_micro(_mk("exa"), b'{"costDollars": 0.007}') is None
+    assert A._observed_cost_micro(_mk("exa"), b'{"results": []}') is None
     assert A._observed_cost_micro(_mk("scrapecreators"), b'{"credits_charged": 2}') == 2 * EP_CALL_MICRO
     assert A._observed_cost_micro(_mk("scrapecreators"), b'{"success": true}') is None
     # akta reports `credits_consumed` — the field that makes its per-section enrich billable at
@@ -818,6 +824,15 @@ def test_crustdata_and_aviato_catalogs_are_platform_priced():
     rows = cat.for_provider("crustdata") + cat.for_provider("aviato")
     assert len(rows) == 29
     assert all(cat.platform_eligible(ep) for ep in rows)
+
+
+def test_exa_catalog_is_platform_priced():
+    """Exa prices in dollars per call, so every curated route converts natively and is eligible."""
+    cat = A.catalog_store.load()
+    rows = cat.for_provider("exa")
+    assert len(rows) == 9
+    assert all(cat.platform_eligible(ep) for ep in rows)
+    assert all(cat.cost_view(ep["cost"], "exa")["usd"] > 0 for ep in rows)
 
 
 def test_brightdata_estimate_counts_the_body_array():

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -45,7 +45,7 @@ def test_every_provider_is_registered():
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
-        "dataforseo", "seranking", "moz", "majestic", "serpstat",
+        "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
         "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",
         "icypeas", "leadsforge", "influencersclub", "crustdata", "aviato",


### PR DESCRIPTION
Adds **Exa** (`exa`) as a key-auth provider: nine curated endpoints on BYOK **and** treg's platform key.

**Why now:** the people-search benchmark run on 2026-08-27 showed Exa's free-text people search is the cheap, fuzzy-query discovery option treg's structured providers lack (`$0.007` per 10 results, ~72% R@1 on Exa's open benchmark). It also brings the first generic web search / page-contents / similar-links / cited-answer capabilities into the catalog (all proposed in the provider file — none existed).

Listing owner / contact: Jason (the platform key is his own Exa account) — no external vendor contact needed.

## What's in the diff
- `oauth_providers.py` — `EXA` registry entry, `x-api-key` header, **POST probe** (`/contents` on example.com, $0.001 cached) because Exa has no free account route (`/v0/teams/me` 404s on every key); appended to `REGISTRY`
- `providers.py` — `CATALOG_VERSION` 11 → 12 (the env-scanner already had an Exa row; no duplicate)
- `config.py` / `render.yaml` — `platform_key_exa` / `TREG_PLATFORM_KEY_EXA` (no value)
- `api.py` — `_observed_cost_micro`: settle from `costDollars.total` (same contract as dataforseo's `cost`), so per-result riders beyond 10, deep-mode uplifts and each contents type bill exactly as Exa reports them
- `catalog/exa.yaml` — 9 endpoints, 7 `proposed_capabilities` (`web.search`, `web.search.deep`, `web.search.news`, `web.search.publications`, `web.contents.get`, `web.similar`, `web.answer`), all `source: observed / confidence: verified`, all stamped `verified: 2026-08-27` with captured examples (people example scrubbed to placeholder identities)
- `logos/exa.svg` neutral lettermark; tests: registry/offerable lists, `test_exa_catalog_is_platform_priced`, observed-cost unit cases; front-door counts 2,835/59 → 2,895/60 with plugin mirrors regenerated; docs fragments (money, catalog, expanding-a-category, env-import, deploy)
- **No fx.yaml row**: Exa prices in USD.

## Verification evidence ledger (2026-08-27)

Meter for every row: `costDollars.total` in the response body (Exa's own charge report), cross-checked against the dashboard rate card ($7/1k search ≤10 results, +$1/1k results beyond, $12/1k deep, $1/1k page per contents type, $5/1k answer).

| endpoint | http | test target | $ observed | catalog price | matches? | evidence |
|---|---|---|---|---|---|---|
| exa.web.search | 200 | "open source vector database written in rust", 3 / 10 / 20 results | 0.007 / 0.007 / 0.016 | per_call $7/1k + $1/1k >10 | ✅ | `costDollars.search.neural`; 20 asked → 19 returned = 0.007 + 9×0.001 |
| exa.web.search (type fast / instant) | 200 | same query, 5 results | 0.007 / 0.007 | same base | ✅ | `costDollars.total` |
| exa.web.search.deep | 200 | same query, deep-lite, 3 & 5 results | 0.012 | per_call $12/1k | ✅ (deep-reasoning $15/1k unobserved, noted) | `costDollars.total` |
| exa.people.search | 200 | "head of security at a fintech in berlin", category people, 3 & 5 | 0.007 | per_call $7/1k | ✅ | `costDollars.search.neural` |
| exa.companies.search | 200 | "vector database startups", category company | 0.007 | per_call $7/1k | ✅ | `costDollars.search.neural` |
| exa.web.search.news | 200 | "vector database funding round", news, since 2026-07-01 | 0.007 | per_call $7/1k | ✅ | `costDollars.search.neural` |
| exa.web.search.publications | 200 | "approximate nearest neighbor search HNSW", publication | 0.007 | per_call $7/1k | ✅ | `costDollars.search.neural` |
| exa.web.contents.get | 200 | wikipedia HNSW page: text; then highlights+summary | 0.001; 0.002 | per_result $1/1k page per type | ✅ | `costDollars.contents: {text: 0.001}` / `{highlights: 0.001, summary: 0.001}` |
| exa.web.similar | 200 | https://qdrant.tech, 5 results, excludeSourceDomain | 0.007 | per_call $7/1k | ✅ | `costDollars.search.neural` |
| exa.web.answer | 200 | "What year was the HNSW paper published and by whom?" | 0.005 | per_call $5/1k | ✅ | `costDollars.total` |

Observed and recorded in the file header: highlights requested **inside** a `/search` call were not billed on top ($0.007, not $0.012).

**Bogus-key probe (live, dev server on this branch):** `POST /connections/token {"provider":"exa","token":"bogus-key-000"}` → `422 {"detail":"Exa rejected that token (Invalid API key)"}` (upstream: `401 {"tag":"INVALID_API_KEY"}`). Real key → `200`, connection `health: ok`; BYOK `/call/exa.web.search` → 200 with `costDollars`. Connection deleted after.

**Tier-4 settle (live, dev server with `TREG_PLATFORM_KEY_EXA` + `exa` allow-listed):** 12-result search → reserve $0.007, **settle $0.009** from `costDollars.total`, `x-treg-cost-micro: 9000`, balance 1.000 → 0.991, ledger rows `reserve -0.007 / settle -0.009 exa.web.search`.

`catalog_validate.py`: OK — 81 provider file(s), 2895 endpoint(s), 0 error(s), 0 warning(s). `build_plugin.py --check`: all five mirrors OK. Suite: 1985 passed; the 63 `test_agent_pages` failures are identical on `main` (`{"detail":"unknown agent"}`), unrelated to this branch.

## Ops (Jason)
- Render: set `TREG_PLATFORM_KEY_EXA` to your Exa key and add `exa` to `TREG_PLATFORM_PROVIDERS`. The key was pasted in chat during this work — **rotate it** on the Exa dashboard after setting the new one in Render.
- Reviewer call: the `web` platform's marketplace label is backlink-centric ("Backlinks, authority & domain metrics"); with search/contents/answer now under it, consider widening the label when merging the proposed capabilities into `capabilities.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ekkEhMZcniBQ4aGX5ZsRD
