### PR TITLE
feat(archive): catalog cache field + phase-0 report — PR 3 of 5

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -83,7 +83,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/catalog/google-search-console.yaml` | architecture/catalog.md |
 | `src/treg/catalog/justoneapi.extended.yaml` | architecture/catalog.md |
 | `src/treg/catalog/tikhub.extended.yaml` | architecture/catalog.md |
-| `src/treg/catalog_store.py` | architecture/catalog.md, interface/api.md, interface/catalog-review-proposal.md |
+| `src/treg/catalog_store.py` | architecture/archive.md, architecture/catalog.md, interface/api.md, interface/catalog-review-proposal.md |
 | `src/treg/cli.py` | interface/cli.md, interface/onboarding.md, interface/shell.md |
 | `src/treg/config.py` | architecture/super-admin.md, guides/expanding-a-category.md, ops/deploy.md |
 | `src/treg/convert.py` | interface/cli.md |
@@ -112,7 +112,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/reconcile.py` | architecture/money.md |
 | `src/treg/referrals.py` | architecture/data-model.md, architecture/money.md |
 | `src/treg/routers/__init__.py` | interface/api.md |
-| `src/treg/routers/admin.py` | architecture/composition.md, architecture/money.md, architecture/super-admin.md, interface/api.md |
+| `src/treg/routers/admin.py` | architecture/archive.md, architecture/composition.md, architecture/money.md, architecture/super-admin.md, interface/api.md |
 | `src/treg/routers/catalog.py` | architecture/catalog.md, interface/api.md |
 | `src/treg/routers/dependencies.py` | architecture/multi-tenancy.md, architecture/super-admin.md, interface/api.md |
 | `src/treg/routers/web.py` | architecture/composition.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
@@ -147,7 +147,7 @@ Regenerate via `scripts/build-map.py`.
 | Fragment | Sources |
 |---|---|
 | `architecture/ads-conversions.md` | `adsconv.py`, `adtrack.js` |
-| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py`, `api.py`, `bootstrap.py` |
+| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py`, `api.py`, `bootstrap.py`, `catalog_store.py`, `admin.py` |
 | `architecture/auth-secrets.md` | `injectors.py`, `crypto.py`, `oauth.py`, `oauth_providers.py`, `health.py` |
 | `architecture/catalog.md` | `catalog-drift.yml`, `catalog_drift.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `catalog_store.py`, `endpoint_stats.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `admin.py`, `web.py`, `dump_surface.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -17,7 +17,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Google Ads conversion tracking — capture, outbox, upload](architecture/ads-conversions.md) | shipped | adsconv.py, adtrack.js |
-| [Archive — every platform answer, kept and versioned (cache = the newest layer)](architecture/archive.md) | building | archive.py, 0002_archive_tables.py, api.py, bootstrap.py |
+| [Archive — every platform answer, kept and versioned (cache = the newest layer)](architecture/archive.md) | building | archive.py, 0002_archive_tables.py, api.py, bootstrap.py, … |
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, crypto.py, oauth.py, oauth_providers.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | catalog-drift.yml, catalog_drift.py, catalog_validate.py, aliases.yaml, … |
 | [Application composition and deployment roles](architecture/composition.md) | shipped | bootstrap.py, admin.py, web.py, dump_surface.py |

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -6,6 +6,8 @@ sources:
   - alembic/versions/0002_archive_tables.py
   - src/treg/api.py
   - src/treg/bootstrap.py
+  - src/treg/catalog_store.py
+  - src/treg/routers/admin.py
 related:
   - architecture/data-model.md
   - architecture/proxy-model.md
@@ -20,10 +22,33 @@ fresh; **archive** is every version of every answer, kept with its timestamp. Th
 archive's top layer. History is kept on purpose: it is the future data product (per-key
 time-series — backlink profiles over time, price history), not waste.
 
-**Build state (PR 2 of 5).** The skeleton (PR 1) and the recorder (PR 2) exist: in `shadow` or
-`serve` mode, every metered 2xx platform answer is observed. The catalog `cache` field at scale
-(PR 3), the serve path (PR 4) and the timer learner + refresh worker (PR 5) land behind the same
-switch. Do not document any of those as existing until they do.
+**Build state (PR 3 of 5).** The skeleton (PR 1), the recorder (PR 2) and the catalog `cache`
+field + phase-0 report (PR 3) exist. The serve path (PR 4) and the timer learner + refresh worker
+(PR 5) land behind the same switch. Do not document either as existing until they do.
+
+## The catalog `cache` field (PR 3)
+
+One licence judgment per PROVIDER, written once at the YAML file header and inherited by every
+endpoint below it; an endpoint's own `cache:` overrides. `catalog_store` carries the header form
+into `provider_meta["cache"]` (dict, not stringified) and stamps the effective value onto each
+normalized endpoint (`entry["cache"]`, absent ⇒ None ⇒ forbidden). The provenance form is
+`{mode, license_quote, source_url, checked}` plus optional `max_age_s` — a vendor-imposed refresh
+ceiling the learner (PR 5) must treat as a hard cap. `tests/test_archive.py` validates every
+declared field in the shipped catalog: a judged entry must carry its quote, source and date.
+
+First judged set (checked 2026-08-27): **coingecko** `transient` with `max_age_s: 86400` — their
+API terms permit caching with a mandatory 24-hour refresh and §6.2 forbids anything longer-lived;
+**finnhub** `forbidden` — their terms bar sharing data or derived results with any third party,
+and serving one team's cached fetch to another is exactly that. DataForSEO and SerpApi terms were
+read the same day and are SILENT on storage — left absent (= forbidden) rather than guessed.
+36 other platform providers remain unjudged: absent, forbidden, safe.
+
+## The phase-0 report (PR 3)
+
+`GET /admin/archive` (superadmin): totals (mode, keys, snapshots, bodies kept, kept bytes) and
+per-endpoint rows — keys, refetches (stable+changed), `change_ratio` = changed/refetches (the raw
+how-fast-does-it-move signal), newest fetch. This is the evidence surface for cache judgments and
+later for the timers; it complements `/admin/reconcile/repeats`, which prices what repeats cost.
 
 ## The recorder (PR 2)
 

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -230,6 +230,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/admin/reconcile/drift', ('GET',), 'admin_reconcile_drift'),
     ('/admin/reconcile/spend', ('GET',), 'admin_reconcile_spend'),
     ('/admin/reconcile/repeats', ('GET',), 'admin_reconcile_repeats'),
+    ('/admin/archive', ('GET',), 'admin_archive'),
     ('/admin/referrals', ('GET',), 'admin_referrals'),
     ('/catalog/endpoints/{endpoint_id}/access', ('GET',), 'catalog_endpoint_access'),
     ('/run', ('POST',), 'run_tool_server'),

--- a/src/treg/catalog/coingecko.yaml
+++ b/src/treg/catalog/coingecko.yaml
@@ -12,6 +12,15 @@ source:
 # The demo host answers 200 to anything and demo keys ride a different header; neither is served
 # here. Verified live 2026-08-15 on treg's own Basic key; examples captured the same day.
 pricing_url: https://www.coingecko.com/en/api/pricing
+# Archive/cache judgment (applies to every endpoint below; see docs/context/architecture/archive.md).
+# CoinGecko PERMITS caching with a mandatory refresh ceiling; §6.2 forbids anything longer-lived
+# ("duplicate, reproduce, copy, store"), so this is transient with a hard 24h cap, never archive.
+cache:
+  mode: transient
+  max_age_s: 86400
+  license_quote: "We do not encourage caching or storage of Data. However, if you must cache or store Data: You should refresh the cache at least every 24 hours"
+  source_url: https://www.coingecko.com/en/api_terms
+  checked: "2026-08-27"
 endpoints:
   - id: coingecko.simple.price
     domain: crypto

--- a/src/treg/catalog/finnhub.yaml
+++ b/src/treg/catalog/finnhub.yaml
@@ -8,6 +8,14 @@ source:
 # licensing table). No fx rate -> usd null -> platform_eligible FALSE by construction. A team pasting
 # its own Finnhub key gets everything at their own tier's limits.
 pricing_url: https://finnhub.io/pricing
+# Archive/cache judgment: a JUDGED forbidden, distinct from unjudged-absent. Finnhub's terms bar
+# sharing data or derived results with any third party without written approval, and serving one
+# team's cached fetch to another team is exactly that. Live relaying stays as-is; storage is out.
+cache:
+  mode: forbidden
+  license_quote: "You hereby agree to not redistribute or share access to data or derived results from the data obtained from Finnhub with anyone or any 3rd party without written approval from Finnhub."
+  source_url: https://finnhub.io/terms-of-service
+  checked: "2026-08-27"
 endpoints:
   - id: finnhub.quote
     domain: stocks

--- a/src/treg/catalog_store.py
+++ b/src/treg/catalog_store.py
@@ -238,9 +238,16 @@ def _parse(directory: Path) -> Catalog:
                            ("docs", (doc.get("source") or {}).get("docs"))):
             if value and not meta.get(key):
                 meta[key] = str(value)
+        # The provider's cache policy (docs/context/architecture/archive.md): one licence judgment
+        # at the file header covers every endpoint below it; an endpoint's own `cache:` overrides.
+        # Kept as the dict/provenance form, not stringified — archive.policy reads `mode` from it.
+        if doc.get("cache") and not meta.get("cache"):
+            meta["cache"] = doc["cache"]
         for raw in doc.get("endpoints") or []:
             if not isinstance(raw, dict) or not raw.get("id"):
                 continue
+            if "cache" not in raw and meta.get("cache") is not None:
+                raw = {**raw, "cache": meta["cache"]}
             ep = _normalize(raw, provider, directory)
             if ep["id"] in by_id:  # first file wins; ids are unique by validator contract
                 continue
@@ -415,6 +422,9 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # Absent `tier` means core: the curated first wave predates the split, and treating an
         # unmarked endpoint as extended would hide it from the platform view entirely.
         "tier": raw.get("tier") or "core",
+        # The archive's per-endpoint cache policy (absent ⇒ forbidden — see archive.policy);
+        # inherited from the file header unless the endpoint declares its own.
+        "cache": raw.get("cache"),
         "verified": str(verified) if verified else None,
         # {status, means} — a status the provider uses for "asked and answered: no result" (PDL
         # 404s a person it has no record of). Only endpoints with evidenced miss semantics carry

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -13,7 +13,7 @@ from sqlmodel import select
 from .. import reconcile
 from ..config import get_settings
 from ..db import get_session, session_maker
-from ..models import Bundle, CallRecord, Membership, Org, Referral, Secret, Tool, User
+from ..models import ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, Membership, Org, Referral, Secret, Tool, User
 from ..timeutil import as_naive as _as_naive
 from ..timeutil import utcnow_naive as _utcnow_naive
 from .dependencies import require_superadmin
@@ -321,6 +321,50 @@ async def admin_reconcile_repeats(
     since = reconcile.window_start(since_days)
     return {"since": since.isoformat(), "since_days": since_days,
             **await reconcile.repeat_rate(db, since, top=top)}
+
+
+@app.get("/admin/archive")
+async def admin_archive(
+    top: int = 50,
+    _: str = Depends(require_superadmin), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Phase 0's read-out: what the recorder has observed, per endpoint — the evidence for the
+    per-provider cache judgments (PR 3) and later for the timers. `refetches` counts repeat
+    observations of an existing key (stable + changed); `change_ratio` is changed/refetches, the
+    raw signal for how fast an endpoint's answers move. `kept_bytes` only grows where a judged
+    licence allows storing (docs/context/architecture/archive.md)."""
+    from .. import archive as archive_mod
+
+    keys = func.count(ArchiveKey.id)
+    stable = func.coalesce(func.sum(ArchiveKey.stable_seen), 0)
+    changed = func.coalesce(func.sum(ArchiveKey.change_seen), 0)
+    per_ep = (await db.execute(
+        select(ArchiveKey.endpoint_id, ArchiveKey.provider, ArchiveKey.policy,
+               keys, stable, changed, func.max(ArchiveKey.fetched_at))
+        .group_by(ArchiveKey.endpoint_id, ArchiveKey.provider, ArchiveKey.policy)
+        .order_by((stable + changed).desc(), keys.desc()).limit(max(1, min(top, 500))))).all()
+
+    snap_totals = (await db.execute(
+        select(func.count(ArchiveSnapshot.id),
+               func.coalesce(func.sum(ArchiveSnapshot.size_bytes), 0))
+        .where(ArchiveSnapshot.body.is_not(None)))).one()
+    all_snaps = (await db.execute(select(func.count(ArchiveSnapshot.id)))).scalar_one()
+    total_keys = (await db.execute(select(func.count(ArchiveKey.id)))).scalar_one()
+
+    rows = []
+    for endpoint_id, provider, pol, n_keys, n_stable, n_changed, newest in per_ep:
+        refetches = int(n_stable) + int(n_changed)
+        rows.append({
+            "endpoint_id": endpoint_id, "provider": provider, "policy": pol,
+            "keys": int(n_keys), "refetches": refetches,
+            "stable": int(n_stable), "changed": int(n_changed),
+            "change_ratio": round(int(n_changed) / refetches, 4) if refetches else None,
+            "newest_fetch": newest.isoformat() if newest else None,
+        })
+    return {"mode": archive_mod.mode(),
+            "keys": int(total_keys), "snapshots": int(all_snaps),
+            "bodies_kept": int(snap_totals[0]), "kept_bytes": int(snap_totals[1]),
+            "endpoints": rows}
 
 
 @app.get("/admin/referrals")

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -1404,6 +1404,69 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/admin/archive": {
+      "get": {
+        "description": "Phase 0's read-out: what the recorder has observed, per endpoint — the evidence for the\nper-provider cache judgments (PR 3) and later for the timers. `refetches` counts repeat\nobservations of an existing key (stable + changed); `change_ratio` is changed/refetches, the\nraw signal for how fast an endpoint's answers move. `kept_bytes` only grows where a judged\nlicence allows storing (docs/context/architecture/archive.md).",
+        "operationId": "admin_archive_admin_archive_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "top",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "title": "Top",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-token",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Token",
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "treg_session",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Treg Session",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Admin Archive Admin Archive Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Archive"
+      }
+    },
     "/admin/calls": {
       "get": {
         "operationId": "admin_calls_admin_calls_get",

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -1807,6 +1807,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "admin_archive",
+    "path": "/admin/archive"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "admin_referrals",
     "path": "/admin/referrals"
   },

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -286,3 +286,74 @@ async def test_a_recorder_crash_never_fails_the_call(clients: AsyncClient, shado
     r = await clients.get(f"/call/{EP}?aweme_id=7")
     assert r.status_code == 200, r.text
     await archive.drain()
+
+
+# ---------------------------------------------------------------------------------------------
+# The catalog cache field (PR 3): one judgment at the file header covers the provider
+
+def test_header_cache_is_inherited_by_endpoints():
+    c = catalog_store.load()
+    entry = c.by_id["coingecko.simple.price"]
+    assert entry["cache"]["mode"] == "transient"          # inherited from the file header
+    assert archive.policy(entry) == "transient"
+    assert entry["cache"]["max_age_s"] == 86400           # CoinGecko's own 24h refresh ceiling
+    assert archive.policy(c.by_id["finnhub.quote"]) == "forbidden"   # judged forbidden
+    assert c.by_id["finnhub.quote"]["cache"]["license_quote"]        # …with its evidence attached
+    assert c.by_id["tikhub.tiktok.video.comments"]["cache"] is None  # unjudged stays absent
+
+
+def test_every_declared_cache_field_in_the_catalog_is_valid():
+    """A judged entry must be complete: a known mode, and provenance when declared as a dict.
+    Absent is always legal (⇒ forbidden). This is the validator for the whole shipped catalog."""
+    for ep in catalog_store.load().by_id.values():
+        declared = ep.get("cache")
+        if declared is None:
+            continue
+        if isinstance(declared, dict):
+            assert declared.get("mode") in ("forbidden", "transient", "archive"), ep["id"]
+            assert declared.get("license_quote"), f"{ep['id']}: judged cache needs its quote"
+            assert declared.get("source_url"), f"{ep['id']}: judged cache needs its source"
+            assert declared.get("checked"), f"{ep['id']}: judged cache needs its check date"
+        else:
+            assert declared in ("forbidden", "transient", "archive"), ep["id"]
+
+
+@pytest.mark.anyio
+async def test_recorder_respects_a_judged_forbidden(clients: AsyncClient, shadow, monkeypatch):
+    """A provider judged forbidden is counted, never kept — even though the policy is declared."""
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache",
+                        {"mode": "forbidden", "license_quote": "q", "source_url": "u", "checked": "d"})
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    keys, snaps = await _rows()
+    assert keys[0].policy == "forbidden"
+    assert snaps[0].body is None and snaps[0].size_bytes > 0
+
+
+# ---------------------------------------------------------------------------------------------
+# The phase-0 report (PR 3): GET /admin/archive
+
+@pytest.mark.anyio
+async def test_admin_archive_report(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setenv("TREG_ADMIN_TOKEN", "ADM-TOKEN")
+    get_settings.cache_clear()
+    try:
+        monkeypatch.setattr(get_settings(), "archive_mode", "shadow")
+        monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+        await clients.get(f"/call/{EP}?aweme_id=7")
+        await clients.get(f"/call/{EP}?aweme_id=7")   # refetch, identical ⇒ stable
+        await clients.get(f"/call/{EP}?aweme_id=9")   # second key
+        await archive.drain()
+
+        assert (await clients.get("/admin/archive")).status_code == 403  # org token is not admin
+        r = await clients.get("/admin/archive", headers={"X-Treg-Token": "ADM-TOKEN"})
+        assert r.status_code == 200, r.text
+        d = r.json()
+        assert d["mode"] == "shadow" and d["keys"] == 2 and d["snapshots"] == 3
+        assert d["bodies_kept"] == 2 and d["kept_bytes"] > 0   # v2 deduplicated, never re-stored
+        row = next(x for x in d["endpoints"] if x["endpoint_id"] == EP)
+        assert row == {"endpoint_id": EP, "provider": "tikhub", "policy": "transient",
+                       "keys": 2, "refetches": 1, "stable": 1, "changed": 0,
+                       "change_ratio": 0.0, "newest_fetch": row["newest_fetch"]}
+        assert row["newest_fetch"] is not None
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
Third slice. One licence judgment per provider at the YAML header, inherited by its endpoints; provenance form with quote, source and check date, validated catalog-wide by test. First judged set from the vendors' own terms read today: coingecko transient with a 24h ceiling (their explicit refresh requirement), finnhub judged forbidden (third-party sharing ban). DataForSEO and SerpApi are silent on storage, so they stay absent = forbidden rather than guessed.

Plus GET /admin/archive: the phase-0 evidence report (keys, refetches, change ratio per endpoint; kept bytes only where a judged licence allows).

4 new tests; surface snapshots regenerated for the new route.