### PR TITLE
feat(archive): tables + skeleton — PR 1 of 5 of the cache/archive

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -18,6 +18,7 @@ Regenerate via `scripts/build-map.py`.
 | `alembic.ini` | architecture/data-model.md |
 | `alembic/env.py` | architecture/data-model.md |
 | `alembic/versions/0001_baseline_current_schema.py` | architecture/data-model.md |
+| `alembic/versions/0002_archive_tables.py` | architecture/archive.md, architecture/data-model.md |
 | `assets/brand/og-card.html` | interface/seo.md |
 | `dsh/cordis.patch.yml` | interface/skill.md |
 | `dsh/index.js` | interface/skill.md |
@@ -40,6 +41,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/agents.py` | interface/cli.md |
 | `src/treg/analytics.py` | architecture/data-model.md |
 | `src/treg/api.py` | architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, guides/expanding-a-category.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
+| `src/treg/archive.py` | architecture/archive.md |
 | `src/treg/audit.py` | architecture/data-model.md, ops/deploy.md |
 | `src/treg/billing.py` | architecture/money.md |
 | `src/treg/bootstrap.py` | architecture/composition.md |
@@ -145,10 +147,11 @@ Regenerate via `scripts/build-map.py`.
 | Fragment | Sources |
 |---|---|
 | `architecture/ads-conversions.md` | `adsconv.py`, `adtrack.js` |
+| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py` |
 | `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
 | `architecture/catalog.md` | `catalog-drift.yml`, `catalog_drift.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `catalog_store.py`, `endpoint_stats.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `admin.py`, `web.py`, `dump_surface.py` |
-| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py` |
+| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `test_import_lightness.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           tests/test_migration.py
           tests/test_migration_ddl.py
           tests/test_alembic_baseline.py
+          tests/test_archive.py
           tests/test_call_pool_discipline.py
           tests/test_marketplace_call.py
           tests/test_billing.py

--- a/alembic/versions/0002_archive_tables.py
+++ b/alembic/versions/0002_archive_tables.py
@@ -1,0 +1,84 @@
+"""archive tables — archivekey + archivesnapshot (PR 1 of the cache/archive; treg/archive.py)
+
+Two tables, no writers yet: the recorder arrives in the next PR, so upgrading is pure shape.
+Bodies live in Postgres on purpose — the IdempotentCall precedent (a paid answer worth keeping is
+already stored there). Downgrade drops both; nothing else references them.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-08-27
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision: str = '0002'
+down_revision: str | Sequence[str] | None = '0001'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'archivekey',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('key_hash', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('endpoint_id', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('provider', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('policy', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('ttl_s', sa.Integer(), nullable=False),
+        sa.Column('fetched_at', sa.DateTime(), nullable=False),
+        sa.Column('change_seen', sa.Integer(), nullable=False),
+        sa.Column('stable_seen', sa.Integer(), nullable=False),
+        sa.Column('last_changed_at', sa.DateTime(), nullable=True),
+        sa.Column('volatile_paths', sa.JSON(), nullable=True),
+        sa.Column('heat', sa.Float(), nullable=False),
+        sa.Column('last_requested_at', sa.DateTime(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('key_hash', name='uq_archive_key_hash'),
+    )
+    op.create_index(op.f('ix_archivekey_key_hash'), 'archivekey', ['key_hash'], unique=False)
+    op.create_index(op.f('ix_archivekey_endpoint_id'), 'archivekey', ['endpoint_id'], unique=False)
+    op.create_index(op.f('ix_archivekey_provider'), 'archivekey', ['provider'], unique=False)
+    op.create_index(op.f('ix_archivekey_fetched_at'), 'archivekey', ['fetched_at'], unique=False)
+
+    op.create_table(
+        'archivesnapshot',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('key_id', sa.Integer(), nullable=False),
+        sa.Column('version', sa.Integer(), nullable=False),
+        sa.Column('status_code', sa.Integer(), nullable=False),
+        sa.Column('media_type', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('content_hash', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column('body', sa.LargeBinary(), nullable=True),
+        sa.Column('body_of', sa.Integer(), nullable=True),
+        sa.Column('size_bytes', sa.Integer(), nullable=False),
+        sa.Column('fetched_at', sa.DateTime(), nullable=False),
+        sa.Column('origin', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.ForeignKeyConstraint(['key_id'], ['archivekey.id']),
+        sa.ForeignKeyConstraint(['body_of'], ['archivesnapshot.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('key_id', 'version', name='uq_archive_snapshot_version'),
+    )
+    op.create_index(op.f('ix_archivesnapshot_key_id'), 'archivesnapshot', ['key_id'], unique=False)
+    op.create_index(op.f('ix_archivesnapshot_fetched_at'), 'archivesnapshot', ['fetched_at'], unique=False)
+    op.create_index('ix_archive_snapshot_content', 'archivesnapshot', ['content_hash'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_archive_snapshot_content', table_name='archivesnapshot')
+    op.drop_index(op.f('ix_archivesnapshot_fetched_at'), table_name='archivesnapshot')
+    op.drop_index(op.f('ix_archivesnapshot_key_id'), table_name='archivesnapshot')
+    op.drop_table('archivesnapshot')
+    op.drop_index(op.f('ix_archivekey_fetched_at'), table_name='archivekey')
+    op.drop_index(op.f('ix_archivekey_provider'), table_name='archivekey')
+    op.drop_index(op.f('ix_archivekey_endpoint_id'), table_name='archivekey')
+    op.drop_index(op.f('ix_archivekey_key_hash'), table_name='archivekey')
+    op.drop_table('archivekey')

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -17,10 +17,11 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Google Ads conversion tracking — capture, outbox, upload](architecture/ads-conversions.md) | shipped | adsconv.py, adtrack.js |
+| [Archive — every platform answer, kept and versioned (cache = the newest layer)](architecture/archive.md) | building | archive.py, 0002_archive_tables.py |
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog-drift.yml, catalog_drift.py, catalog_validate.py, aliases.yaml, … |
 | [Application composition and deployment roles](architecture/composition.md) | shipped | bootstrap.py, admin.py, web.py, dump_surface.py |
-| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, sitetrack.js, … |
+| [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, test_import_lightness.py |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -1,0 +1,80 @@
+---
+title: Archive — every platform answer, kept and versioned (cache = the newest layer)
+status: building
+sources:
+  - src/treg/archive.py
+  - alembic/versions/0002_archive_tables.py
+related:
+  - architecture/data-model.md
+  - architecture/proxy-model.md
+  - architecture/catalog.md
+---
+
+# The archive
+
+Two concepts, one word each — the vocabulary is deliberate and mirrors the charter's discipline:
+**cache** is the newest stored answer for a key, served instead of a vendor call while it is
+fresh; **archive** is every version of every answer, kept with its timestamp. The cache is the
+archive's top layer. History is kept on purpose: it is the future data product (per-key
+time-series — backlink profiles over time, price history), not waste.
+
+**Build state (PR 1 of 5).** Only the skeleton exists: the mode gate, the eligibility policy, the
+cache key, and the two tables. Nothing writes or reads them yet. The recorder (PR 2), the catalog
+`cache` field at scale (PR 3), the serve path (PR 4) and the timer learner + refresh worker
+(PR 5) land behind the same switch. Do not document any of those as existing until they do.
+
+## The mode switch
+
+`TREG_ARCHIVE_MODE` (config `archive_mode`, default `off`) → `archive.mode()`:
+`off` | `shadow` (record + learn, serve nothing — phase 0) | `serve` (shadow + answer eligible
+fresh hits — phase 1+). Any unrecognized value degrades to `off`: a typo must disable, never
+enable. Rollback in production is a dashboard env edit, no deploy.
+
+## Eligibility — three gates, in order
+
+1. **Kind.** `kind: action` entries are never stored; only data reads pass.
+2. **License.** Per catalog entry: `cache: forbidden | transient | archive` — either a bare
+   string or a provenance dict `{mode, license_quote, source_url, checked}`, exactly like `cost`
+   provenance. **Absent ⇒ forbidden**: an unjudged provider is never stored (the same posture as
+   the platform offer's free-only guard — the safe answer is the silent one).
+3. **Tier.** Only METERED PLATFORM calls are recorded. Those responses are already fully buffered
+   for the settle (`_buffer_response` needs the provider's reported cost), so recording adds no
+   latency and no new data path. Own-key and own-tool calls stream and are never touched — that
+   is the privacy line, enforced at write time, not filtered at read time.
+
+Gates 1+2 are `archive.policy(entry)`; gate 3 is the hook site's own context.
+
+## The cache key
+
+`archive.cache_key(method, endpoint_id, upstream_url, body, headers)` → sha256 over the canonical
+request: uppercased method, catalog endpoint id (a provider URL reshuffle starts a fresh history),
+sorted query pairs, canonical-JSON body hash (raw hash for non-JSON), plus only `Accept` and
+`Accept-Language` from the caller's headers. Auth/cookies/tracing/encodings never enter the key —
+and credentials could not anyway: injection happens after the key is taken.
+
+## Tables (migration 0002)
+
+`ArchiveKey` — one logical question: `key_hash` (unique), `endpoint_id`, `provider`, effective
+`policy`, AIMD timer state (`ttl_s`, grow ×1.5 capped on stable refetch / shrink ×0.5 floored on
+change — the learner lands in PR 5), change statistics (`change_seen`/`stable_seen`/
+`last_changed_at`), learned `volatile_paths` (noisy JSON paths excluded from change detection,
+never from stored bytes), and demand (`heat`, `last_requested_at`). Platform-scoped, no `org_id`:
+one team's fetch may warm another team's hit, and own-key traffic never enters.
+
+`ArchiveSnapshot` — one version: unique `(key_id, version)`, verbatim `body` bytes, `content_hash`
+(raw sha256) for dedup — an identical consecutive answer stores a version row with `body=NULL,
+body_of=<carrier row>` instead of the bytes again. Bodies live in Postgres (the `IdempotentCall`
+precedent); oversized bodies are skipped by the recorder, never truncated. `origin` says who
+fetched: `caller` | `refresh` | `sample`.
+
+## What the archive must never touch
+
+Money. A cached hit will only TAG existing records "cached" — billing of a cached hit is an
+explicitly deferred founder decision, and no archive code imports ledger/billing. Relay
+faithfulness also extends through time: served bytes are exactly what the vendor sent; noisy-field
+stripping exists only on comparison copies inside change detection.
+
+## Tests
+
+`tests/test_archive.py` — mode degradation, policy refusal-by-default, key canonicalization, and
+table round-trips; listed in CI's serial Postgres job (never xdist — shared database).

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -5,6 +5,7 @@ sources:
   - alembic.ini
   - alembic/env.py
   - alembic/versions/0001_baseline_current_schema.py
+  - alembic/versions/0002_archive_tables.py
   - src/treg/web/sitetrack.js
   - src/treg/models.py
   - src/treg/timeutil.py
@@ -14,6 +15,7 @@ sources:
   - src/treg/analytics.py
   - src/treg/ratestore.py
 related:
+  - architecture/archive.md
   - architecture/proxy-model.md
   - architecture/auth-secrets.md
   - architecture/ads-conversions.md

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -1,0 +1,158 @@
+"""The archive — every platform answer, kept and versioned. (PR 1: skeleton, no behavior.)
+
+Two concepts, one word each (charter discipline):
+
+- **cache**: the newest stored answer for a key, served instead of a vendor call while it is
+  fresh. Serving arrives in a later PR and only when `TREG_ARCHIVE_MODE=serve`.
+- **archive**: every version of every answer, forever, each with its timestamp. The cache is the
+  archive's newest layer. History is deliberately kept — it is the future data product, not waste.
+
+What this module owns: the mode gate, the per-endpoint eligibility policy, and the cache key.
+What it will NEVER own: money. A cached hit tags records "cached" and nothing else — billing of a
+cached hit is an explicitly deferred product decision, and no code here may touch ledger/billing.
+
+The mode is a three-position switch, staged like a rollout and reversible without a deploy:
+  off    → the archive does not exist at runtime (default).
+  shadow → record + learn from responses we already relay; serve nothing (phase 0).
+  serve  → shadow, plus eligible fresh hits are answered from the store (phase 1+).
+
+Eligibility is three gates, in order, all of which must pass:
+  1. Kind — actions (submit/send/write) are never stored; only data reads pass.
+  2. License — per catalog entry: `cache: forbidden | transient | archive`, carried with the
+     license quote and source URL exactly like `cost` provenance. Absent field ⇒ forbidden:
+     a provider nobody has judged must not be stored by default.
+  3. Tier — only METERED PLATFORM calls (treg's own vendor key) are recorded; those responses are
+     already fully buffered for the settle, so recording adds no latency and no new data path.
+     Own-key and own-tool calls stream and are never touched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+from urllib.parse import parse_qsl
+
+from .config import get_settings
+
+# ---------------------------------------------------------------------------------------------
+# Mode
+
+MODES = ("off", "shadow", "serve")
+
+
+def mode() -> str:
+    """The archive's runtime mode. Any unrecognized value degrades to "off": a typo in an env var
+    must disable the feature, never accidentally enable serving."""
+    m = (get_settings().archive_mode or "off").strip().lower()
+    return m if m in MODES else "off"
+
+
+def recording() -> bool:
+    return mode() in ("shadow", "serve")
+
+
+def serving() -> bool:
+    return mode() == "serve"
+
+
+# ---------------------------------------------------------------------------------------------
+# Eligibility (gates 1 + 2; gate 3 — the tier — is the caller's context and is checked at the
+# hook site, where "metered platform call" is already an established fact)
+
+# The catalog's per-entry cache policy values. Absent/unknown ⇒ "forbidden" (see policy()).
+CACHE_FORBIDDEN = "forbidden"   # license forbids storing, or nobody has judged it yet
+CACHE_TRANSIENT = "transient"   # short-lived cache only; old versions are prunable
+CACHE_ARCHIVE = "archive"       # keep versions long-term (public-domain and license-cleared)
+
+_STORABLE = (CACHE_TRANSIENT, CACHE_ARCHIVE)
+
+
+def policy(entry: dict[str, Any] | None) -> str:
+    """Gates 1+2 for one catalog entry, returning the effective cache policy.
+
+    `entry` is the endpoint's catalog mapping (the same dict the resolver already holds). The
+    default is FORBIDDEN on every uncertain branch — an entry that is missing, an action, or an
+    unjudged license must never be stored. This is the same posture as the platform offer's
+    free-only guard: the safe answer is the silent one.
+    """
+    if not entry:
+        return CACHE_FORBIDDEN
+    if entry.get("kind") == "action":  # gate 1 — never store an action's answer
+        return CACHE_FORBIDDEN
+    declared = entry.get("cache")
+    if isinstance(declared, dict):  # provenance form: {mode, license_quote, source_url, checked}
+        declared = declared.get("mode")
+    if declared in _STORABLE:  # gate 2 — an explicit, judged license decision
+        return str(declared)
+    return CACHE_FORBIDDEN
+
+
+def storable(entry: dict[str, Any] | None) -> bool:
+    return policy(entry) in _STORABLE
+
+
+# ---------------------------------------------------------------------------------------------
+# The cache key
+
+
+
+def cache_key(
+    method: str,
+    endpoint_id: str,
+    upstream_url: str,
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> str:
+    """One deterministic key per logical request: sha256 over the canonical request shape.
+
+    Canonical means: uppercased method, the catalog endpoint id (so a provider's URL reshuffle
+    starts a fresh history instead of poisoning the old one), the URL with its query pairs
+    SORTED (param order is transport noise, not meaning), a hash of the body bytes, and the few
+    caller headers that can change a vendor's answer (Accept, Accept-Language) — everything else
+    (auth, cookies, tracing, encodings) is excluded by the allow-list below: headers vary per
+    caller/hop without changing what the vendor computes, and keying on them would shatter one
+    logical answer into many dead entries. Credentials never appear at all — injection happens
+    after the key is taken.
+
+    POST bodies hash canonically when they parse as JSON (sorted keys, separators pinned), raw
+    otherwise: two JSON bodies that differ only in key order are the same question.
+    """
+    base, _, query = upstream_url.partition("?")
+    pairs = sorted(parse_qsl(query, keep_blank_values=True))
+    kept_headers = sorted(
+        (k.lower(), v.strip())
+        for k, v in (headers or {}).items()
+        if k.lower() in ("accept", "accept-language")
+    )
+    material = json.dumps(
+        {
+            "m": method.upper(),
+            "e": endpoint_id,
+            "u": base,
+            "q": pairs,
+            "b": _body_digest(body),
+            "h": kept_headers,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(material.encode()).hexdigest()
+
+
+def _body_digest(body: bytes | None) -> str:
+    if not body:
+        return ""
+    try:
+        parsed = json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return hashlib.sha256(body).hexdigest()
+    canonical = json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def content_hash(body: bytes) -> str:
+    """The stored body's identity, for deduplication across versions: same bytes, one blob.
+    (Change DETECTION will strip noisy fields before comparing — that arrives with the learner in
+    a later PR and never alters what is stored: bytes are kept verbatim, always.)"""
+    return hashlib.sha256(body).hexdigest()

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -243,6 +243,12 @@ class Settings(BaseSettings):
     # default; the test suite disables it (its upstream is an in-process ASGI transport, not real DNS).
     proxy_ssrf_check: bool = True
 
+    # The archive's rollout switch (see treg/archive.py): "off" (default) | "shadow" (record +
+    # learn from metered platform responses, serve nothing) | "serve" (shadow + answer eligible
+    # fresh hits from the store). Any other value degrades to "off" — a typo must disable, never
+    # enable. Staged deliberately so production can sit in "shadow" while phase 0 measures.
+    archive_mode: str = "off"
+
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.
     public_url: str = "https://treg.to"

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1027,3 +1027,82 @@ class SearchMiss(SQLModel, table=True):
     query: str  # the search text that matched nothing, capped by the writer
     source: str = Field(default="api", index=True)  # api (HTTP /catalog/search: web + CLI) | mcp
     created_at: datetime = Field(default_factory=_now, index=True)
+
+
+class ArchiveKey(SQLModel, table=True):
+    """One logical question the platform has answered at least once — the archive's index row.
+
+    The key hash comes from `archive.cache_key`: method + endpoint + canonical URL/query/body,
+    credentials and transport noise excluded. One row carries everything the timer learner and the
+    refresh worker need about this question: when it was last fetched, how it has changed across
+    refetches, how often callers ask (heat), and which JSON paths turned out to be noise.
+
+    **Scoped to the platform, not to an org.** Only metered platform-tier calls are recorded (the
+    module docstring's gate 3): those run on treg's own vendor account, so the answer belongs to
+    the platform and one team's fetch may warm another team's hit. Own-key responses never enter
+    this table — that is the privacy line, drawn at write time, not filtered at read time.
+
+    Timer state is AIMD (grow slowly on stability, shrink fast on change): `ttl_s` is the current
+    per-key timer, adjusted by the learner on every refetch outcome. `change_seen` / `stable_seen`
+    count outcomes so the learner and the admin report can show their evidence. `volatile_paths`
+    holds the learned noisy JSON paths (request ids, server timestamps) excluded from change
+    detection — stored per key, applied before comparing, never applied to stored bytes.
+
+    PR 1 creates the shape only; nothing writes it until the recorder lands (PR 2).
+    """
+
+    __table_args__ = (UniqueConstraint("key_hash", name="uq_archive_key_hash"),)
+
+    id: int | None = Field(default=None, primary_key=True)
+    key_hash: str = Field(index=True)              # sha256 from archive.cache_key
+    endpoint_id: str = Field(index=True)           # catalog endpoint id — policy + report joins
+    provider: str = Field(default="", index=True)  # denormalized for per-provider budgets/reports
+    policy: str = Field(default="forbidden")       # effective policy when last written (see archive)
+    # --- timer (AIMD) ---
+    ttl_s: int = Field(default=0)                  # current per-key timer; 0 = no serving opinion yet
+    fetched_at: datetime = Field(default_factory=_now, index=True)  # newest snapshot's fetch time
+    # --- change statistics (the learner's evidence) ---
+    change_seen: int = Field(default=0)            # refetches whose stripped hash differed
+    stable_seen: int = Field(default=0)            # refetches whose stripped hash matched
+    last_changed_at: datetime | None = Field(default=None)
+    volatile_paths: list = Field(default_factory=list, sa_column=Column(JSON))
+    # --- demand (what earns a refresh) ---
+    heat: float = Field(default=0.0)               # decayed request rate, updated on each hit/miss
+    last_requested_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_now)
+
+
+class ArchiveSnapshot(SQLModel, table=True):
+    """One stored answer — a version in a key's history. The newest fresh one is the cache.
+
+    Bytes are kept VERBATIM: change detection strips noisy fields on a comparison copy, never on
+    what is stored, so a served hit replays exactly what the vendor sent (relay faithfulness,
+    extended through time). `content_hash` (sha256 of the raw body) deduplicates: consecutive
+    identical answers add a version row but reference the same bytes via `body_of` instead of
+    storing them again — the history of "asked on these dates, same answer" is itself data.
+
+    Bodies live in Postgres, the IdempotentCall precedent (a paid answer worth keeping is already
+    stored there today); `body` is NULL when `body_of` points at the row that carries the bytes.
+    Oversized bodies are skipped by the recorder, not truncated — a half answer is worse than none.
+
+    Old versions of a `transient`-policy key are prunable; an `archive`-policy key keeps its
+    history — that difference is enforced by the (future) worker's pruning pass, not by schema.
+    """
+
+    __table_args__ = (
+        UniqueConstraint("key_id", "version", name="uq_archive_snapshot_version"),
+        Index("ix_archive_snapshot_content", "content_hash"),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    key_id: int = Field(foreign_key="archivekey.id", index=True)
+    version: int = Field(default=1)                # 1..N within the key, newest = max
+    status_code: int = Field(default=200)
+    media_type: str = Field(default="")
+    content_hash: str                              # sha256 of the RAW body (dedup identity)
+    body: bytes | None = Field(default=None)       # verbatim bytes, or NULL when body_of is set
+    body_of: int | None = Field(default=None, foreign_key="archivesnapshot.id")
+    size_bytes: int = Field(default=0)             # of the raw body, even when deduplicated
+    fetched_at: datetime = Field(default_factory=_now, index=True)
+    # Who triggered the fetch: "caller" (a real request) | "refresh" (worker) | "sample" (learner).
+    origin: str = Field(default="caller")

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,161 @@
+"""The archive skeleton (PR 1): mode gate, eligibility policy, cache key, and the two tables.
+
+No behavior exists yet — the recorder and the serve path arrive in later PRs — so these tests pin
+the contracts everything later builds on: the mode degrades safely, the policy refuses every
+uncertain input, the key is canonical, and the tables round-trip on both engines (this file runs
+in the sqlite suite and in CI's serial Postgres job).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from treg import archive
+from treg.archive import cache_key, content_hash, policy, storable
+from treg.models import ArchiveKey, ArchiveSnapshot
+
+
+# ---------------------------------------------------------------------------------------------
+# Mode: a typo must disable, never enable
+
+def test_mode_defaults_off():
+    assert archive.mode() == "off"
+    assert not archive.recording()
+    assert not archive.serving()
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("shadow", "shadow"), ("serve", "serve"), ("off", "off"),
+    ("SERVE", "serve"), ("  shadow ", "shadow"),          # env-var hygiene
+    ("on", "off"), ("true", "off"), ("", "off"), ("srve", "off"),  # typos degrade to off
+])
+def test_mode_parses_and_degrades(monkeypatch, raw, expected):
+    from treg.config import get_settings
+    monkeypatch.setattr(get_settings(), "archive_mode", raw)
+    assert archive.mode() == expected
+
+
+def test_serve_implies_recording(monkeypatch):
+    from treg.config import get_settings
+    monkeypatch.setattr(get_settings(), "archive_mode", "serve")
+    assert archive.recording() and archive.serving()
+    monkeypatch.setattr(get_settings(), "archive_mode", "shadow")
+    assert archive.recording() and not archive.serving()
+
+
+# ---------------------------------------------------------------------------------------------
+# Policy: forbidden on every uncertain branch
+
+def test_policy_refuses_uncertainty():
+    assert policy(None) == "forbidden"
+    assert policy({}) == "forbidden"
+    assert policy({"kind": "read"}) == "forbidden"                  # unjudged license
+    assert policy({"cache": "everything"}) == "forbidden"           # unknown value
+    assert policy({"cache": {"mode": "keep"}}) == "forbidden"       # unknown value, dict form
+
+
+def test_policy_action_beats_license():
+    # Gate order: an action is never stored even when a license field says archive.
+    assert policy({"kind": "action", "cache": "archive"}) == "forbidden"
+
+
+def test_policy_accepts_judged_entries():
+    assert policy({"cache": "transient"}) == "transient"
+    assert policy({"cache": "archive"}) == "archive"
+    # Provenance form — the catalog carries the license quote alongside, policy reads only mode.
+    entry = {"cache": {"mode": "archive", "license_quote": "CC0", "source_url": "https://x"}}
+    assert policy(entry) == "archive"
+    assert storable(entry)
+    assert not storable({"kind": "action", "cache": "archive"})
+
+
+# ---------------------------------------------------------------------------------------------
+# Cache key: canonical, deterministic, and blind to transport noise
+
+def test_key_is_deterministic_and_canonical():
+    a = cache_key("POST", "prov.x", "https://api.x/v1/q?b=2&a=1", b'{"z": 1, "a": 2}')
+    b = cache_key("post", "prov.x", "https://api.x/v1/q?a=1&b=2", b'{"a": 2, "z": 1}')
+    assert a == b and len(a) == 64
+
+
+def test_key_separates_real_differences():
+    base = cache_key("GET", "prov.x", "https://api.x/v1/q?a=1")
+    assert base != cache_key("POST", "prov.x", "https://api.x/v1/q?a=1")      # method
+    assert base != cache_key("GET", "prov.y", "https://api.x/v1/q?a=1")       # endpoint id
+    assert base != cache_key("GET", "prov.x", "https://api.x/v1/q?a=2")       # param value
+    assert base != cache_key("GET", "prov.x", "https://api.x/v1/q?a=1&b=1")   # extra param
+
+
+def test_key_ignores_caller_noise_headers():
+    quiet = cache_key("GET", "p.e", "https://api.x/q?a=1")
+    noisy = cache_key("GET", "p.e", "https://api.x/q?a=1", headers={
+        "Authorization": "Bearer zzz", "Cookie": "s=1", "User-Agent": "curl",
+        "X-Treg-Token": "t", "Accept-Encoding": "gzip", "traceparent": "00-x",
+    })
+    assert quiet == noisy
+    # …but Accept genuinely changes some vendors' answers, so it keys.
+    assert quiet != cache_key("GET", "p.e", "https://api.x/q?a=1",
+                              headers={"Accept": "text/csv"})
+
+
+def test_key_non_json_body_hashes_raw():
+    a = cache_key("POST", "p.e", "https://api.x/q", b"plain text body")
+    b = cache_key("POST", "p.e", "https://api.x/q", b"plain text body")
+    c = cache_key("POST", "p.e", "https://api.x/q", b"other text body")
+    assert a == b != c
+
+
+def test_content_hash_is_raw_identity():
+    assert content_hash(b"same") == content_hash(b"same")
+    assert content_hash(b"same") != content_hash(b"Same")
+
+
+# ---------------------------------------------------------------------------------------------
+# Tables: round-trip on the running engine (sqlite locally, Postgres in CI's serial job)
+
+@pytest.mark.anyio
+async def test_tables_round_trip(clients):  # clients fixture resets the schema on this engine
+    from sqlmodel import select
+    from treg.db import session_maker
+
+    async with session_maker() as s:
+        key = ArchiveKey(key_hash="k" * 64, endpoint_id="prov.search", provider="prov",
+                         policy="transient", ttl_s=3600, volatile_paths=["$.request_id"])
+        s.add(key)
+        await s.commit()
+        await s.refresh(key)
+
+        first = ArchiveSnapshot(key_id=key.id, version=1, status_code=200,
+                                media_type="application/json", content_hash=content_hash(b"{}"),
+                                body=b"{}", size_bytes=2, origin="caller")
+        s.add(first)
+        await s.commit()
+        await s.refresh(first)
+        # Deduplicated second version: same bytes, body carried by reference, not stored again.
+        s.add(ArchiveSnapshot(key_id=key.id, version=2, status_code=200,
+                              media_type="application/json", content_hash=first.content_hash,
+                              body=None, body_of=first.id, size_bytes=2, origin="refresh"))
+        await s.commit()
+
+        rows = (await s.execute(select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
+                                .order_by(ArchiveSnapshot.version))).scalars().all()
+        assert [r.version for r in rows] == [1, 2]
+        assert rows[0].body == b"{}" and rows[1].body is None
+        assert rows[1].body_of == rows[0].id
+        stored = (await s.execute(select(ArchiveKey)
+                                  .where(ArchiveKey.key_hash == "k" * 64))).scalars().one()
+        assert stored.volatile_paths == ["$.request_id"]
+        assert stored.change_seen == 0 and stored.heat == 0.0
+
+
+@pytest.mark.anyio
+async def test_key_hash_is_unique(clients):
+    from sqlalchemy.exc import IntegrityError
+    from treg.db import session_maker
+
+    async with session_maker() as s:
+        s.add(ArchiveKey(key_hash="dup", endpoint_id="a"))
+        await s.commit()
+        s.add(ArchiveKey(key_hash="dup", endpoint_id="b"))
+        with pytest.raises(IntegrityError):
+            await s.commit()


### PR DESCRIPTION
First slice of the cache/archive system (design + implementation pages reviewed with Unclecode). Shape only: the two tables, the migration, the archive module (mode gate, eligibility policy, canonical cache key), and the mode setting defaulting to off. Nothing writes or reads the tables yet; production behavior is unchanged.

Next slices, each behind the same switch: recorder (phase 0 shadow), catalog cache field, serve path, learner + refresh worker.

Out of scope by founder decision: billing of a cached hit. No archive code touches ledger/billing.

Tests: 21 new, in both the sqlite suite and the serial Postgres job. Schema parity with the migration is enforced by test_alembic_baseline.