### PR TITLE
feat(archive): the serve path — PR 4 of 5

### DIFF
--- a/alembic/versions/0003_callrecord_cached.py
+++ b/alembic/versions/0003_callrecord_cached.py
@@ -1,0 +1,37 @@
+"""callrecord.cached — the archive's serve tag (PR 4; treg/archive.py serving)
+
+One boolean on the audit row: True when the archive answered instead of the vendor. Money
+columns stay identical to a live call on purpose — pricing a hit is a deferred founder decision
+that will attach to this tag. server_default false backfills every historical row correctly:
+nothing before this migration was ever served from the store.
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-08-27
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '0003'
+down_revision: str | Sequence[str] | None = '0002'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('callrecord', sa.Column('cached', sa.Boolean(), nullable=False,
+                                          server_default=sa.false()))
+    # Drop the backfill default so the schema matches the model (no server default). SQLite cannot
+    # ALTER a default in place; batch mode rebuilds the table there and is a plain ALTER on Postgres.
+    with op.batch_alter_table('callrecord') as batch:
+        batch.alter_column('cached', server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callrecord', 'cached')

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -22,9 +22,33 @@ fresh; **archive** is every version of every answer, kept with its timestamp. Th
 archive's top layer. History is kept on purpose: it is the future data product (per-key
 time-series — backlink profiles over time, price history), not waste.
 
-**Build state (PR 3 of 5).** The skeleton (PR 1), the recorder (PR 2) and the catalog `cache`
-field + phase-0 report (PR 3) exist. The serve path (PR 4) and the timer learner + refresh worker
-(PR 5) land behind the same switch. Do not document either as existing until they do.
+**Build state (PR 4 of 5).** The skeleton, the recorder, the catalog `cache` field + report,
+and the serve path exist. The timer learner + refresh worker (PR 5) land behind the same switch.
+Do not document them as existing until they do.
+
+## Serving (PR 4)
+
+`archive.lookup()` runs in `call_tool` at the RELAY's position — after every access/deny/cap gate
+AND after the money reserve, replacing only the network trip. **Money on a hit is identical to a
+live call, on purpose**: reserve, settle, cost header and ledger rows are byte-for-byte the same;
+the response carries `X-Treg-Cache: hit`, `X-Treg-Fetched-At`, `X-Treg-Age`, and the audit row
+(+ `/calls`) carries `cached: true`. The founder's deferred pricing decision attaches to that tag
+later without touching this code. A hit is NOT a new observation: no snapshot, no change
+statistics — only `last_requested_at` (fire-and-forget `_touch`), the demand signal PR 5 reads.
+
+Freshness (phase 1) is `archive.ttl_for(entry)`: FIXED guesses per capability prefix
+(`crypto.price` 5 min, `web.search` 1 h, `people.`/`company.` 7 d, default 1 h), always capped by
+a judged `cache.max_age_s` (CoinGecko's 24 h duty). The learner (PR 5) replaces these per key.
+
+Caller controls, always honored: `Cache-Control: no-cache`/`no-store` forces a live call (the
+read-after-write escape — the archive never guesses cross-endpoint effects); `X-Treg-Max-Age`
+tightens (never widens) the window; malformed values are ignored. None on every uncertain branch
+— serving off, veto, unjudged policy, no/stale/hash-only snapshot — and a lookup fault degrades
+to a live call (an api-side belt catches even a fault in lookup's own plumbing; tested by making
+it explode).
+
+`CallRecord.cached` (migration 0003) is declared LAST in the model to match ALTER TABLE's
+append position — the baseline parity test compares column order.
 
 ## The catalog `cache` field (PR 3)
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -5723,6 +5723,9 @@ async def list_calls(
             "endpoint_id": c.endpoint_id,
             "provider": c.provider,
             "credential_tier": c.credential_tier,
+            # The archive answered instead of the vendor; the money columns are still identical to
+            # a live call on purpose (docs/context/architecture/archive.md).
+            "cached": c.cached,
             "cost_estimated_micro": c.cost_estimated_micro,
             "cost_observed_micro": c.cost_observed_micro,
             "cost_charged_micro": c.cost_charged_micro,
@@ -9028,6 +9031,7 @@ async def call_tool(
         request.state.idem_claim = (caller.membership.id, idem_key)
 
     drop_params: set[str] = set()
+    served_hit = False  # a cached hit — set where the archive answers instead of the vendor
     mk: MarketplaceCall | None = None
     own_tool_miss: dict | None = None
     try:
@@ -9120,6 +9124,9 @@ async def call_tool(
         if mk is not None:
             telemetry |= {
                 "endpoint_id": mk.endpoint_id, "provider": mk.provider, "credential_tier": mk.tier,
+                # The archive answered instead of the vendor; money columns are identical to a
+                # live call ON PURPOSE (the pricing of a hit is a deferred founder decision).
+                **({"cached": True} if served_hit else {}),
                 # An org credential riding treg's pay-per-use OAuth app: tier stays tool/credential
                 # (the credential IS theirs), this says who the upstream billed.
                 **({"oauth_billed": True} if mk.billed_oauth else {}),
@@ -9267,10 +9274,34 @@ async def call_tool(
         # is `expire_on_commit=False`, so `tool`/`secrets`/`caller.org` stay usable without a reload.
         await db.commit()
         try:
-            response = await relay(request, upstream_url, tool, secrets, request.app.state.http,
-                                   drop_params=drop_params or None,
-                                   force_identity=mk is not None and mk.metered)
-            if mk is not None and mk.metered:
+            # The archive's serve path (docs/context/architecture/archive.md): a fresh stored
+            # answer replaces ONLY the network trip. Reserve already ran, settle/audit/cost header
+            # run below unchanged — a cached hit is billed exactly like the live call it stands in
+            # for, tagged `cached`, and the founder's later pricing decision attaches to that tag.
+            served = None
+            if mk is not None and mk.metered and archive.serving():
+                try:
+                    served = await archive.lookup(
+                        method=request.method, endpoint_id=mk.endpoint_id,
+                        url=archive.key_url(upstream_url, request.query_params.multi_items(),
+                                            drop_params or set()),
+                        caller_body=caller_body, request_headers=request.headers)
+                except Exception:  # noqa: BLE001 — lookup swallows internally; this catches even a
+                    served = None  # fault in its own plumbing. Cache trouble must cost a vendor
+                    #              call, never a 500.
+            if served is not None:
+                body = served["body"]
+                response = Response(content=body, status_code=served["status_code"],
+                                    media_type=served["media_type"] or None)
+                response.headers["X-Treg-Cache"] = "hit"
+                response.headers["X-Treg-Fetched-At"] = served["fetched_at"].isoformat() + "Z"
+                response.headers["X-Treg-Age"] = str(served["age_s"])
+                served_hit = True
+            else:
+                response = await relay(request, upstream_url, tool, secrets, request.app.state.http,
+                                       drop_params=drop_params or None,
+                                       force_identity=mk is not None and mk.metered)
+            if served is None and mk is not None and mk.metered:
                 # Metered calls don't stream: settling needs the provider's own reported cost, which is
                 # in the body (see _buffer_response). A failure while draining is still an upstream
                 # failure, so it becomes a 502 and the hold goes back.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -298,3 +298,155 @@ async def _store(
                 await s.rollback()
     except Exception:  # noqa: BLE001 — recording must never surface anywhere
         _log.warning("archive recording dropped for %s", endpoint_id, exc_info=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# Serving (PR 4) — the cache answers instead of the vendor, and NOTHING about money changes.
+# The lookup replaces only the network trip: reserve, settle, audit and the cost header all run
+# exactly as on a live call, at today's price, and the response is tagged cached. Whatever
+# billing rule the founder later chooses attaches to that tag without touching this code.
+
+# Phase-1 freshness: FIXED guesses per capability prefix, longest prefix wins, seconds. These are
+# deliberately conservative starting values, not knowledge — the learner (PR 5) replaces them per
+# key. A vendor-declared `cache.max_age_s` (CoinGecko's 24h refresh duty) always CAPS the result.
+_TTL_DEFAULTS: tuple[tuple[str, int], ...] = (
+    ("crypto.price", 300),        # live-ish market numbers: minutes, not hours
+    ("crypto.", 3600),
+    ("web.search", 3600),         # SERPs move within hours
+    ("web.papers", 86400),        # scholarly metadata barely moves
+    ("people.", 7 * 86400),       # person/company enrichment: weeks in practice, start at one
+    ("company.", 7 * 86400),
+    ("seo.", 86400),              # backlink/rank profiles: days
+)
+DEFAULT_TTL_S = 3600
+
+
+def ttl_for(entry: dict[str, Any] | None) -> int:
+    """The phase-1 freshness window for one endpoint, in seconds. Longest matching capability
+    prefix from the fixed table (else the 1-hour default), always capped by the vendor's own
+    declared ceiling when the judged `cache` block carries `max_age_s`."""
+    capability = str((entry or {}).get("capability") or "")
+    ttl = DEFAULT_TTL_S
+    best = -1
+    for prefix, seconds in _TTL_DEFAULTS:
+        if capability.startswith(prefix) and len(prefix) > best:
+            best, ttl = len(prefix), seconds
+    declared = (entry or {}).get("cache")
+    if isinstance(declared, dict):
+        try:
+            cap = int(declared.get("max_age_s") or 0)
+        except (TypeError, ValueError):
+            cap = 0
+        if cap > 0:
+            ttl = min(ttl, cap)
+    return ttl
+
+
+def caller_forces_live(headers) -> bool:
+    """`Cache-Control: no-cache` (or no-store) is the caller's veto — always honored, billed as
+    the live call it causes. This is also the read-after-write escape: the archive never guesses
+    cross-endpoint effects (that would be modeling the upstream)."""
+    cc = (headers.get("cache-control") or "").lower()
+    return "no-cache" in cc or "no-store" in cc
+
+
+def caller_max_age_s(headers) -> int | None:
+    """`X-Treg-Max-Age`: the caller's own freshness bar in seconds, tightening (never widening)
+    the endpoint's window. Malformed values are ignored — a typo must not change behavior."""
+    raw = headers.get("x-treg-max-age")
+    if raw is None:
+        return None
+    try:
+        v = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return v if v >= 0 else None
+
+
+async def lookup(
+    *,
+    method: str,
+    endpoint_id: str,
+    url: str,
+    caller_body: bytes,
+    request_headers,
+) -> dict[str, Any] | None:
+    """A fresh stored answer for this exact question, or None (= make the live call).
+
+    None on every uncertain branch: serving off, caller veto, unjudged/forbidden policy, no
+    snapshot, stale snapshot, bytes not on file. The age check runs against the newest snapshot's
+    own fetch time, and the window is min(endpoint TTL, caller X-Treg-Max-Age). Returns the
+    verbatim stored bytes plus what the hook needs for headers: fetched_at and age_s."""
+    try:
+        if not serving() or caller_forces_live(request_headers):
+            return None
+        from sqlalchemy import select
+
+        from . import catalog_store
+        from .db import session_maker
+        from .models import ArchiveKey, ArchiveSnapshot
+
+        entry = catalog_store.load().by_id.get(endpoint_id)
+        if not storable(entry):
+            return None
+        window = ttl_for(entry)
+        wanted = caller_max_age_s(request_headers)
+        if wanted is not None:
+            window = min(window, wanted)
+        if window <= 0:
+            return None
+
+        kh = cache_key(method, endpoint_id, url, caller_body, {
+            k: request_headers.get(k, "") for k in ("accept", "accept-language")})
+        async with session_maker() as s:
+            key = (await s.execute(
+                select(ArchiveKey).where(ArchiveKey.key_hash == kh))).scalars().one_or_none()
+            if key is None:
+                return None
+            newest = (await s.execute(
+                select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
+                .order_by(ArchiveSnapshot.version.desc()).limit(1))).scalars().first()
+            if newest is None or not (200 <= newest.status_code < 300):
+                return None
+            age_s = int((_utcnow() - newest.fetched_at).total_seconds())
+            if age_s < 0 or age_s > window:
+                return None
+            body = newest.body
+            if body is None and newest.body_of is not None:  # deduplicated — follow the carrier
+                carrier = await s.get(ArchiveSnapshot, newest.body_of)
+                body = carrier.body if carrier is not None else None
+            if body is None:  # hash-only history (policy or size cap at record time)
+                return None
+        _touch(kh)
+        return {"body": body, "media_type": newest.media_type,
+                "status_code": newest.status_code, "fetched_at": newest.fetched_at,
+                "age_s": age_s}
+    except Exception:  # noqa: BLE001 — a lookup fault must degrade to a live call, never a 500
+        _log.warning("archive lookup failed for %s — serving live", endpoint_id, exc_info=True)
+        return None
+
+
+def _touch(key_hash: str) -> None:
+    """Note that a stored answer was actually wanted (last_requested_at) — fire-and-forget, the
+    demand signal the refresh worker (PR 5) will read. A served hit is NOT a recording: it adds
+    no snapshot and no change statistics, because nothing new was observed."""
+    if len(_pending) >= _MAX_PENDING:
+        return
+    task = asyncio.create_task(_touch_write(key_hash))
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)
+
+
+async def _touch_write(key_hash: str) -> None:
+    try:
+        from sqlalchemy import update
+
+        from .db import session_maker
+        from .models import ArchiveKey
+
+        async with session_maker() as s:
+            await s.execute(update(ArchiveKey).where(ArchiveKey.key_hash == key_hash)
+                            .values(last_requested_at=_utcnow()))
+            await s.commit()
+    except Exception:  # noqa: BLE001
+        _log.warning("archive touch dropped", exc_info=True)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -285,6 +285,11 @@ class CallRecord(SQLModel, table=True):
     budget_val: str = Field(default="", index=True)
     tags: dict | None = Field(default=None, sa_column=Column("tags", JSON, nullable=True))
     created_at: datetime = Field(default_factory=_now)
