### PR TITLE
feat(catalog): add AgentLine telephony account tools

### DIFF
--- a/src/treg/catalog/agentline.yaml
+++ b/src/treg/catalog/agentline.yaml
@@ -1,0 +1,284 @@
+provider: agentline
+source:
+  docs: https://docs.agentline.cloud
+  openapi: https://api.agentline.cloud/openapi.json
+  curated: '2026-08-27'
+limits: "OTP routes publish per-email and per-IP limits; numeric limits for authenticated API routes are not currently published."
+pricing_url: https://agentline.cloud/pricing
+
+# AgentLine's core paid actions have real-world effects: provisioning buys a phone number, calls
+# dial a person, and messages send SMS. Their required agent/number/call IDs are account-specific,
+# so they cannot be replayed safely by treg's independent verifier. This curated core therefore
+# covers the useful, repeatable account inventory, history, event, voice and billing reads. The PR
+# surface map records every excluded action and why it is not a safe fixed test request.
+#
+# All rows are own-account data and intentionally BYOK-only. Serving them through treg's shared
+# platform key would expose one shared AgentLine account rather than the caller's agents, numbers,
+# calls and messages.
+
+proposed_capabilities:
+  account.telephony.agents.list: "List the AI phone agents on your account"
+  account.telephony.numbers.list: "List the phone numbers on your account"
+  account.telephony.calls.list: "List your AI agents' voice call history"
+  account.telephony.messages.list: "List your AI agents' SMS history"
+  account.telephony.conversations.list: "List your AI agents' SMS conversations"
+  account.telephony.events.peek: "Preview pending telephony events without consuming them"
+  account.telephony.webhooks.list: "List your telephony event webhooks"
+  account.telephony.voices.list: "List the available phone-agent voices"
+  account.telephony.voice.get: "Get your account's default phone-agent voice"
+  account.telephony.expenditure: "Break down telephony spending by category"
+  account.telephony.call_charges: "List individual voice-call charges"
+  account.telephony.number_charges: "List individual phone-number charges"
+  account.telephony.spending_summary: "Summarize telephony spending by month"
+  account.telephony.usage: "Summarize call, message and phone-number usage"
+
+endpoints:
+  - id: agentline.account.telephony.agents.list
+    kind: account
+    capability: account.telephony.agents.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/agents
+    name: "AI phone agents with prompts, voices and numbers"
+    summary: "List all AI voice agents configured on your account."
+    input:
+      note: "no parameters"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/agents/list-agents
+
+  - id: agentline.account.telephony.numbers.list
+    kind: account
+    capability: account.telephony.numbers.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/numbers
+    name: "Phone numbers by agent, country and status"
+    summary: "List all phone numbers provisioned on your account."
+    input:
+      note: "no parameters"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27; provisioning is billed separately."}
+    docs_url: https://docs.agentline.cloud/api-reference/numbers/list-numbers
+
+  - id: agentline.account.telephony.calls.list
+    capability: account.telephony.calls.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/calls
+    name: "Voice call history by agent or status"
+    summary: "List voice calls made by your AI agents."
+    input:
+      queryParams:
+        agent_id: {type: string, required: false, note: "AI agent ID from GET /v1/agents", example: "agt_xxx"}
+        status: {type: string, required: false, note: "initiated | in-progress | completed | failed", example: "completed"}
+        limit: {type: integer, required: false, note: "1-200; default 50", example: 20}
+        offset: {type: integer, required: false, note: "pagination offset, minimum 0", example: 0}
+    test_request:
+      queryParams: {limit: 1, offset: 0}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27; live voice minutes are billed separately."}
+    docs_url: https://docs.agentline.cloud/api-reference/calls/list-calls
+
+  - id: agentline.account.telephony.messages.list
+    capability: account.telephony.messages.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/messages
+    name: "SMS history by agent or conversation"
+    summary: "List SMS messages sent and received by your AI agents."
+    input:
+      queryParams:
+        agent_id: {type: string, required: false, note: "AI agent ID from GET /v1/agents", example: "agt_xxx"}
+        conversation_id: {type: string, required: false, note: "conversation ID from GET /v1/messages/conversations", example: "conv_xxx"}
+        limit: {type: integer, required: false, note: "1-200; default 50", example: 20}
+        offset: {type: integer, required: false, note: "pagination offset, minimum 0", example: 0}
+    test_request:
+      queryParams: {limit: 1, offset: 0}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27; SMS delivery is billed separately."}
+    docs_url: https://docs.agentline.cloud/api-reference/messages/list-messages
+
+  - id: agentline.account.telephony.conversations.list
+    capability: account.telephony.conversations.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/messages/conversations
+    name: "SMS conversations by AI phone agent"
+    summary: "List all SMS conversations for your AI agents."
+    input:
+      queryParams:
+        agent_id: {type: string, required: false, note: "AI agent ID from GET /v1/agents", example: "agt_xxx"}
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/messages/list-conversations
+
+  - id: agentline.account.telephony.events.peek
+    capability: account.telephony.events.peek
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/events/peek
+    name: "Pending call and SMS events without consuming them"
+    summary: "Peek at pending telephony events without consuming them."
+    input:
+      queryParams:
+        agent_id: {type: string, required: false, note: "AI agent ID from GET /v1/agents", example: "agt_xxx"}
+        event_type: {type: string, required: false, note: "for example call.completed or sms.received", example: "call.completed"}
+        limit: {type: integer, required: false, note: "1-200; default 50", example: 20}
+    test_request:
+      queryParams: {limit: 1}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27; peeking leaves every event pending."}
+    docs_url: https://docs.agentline.cloud/api-reference/events/peek-events
+
+  - id: agentline.account.telephony.webhooks.list
+    kind: account
+    capability: account.telephony.webhooks.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/webhooks
+    name: "Event webhooks by AI phone agent"
+    summary: "List the account's per-agent webhook configuration(s)."
+    input:
+      queryParams:
+        agent_id: {type: string, required: false, note: "AI agent ID from GET /v1/agents", example: "agt_xxx"}
+      note: "Webhook secrets are masked in this response."
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/webhooks/get-webhooks
+
+  - id: agentline.account.telephony.voices.list
+    kind: utility
+    capability: account.telephony.voices.list
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/voices
+    name: "Available phone-agent voice presets"
+    summary: "List all available voice presets for AI phone agents."
+    input:
+      note: "no parameters; this route is public but remains useful through a connected tool"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/voice/get-available-voices
+
+  - id: agentline.account.telephony.voice.get
+    kind: account
+    capability: account.telephony.voice.get
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/account/voice
+    name: "Default phone-agent voice for your account"
+    summary: "Get the current account-level default voice for AI phone agents."
+    input:
+      note: "no parameters"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/voice/get-account-voice
+
+  - id: agentline.account.usage
+    kind: account
+    capability: account.usage
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/billing/balance
+    name: "Telephony balance, live rates and affordability"
+    summary: "Get your AI telephony account balance and rate card."
+    input:
+      note: "no parameters; this is also the free credential probe"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27; this response also reported the live rate card."}
+    docs_url: https://docs.agentline.cloud/api-reference/billing/get-balance
+
+  - id: agentline.account.telephony.expenditure
+    kind: account
+    capability: account.telephony.expenditure
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/billing/expenditure
+    name: "Telephony spend by calls and phone numbers"
+    summary: "Get a detailed expenditure breakdown for AI telephony usage."
+    input:
+      queryParams:
+        period: {type: string, required: false, note: "current_month | last_month | all_time | YYYY-MM; default current_month", example: "current_month"}
+    test_request:
+      queryParams: {period: "current_month"}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/billing/get-expenditure
+
+  - id: agentline.account.telephony.call_charges
+    kind: account
+    capability: account.telephony.call_charges
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/billing/expenditure/calls
+    name: "Voice-call charges with duration and direction"
+    summary: "List individual call charges from AI agent phone calls."
+    input:
+      queryParams:
+        limit: {type: integer, required: false, note: "1-200; default 50", example: 20}
+        offset: {type: integer, required: false, note: "pagination offset, minimum 0", example: 0}
+    test_request:
+      queryParams: {limit: 1, offset: 0}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/billing/get-call-expenditure
+
+  - id: agentline.account.telephony.number_charges
+    kind: account
+    capability: account.telephony.number_charges
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/billing/expenditure/numbers
+    name: "Phone-number charges with country and status"
+    summary: "List phone number provisioning charges."
+    input:
+      queryParams:
+        limit: {type: integer, required: false, note: "1-200; default 50", example: 20}
+        offset: {type: integer, required: false, note: "pagination offset, minimum 0", example: 0}
+    test_request:
+      queryParams: {limit: 1, offset: 0}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/billing/get-number-expenditure
+
+  - id: agentline.account.telephony.spending_summary
+    kind: account
+    capability: account.telephony.spending_summary
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/billing/summary
+    name: "Monthly telephony spending trends"
+    summary: "Month-over-month spending summary."
+    input:
+      queryParams:
+        months: {type: integer, required: false, note: "1-24; default 6", example: 6}
+    test_request:
+      queryParams: {months: 1}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://docs.agentline.cloud/api-reference/billing/get-spending-summary
+
+  - id: agentline.account.telephony.usage
+    kind: account
+    capability: account.telephony.usage
+    platform: account
+    scope: own_account
+    method: GET
+    path: /v1/usage
+    name: "Call, message and phone-number usage by period"
+    summary: "Get usage statistics for your AI telephony account."
+    input:
+      queryParams:
+        period: {type: string, required: false, note: "current_month | last_month | all_time | YYYY-MM; default current_month", example: "current_month"}
+    test_request:
+      queryParams: {period: "current_month"}
+    cost: {type: free, value: 0, currency: USD, per: 1, unit: call, source: observed, source_url: https://agentline.cloud/pricing, checked: '2026-08-27', confidence: verified, note: "Observed with no balance change or billing-ledger entry on 2026-08-27."}
+    docs_url: https://api.agentline.cloud/docs

--- a/src/treg/catalog/agentline.yaml
+++ b/src/treg/catalog/agentline.yaml
@@ -64,6 +64,7 @@ endpoints:
     docs_url: https://docs.agentline.cloud/api-reference/numbers/list-numbers
 
   - id: agentline.account.telephony.calls.list
+    kind: account
     capability: account.telephony.calls.list
     platform: account
     scope: own_account
@@ -83,6 +84,7 @@ endpoints:
     docs_url: https://docs.agentline.cloud/api-reference/calls/list-calls
 
   - id: agentline.account.telephony.messages.list
+    kind: account
     capability: account.telephony.messages.list
     platform: account
     scope: own_account
@@ -102,6 +104,7 @@ endpoints:
     docs_url: https://docs.agentline.cloud/api-reference/messages/list-messages
 
   - id: agentline.account.telephony.conversations.list
+    kind: account
     capability: account.telephony.conversations.list
     platform: account
     scope: own_account
@@ -117,6 +120,7 @@ endpoints:
     docs_url: https://docs.agentline.cloud/api-reference/messages/list-conversations
 
   - id: agentline.account.telephony.events.peek
+    kind: account
     capability: account.telephony.events.peek
     platform: account
     scope: own_account

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1548,6 +1548,37 @@ EXA = OAuthProvider(
     probe_json={"urls": ["https://example.com"], "text": {"maxCharacters": 1}},
 )
 
+AGENTLINE = OAuthProvider(
+    service="agentline",
+    display_name="AgentLine",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="al_live_...",
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://agentline.cloud/signup",
+    setup_action_label="Get your AgentLine API key",
+    setup_steps=(
+        "Sign up or sign in to AgentLine with your email address.",
+        "Copy the API key shown after verification.",
+    ),
+    setup_note=(
+        "Account and history reads are free; voice calls cost $0.10/minute, phone number "
+        "provisioning costs $2.00, and inbound SMS costs $0.02/message."
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Other",
+    summary=(
+        "Give AI agents phone numbers, voice calls, SMS history, event delivery and telephony "
+        "spend tracking."
+    ),
+    base_url="https://api.agentline.cloud",
+    docs_url="https://docs.agentline.cloud",
+    probe_path="/v1/billing/balance",
+)
+
 
 # ---- more Enrichment API-key providers (2026-08 category expansion) ---------------------------
 # Eight providers added together to deepen Enrichment: company/people enrichment with prospecting
@@ -2348,7 +2379,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
-        SCRAPECREATORS,
+        SCRAPECREATORS, AGENTLINE,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT, EXA,
         # more Enrichment API-key providers

--- a/src/treg/web/logos/agentline.svg
+++ b/src/treg/web/logos/agentline.svg
@@ -1,0 +1,5 @@
+<svg width="65" height="65" viewBox="0 0 65 65" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="agentline">
+  <rect x="0.75" y="0.75" width="63.5" height="63.5" rx="12.5" fill="#162033"/>
+  <text x="32.5" y="43" text-anchor="middle" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="30" font-weight="700" fill="#FFFFFF">A</text>
+  <rect x="1.25" y="1.25" width="62.5" height="62.5" rx="12" stroke="#DDE5F2"/>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -20,6 +20,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
+                "agentline",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
                 "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",
                 "icypeas", "leadsforge", "influencersclub", "crustdata", "aviato",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -45,7 +45,7 @@ def test_every_provider_is_registered():
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
-        "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
+        "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa", "agentline",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
         "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",
         "icypeas", "leadsforge", "influencersclub", "crustdata", "aviato",


### PR DESCRIPTION
Adds AgentLine (`agentline`) as a Bearer-key provider with 15 curated, replay-safe account, history, event, voice, and billing endpoints.

Contact: sam@agentline.cloud

## Eligibility and provider details

- Self-serve key: email OTP signup at https://agentline.cloud/signup; no sales call.
- Auth: `Authorization: Bearer al_live_...`.
- Base URL: `https://api.agentline.cloud`.
- Docs: https://docs.agentline.cloud.
- Stable OpenAPI: https://api.agentline.cloud/openapi.json.
- Free probe: `GET /v1/billing/balance`.
- Pricing: https://agentline.cloud/pricing.
- Billing model: prepaid USD balance; phone numbers are $2.00/month, inbound and outbound calls are $0.10/minute, and inbound SMS/MMS is $0.02/provider message. Calls have a one-minute minimum and are then prorated by second, rounded up to the cent.
- Machine-readable rate card: authenticated `GET /v1/billing/balance`, currently reporting `call_per_minute: 0.1`, `number_provision: 2.0`, and `inbound_sms_per_message: 0.02`.
- Rate limits: the OTP flow publishes per-email and per-IP limits. Numeric limits for authenticated API routes are not currently published.

This listing is intentionally BYOK-only. Every catalogued endpoint reads the connected customer's own AgentLine account. A treg platform key would expose a shared account's agents, numbers, calls, messages, and billing data instead of the caller's resources.

No endpoint has a `verified:` stamp and no example response is committed; those remain for maintainer-observed verification.

## Bad-key probe

Observed live on 2026-08-27:

- Direct upstream: `GET https://api.agentline.cloud/v1/billing/balance` with a garbage Bearer key returned `401 {"detail":"Invalid or revoked API key / OAuth token."}`.
- Through this branch's treg connect flow: `POST /connections/token` with provider `agentline` and a garbage key returned `422 {"detail":"AgentLine rejected that token (HTTP 401)"}`.

## Self-verification ledger

All calls used the YAML's exact `test_request` on 2026-08-27. The meter was checked before and after the batch: AgentLine balance `$9.2200 -> $9.2200` and billing-ledger transaction count `10 -> 10`. Thus every listed read cost `$0.00`, matching the catalog. No credential value was logged or written.

| endpoint | HTTP | test target | catalog cost | metered cost | match | evidence |
|---|---:|---|---:|---:|---|---|
| `agentline.account.telephony.agents.list` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.numbers.list` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.calls.list` | 200 | `limit=1&offset=0` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.messages.list` | 200 | `limit=1&offset=0` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.conversations.list` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.events.peek` | 200 | `limit=1` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.webhooks.list` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.voices.list` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.voice.get` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.usage` | 200 | no params | $0.00 | $0.00 | yes | batch balance and ledger unchanged; response carried live rate card |
| `agentline.account.telephony.expenditure` | 200 | `period=current_month` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.call_charges` | 200 | `limit=1&offset=0` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.number_charges` | 200 | `limit=1&offset=0` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.spending_summary` | 200 | `months=1` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |
| `agentline.account.telephony.usage` | 200 | `period=current_month` | $0.00 | $0.00 | yes | batch balance and ledger unchanged |

## Full surface map

The deployed OpenAPI documents 60 HTTP operations. The core catalog selects the 15 replay-safe operations above. Paid actions, destructive operations, routes requiring account-specific IDs, and integration plumbing are excluded as detailed below.

### Catalogued

- `GET /v1/agents`: account agent inventory.
- `GET /v1/numbers`: account phone-number inventory.
- `GET /v1/calls`: replay-safe call history with bounded pagination.
- `GET /v1/messages`: replay-safe SMS history with bounded pagination.
- `GET /v1/messages/conversations`: replay-safe conversation inventory.
- `GET /v1/events/peek`: previews events without consuming them.
- `GET /v1/webhooks`: lists masked webhook configuration.
- `GET /v1/voices`: public voice-preset inventory.
- `GET /v1/account/voice`: current account voice setting.
- `GET /v1/billing/balance`: balance, affordability, and machine-readable rate card; also the auth probe.
- `GET /v1/billing/expenditure`: aggregate spend by category and period.
- `GET /v1/billing/expenditure/calls`: bounded individual call charges.
- `GET /v1/billing/expenditure/numbers`: bounded individual number charges.
- `GET /v1/billing/summary`: bounded monthly spending summary.
- `GET /v1/usage`: aggregate calls, messages, numbers, estimated costs, and rates by period.

### Excluded

- `POST /v1/agents`: creates persistent account state; no replay-safe fixed test.
- `GET /v1/agents/{agent_id}`: requires an account-specific ID; the list route covers the core read.
- `PATCH /v1/agents/{agent_id}`: mutates account configuration and requires an account-specific ID.
- `DELETE /v1/agents/{agent_id}`: destructive and cascades related account data.
- `POST /v1/auth/otp`: sends email and consumes auth rate limits; setup flow, not a connected-key tool.
- `POST /v1/auth/verify`: creates/signs into an account and mints a plaintext key; setup flow.
- `POST /v1/auth/keys`: mints a new plaintext API key and creates persistent credential state.
- `GET /v1/auth/keys`: credential administration; omitted in favor of telephony and billing operations.
- `DELETE /v1/auth/keys/{key_id}`: permanently revokes a credential and requires an account-specific ID.
- `POST /v1/calls`: places a real paid phone call and requires account-specific agent/number resources.
- `GET /v1/calls/{call_id}`: requires an account-specific ID; call history covers the core read.
- `GET /v1/calls/{call_id}/transcript`: requires a real account call ID and may expose private conversation content.
- `POST /v1/calls/{call_id}/hangup`: terminates a live call.
- `POST /v1/calls/{call_id}/context`: mutates a specific live relay turn and may speak text to a caller.
- `POST /v1/messages`: sends a real SMS and requires account-specific resources.
- `POST /v1/numbers`: purchases a real phone number and debits the account.
- `GET /v1/numbers/{number_id}`: requires an account-specific ID; number inventory covers the core read.
- `POST /v1/numbers/attach`: attaches a provider number, creates state, and debits the account.
- `PATCH /v1/numbers/{number_id}/reassign`: mutates number assignment and requires account-specific IDs.
- `GET /v1/usage/balance`: duplicates the richer catalogued billing balance/rate-card route.
- `GET /v1/usage/transactions`: overlaps the curated expenditure and charge-history routes.
- `GET /v1/billing/verify/{call_id}`: requires a real account call ID; useful only after a paid call.
- `GET /v1/billing/topup/x402/pay`: x402 payment discovery plumbing, not telephony functionality.
- `POST /v1/billing/topup/x402`: creates a persistent payment quote.
- `GET /v1/billing/topup/x402`: payment-quote history omitted from the telephony core.
- `GET /v1/billing/topup/x402/{topup_id}`: requires an account-specific payment ID.
- `POST /v1/billing/topup/x402/{topup_id}/settle`: settles an on-chain payment and changes balance.
- `PATCH /v1/account/voice`: mutates the account-wide voice setting.
- `DELETE /v1/account/voice`: mutates the account-wide voice setting.
- `GET /v1/events`: consumes and deletes returned mailbox events; `peek` is the replay-safe alternative.
- `POST /v1/webhooks`: creates/replaces webhook state and returns a signing secret.
- `DELETE /v1/webhooks`: deletes webhook state.
- `POST /v1/webhooks/test`: emits an event and performs external webhook delivery.
- `GET /v1/feedback`: account support workflow, outside the telephony core.
- `POST /v1/feedback`: creates persistent support/feedback state.
- `GET /`: unauthenticated service health metadata.
- `GET /health`: unauthenticated deployment liveness probe.
- `GET /debug/urls`: internal callback diagnostics that can contain callback credentials.
- `GET /.well-known/agentline.json`: unauthenticated integration discovery metadata.
- `GET /.well-known/x402.json`: unauthenticated payment discovery metadata.
- `POST /signalwire/answer/{call_id}`: internal provider callback.
- `POST /signalwire/sms`: internal provider callback that stores and meters inbound SMS/MMS.
- `POST /signalwire/hangup/{call_id}`: internal provider callback that finalizes and bills calls.
- `POST /signalwire/inbound`: internal provider callback that answers real inbound calls.
- `POST /signalwire/inbound_hangup`: internal provider callback that finalizes inbound calls.

The separately documented `wss://api.agentline.cloud/v1/events/ws` transport is also excluded because treg's HTTP catalog cannot replay a persistent authenticated WebSocket session.

## Validation

- `catalog_validate.py`: `OK - 82 provider file(s), 2910 endpoint(s), 0 error(s), 0 warning(s)`.
- `build_plugin.py --check`: all five skill mirrors match.
- Focused registry/catalog/logo checks: `19 passed`.
- Full suite under WSL on the Windows checkout: `2045 passed`; five unrelated NTFS-mount failures remain (one executable-bit validator and four CRLF-sensitive surface snapshots). The earlier native Windows run had the expected POSIX shell/mode failures. GitHub Actions runs on a native Linux checkout and is the authoritative complete-suite result.
