### PR TITLE
feat(archive): the recorder — PR 2 of 5, phase 0 shadow

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -40,11 +40,11 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/agent_pages.py` | interface/seo.md |
 | `src/treg/agents.py` | interface/cli.md |
 | `src/treg/analytics.py` | architecture/data-model.md |
-| `src/treg/api.py` | architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, guides/expanding-a-category.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
+| `src/treg/api.py` | architecture/archive.md, architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, guides/expanding-a-category.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
 | `src/treg/archive.py` | architecture/archive.md |
 | `src/treg/audit.py` | architecture/data-model.md, ops/deploy.md |
 | `src/treg/billing.py` | architecture/money.md |
-| `src/treg/bootstrap.py` | architecture/composition.md |
+| `src/treg/bootstrap.py` | architecture/archive.md, architecture/composition.md |
 | `src/treg/catalog/aliases.yaml` | architecture/catalog.md |
 | `src/treg/catalog/aviato.yaml` | architecture/catalog.md |
 | `src/treg/catalog/capabilities.yaml` | interface/catalog-review-proposal.md |
@@ -147,7 +147,7 @@ Regenerate via `scripts/build-map.py`.
 | Fragment | Sources |
 |---|---|
 | `architecture/ads-conversions.md` | `adsconv.py`, `adtrack.js` |
-| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py` |
+| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py`, `api.py`, `bootstrap.py` |
 | `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
 | `architecture/catalog.md` | `catalog-drift.yml`, `catalog_drift.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `catalog_store.py`, `endpoint_stats.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `admin.py`, `web.py`, `dump_surface.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -17,7 +17,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Google Ads conversion tracking — capture, outbox, upload](architecture/ads-conversions.md) | shipped | adsconv.py, adtrack.js |
-| [Archive — every platform answer, kept and versioned (cache = the newest layer)](architecture/archive.md) | building | archive.py, 0002_archive_tables.py |
+| [Archive — every platform answer, kept and versioned (cache = the newest layer)](architecture/archive.md) | building | archive.py, 0002_archive_tables.py, api.py, bootstrap.py |
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog-drift.yml, catalog_drift.py, catalog_validate.py, aliases.yaml, … |
 | [Application composition and deployment roles](architecture/composition.md) | shipped | bootstrap.py, admin.py, web.py, dump_surface.py |

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -4,6 +4,8 @@ status: building
 sources:
   - src/treg/archive.py
   - alembic/versions/0002_archive_tables.py
+  - src/treg/api.py
+  - src/treg/bootstrap.py
 related:
   - architecture/data-model.md
   - architecture/proxy-model.md
@@ -18,10 +20,29 @@ fresh; **archive** is every version of every answer, kept with its timestamp. Th
 archive's top layer. History is kept on purpose: it is the future data product (per-key
 time-series — backlink profiles over time, price history), not waste.
 
-**Build state (PR 1 of 5).** Only the skeleton exists: the mode gate, the eligibility policy, the
-cache key, and the two tables. Nothing writes or reads them yet. The recorder (PR 2), the catalog
-`cache` field at scale (PR 3), the serve path (PR 4) and the timer learner + refresh worker
-(PR 5) land behind the same switch. Do not document any of those as existing until they do.
+**Build state (PR 2 of 5).** The skeleton (PR 1) and the recorder (PR 2) exist: in `shadow` or
+`serve` mode, every metered 2xx platform answer is observed. The catalog `cache` field at scale
+(PR 3), the serve path (PR 4) and the timer learner + refresh worker (PR 5) land behind the same
+switch. Do not document any of those as existing until they do.
+
+## The recorder (PR 2)
+
+Hooked in `call_tool` immediately after `_buffer_response` — the one line where "metered platform
+call, body already in memory" is a fact, which IS eligibility gate 3. Metered 2xx only; the
+`X-Treg-Cache`-style serve headers do not exist yet. `archive.record()` is fire-and-forget with
+audit's discipline: bounded pending set (512), failures swallowed with a log line, `drain()` on
+shutdown (bootstrap) and in tests. A recorder crash cannot fail a call (tested).
+
+**Counted vs kept.** Statistics and the raw-body `content_hash` are recorded for every observed
+answer (a hash is an identity, not the content); body BYTES are kept only when the entry's cache
+policy is `transient`/`archive` AND the body fits `archive_max_body_bytes` (default 2 MB —
+skipped whole, never truncated). Consecutive identical answers dedup via `body_of`; an identical
+answer arriving where bytes were never kept stores them now, so a policy upgrade heals forward
+without a backfill. The key URL is rebuilt as the vendor sees it (resolved upstream + forwarded
+caller params, resolution-consumed names excluded) — credential injection happens later, in the
+relay, so a credential cannot enter the key or the store from the request side. One considered
+edge for PR 3's per-provider judgment: a vendor that ECHOES the request credential in a 2xx body
+would have it stored — judge `cache` per provider with that in mind.
 
 ## The mode switch
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -52,7 +52,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer
 from sqlmodel import select
 
-from . import adsconv, agent_pages, analytics, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, health, injectors, ledger, localrun, oauth
+from . import adsconv, agent_pages, analytics, archive, audit, billing, catalog_store, crypto, demo as demo_seed, email as email_sender, health, injectors, ledger, localrun, oauth
 from . import oauth_providers
 from . import pubfeed, ratestore, reconcile, referrals, runner, sandbox as demo_sandbox, session as sess
 from .config import LEGACY_PUBLIC_HOSTS, PUBLIC_HOST_ALIASES, get_settings, platform_setting_name
@@ -9275,6 +9275,20 @@ async def call_tool(
                 # in the body (see _buffer_response). A failure while draining is still an upstream
                 # failure, so it becomes a 502 and the hold goes back.
                 response, body = await _buffer_response(response)
+                # The archive's recorder (docs/context/architecture/archive.md): the body is already
+                # in memory here for the settle, so observing it costs nothing on-request. Metered
+                # 2xx only — gate 3 of eligibility is exactly "this fact, at this line". Off unless
+                # TREG_ARCHIVE_MODE says otherwise; record() is fire-and-forget and never raises.
+                if archive.recording() and 200 <= response.status_code < 300:
+                    archive.record(
+                        method=request.method, endpoint_id=mk.endpoint_id, provider=mk.provider,
+                        url=archive.key_url(upstream_url, request.query_params.multi_items(),
+                                            drop_params or set()),
+                        caller_body=caller_body,
+                        headers={k: request.headers.get(k, "") for k in ("accept", "accept-language")},
+                        status_code=response.status_code,
+                        media_type=response.headers.get("content-type", ""),
+                        body=body)
             elif response.status_code >= 400:
                 # Preserve streaming for own-key and own-tool calls while retaining only the small
                 # diagnostic head. The replacement response replays every consumed byte verbatim.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -156,3 +156,145 @@ def content_hash(body: bytes) -> str:
     (Change DETECTION will strip noisy fields before comparing — that arrives with the learner in
     a later PR and never alters what is stored: bytes are kept verbatim, always.)"""
     return hashlib.sha256(body).hexdigest()
+
+
+# ---------------------------------------------------------------------------------------------
+# The recorder (PR 2) — fire-and-forget, audit's discipline: bounded, swallowed, drainable.
+# A recording hiccup must NEVER surface into a call's result, and a burst must never OOM the
+# server. Unlike audit there is no shed-counter subtlety: a dropped snapshot is one lost sample
+# in a statistics stream that the next identical call re-supplies.
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+_log = logging.getLogger("treg.archive")
+_pending: set[asyncio.Task] = set()
+_MAX_PENDING = 512
+
+
+def _utcnow() -> datetime:
+    # Naive UTC, matching every models.py datetime column (see models._now).
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def key_url(upstream_url: str, query_items: list[tuple[str, str]], exclude: set[str]) -> str:
+    """The URL as the vendor effectively sees it, before credential injection: the resolved
+    upstream (fixed query included) plus the caller's forwarded params — minus `exclude`, the
+    resolution-consumed names the relay drops. Order does not matter; cache_key sorts."""
+    from urllib.parse import urlencode
+    q = urlencode([(k, v) for k, v in query_items if k not in exclude])
+    if not q:
+        return upstream_url
+    return f"{upstream_url}&{q}" if "?" in upstream_url else f"{upstream_url}?{q}"
+
+
+def record(
+    *,
+    method: str,
+    endpoint_id: str,
+    provider: str,
+    url: str,
+    caller_body: bytes,
+    headers: dict[str, str],
+    status_code: int,
+    media_type: str,
+    body: bytes,
+) -> None:
+    """Schedule one observation of a metered platform answer. Returns immediately; the write runs
+    off-request on its own session. Call sites gate on `recording()` and 2xx — this function
+    trusts them and never raises."""
+    if len(_pending) >= _MAX_PENDING:  # shed load; the stream self-heals on the next call
+        return
+    task = asyncio.create_task(_store(
+        method=method, endpoint_id=endpoint_id, provider=provider, url=url,
+        caller_body=caller_body, headers=headers, status_code=status_code,
+        media_type=media_type, body=body))
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
+
+
+async def drain() -> None:
+    """Flush in-flight recordings — shutdown and tests."""
+    while _pending:
+        await asyncio.gather(*list(_pending), return_exceptions=True)
+
+
+async def _store(
+    *,
+    method: str,
+    endpoint_id: str,
+    provider: str,
+    url: str,
+    caller_body: bytes,
+    headers: dict[str, str],
+    status_code: int,
+    media_type: str,
+    body: bytes,
+) -> None:
+    """One recording: upsert the key, append a version, keep the change statistics honest.
+
+    The license decides what is KEPT, not what is COUNTED: statistics and the content hash are
+    recorded for every metered 2xx (a hash is an identity, not the content), while the body bytes
+    are stored only when the catalog entry's cache policy allows it AND the body fits the size
+    cap. Oversized bodies are skipped whole, never truncated. Consecutive identical answers
+    deduplicate: the new version row points at the row carrying the bytes (`body_of`) — and when
+    an identical answer arrives at a key whose bytes were never kept (policy or cap changed), the
+    bytes are stored now, so a policy upgrade heals the store forward without a backfill."""
+    try:
+        from sqlalchemy import select
+        from sqlalchemy.exc import IntegrityError
+
+        from . import catalog_store
+        from .db import session_maker
+        from .models import ArchiveKey, ArchiveSnapshot
+
+        entry = catalog_store.load().by_id.get(endpoint_id)
+        pol = policy(entry)
+        kh = cache_key(method, endpoint_id, url, caller_body, headers)
+        ch = content_hash(body)
+        cap = get_settings().archive_max_body_bytes
+        keep_bytes = pol in _STORABLE and len(body) <= cap
+        now = _utcnow()
+
+        async with session_maker() as s:
+            key = (await s.execute(
+                select(ArchiveKey).where(ArchiveKey.key_hash == kh))).scalars().one_or_none()
+            if key is None:
+                key = ArchiveKey(key_hash=kh, endpoint_id=endpoint_id, provider=provider,
+                                 policy=pol, fetched_at=now, last_requested_at=now)
+                s.add(key)
+                try:
+                    await s.commit()
+                except IntegrityError:  # two first-calls raced; the winner's row is the key
+                    await s.rollback()
+                    key = (await s.execute(
+                        select(ArchiveKey).where(ArchiveKey.key_hash == kh))).scalars().one()
+
+            newest = (await s.execute(
+                select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
+                .order_by(ArchiveSnapshot.version.desc()).limit(1))).scalars().first()
+
+            snap = ArchiveSnapshot(
+                key_id=key.id, version=1 if newest is None else newest.version + 1,
+                status_code=status_code, media_type=media_type, content_hash=ch,
+                body=body if keep_bytes else None, size_bytes=len(body),
+                fetched_at=now, origin="caller")
+            if newest is not None:
+                if newest.content_hash == ch:
+                    key.stable_seen += 1
+                    carrier = newest.body_of or (newest.id if newest.body is not None else None)
+                    if carrier is not None:      # bytes already on file — reference, don't repeat
+                        snap.body, snap.body_of = None, carrier
+                else:
+                    key.change_seen += 1
+                    key.last_changed_at = now
+            key.fetched_at, key.last_requested_at, key.policy = now, now, pol
+            s.add(key)
+            s.add(snap)
+            try:
+                await s.commit()
+            except IntegrityError:  # version race with a concurrent recording — drop this sample
+                await s.rollback()
+    except Exception:  # noqa: BLE001 — recording must never surface anywhere
+        _log.warning("archive recording dropped for %s", endpoint_id, exc_info=True)

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.routing import BaseRoute, Mount
 
-from . import adsconv, analytics, audit
+from . import adsconv, analytics, archive, audit
 from .config import get_settings
 from .db import init_db, session_maker
 
@@ -415,6 +415,7 @@ def _lifespan(api_module, role: AppRole):
                 ads_task.cancel()
             await audit.drain()
             await analytics.drain()
+            await archive.drain()
             await app.state.http.aclose()
 
     return lifespan

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -249,6 +249,9 @@ class Settings(BaseSettings):
     # fresh hits from the store). Any other value degrades to "off" — a typo must disable, never
     # enable. Staged deliberately so production can sit in "shadow" while phase 0 measures.
     archive_mode: str = "off"
+    # Bodies above this size are hash-counted but never stored (skipped whole, not truncated):
+    # the archive is for API JSON answers, not downloads. Statistics still record size_bytes.
+    archive_max_body_bytes: int = 2_000_000
 
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from treg import archive
+from treg import api as A, archive
 from treg.archive import cache_key, content_hash, policy, storable
 from treg.models import ArchiveKey, ArchiveSnapshot
 
@@ -159,3 +159,130 @@ async def test_key_hash_is_unique(clients):
         s.add(ArchiveKey(key_hash="dup", endpoint_id="b"))
         with pytest.raises(IntegrityError):
             await s.commit()
+
+
+# ---------------------------------------------------------------------------------------------
+# The recorder (PR 2): observe metered platform answers, never touch the call
+
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from treg import catalog_store
+from treg.config import get_settings
+from treg.db import session_maker
+
+EP = "tikhub.tiktok.video.comments"   # tier-4 eligible in the test allow-list, GET, $0.001/call
+
+
+@pytest.fixture
+def platform_on(monkeypatch):
+    """Tier 4 the way a deploy turns it on (mirrors test_marketplace_call)."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_TIKHUB", "PLATFORM-TIKHUB-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def shadow(platform_on, monkeypatch):
+    monkeypatch.setattr(get_settings(), "archive_mode", "shadow")
+
+
+async def _rows():
+    await archive.drain()
+    async with session_maker() as s:
+        keys = (await s.execute(select(ArchiveKey))).scalars().all()
+        snaps = (await s.execute(
+            select(ArchiveSnapshot).order_by(ArchiveSnapshot.version))).scalars().all()
+        return keys, snaps
+
+
+@pytest.mark.anyio
+async def test_recorder_observes_a_metered_call(clients: AsyncClient, shadow):
+    r = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r.status_code == 200, r.text
+    keys, snaps = await _rows()
+    assert len(keys) == 1 and len(snaps) == 1
+    assert keys[0].endpoint_id == EP and keys[0].provider == "tikhub"
+    # No cache field on this entry yet → policy forbidden → hash-only: counted, never kept.
+    assert keys[0].policy == "forbidden"
+    assert snaps[0].body is None and snaps[0].body_of is None
+    assert snaps[0].size_bytes > 0 and len(snaps[0].content_hash) == 64
+    assert snaps[0].origin == "caller"
+
+
+@pytest.mark.anyio
+async def test_recorder_off_by_default(clients: AsyncClient, platform_on):
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200
+    keys, snaps = await _rows()
+    assert keys == [] and snaps == []
+
+
+@pytest.mark.anyio
+async def test_storable_policy_keeps_bytes_and_dedups(clients: AsyncClient, shadow, monkeypatch):
+    entry = catalog_store.load().by_id[EP]
+    monkeypatch.setitem(entry, "cache", "transient")
+    r1 = await clients.get(f"/call/{EP}?aweme_id=7")
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7")   # same key, identical echo answer
+    assert r1.status_code == r2.status_code == 200
+    keys, snaps = await _rows()
+    assert len(keys) == 1 and [s.version for s in snaps] == [1, 2]
+    assert keys[0].policy == "transient"
+    assert snaps[0].body is not None                    # bytes kept once…
+    assert snaps[1].body is None and snaps[1].body_of == snaps[0].id  # …then referenced
+    assert keys[0].stable_seen == 1 and keys[0].change_seen == 0
+
+
+@pytest.mark.anyio
+async def test_different_answer_counts_as_change(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"n": 1}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"n": 2}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    keys, snaps = await _rows()
+    assert len(keys) == 1 and len(snaps) == 2
+    assert keys[0].change_seen == 1 and keys[0].stable_seen == 0
+    assert keys[0].last_changed_at is not None
+    assert snaps[0].body == b'{"n": 1}' and snaps[1].body == b'{"n": 2}'
+
+
+@pytest.mark.anyio
+async def test_different_params_are_different_keys(clients: AsyncClient, shadow):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await clients.get(f"/call/{EP}?aweme_id=8")
+    keys, _ = await _rows()
+    assert len(keys) == 2
+
+
+@pytest.mark.anyio
+async def test_oversized_body_is_counted_not_kept(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    monkeypatch.setattr(get_settings(), "archive_max_body_bytes", 4)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200
+    _, snaps = await _rows()
+    assert len(snaps) == 1 and snaps[0].body is None and snaps[0].size_bytes > 4
+
+
+@pytest.mark.anyio
+async def test_error_responses_are_not_recorded(clients: AsyncClient, shadow, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setattr(A, "relay", _fake_relay(500, b"boom"))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 500
+    keys, snaps = await _rows()
+    assert keys == [] and snaps == []
+
+
+@pytest.mark.anyio
+async def test_a_recorder_crash_never_fails_the_call(clients: AsyncClient, shadow, monkeypatch):
+    async def _boom(**kwargs):
+        raise RuntimeError("recorder exploded")
+    monkeypatch.setattr(archive, "_store", _boom)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200, r.text
+    await archive.drain()


### PR DESCRIPTION
Second slice. In shadow mode every metered 2xx platform answer is observed: key + versioned snapshot + change statistics, fire-and-forget after the buffer that already exists for the settle, so the request path pays nothing. Statistics and content hash are recorded for every observed answer; body bytes only where the catalog cache policy allows (none yet — that is PR 3) and under the 2 MB cap. A recorder crash cannot fail a call (tested). Production behavior with the switch off: none.

8 new tests through the real tier-4 metered path.