+    # True when the archive served this answer instead of the vendor (X-Treg-Cache: hit).
+    # Money columns stay identical to a live call on purpose — pricing a hit is a deferred
+    # founder decision (docs/context/architecture/archive.md). Declared LAST to match the
+    # migration's ALTER TABLE ADD COLUMN position (the baseline parity test compares order).
+    cached: bool = Field(default=False)
 
 
 class RunRecord(SQLModel, table=True):

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import pytest
 
-from treg import api as A, archive
+from treg import api as A, archive, audit
 from treg.archive import cache_key, content_hash, policy, storable
 from treg.models import ArchiveKey, ArchiveSnapshot
 
@@ -357,3 +357,122 @@ async def test_admin_archive_report(clients: AsyncClient, shadow, monkeypatch):
         assert row["newest_fetch"] is not None
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------------------------
+# Serving (PR 4): the cache answers instead of the vendor; money is IDENTICAL to a live call
+
+def test_ttl_fixed_guesses_and_vendor_ceiling():
+    assert archive.ttl_for({"capability": "crypto.price.current"}) == 300
+    assert archive.ttl_for({"capability": "ads.library.search"}) == 3600      # table default
+    assert archive.ttl_for({"capability": "people.email.verify"}) == 7 * 86400
+    # The vendor's declared ceiling CAPS, never widens.
+    assert archive.ttl_for({"capability": "people.email.verify",
+                            "cache": {"mode": "transient", "max_age_s": 60}}) == 60
+    assert archive.ttl_for({"capability": "crypto.price.current",
+                            "cache": {"mode": "transient", "max_age_s": 86400}}) == 300
+
+
+@pytest.fixture
+def serve(platform_on, monkeypatch):
+    monkeypatch.setattr(get_settings(), "archive_mode", "serve")
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+
+
+async def _spend_entries(clients):
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    return (await clients.get(f"/orgs/{org_id}/balance")).json()["entries"]["items"]
+
+
+@pytest.mark.anyio
+async def test_a_hit_serves_stored_bytes_and_bills_like_live(clients: AsyncClient, serve):
+    r1 = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r1.status_code == 200 and "x-treg-cache" not in r1.headers
+    await archive.drain()
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r2.status_code == 200, r2.text
+    assert r2.headers["X-Treg-Cache"] == "hit"
+    assert int(r2.headers["X-Treg-Age"]) >= 0 and r2.headers["X-Treg-Fetched-At"]
+    assert r2.content == r1.content                      # verbatim stored bytes
+    # Money identical to live, ON PURPOSE: both calls reserved and settled at the same price.
+    assert r2.headers.get("X-Treg-Cost-Micro") == r1.headers.get("X-Treg-Cost-Micro")
+    kinds = [e["kind"] for e in await _spend_entries(clients)]
+    assert kinds[:4] == ["settle", "reserve", "settle", "reserve"]
+    # The audit rows disagree only on the tag.
+    await audit.drain()
+    rows = (await clients.get("/calls")).json()
+    assert [row.get("cached") for row in rows[:2]] == [True, False]
+
+
+@pytest.mark.anyio
+async def test_a_hit_is_not_a_new_observation(clients: AsyncClient, serve):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    await clients.get(f"/call/{EP}?aweme_id=7")          # hit
+    keys, snaps = await _rows()
+    assert len(snaps) == 1                                # no snapshot added by the hit
+    assert keys[0].stable_seen == 0 and keys[0].change_seen == 0
+    assert keys[0].last_requested_at is not None          # …but demand was noted
+
+
+@pytest.mark.anyio
+async def test_no_cache_forces_live(clients: AsyncClient, serve):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Cache-Control": "no-cache"})
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers
+    _, snaps = await _rows()
+    assert len(snaps) == 2                                # the forced live call was recorded
+
+
+@pytest.mark.anyio
+async def test_max_age_zero_forces_live(clients: AsyncClient, serve):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"X-Treg-Max-Age": "0"})
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers
+
+
+@pytest.mark.anyio
+async def test_a_stale_snapshot_is_not_served(clients: AsyncClient, serve, monkeypatch):
+    from datetime import timedelta
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    async with session_maker() as s:                      # age the snapshot past every window
+        snap = (await s.execute(select(ArchiveSnapshot))).scalars().one()
+        snap.fetched_at = snap.fetched_at - timedelta(days=30)
+        s.add(snap)
+        await s.commit()
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers
+
+
+@pytest.mark.anyio
+async def test_unjudged_policy_never_serves(clients: AsyncClient, platform_on, monkeypatch):
+    monkeypatch.setattr(get_settings(), "archive_mode", "serve")
+    # EP carries no cache judgment here: recorded hash-only, and never served.
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers
+
+
+@pytest.mark.anyio
+async def test_shadow_mode_never_serves(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers
+
+
+@pytest.mark.anyio
+async def test_a_lookup_crash_degrades_to_live(clients: AsyncClient, serve, monkeypatch):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    async def _boom(**kwargs):
+        raise RuntimeError("lookup exploded")
+    monkeypatch.setattr(archive, "_touch", lambda kh: (_ for _ in ()).throw(RuntimeError))
+    monkeypatch.setattr(archive, "lookup", _boom)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and "x-treg-cache" not in r.headers


### PR DESCRIPTION
Fourth slice, the first that changes what a caller can receive — only when TREG_ARCHIVE_MODE=serve, and only for endpoints with a judged storable licence.

The lookup replaces the network trip alone: money on a hit is identical to a live call on purpose (reserve, settle, cost header unchanged), the response is tagged with X-Treg-Cache/Fetched-At/Age, and the audit row carries cached:true — the deferred pricing decision attaches to that tag later. Caller vetoes always win (Cache-Control: no-cache, X-Treg-Max-Age). Freshness is fixed per-capability guesses capped by the vendor's own declared ceiling; the learner replaces them in PR 5. Every uncertain branch — and even a crash inside the lookup — degrades to a live call.

9 new tests; migration 0003 adds CallRecord.cached; surface snapshots regenerated.