### PR TITLE
feat(archive): learner + refresh worker — PR 5 of 5

### DIFF
--- a/alembic/versions/0004_archivekey_request_shape.py
+++ b/alembic/versions/0004_archivekey_request_shape.py
@@ -1,0 +1,45 @@
+"""archivekey request shape — req_method/req_url/req_body (PR 5; the refresh worker's memory)
+
+The worker can only re-ask a question that was written down. This is the PRE-INJECTION request:
+method, vendor-facing URL (fixed upstream + forwarded caller params), and the caller body.
+Credentials cannot appear — injection happens inside the relay, after this shape is fixed.
+Backfill is empty strings/NULL: keys recorded before this migration simply cannot be refreshed
+until a caller asks their question again, which re-stores the shape.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-08-27
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision: str = '0004'
+down_revision: str | Sequence[str] | None = '0003'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('archivekey', sa.Column('req_method', sqlmodel.sql.sqltypes.AutoString(),
+                                          nullable=False, server_default=''))
+    op.add_column('archivekey', sa.Column('req_url', sqlmodel.sql.sqltypes.AutoString(),
+                                          nullable=False, server_default=''))
+    op.add_column('archivekey', sa.Column('req_body', sa.LargeBinary(), nullable=True))
+    op.add_column('archivekey', sa.Column('req_headers', sa.JSON(), nullable=True))
+    with op.batch_alter_table('archivekey') as batch:
+        batch.alter_column('req_method', server_default=None)
+        batch.alter_column('req_url', server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('archivekey', 'req_headers')
+    op.drop_column('archivekey', 'req_body')
+    op.drop_column('archivekey', 'req_url')
+    op.drop_column('archivekey', 'req_method')

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -22,9 +22,41 @@ fresh; **archive** is every version of every answer, kept with its timestamp. Th
 archive's top layer. History is kept on purpose: it is the future data product (per-key
 time-series — backlink profiles over time, price history), not waste.
 
-**Build state (PR 4 of 5).** The skeleton, the recorder, the catalog `cache` field + report,
-and the serve path exist. The timer learner + refresh worker (PR 5) land behind the same switch.
-Do not document them as existing until they do.
+**Build state: COMPLETE (PR 5 of 5).** All five slices exist behind `TREG_ARCHIVE_MODE`:
+skeleton, recorder, catalog `cache` field + report, serve path, and the learner + refresh worker.
+What does NOT exist: any billing difference for a cached hit (deferred founder decision), and the
+phase-3 aggregator surfaces (history endpoints) — do not document either as existing.
+
+## The learner (PR 5)
+
+Runs inside the recorder on every refetch of a known key. AIMD on `ttl_s`: stable ⇒ ×1.5, capped
+by min(30 d, the judged `cache.max_age_s`); changed ⇒ ×0.5, floored at 60 s. A key whose first
+`_NEVER_AFTER` (4) refetches ALL changed marks itself `ttl_s = TTL_NEVER (-1)` — never served
+until a stable refetch resets it. The lookup prefers the learned timer (`ttl_s > 0`) over the
+fixed phase-1 guesses.
+
+**Noise vs change.** When a refetch differs, the diff's leaf paths (lists collapse to `[]`,
+bounded depth 6 / 400 paths) are compared to the previous diff-set (`volatile_paths`, kept per
+key). The SAME set repeating counts as noise ⇒ stable, under two guards: it must be a minor
+share (< 40%) of a body with ≥ 5 leaves — a tiny body whose one value moves every fetch is a
+price and stays "changed". First occurrence always counts as changed. Stored bytes are never
+touched; stripping exists only in comparison.
+
+## The refresh worker (PR 5)
+
+`archive.refresh_worker` runs in-process from lifespan (adsconv's discipline), gated by
+`worker_enabled()` = serve mode AND `archive_refresh_daily_cap > 0`; interval
+`archive_refresh_interval_s` (300 s). A key EARNS refreshing: window ≥ 80% consumed AND
+`last_requested_at > fetched_at` (a caller asked since the last fetch — a refresh itself never
+counts as demand). Brakes: per-provider daily call cap (counted from `origin="refresh"`
+snapshots — no bookkeeping table to drift) and 10 per pass. The call replays the stored
+request shape — method, vendor-facing URL, body, and the KEYING headers (`req_headers`; without
+them the recording lands under a different key, found the hard way in tests) — with injection
+built by the ONE authoritative builder (`api._platform_bindings`, imported lazily inside the
+call: api imports this module, so the import cannot live at the top) and the key value from
+settings. The refresh spend is treg's own, attached to no org and absent from the ledger — the
+cap is the brake. Each refresh records through the same `_store` (`origin="refresh"`), so
+refreshing IS the sampling that teaches the timer.
 
 ## Serving (PR 4)
 

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -52,9 +52,9 @@ counts as demand). Brakes: per-provider daily call cap (counted from `origin="re
 snapshots — no bookkeeping table to drift) and 10 per pass. The call replays the stored
 request shape — method, vendor-facing URL, body, and the KEYING headers (`req_headers`; without
 them the recording lands under a different key, found the hard way in tests) — with injection
-built by the ONE authoritative builder (`api._platform_bindings`, imported lazily inside the
-call: api imports this module, so the import cannot live at the top) and the key value from
-settings. The refresh spend is treg's own, attached to no org and absent from the ledger — the
+built by the ONE authoritative builder (`oauth_providers.platform_bindings` — moved out of
+api.py so this worker never imports api; the routers→api import boundary forbids that chain)
+and the key value from settings. The refresh spend is treg's own, attached to no org and absent from the ledger — the
 cap is the brake. Each refresh records through the same `_store` (`origin="refresh"`), so
 refreshing IS the sampling that teaches the timer.
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -7359,34 +7359,6 @@ def _params_hash(endpoint_id: str, query_items: list[tuple[str, str]], body: byt
     return h.hexdigest()
 
 
-def _platform_bindings(provider) -> list[dict]:
-    """Tier 4's injection: the SAME header/param shape a pasted key of this provider gets
-    (`_provider_bindings`), except the value is named rather than carried — `relay` reads
-    `platform_setting` from settings at call time. That is the whole security model: treg's key is
-    never written to a Secret row (unreadable by the tenant, unexportable by a local run, and
-    `api.py`'s cross-org secret check would reject it anyway)."""
-    setting = platform_setting_name(provider.service)
-    if provider.token_location == "query":
-        bindings = [{"platform_setting": setting, "injector": "env", "location": "query",
-                     "name": provider.token_param, "format": provider.token_format}]
-    else:
-        bindings = [{"platform_setting": setting, "injector": "env", "location": "header",
-                     "name": provider.token_header, "format": provider.token_format}]
-    # Keep tier 4 protocol-identical to BYOK. Required provider headers are constants, but they
-    # still use the same platform setting reference so the normal binding validator and injector
-    # own the whole shape. Crustdata's x-api-version pin is the first provider that needs this.
-    source = {k: v for k, v in bindings[0].items()
-              if k in ("platform_setting", "injector", "secret_field")}
-    bindings.extend({**source, "location": "header", "name": name, "format": value}
-                    for name, value in provider.required_headers)
-    # A per-user credential PAIR (Tomba's key+secret headers) needs treg's own second half on
-    # tier 4. platform_extra_setting is tier-4-only by design: extra_credential_setting would also
-    # ride user connects, pairing a user's key with treg's secret — a pair the provider rejects.
-    if provider.needs_extra_credential and provider.platform_extra_setting:
-        bindings.append({"platform_setting": provider.platform_extra_setting, "injector": "env",
-                         "location": "header", "name": provider.extra_credential_header,
-                         "format": "{secret}"})
-    return bindings
 
 
 def _platform_offer(ep: dict, provider, org: Org) -> dict | None:
@@ -7945,7 +7917,7 @@ async def _resolve_marketplace_call(
         virtual = Tool(
             org_id=caller.org_id, name=ep["id"], owner=caller.email,
             base_url=provider.base_url, host=_host_of(provider.base_url),
-            bindings=_platform_bindings(provider),
+            bindings=oauth_providers.platform_bindings(provider),
         )
         return MarketplaceCall(tool=virtual, tier="platform", **{
             **common, "cost_type": str(cost.get("type") or "per_call"),

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -663,12 +663,11 @@ async def refresh_once(client) -> int:
 
 async def _refresh_call(client, key) -> bool:
     """Re-make one stored question on treg's own key. Injection reuses the ONE authoritative
-    binding builder (api._platform_bindings, imported lazily — api imports this module, so the
-    import cannot live at the top) plus the same injectors that serve a live call; the key
-    value resolves from settings exactly as the relay does it."""
+    binding builder (oauth_providers.platform_bindings — moved there so this worker never
+    imports api; the routers→api boundary forbids that chain); the key value resolves from
+    settings exactly as the relay does it."""
     try:
-        from . import injectors, oauth_providers
-        from . import api as _api  # lazy: circular at module level, settled by now at runtime
+        from . import oauth_providers
 
         provider = oauth_providers.get(key.provider)
         secret_value = get_settings().platform_key_for(key.provider)
@@ -676,7 +675,7 @@ async def _refresh_call(client, key) -> bool:
             return False  # key withdrawn or provider de-listed — quietly not refreshable
         headers: dict[str, str] = dict(key.req_headers or {})  # replay what keyed the question
         params: list = []
-        for binding in _api._platform_bindings(provider):
+        for binding in oauth_providers.platform_bindings(provider):
             value = getattr(get_settings(), binding.get("platform_setting", ""), "") or ""
             fmt = binding.get("format") or "{secret}"
             rendered = fmt.replace("{secret}", value) if value else fmt

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -123,7 +123,7 @@ def cache_key(
     kept_headers = sorted(
         (k.lower(), v.strip())
         for k, v in (headers or {}).items()
-        if k.lower() in ("accept", "accept-language")
+        if k.lower() in ("accept", "accept-language") and v.strip()
     )
     material = json.dumps(
         {
@@ -200,6 +200,7 @@ def record(
     status_code: int,
     media_type: str,
     body: bytes,
+    origin: str = "caller",
 ) -> None:
     """Schedule one observation of a metered platform answer. Returns immediately; the write runs
     off-request on its own session. Call sites gate on `recording()` and 2xx — this function
@@ -209,7 +210,7 @@ def record(
     task = asyncio.create_task(_store(
         method=method, endpoint_id=endpoint_id, provider=provider, url=url,
         caller_body=caller_body, headers=headers, status_code=status_code,
-        media_type=media_type, body=body))
+        media_type=media_type, body=body, origin=origin))
     _pending.add(task)
     task.add_done_callback(_pending.discard)
 
@@ -231,6 +232,7 @@ async def _store(
     status_code: int,
     media_type: str,
     body: bytes,
+    origin: str = "caller",
 ) -> None:
     """One recording: upsert the key, append a version, keep the change statistics honest.
 
@@ -261,8 +263,17 @@ async def _store(
             key = (await s.execute(
                 select(ArchiveKey).where(ArchiveKey.key_hash == kh))).scalars().one_or_none()
             if key is None:
+                # The request shape is stored WITH the key so the refresh worker can re-ask the
+                # exact question later. It is the pre-injection request: credentials cannot be in
+                # it (they are added inside the relay, after this shape is fixed).
+                kept = {k.lower(): v.strip() for k, v in (headers or {}).items()
+                        if k.lower() in ("accept", "accept-language") and v.strip()}
                 key = ArchiveKey(key_hash=kh, endpoint_id=endpoint_id, provider=provider,
-                                 policy=pol, fetched_at=now, last_requested_at=now)
+                                 policy=pol, fetched_at=now,
+                                 last_requested_at=now if origin == "caller" else None,
+                                 ttl_s=ttl_for(entry),
+                                 req_method=method.upper(), req_url=url,
+                                 req_body=caller_body or None, req_headers=kept)
                 s.add(key)
                 try:
                     await s.commit()
@@ -279,17 +290,30 @@ async def _store(
                 key_id=key.id, version=1 if newest is None else newest.version + 1,
                 status_code=status_code, media_type=media_type, content_hash=ch,
                 body=body if keep_bytes else None, size_bytes=len(body),
-                fetched_at=now, origin="caller")
+                fetched_at=now, origin=origin)
             if newest is not None:
                 if newest.content_hash == ch:
                     key.stable_seen += 1
+                    learn(key, stable=True, entry=entry)
                     carrier = newest.body_of or (newest.id if newest.body is not None else None)
                     if carrier is not None:      # bytes already on file — reference, don't repeat
                         snap.body, snap.body_of = None, carrier
                 else:
-                    key.change_seen += 1
-                    key.last_changed_at = now
-            key.fetched_at, key.last_requested_at, key.policy = now, now, pol
+                    old_body = newest.body
+                    if old_body is None and newest.body_of is not None:
+                        old = await s.get(ArchiveSnapshot, newest.body_of)
+                        old_body = old.body if old is not None else None
+                    if _noise_only(old_body, body, key):
+                        # Learned request ids / server timestamps moved; the data did not.
+                        key.stable_seen += 1
+                        learn(key, stable=True, entry=entry)
+                    else:
+                        key.change_seen += 1
+                        key.last_changed_at = now
+                        learn(key, stable=False, entry=entry)
+            key.fetched_at, key.policy = now, pol
+            if origin == "caller":     # a refresh is treg asking itself — never demand
+                key.last_requested_at = now
             s.add(key)
             s.add(snap)
             try:
@@ -389,12 +413,7 @@ async def lookup(
         entry = catalog_store.load().by_id.get(endpoint_id)
         if not storable(entry):
             return None
-        window = ttl_for(entry)
         wanted = caller_max_age_s(request_headers)
-        if wanted is not None:
-            window = min(window, wanted)
-        if window <= 0:
-            return None
 
         kh = cache_key(method, endpoint_id, url, caller_body, {
             k: request_headers.get(k, "") for k in ("accept", "accept-language")})
@@ -402,6 +421,15 @@ async def lookup(
             key = (await s.execute(
                 select(ArchiveKey).where(ArchiveKey.key_hash == kh))).scalars().one_or_none()
             if key is None:
+                return None
+            if key.ttl_s == TTL_NEVER:   # the key marked itself: changes on every fetch
+                return None
+            # The learned per-key timer when one exists, else the fixed phase-1 guess; the
+            # caller's own bar tightens, never widens.
+            window = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
+            if wanted is not None:
+                window = min(window, wanted)
+            if window <= 0:
                 return None
             newest = (await s.execute(
                 select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
@@ -450,3 +478,223 @@ async def _touch_write(key_hash: str) -> None:
             await s.commit()
     except Exception:  # noqa: BLE001
         _log.warning("archive touch dropped", exc_info=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# The learner (PR 5) — AIMD timers and noise detection, applied inside the recorder.
+
+TTL_FLOOR_S = 60
+TTL_CEILING_S = 30 * 86400
+TTL_NEVER = -1          # the key marked itself never-cache: changes on every fetch
+_NEVER_AFTER = 4        # consecutive changed refetches (no stables) before self-marking
+_NOISE_MAX_LEAF_SHARE = 0.4   # a repeated identical diff-set is noise only if it is a MINOR
+_NOISE_MIN_LEAVES = 5         # corner of a body with at least this many leaves — a tiny body
+#                               whose one value moves (a price) must stay "changed", never noise.
+
+
+def _leaf_paths(node: Any, prefix: str = "$", *, depth: int = 0, out: list | None = None) -> list[str]:
+    """Dotted leaf paths of a JSON tree; list items collapse to `[]` so per-row ids do not
+    explode one logical path into hundreds. Bounded by depth and count — comparison machinery
+    must never be the expensive part of a recording."""
+    if out is None:
+        out = []
+    if len(out) >= 400 or depth > 6:
+        return out
+    if isinstance(node, dict):
+        for k, v in node.items():
+            _leaf_paths(v, f"{prefix}.{k}", depth=depth + 1, out=out)
+    elif isinstance(node, list):
+        for v in node[:50]:
+            _leaf_paths(v, f"{prefix}[]", depth=depth + 1, out=out)
+    else:
+        out.append(prefix)
+    return out
+
+
+def _changed_paths(old: Any, new: Any, prefix: str = "$", *, depth: int = 0,
+                   out: set | None = None) -> set[str]:
+    """Leaf paths whose values differ between two JSON trees (same collapse rules as above)."""
+    if out is None:
+        out = set()
+    if len(out) >= 400 or depth > 6:
+        return out
+    if isinstance(old, dict) and isinstance(new, dict):
+        for k in set(old) | set(new):
+            _changed_paths(old.get(k), new.get(k), f"{prefix}.{k}", depth=depth + 1, out=out)
+    elif isinstance(old, list) and isinstance(new, list):
+        for a, b in zip(old[:50], new[:50]):
+            _changed_paths(a, b, f"{prefix}[]", depth=depth + 1, out=out)
+        if len(old) != len(new):
+            out.add(f"{prefix}[]")
+    elif old != new:
+        out.add(prefix)
+    return out
+
+
+def _noise_only(old_body: bytes | None, new_body: bytes, key) -> bool:
+    """True when this refetch's difference is the SAME small diff-set as last time — learned
+    request ids and server timestamps, not data. Two guards keep a real signal out of the noise
+    bin: the identical set must repeat (first occurrence always counts as changed, and gets
+    remembered as the candidate), and it must be a minor share (< 40%) of a body with at least
+    5 leaves — a tiny body whose one value moves every fetch is a PRICE, not noise."""
+    if not old_body:
+        return False
+    try:
+        old_json, new_json = json.loads(old_body), json.loads(new_body)
+    except (ValueError, UnicodeDecodeError):
+        return False
+    changed = _changed_paths(old_json, new_json)
+    if not changed:
+        return False
+    known = set(key.volatile_paths or [])
+    leaves = len(_leaf_paths(new_json))
+    is_noise = (changed <= known
+                and leaves >= _NOISE_MIN_LEAVES
+                and len(changed) / leaves < _NOISE_MAX_LEAF_SHARE)
+    # Remember this diff-set as the next candidate either way (bounded), so the SAME noise
+    # repeating is recognized from its second occurrence on.
+    key.volatile_paths = sorted(changed)[:50]
+    return is_noise
+
+
+def learn(key, *, stable: bool, entry: dict[str, Any] | None) -> None:
+    """One AIMD step on the key's timer. Grow slowly on stability (×1.5, capped), shrink fast on
+    change (×0.5, floored). The vendor's declared ceiling always caps; a key that only ever
+    changes marks itself TTL_NEVER and is never served again until a stable refetch resets it."""
+    ceiling = TTL_CEILING_S
+    declared = (entry or {}).get("cache")
+    if isinstance(declared, dict):
+        try:
+            cap = int(declared.get("max_age_s") or 0)
+        except (TypeError, ValueError):
+            cap = 0
+        if cap > 0:
+            ceiling = min(ceiling, cap)
+    current = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
+    if stable:
+        key.ttl_s = min(int(current * 1.5), ceiling)
+    elif key.change_seen >= _NEVER_AFTER and key.stable_seen == 0:
+        key.ttl_s = TTL_NEVER
+    else:
+        key.ttl_s = max(int(current * 0.5), TTL_FLOOR_S)
+
+
+# ---------------------------------------------------------------------------------------------
+# The refresh worker (PR 5) — serve mode only. A key EARNS refreshing; it is never entitled:
+# refreshed only when its window is ≥80% consumed AND a caller asked for it since its last fetch.
+# A refresh is treg's own vendor spend with no caller attached, so two brakes bound it — the
+# per-provider daily call cap (archive_refresh_daily_cap; 0 disables) and the per-pass limit.
+# Every refresh is an observation: it lands through the same _store, teaching the timer.
+
+_REFRESH_PER_PASS = 10
+_DUE_SHARE = 0.8
+
+
+def worker_enabled() -> bool:
+    return serving() and get_settings().archive_refresh_daily_cap > 0
+
+
+async def refresh_worker(client) -> None:
+    """Run forever from lifespan, adsconv.worker's discipline: a bad pass must never kill the
+    loop, and only cancellation ends it."""
+    while True:
+        try:
+            done = await refresh_once(client)
+            if done:
+                _log.info("archive refresh: %d key(s) refreshed", done)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _log.warning("archive refresh pass failed", exc_info=True)
+        await asyncio.sleep(get_settings().archive_refresh_interval_s)
+
+
+async def refresh_once(client) -> int:
+    """One pass: find due-and-demanded keys, re-ask each question on treg's platform key, and
+    record the answers (origin="refresh"). Returns how many were refreshed."""
+    if not worker_enabled():
+        return 0
+    from sqlalchemy import func, select
+
+    from . import catalog_store
+    from .db import session_maker
+    from .models import ArchiveKey, ArchiveSnapshot
+
+    now = _utcnow()
+    cat = catalog_store.load()
+    async with session_maker() as s:
+        candidates = (await s.execute(
+            select(ArchiveKey)
+            .where(ArchiveKey.ttl_s > 0, ArchiveKey.req_url != "",
+                   ArchiveKey.last_requested_at.is_not(None))
+            .order_by(ArchiveKey.fetched_at))).scalars().all()
+        # Today's refresh spend per provider — counted from the snapshots themselves, no extra
+        # bookkeeping table to drift.
+        day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        spent_rows = (await s.execute(
+            select(ArchiveKey.provider, func.count(ArchiveSnapshot.id))
+            .join(ArchiveSnapshot, ArchiveSnapshot.key_id == ArchiveKey.id)
+            .where(ArchiveSnapshot.origin == "refresh", ArchiveSnapshot.fetched_at >= day_start)
+            .group_by(ArchiveKey.provider))).all()
+    spent = {provider: int(n) for provider, n in spent_rows}
+    cap = get_settings().archive_refresh_daily_cap
+
+    refreshed = 0
+    for key in candidates:
+        if refreshed >= _REFRESH_PER_PASS:
+            break
+        entry = cat.by_id.get(key.endpoint_id)
+        if not storable(entry):
+            continue  # judgment changed since recording — never refresh what may not be kept
+        window = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
+        age = (now - key.fetched_at).total_seconds()
+        demanded = key.last_requested_at is not None and key.last_requested_at > key.fetched_at
+        if age < window * _DUE_SHARE or not demanded:
+            continue
+        if spent.get(key.provider, 0) >= cap:
+            continue
+        if await _refresh_call(client, key):
+            spent[key.provider] = spent.get(key.provider, 0) + 1
+            refreshed += 1
+    if refreshed:
+        await drain()  # the recordings ARE this pass's output — land them before returning
+    return refreshed
+
+
+async def _refresh_call(client, key) -> bool:
+    """Re-make one stored question on treg's own key. Injection reuses the ONE authoritative
+    binding builder (api._platform_bindings, imported lazily — api imports this module, so the
+    import cannot live at the top) plus the same injectors that serve a live call; the key
+    value resolves from settings exactly as the relay does it."""
+    try:
+        from . import injectors, oauth_providers
+        from . import api as _api  # lazy: circular at module level, settled by now at runtime
+
+        provider = oauth_providers.get(key.provider)
+        secret_value = get_settings().platform_key_for(key.provider)
+        if provider is None or not secret_value:
+            return False  # key withdrawn or provider de-listed — quietly not refreshable
+        headers: dict[str, str] = dict(key.req_headers or {})  # replay what keyed the question
+        params: list = []
+        for binding in _api._platform_bindings(provider):
+            value = getattr(get_settings(), binding.get("platform_setting", ""), "") or ""
+            fmt = binding.get("format") or "{secret}"
+            rendered = fmt.replace("{secret}", value) if value else fmt
+            if binding.get("location") == "query":
+                params.append((binding.get("name"), rendered))
+            else:
+                headers[binding.get("name", "")] = rendered
+        resp = await client.request(key.req_method or "GET", key.req_url, params=params or None,
+                                    headers=headers, content=key.req_body or None)
+        body = resp.content
+        if not (200 <= resp.status_code < 300):
+            _log.warning("archive refresh got %s for %s", resp.status_code, key.endpoint_id)
+            return False
+        record(method=key.req_method or "GET", endpoint_id=key.endpoint_id,
+               provider=key.provider, url=key.req_url, caller_body=key.req_body or b"",
+               headers=dict(key.req_headers or {}), status_code=resp.status_code,
+               media_type=resp.headers.get("content-type", ""), body=body, origin="refresh")
+        return True
+    except Exception:  # noqa: BLE001 — one dead key must not stop the pass
+        _log.warning("archive refresh call failed for %s", key.endpoint_id, exc_info=True)
+        return False

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -405,6 +405,14 @@ def _lifespan(api_module, role: AppRole):
             if ROLE_BACKGROUND_TASKS[role] and adsconv.enabled()
             else None
         )
+        # The archive's refresh worker (docs/context/architecture/archive.md): serve mode only,
+        # and a zero daily cap disables it without touching serving. Same discipline as the ads
+        # task — in-process, cancelled on shutdown, a bad pass never kills the loop.
+        archive_task = (
+            asyncio.create_task(archive.refresh_worker(app.state.http))
+            if ROLE_BACKGROUND_TASKS[role] and archive.worker_enabled()
+            else None
+        )
         try:
             if role == "dataplane" or _mcp is None:
                 yield
@@ -414,6 +422,8 @@ def _lifespan(api_module, role: AppRole):
         finally:
             if ads_task is not None:
                 ads_task.cancel()
+            if archive_task is not None:
+                archive_task.cancel()
             await audit.drain()
             await analytics.drain()
             await archive.drain()

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -252,6 +252,11 @@ class Settings(BaseSettings):
     # Bodies above this size are hash-counted but never stored (skipped whole, not truncated):
     # the archive is for API JSON answers, not downloads. Statistics still record size_bytes.
     archive_max_body_bytes: int = 2_000_000
+    # The refresh worker (serve mode only): how often it scans for due keys, and how many
+    # refresh calls ONE provider may spend per UTC day. A refresh is treg's own vendor spend with
+    # no caller attached, so the cap is the brake — 0 disables refreshing without touching serving.
+    archive_refresh_interval_s: int = 300
+    archive_refresh_daily_cap: int = 50
 
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1075,6 +1075,15 @@ class ArchiveKey(SQLModel, table=True):
     heat: float = Field(default=0.0)               # decayed request rate, updated on each hit/miss
     last_requested_at: datetime | None = Field(default=None)
     created_at: datetime = Field(default_factory=_now)
+    # The pre-injection request shape, stored so the refresh worker can re-ask the exact question.
+    # Credentials cannot appear here: injection happens inside the relay, after this shape is
+    # fixed. Declared LAST to match the migration's ALTER TABLE append position (parity test).
+    req_method: str = Field(default="")
+    req_url: str = Field(default="")
+    req_body: bytes | None = Field(default=None)
+    # Only the headers that KEY (Accept / Accept-Language, when the caller sent them): the worker
+    # must replay them or its recording lands under a different key than the caller's question.
+    req_headers: dict = Field(default_factory=dict, sa_column=Column(JSON))
 
 
 class ArchiveSnapshot(SQLModel, table=True):

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .config import get_settings
+from .config import platform_setting_name, get_settings
 
 
 @dataclass(frozen=True)
@@ -2545,3 +2545,36 @@ def listing() -> list[dict]:
             ),
         )
     ]
+
+
+# Moved from api.py (2026-08-27) so BOTH callers — the relay path in api and the archive's
+# refresh worker — reach the ONE authoritative builder without the worker importing api
+# (the routers→api import boundary forbids that chain).
+def platform_bindings(provider) -> list[dict]:
+    """Tier 4's injection: the SAME header/param shape a pasted key of this provider gets
+    (`_provider_bindings`), except the value is named rather than carried — `relay` reads
+    `platform_setting` from settings at call time. That is the whole security model: treg's key is
+    never written to a Secret row (unreadable by the tenant, unexportable by a local run, and
+    `api.py`'s cross-org secret check would reject it anyway)."""
+    setting = platform_setting_name(provider.service)
+    if provider.token_location == "query":
+        bindings = [{"platform_setting": setting, "injector": "env", "location": "query",
+                     "name": provider.token_param, "format": provider.token_format}]
+    else:
+        bindings = [{"platform_setting": setting, "injector": "env", "location": "header",
+                     "name": provider.token_header, "format": provider.token_format}]
+    # Keep tier 4 protocol-identical to BYOK. Required provider headers are constants, but they
+    # still use the same platform setting reference so the normal binding validator and injector
+    # own the whole shape. Crustdata's x-api-version pin is the first provider that needs this.
+    source = {k: v for k, v in bindings[0].items()
+              if k in ("platform_setting", "injector", "secret_field")}
+    bindings.extend({**source, "location": "header", "name": name, "format": value}
+                    for name, value in provider.required_headers)
+    # A per-user credential PAIR (Tomba's key+secret headers) needs treg's own second half on
+    # tier 4. platform_extra_setting is tier-4-only by design: extra_credential_setting would also
+    # ride user connects, pairing a user's key with treg's secret — a pair the provider rejects.
+    if provider.needs_extra_credential and provider.platform_extra_setting:
+        bindings.append({"platform_setting": provider.platform_extra_setting, "injector": "env",
+                         "location": "header", "name": provider.extra_credential_header,
+                         "format": "{secret}"})
+    return bindings

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -8,6 +8,8 @@ in the sqlite suite and in CI's serial Postgres job).
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from treg import api as A, archive, audit
@@ -476,3 +478,156 @@ async def test_a_lookup_crash_degrades_to_live(clients: AsyncClient, serve, monk
     monkeypatch.setattr(archive, "lookup", _boom)
     r = await clients.get(f"/call/{EP}?aweme_id=7")
     assert r.status_code == 200 and "x-treg-cache" not in r.headers
+
+
+# ---------------------------------------------------------------------------------------------
+# The learner (PR 5): timers that adjust, noise that stops counting, keys that opt out
+
+@pytest.mark.anyio
+async def test_stable_refetch_grows_the_timer(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await clients.get(f"/call/{EP}?aweme_id=7")     # identical echo answer ⇒ stable
+    keys, _ = await _rows()
+    # other.* capability default is 3600; one stable step ⇒ ×1.5
+    assert keys[0].ttl_s == int(keys[0].ttl_s)  # int stays int
+    assert keys[0].stable_seen == 1 and keys[0].ttl_s > 3600 * 1.4
+
+
+@pytest.mark.anyio
+async def test_changed_refetch_shrinks_the_timer(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"n": 1}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"n": 2}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    keys, _ = await _rows()
+    assert keys[0].change_seen == 1 and keys[0].ttl_s == 1800   # 3600 × 0.5
+
+
+@pytest.mark.anyio
+async def test_repeated_noise_counts_as_stable(clients: AsyncClient, shadow, monkeypatch):
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "transient")
+    from tests.test_marketplace_call import _fake_relay
+    bodies = [json.dumps({"req_id": i, "ts": i * 10,
+                          "data": {"a": 1, "b": 2, "c": 3, "d": 4}}).encode() for i in range(3)]
+    for b in bodies:
+        monkeypatch.setattr(A, "relay", _fake_relay(200, b))
+        await clients.get(f"/call/{EP}?aweme_id=7")
+    keys, _ = await _rows()
+    # fetch 2 differs (first diff: counts changed, remembers the set); fetch 3 repeats the SAME
+    # small diff-set ⇒ noise ⇒ stable.
+    assert keys[0].change_seen == 1 and keys[0].stable_seen == 1
+    assert keys[0].volatile_paths == ["$.req_id", "$.ts"]
+
+
+@pytest.mark.anyio
+async def test_always_changing_key_marks_itself_never_cache(clients: AsyncClient, serve, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    for i in range(5):   # tiny 1-leaf body: the noise guard must NEVER rescue a moving price
+        monkeypatch.setattr(A, "relay", _fake_relay(200, json.dumps({"price": i}).encode()))
+        r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Cache-Control": "no-cache"})
+        assert r.status_code == 200
+        await archive.drain()
+    keys, _ = await _rows()
+    assert keys[0].ttl_s == archive.TTL_NEVER and keys[0].stable_seen == 0
+    # …and a fresh call is NOT served from the store, however young the newest snapshot is.
+    monkeypatch.setattr(A, "relay", _fake_relay(200, b'{"price": 99}'))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert "x-treg-cache" not in r.headers
+
+
+# ---------------------------------------------------------------------------------------------
+# The refresh worker (PR 5): due + demanded + capped, through the real injection shape
+
+class _FakeUpstream:
+    """Stands in for app.state.http: answers like the vendor and remembers each request."""
+    def __init__(self, body: bytes = b'{"fresh": true}'):
+        self.body, self.calls = body, []
+
+    async def request(self, method, url, params=None, headers=None, content=None):
+        self.calls.append({"method": method, "url": url, "params": params or [],
+                           "headers": headers or {}})
+        import httpx
+        return httpx.Response(200, content=self.body,
+                              headers={"content-type": "application/json"})
+
+
+async def _age_key(days: float, *, demanded: bool = True):
+    from datetime import timedelta
+    async with session_maker() as s:
+        key = (await s.execute(select(ArchiveKey))).scalars().one()
+        key.fetched_at = key.fetched_at - timedelta(days=days)
+        key.last_requested_at = (key.fetched_at + timedelta(seconds=60)) if demanded else None
+        s.add(key)
+        await s.commit()
+        return key.key_hash
+
+
+@pytest.mark.anyio
+async def test_refresh_worker_refreshes_a_due_demanded_key(clients: AsyncClient, serve):
+    r = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r.status_code == 200
+    await archive.drain()
+    await _age_key(days=1)               # window 3600s ⇒ a day old is far past 80%
+    fake = _FakeUpstream()
+    assert await archive.refresh_once(fake) == 1
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["method"] == "GET" and "fetch_post_comment" in call["url"]
+    assert ("aweme_id", "7") in [tuple(x) for x in _qs(call["url"])]
+    # treg's platform key rode the provider's own injection shape (tikhub: Bearer header).
+    assert call["headers"].get("Authorization") == "Bearer PLATFORM-TIKHUB-KEY"
+    keys, snaps = await _rows()
+    assert [s_.origin for s_ in snaps] == ["caller", "refresh"]
+    assert keys[0].last_requested_at < keys[0].fetched_at   # a refresh is never demand
+
+
+def _qs(url: str):
+    from urllib.parse import parse_qsl, urlsplit
+    return parse_qsl(urlsplit(url).query)
+
+
+@pytest.mark.anyio
+async def test_refresh_skips_undemanded_and_fresh_keys(clients: AsyncClient, serve):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    fake = _FakeUpstream()
+    assert await archive.refresh_once(fake) == 0            # fresh: not due
+    await _age_key(days=1, demanded=False)
+    assert await archive.refresh_once(fake) == 0            # due but nobody asked
+    assert fake.calls == []
+
+
+@pytest.mark.anyio
+async def test_refresh_daily_cap_holds(clients: AsyncClient, serve, monkeypatch):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await clients.get(f"/call/{EP}?aweme_id=8")
+    await archive.drain()
+    from datetime import timedelta
+    async with session_maker() as s:                        # both keys due and demanded
+        for key in (await s.execute(select(ArchiveKey))).scalars().all():
+            key.fetched_at = key.fetched_at - timedelta(days=1)
+            key.last_requested_at = key.fetched_at + timedelta(seconds=60)
+            s.add(key)
+        await s.commit()
+    monkeypatch.setattr(get_settings(), "archive_refresh_daily_cap", 1)
+    fake = _FakeUpstream()
+    assert await archive.refresh_once(fake) == 1            # the cap, not the queue, decided
+    assert await archive.refresh_once(fake) == 0            # today's budget is spent
+    assert len(fake.calls) == 1
+
+
+@pytest.mark.anyio
+async def test_refresh_disabled_off_serve_or_at_cap_zero(clients: AsyncClient, serve, monkeypatch):
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    await _age_key(days=1)
+    fake = _FakeUpstream()
+    monkeypatch.setattr(get_settings(), "archive_refresh_daily_cap", 0)
+    assert await archive.refresh_once(fake) == 0
+    monkeypatch.setattr(get_settings(), "archive_refresh_daily_cap", 50)
+    monkeypatch.setattr(get_settings(), "archive_mode", "shadow")
+    assert await archive.refresh_once(fake) == 0
+    assert fake.calls == []

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -779,7 +779,7 @@ def test_local_run_cannot_export_a_platform_binding():
 
     provider = A.oauth_providers.get("tikhub")
     tool = Tool(org_id=1, name=EP, base_url=provider.base_url, host="api.tikhub.io",
-                bindings=A._platform_bindings(provider),
+                bindings=A.oauth_providers.platform_bindings(provider),
                 cli={"enabled": True, "bin": "sh", "inject": [{"via": "env", "name": "TIKHUB_API_KEY"}]})
     assert all(b.get("secret_id") is None for b in tool.bindings)
     assert localrun._resolve_secret_id(tool.cli["inject"][0], tool) is None
@@ -804,14 +804,14 @@ def test_brightdata_platform_key_injects_as_bearer(platform_on):
     field is found by name (`platform_key_for`) and the header shape comes from the registry entry,
     so this is the regression guard on the generic path staying generic."""
     assert get_settings().platform_key_for("brightdata") == PLATFORM_KEYS["BRIGHTDATA"]
-    assert A._platform_bindings(A.oauth_providers.get("brightdata")) == [
+    assert A.oauth_providers.platform_bindings(A.oauth_providers.get("brightdata")) == [
         {"platform_setting": "platform_key_brightdata", "injector": "env", "location": "header",
          "name": "Authorization", "format": "Bearer {secret}"}]
 
 
 def test_crustdata_platform_key_keeps_the_required_version_header():
     """Tier 4 must speak the same provider protocol as BYOK, not only inject the key."""
-    assert A._platform_bindings(A.oauth_providers.get("crustdata")) == [
+    assert A.oauth_providers.platform_bindings(A.oauth_providers.get("crustdata")) == [
         {"platform_setting": "platform_key_crustdata", "injector": "env", "location": "header",
          "name": "Authorization", "format": "Bearer {secret}"},
         {"platform_setting": "platform_key_crustdata", "injector": "env", "location": "header",


### PR DESCRIPTION
Final slice. Timers learn per key (AIMD: stable ×1.5 capped by the vendor ceiling, changed ×0.5 floored; four straight changes = self-marked never-cache). Repeated identical diff-sets count as noise under two guards, so request ids stop shrinking timers while a moving price can never be mistaken for stable. The refresh worker runs in-process (ads-uploader pattern), serve-mode-only, refreshing only keys that are ≥80% through their window AND were asked for since their last fetch, bounded by a per-provider daily cap counted from the snapshots themselves. It replays the stored pre-injection request shape with credentials injected by the same authoritative builder the relay uses.

Migration 0004 stores the request shape on the key. 9 new tests, 50 in the archive file.