### PR TITLE
fix(call): release cancelled calls before re-raising

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           tests/test_migration.py
           tests/test_migration_ddl.py
           tests/test_alembic_baseline.py
+          tests/test_call_cancellation.py
           tests/test_call_pool_discipline.py
           tests/test_marketplace_call.py
           tests/test_billing.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
   test-postgres:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -79,6 +79,7 @@ jobs:
           --health-retries 5
     env:
       TREG_TEST_DB_URL: postgresql+asyncpg://treg:treg@127.0.0.1:5432/treg_test
+      PYTHONUNBUFFERED: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -23,8 +23,9 @@ job installs the hand-maintained lock with `uv sync --frozen`, then runs
 `uv run --frozen lint-imports` before the test suite. Keeping the check in that job reuses the
 development environment and avoids a second install for a fast static architecture check.
 The separate `test-postgres` job runs its database-sensitive subset serially against Postgres 16;
-it includes agent attribution, credential health, local-run reporting and ads-conversion coverage so
-naive-UTC assumptions are exercised by asyncpg rather than hidden by SQLite's permissive adapter.
+it uses unbuffered Python output and a 15-minute job budget so a slow test remains diagnosable. The
+subset includes agent attribution, credential health, local-run reporting and ads-conversion coverage
+so naive-UTC assumptions are exercised by asyncpg rather than hidden by SQLite's permissive adapter.
 
 Stage 1 activated the first two contracts:
 

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -88,6 +88,16 @@ never got an answer for (timeout, connect error, SSRF refusal, a failed oauth re
 apart — and it has to, because the error evidence that would otherwise explain the difference is
 purged after 14 days while the journal is permanent.
 
+A caller or task cancelled after reserve releases as `call_cancelled`. Compensation runs under a
+shield before the cancellation is re-raised: it closes an acquired upstream response exactly once,
+releases the hold, and gives back any pending idempotency label. The release uses the call reference
+minted before reserve rather than the later `MarketplaceCall.call_id`, because a database commit may
+have succeeded before `reserve` returned to assign that field. The ledger's conditional hold claim
+makes both outcomes safe: a committed hold is refunded and a rolled-back reserve is a no-op. A DB
+failure still leaves the committed hold to the lazy reaper. The same shielded cleanup covers
+cancellation after an idempotency claim but before reserve; with no hold yet, it gives the label
+back immediately so the next attempt does not wait for claim expiry.
+
 A release that itself fails is logged and left to the reaper (`_platform_settle` never raises).
 The response still reports `X-Treg-Cost-Micro: 0`, which is what the call ends up costing — but the
 balance only catches up when the hold is reaped, so a caller reading its balance immediately after

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -4155,6 +4155,68 @@ async def _platform_settle(
     return charged, observed
 
 
+async def _finish_cancelled_call(
+    request: Request,
+    mk: MarketplaceCall | None,
+    call_ref: str,
+    response: Response | None = None,
+) -> None:
+    """Finish compensation before propagating cancellation from a call that may have reserved."""
+    # A cancelled request cannot own this cleanup: another cancellation while it is returning the
+    # first one would strand the upstream response, hold, or idempotency label halfway through.
+    async def _cleanup() -> None:
+        # Every branch contains its own failure: raising here would replace the original cancellation
+        # when shield joins this task, instead of letting the remaining compensation finish.
+        if response is not None and response.background is not None:
+            background, response.background = response.background, None
+            try:
+                await background()
+            except (Exception, asyncio.CancelledError):  # noqa: BLE001
+                logging.getLogger("treg.proxy").error(
+                    "upstream close failed for cancelled call %s", call_ref, exc_info=True)
+        if mk is not None and mk.metered:
+            # `ledger.reserve` may have committed without returning, so `mk.call_id` is not an
+            # authority here. The pre-reserve call_ref is the hold id in either outcome, and release
+            # conditionally claims it: committed means refund, rolled back means a safe no-op.
+            mk.call_id = None
+            try:
+                async with session_maker() as cleanup_db:
+                    await ledger.release(
+                        cleanup_db,
+                        call_ref,
+                        reason="call_cancelled",
+                        meta={"provider": mk.provider, "cost_type": mk.cost_type,
+                              "status_code": None},
+                    )
+            except (Exception, asyncio.CancelledError):  # noqa: BLE001
+                logging.getLogger("treg.ledger").error(
+                    "cancellation release failed for call %s", call_ref, exc_info=True)
+        try:
+            await _release_idempotent_claim(request)
+        except (Exception, asyncio.CancelledError):  # noqa: BLE001
+            logging.getLogger("treg.idempotency").error(
+                "cancellation claim release failed for call %s", call_ref, exc_info=True)
+
+    cleanup = asyncio.create_task(_cleanup())
+    while not cleanup.done():
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            # A repeated cancel may interrupt the shield await, but not its child. Keep joining the
+            # same cleanup task so compensation completes before the original cancellation escapes.
+            continue
+    await cleanup
+
+
+async def _await_before_reserve(awaitable, request: Request, call_ref: str):
+    """Release an owned idempotency label if cancellation lands before the money gate."""
+    try:
+        return await awaitable
+    except asyncio.CancelledError:
+        await _finish_cancelled_call(request, None, call_ref)
+        raise
+
+
 async def _record_first_call(org_id: int) -> None:
     """Set Org.first_call_at once — the metric that decides whether a marketing channel is real (see
     marketing/landing/_measurement.md). A CONDITIONAL UPDATE, not read-then-write: concurrent first
@@ -4268,7 +4330,8 @@ async def call_tool(
     mk: MarketplaceCall | None = None
     own_tool_miss: dict | None = None
     try:
-        tool, upstream_url = await _resolve_call(rest, caller, db)
+        tool, upstream_url = await _await_before_reserve(
+            _resolve_call(rest, caller, db), request, call_ref)
     except HTTPException as exc:
         # Not a tool → maybe a marketplace endpoint id (`treg call tikhub.tiktok.video.comments`).
         # Only the 404 falls through, so an org tool with the same name always wins.
@@ -4279,7 +4342,8 @@ async def call_tool(
                 and str(exc.detail.get("hint", "")).startswith("your org has tool ")):
             own_tool_miss = exc.detail
         try:
-            mk = await _resolve_marketplace_call(ep, request, caller, db)
+            mk = await _await_before_reserve(
+                _resolve_marketplace_call(ep, request, caller, db), request, call_ref)
         except HTTPException as mkexc:
             # Catalog resolution is allowed to fall through from a named miss, but its own 404 must
             # not discard the useful fact discovered there: this org already has a nearby own tool.
@@ -4310,10 +4374,15 @@ async def call_tool(
     # Policy deny — evaluated on the RESOLVED upstream, so it sees the real host/path/method whichever
     # shape the caller used (named or URL-passthrough), and the relay never follows redirects, so a
     # blocked host can't be reached via a 3xx bounce.
-    await _enforce_deny(caller, upstream_url, request.method, db, tool.project_id)
-    await _enforce_daily_cap(caller, db)  # per-user daily cap (skips sandbox + unmetered members)
+    await _await_before_reserve(
+        _enforce_deny(caller, upstream_url, request.method, db, tool.project_id), request, call_ref)
+    await _await_before_reserve(
+        _enforce_daily_cap(caller, db), request, call_ref
+    )  # per-user daily cap (skips sandbox + unmetered members)
     if caller.org.public_demo and not _role_at_least(caller.role, "admin"):
-        await _enforce_public_demo_ip_cap(request, db)  # shared token → meter by client IP, not user
+        await _await_before_reserve(
+            _enforce_public_demo_ip_cap(request, db), request, call_ref
+        )  # shared token → meter by client IP, not user
 
     # The caller's own request bytes, read ONCE when it is safe to buffer them, so a failure can be
     # explained later (see models.CallRecord.error_request). Metered JSON calls already require full
@@ -4332,7 +4401,7 @@ async def call_tool(
             small_declared_body = False
     if _may_have_body(request) and ((mk is not None and mk.metered) or small_declared_body):
         try:
-            caller_body = await request.body()
+            caller_body = await _await_before_reserve(request.body(), request, call_ref)
         except Exception:  # noqa: BLE001 — a caller that hung up must not become a 500 here
             caller_body = b""
 
@@ -4396,11 +4465,17 @@ async def call_tool(
     if demo_sandbox.is_sandbox(caller.org):
         live_key = get_settings().demo_stripe_key
         if live_key and demo_sandbox.is_live_tool(tool) and request.method in ("GET", "POST"):
-            await _enforce_public_demo_ip_cap(request, db)  # one shared wire → meter by client IP
-            await db.commit()  # end the DB phase before network I/O (see the same call before relay())
+            await _await_before_reserve(
+                _enforce_public_demo_ip_cap(request, db), request, call_ref
+            )  # one shared wire → meter by client IP
+            await _await_before_reserve(
+                db.commit(), request, call_ref
+            )  # end the DB phase before network I/O (see the same call before relay())
             try:
-                response = await _relay_live_demo(
-                    request, upstream_url, live_key, demo_sandbox.visitor_name(caller.org.slug))
+                response = await _await_before_reserve(
+                    _relay_live_demo(
+                        request, upstream_url, live_key, demo_sandbox.visitor_name(caller.org.slug)),
+                    request, call_ref)
             except httpx.RequestError as exc:
                 _audit(502)
                 raise HTTPException(status_code=502, detail=f"upstream request failed: {str(exc) or type(exc).__name__}")
@@ -4408,10 +4483,11 @@ async def call_tool(
             return response
         secrets = {}
         for sid in {b.get("secret_id") for b in tool.bindings if b.get("secret_id") is not None}:
-            s = await db.get(Secret, sid)
+            s = await _await_before_reserve(db.get(Secret, sid), request, call_ref)
             if s is not None and s.org_id == caller.org_id:
                 secrets[sid] = s
-        body = (await request.body()).decode("utf-8", "replace")
+        body = (await _await_before_reserve(request.body(), request, call_ref)).decode(
+            "utf-8", "replace")
         result = demo_sandbox.synthesize(
             request.method, upstream_url, tool, secrets,
             query=request.query_params.multi_items(), body=body)
@@ -4426,7 +4502,7 @@ async def call_tool(
     try:
         # A platform binding carries no secret_id — its value comes from settings at relay time.
         for sid in {b["secret_id"] for b in tool.bindings if b.get("secret_id") is not None}:
-            secret = await db.get(Secret, sid)
+            secret = await _await_before_reserve(db.get(Secret, sid), request, call_ref)
             if secret is None or secret.org_id != caller.org_id:
                 raise HTTPException(status_code=409, detail="a bound secret is missing")
             secrets[sid] = secret
@@ -4442,7 +4518,8 @@ async def call_tool(
             raise HTTPException(status_code=403, detail=(
                 f"{billed_provider.display_name} calls are pay-per-use on treg's app and the "
                 f"public demo can't spend — create your own team to use this"))
-        mk = await _billed_marketplace(mk, billed_provider, tool, upstream_url, request)
+        mk = await _await_before_reserve(
+            _billed_marketplace(mk, billed_provider, tool, upstream_url, request), request, call_ref)
 
     # Metered — treg's own money is about to be spent (tier 4's platform key, or a registry OAuth
     # connect on a pay-per-use app), so take the money FIRST. Deliberately the last gate before the
@@ -4458,6 +4535,9 @@ async def call_tool(
         refusal_secrets = _safe_secret_renderings(tool, secrets)
         try:
             await _platform_reserve(mk, caller, db, meta=meta, call_ref=call_ref)
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, mk, call_ref)
+            raise
         except HTTPException as exc:
             # A call refused for MONEY (402 empty balance / 429 daily cap) is the event the org will
             # ask about first — it must appear in the activity feed, charged 0.
@@ -4482,6 +4562,7 @@ async def call_tool(
                                        _ERROR_RESPONSE_MAX)))
             raise
     body = b""
+    response: Response | None = None
     started = _now_ms()
     try:
         # treg keeps oauth tokens fresh: refresh in place if stale, before injecting. Inside the
@@ -4520,12 +4601,19 @@ async def call_tool(
             raise HTTPException(status_code=502, detail=f"credential injection failed: {exc}")
         except httpx.RequestError as exc:  # upstream down/timeout is a gateway fault, not treg's 500
             raise HTTPException(status_code=502, detail=f"upstream request failed: {str(exc) or type(exc).__name__}")
+    except asyncio.CancelledError:
+        await _finish_cancelled_call(request, mk, call_ref, response)
+        raise
     except HTTPException as exc:
         # The provider never produced a billable answer (our own error, a failed injection, an
         # unreachable upstream) → return the hold in full, regardless of the endpoint's billing type.
         metered = mk is not None and mk.metered
         if metered:
-            await _platform_settle(mk, None, reason=f"call_failed_{exc.status_code}")
+            try:
+                await _platform_settle(mk, None, reason=f"call_failed_{exc.status_code}")
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
             # The shared exception handler builds the response and adds this zero-cost result.
             request.state.call_cost_micro = 0
         # No provider body exists on this branch. treg's own detail is the explanation instead, and
@@ -4544,7 +4632,11 @@ async def call_tool(
         # The reaper would eventually return this hold anyway; returning it now means a bug in the call
         # path can't make a funded org look broke for the next three minutes.
         if mk is not None and mk.metered:
-            await _platform_settle(mk, None, reason="call_crashed")
+            try:
+                await _platform_settle(mk, None, reason="call_crashed")
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
         raise
     duration_ms = _now_ms() - started
     # First successful call. The common case — an org that already has one — is an in-memory check
@@ -4553,16 +4645,24 @@ async def call_tool(
     # does so via _record_first_call's own session, never the request's `db` (which _platform_settle,
     # right below, is about to settle/release — see its docstring for why that session is off-limits).
     if 200 <= response.status_code < 400 and caller.org_id and caller.org.first_call_at is None:
-        await _record_first_call(caller.org_id)
+        try:
+            await _record_first_call(caller.org_id)
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, mk, call_ref, response)
+            raise
     if mk is not None and mk.metered:
-        charged, observed = await _platform_settle(
-            mk, response.status_code, body, headers=response.headers,
-            # `provider_failed_`, not `call_failed_`: the latter is the branch above, where treg
-            # never got an answer (timeout, SSRF refusal, a failed oauth refresh). Both release a
-            # 502 the same way, so a shared prefix would make the two indistinguishable in the
-            # journal once the 14-day error evidence expires — and they need different fixes.
-            reason=(f"provider_failed_{response.status_code}" if response.status_code >= 500 else ""),
-        )
+        try:
+            charged, observed = await _platform_settle(
+                mk, response.status_code, body, headers=response.headers,
+                # `provider_failed_`, not `call_failed_`: the latter is the branch above, where treg
+                # never got an answer (timeout, SSRF refusal, a failed oauth refresh). Both release a
+                # 502 the same way, so a shared prefix would make the two indistinguishable in the
+                # journal once the 14-day error evidence expires — and they need different fixes.
+                reason=(f"provider_failed_{response.status_code}" if response.status_code >= 500 else ""),
+            )
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, mk, call_ref, response)
+            raise
         # A relayed non-2xx arrives HERE, as a Response — the vendor's own status is never raised
         # (see _refusal_kind). So this is where the provider's own explanation is captured, and the
         # only place it exists: nothing downstream keeps the body.
@@ -4581,10 +4681,14 @@ async def call_tool(
             # Here, and not earlier: this is the first point where BOTH the response and what it
             # actually cost are known, and a replay has to hand back the real charge rather than the
             # estimate that was reserved.
+            try:
+                await _store_idempotent(idem_key, caller, status_code=response.status_code, body=body,
+                                        media_type=response.headers.get("content-type", ""),
+                                        charged_micro=charged, metered=True, call_ref=call_ref)
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
             request.state.idem_claim = None      # dealt with; nothing left to release
-            await _store_idempotent(idem_key, caller, status_code=response.status_code, body=body,
-                                    media_type=response.headers.get("content-type", ""),
-                                    charged_micro=charged, metered=True, call_ref=call_ref)
         # Tell the caller what the call actually cost. Both llms.txt and skill.md instruct an agent to
         # report the price it spent, and until now the only way to find out was to read the balance
         # before and after — which races with any other call and cannot attribute a figure to a
@@ -4609,9 +4713,13 @@ async def call_tool(
     if idem_key:
         # Unmetered: nothing was billed, so there is nothing to protect. Dropping the claim frees the
         # label at once instead of making the caller wait out the window to reuse it.
+        try:
+            await _store_idempotent(idem_key, caller, status_code=response.status_code, body=b"",
+                                    media_type="", charged_micro=0, metered=False)
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, mk, call_ref, response)
+            raise
         request.state.idem_claim = None
-        await _store_idempotent(idem_key, caller, status_code=response.status_code, body=b"",
-                                media_type="", charged_micro=0, metered=False)
     response.headers["X-Treg-Call-Id"] = call_ref
     return response
 

--- a/tests/test_call_cancellation.py
+++ b/tests/test_call_cancellation.py
@@ -87,6 +87,33 @@ async def _idempotency_claim(key: str) -> IdempotentCall | None:
         ))).scalar_one_or_none()
 
 
+async def _wait_for_gate(
+    event: asyncio.Event,
+    task: asyncio.Task[httpx.Response],
+    label: str,
+) -> None:
+    event_task = asyncio.create_task(event.wait())
+    try:
+        done, _ = await asyncio.wait(
+            {event_task, task}, timeout=30, return_when=asyncio.FIRST_COMPLETED)
+        if event_task in done:
+            return
+        if task in done:
+            try:
+                response = task.result()
+            except BaseException as exc:
+                raise AssertionError(
+                    f"request task failed before {label}: {type(exc).__name__}: {exc}") from exc
+            raise AssertionError(
+                f"request finished before {label}: HTTP {response.status_code}: "
+                f"{response.text[:500]}")
+        raise AssertionError(f"timed out after 30s waiting for {label}; request is still running")
+    finally:
+        if not event_task.done():
+            event_task.cancel()
+            await asyncio.gather(event_task, return_exceptions=True)
+
+
 async def test_cancelling_a_funded_metered_call_releases_every_resource(
     clients: AsyncClient, platform_on,
 ):
@@ -101,7 +128,7 @@ async def test_cancelling_a_funded_metered_call_releases_every_resource(
     headers = {"Idempotency-Key": "cancelled-funded-call"}
     task = asyncio.create_task(clients.get(f"/call/{EP}?aweme_id=cancel-me", headers=headers))
     try:
-        await asyncio.wait_for(stream.body_started.wait(), timeout=5)
+        await _wait_for_gate(stream.body_started, task, "provider body start")
         holds = await _open_holds(org_id)
         assert len(holds) == 1, "the provider blocks only after the funded call has reserved"
         call_id = holds[0].id
@@ -165,7 +192,7 @@ async def test_cancellation_at_the_reserve_commit_boundary_is_idempotent(
         headers={"Idempotency-Key": f"cancel-at-commit-{reserve_committed}"},
     ))
     try:
-        await asyncio.wait_for(commit_reached.wait(), timeout=5)
+        await _wait_for_gate(commit_reached, task, "reserve commit boundary")
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
@@ -231,17 +258,17 @@ async def test_repeated_cancellation_cannot_interrupt_compensation(
     task = asyncio.create_task(clients.get(
         f"/call/{EP}?aweme_id=cancel-three-times", headers=headers))
     try:
-        await asyncio.wait_for(stream.body_started.wait(), timeout=5)
+        await _wait_for_gate(stream.body_started, task, "provider body start")
         holds = await _open_holds(org_id)
         assert len(holds) == 1
         call_id = holds[0].id
 
         task.cancel()
-        await asyncio.wait_for(cleanup_commit_reached.wait(), timeout=5)
+        await _wait_for_gate(cleanup_commit_reached, task, "cancellation release commit")
         task.cancel()
         await asyncio.sleep(0)
         allow_cleanup_commit.set()
-        await asyncio.wait_for(claim_commit_reached.wait(), timeout=5)
+        await _wait_for_gate(claim_commit_reached, task, "idempotency claim delete commit")
         task.cancel()
         await asyncio.sleep(0)
         allow_claim_commit.set()
@@ -289,7 +316,7 @@ async def test_cancellation_after_claim_before_reserve_releases_the_label(
         headers={"Idempotency-Key": key},
     ))
     try:
-        await asyncio.wait_for(resolve_reached.wait(), timeout=5)
+        await _wait_for_gate(resolve_reached, task, "target resolution gate")
         claim = await _idempotency_claim(key)
         assert claim is not None and claim.status == "pending"
         task.cancel()
@@ -355,7 +382,7 @@ async def test_cancellation_while_failure_release_is_in_flight_finishes_compensa
         headers={"Idempotency-Key": f"cancel-{first_reason}"},
     ))
     try:
-        await asyncio.wait_for(release_commit_reached.wait(), timeout=5)
+        await _wait_for_gate(release_commit_reached, task, "failure release commit")
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/test_call_cancellation.py
+++ b/tests/test_call_cancellation.py
@@ -1,0 +1,373 @@
+"""Cancellation compensation for funded metered calls.
+
+These tests use the real HTTP route, marketplace resolution, reserve, relay, and ledger. The only
+controlled edges are the provider response stream and the reserve commit boundary where cancellation
+must be delivered deterministically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from treg import api as A, ledger
+from treg.api import app
+from treg.db import session_maker
+from treg.models import Hold, IdempotentCall, LedgerEntry
+
+from test_marketplace_call import EP, platform_on  # noqa: F401 - shared tier-4 fixture
+
+
+class _BlockingProviderStream(httpx.AsyncByteStream):
+    def __init__(self) -> None:
+        self.body_started = asyncio.Event()
+        self.allow_body = asyncio.Event()
+        self.close_calls = 0
+
+    async def __aiter__(self):
+        self.body_started.set()
+        await self.allow_body.wait()
+        yield b'{"ok":true}'
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+
+
+class _BlockingProviderTransport(httpx.AsyncBaseTransport):
+    def __init__(self, stream: _BlockingProviderStream) -> None:
+        self.stream = stream
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "application/json"},
+            stream=self.stream,
+            request=request,
+        )
+
+
+async def _funded_org(clients: AsyncClient) -> tuple[int, int]:
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        await ledger.grant(
+            db,
+            org_id,
+            amount_micro=100_000,
+            kind="cancellation_test",
+            once=False,
+        )
+    balance = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+    return org_id, balance
+
+
+async def _open_holds(org_id: int) -> list[Hold]:
+    async with session_maker() as db:
+        return list((await db.execute(select(Hold).where(Hold.org_id == org_id))).scalars().all())
+
+
+async def _release_entries(org_id: int, call_id: str) -> list[LedgerEntry]:
+    async with session_maker() as db:
+        return list((await db.execute(select(LedgerEntry).where(
+            LedgerEntry.org_id == org_id,
+            LedgerEntry.call_id == call_id,
+            LedgerEntry.kind == "release",
+        ))).scalars().all())
+
+
+async def _idempotency_claim(key: str) -> IdempotentCall | None:
+    async with session_maker() as db:
+        return (await db.execute(select(IdempotentCall).where(
+            IdempotentCall.key == key
+        ))).scalar_one_or_none()
+
+
+async def test_cancelling_a_funded_metered_call_releases_every_resource(
+    clients: AsyncClient, platform_on,
+):
+    org_id, balance_before = await _funded_org(clients)
+    stream = _BlockingProviderStream()
+    tracked = AsyncClient(
+        transport=_BlockingProviderTransport(stream),
+        base_url="https://blocking-provider.test",
+    )
+    original_http = app.state.http
+    app.state.http = tracked
+    headers = {"Idempotency-Key": "cancelled-funded-call"}
+    task = asyncio.create_task(clients.get(f"/call/{EP}?aweme_id=cancel-me", headers=headers))
+    try:
+        await asyncio.wait_for(stream.body_started.wait(), timeout=5)
+        holds = await _open_holds(org_id)
+        assert len(holds) == 1, "the provider blocks only after the funded call has reserved"
+        call_id = holds[0].id
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert stream.close_calls == 1, "cancellation closes the provider response exactly once"
+        assert await _open_holds(org_id) == []
+        balance_after = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+        assert balance_after == balance_before
+        releases = await _release_entries(org_id, call_id)
+        assert len(releases) == 1
+        assert releases[0].meta["reason"] == "call_cancelled"
+
+        async with session_maker() as db:
+            claim = (await db.execute(select(IdempotentCall).where(
+                IdempotentCall.key == "cancelled-funded-call"
+            ))).scalar_one_or_none()
+        assert claim is None, "the cancelled request gives its label back immediately"
+    finally:
+        app.state.http = original_http
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await tracked.aclose()
+
+    retry = await clients.get(f"/call/{EP}?aweme_id=cancel-me", headers=headers)
+    assert retry.status_code == 200, retry.text
+    assert retry.headers.get("X-Treg-Idempotent-Replay") is None
+
+
+@pytest.mark.parametrize("reserve_committed", [True, False], ids=["committed", "rolled-back"])
+async def test_cancellation_at_the_reserve_commit_boundary_is_idempotent(
+    clients: AsyncClient, platform_on, monkeypatch, reserve_committed: bool,
+):
+    org_id, balance_before = await _funded_org(clients)
+    commit_reached = asyncio.Event()
+    never_return = asyncio.Event()
+    original_commit = AsyncSession.commit
+    call_id: str | None = None
+
+    async def _gated_commit(db: AsyncSession) -> None:
+        nonlocal call_id
+        new_hold = next((row for row in db.new if isinstance(row, Hold)), None)
+        if new_hold is None:
+            await original_commit(db)
+            return
+        call_id = new_hold.id
+        if reserve_committed:
+            await original_commit(db)
+        else:
+            await db.rollback()
+        commit_reached.set()
+        await never_return.wait()
+
+    monkeypatch.setattr(AsyncSession, "commit", _gated_commit)
+    task = asyncio.create_task(clients.get(
+        f"/call/{EP}?aweme_id=commit-edge",
+        headers={"Idempotency-Key": f"cancel-at-commit-{reserve_committed}"},
+    ))
+    try:
+        await asyncio.wait_for(commit_reached.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert call_id is not None
+    assert await _open_holds(org_id) == []
+    balance_after = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+    assert balance_after == balance_before
+    releases = await _release_entries(org_id, call_id)
+    if reserve_committed:
+        assert len(releases) == 1 and releases[0].meta["reason"] == "call_cancelled"
+    else:
+        assert releases == [], "releasing a rolled-back reservation is a no-op"
+
+
+async def test_repeated_cancellation_cannot_interrupt_compensation(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    key = "cancelled-three-times"
+    org_id, balance_before = await _funded_org(clients)
+    stream = _BlockingProviderStream()
+    tracked = AsyncClient(
+        transport=_BlockingProviderTransport(stream),
+        base_url="https://blocking-provider.test",
+    )
+    original_http = app.state.http
+    original_commit = AsyncSession.commit
+    original_delete = AsyncSession.delete
+    original_release = ledger.release
+    cleanup_commit_reached = asyncio.Event()
+    allow_cleanup_commit = asyncio.Event()
+    claim_commit_reached = asyncio.Event()
+    allow_claim_commit = asyncio.Event()
+
+    async def _tag_cancelled_release(db: AsyncSession, call_id: str, **kwargs):
+        if kwargs.get("reason") == "call_cancelled":
+            db.sync_session.info["cancelled_release"] = True
+        return await original_release(db, call_id, **kwargs)
+
+    async def _tag_claim_delete(db: AsyncSession, row) -> None:
+        if isinstance(row, IdempotentCall) and row.key == key:
+            db.sync_session.info["claim_delete"] = True
+        await original_delete(db, row)
+
+    async def _gate_cleanup_commit(db: AsyncSession) -> None:
+        if db.sync_session.info.get("cancelled_release"):
+            cleanup_commit_reached.set()
+            await allow_cleanup_commit.wait()
+        if db.sync_session.info.get("claim_delete"):
+            claim_commit_reached.set()
+            await allow_claim_commit.wait()
+        await original_commit(db)
+
+    monkeypatch.setattr(ledger, "release", _tag_cancelled_release)
+    monkeypatch.setattr(AsyncSession, "delete", _tag_claim_delete)
+    monkeypatch.setattr(AsyncSession, "commit", _gate_cleanup_commit)
+    app.state.http = tracked
+    headers = {"Idempotency-Key": key}
+    task = asyncio.create_task(clients.get(
+        f"/call/{EP}?aweme_id=cancel-three-times", headers=headers))
+    try:
+        await asyncio.wait_for(stream.body_started.wait(), timeout=5)
+        holds = await _open_holds(org_id)
+        assert len(holds) == 1
+        call_id = holds[0].id
+
+        task.cancel()
+        await asyncio.wait_for(cleanup_commit_reached.wait(), timeout=5)
+        task.cancel()
+        await asyncio.sleep(0)
+        allow_cleanup_commit.set()
+        await asyncio.wait_for(claim_commit_reached.wait(), timeout=5)
+        task.cancel()
+        await asyncio.sleep(0)
+        allow_claim_commit.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert stream.close_calls == 1
+        assert await _open_holds(org_id) == []
+        balance_after = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+        assert balance_after == balance_before
+        releases = await _release_entries(org_id, call_id)
+        assert len(releases) == 1 and releases[0].meta["reason"] == "call_cancelled"
+        assert await _idempotency_claim(key) is None
+    finally:
+        allow_cleanup_commit.set()
+        allow_claim_commit.set()
+        app.state.http = original_http
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await tracked.aclose()
+
+    retry = await clients.get(
+        f"/call/{EP}?aweme_id=cancel-three-times", headers=headers)
+    assert retry.status_code == 200, retry.text
+    assert retry.headers.get("X-Treg-Idempotent-Replay") is None
+
+
+async def test_cancellation_after_claim_before_reserve_releases_the_label(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    key = "cancel-before-reserve"
+    resolve_reached = asyncio.Event()
+    never_resolve = asyncio.Event()
+    original_resolve = A._resolve_call
+
+    async def _blocked_resolve(*args, **kwargs):
+        resolve_reached.set()
+        await never_resolve.wait()
+        return await original_resolve(*args, **kwargs)
+
+    monkeypatch.setattr(A, "_resolve_call", _blocked_resolve)
+    task = asyncio.create_task(clients.get(
+        f"/call/{EP}?aweme_id=pre-reserve",
+        headers={"Idempotency-Key": key},
+    ))
+    try:
+        await asyncio.wait_for(resolve_reached.wait(), timeout=5)
+        claim = await _idempotency_claim(key)
+        assert claim is not None and claim.status == "pending"
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert await _idempotency_claim(key) is None
+    monkeypatch.setattr(A, "_resolve_call", original_resolve)
+    retry = await clients.get(
+        f"/call/{EP}?aweme_id=pre-reserve",
+        headers={"Idempotency-Key": key},
+    )
+    assert retry.status_code == 200, retry.text
+
+
+@pytest.mark.parametrize(
+    ("failure", "first_reason"),
+    [
+        (HTTPException(status_code=502, detail="upstream failed"), "call_failed_502"),
+        (RuntimeError("call path crashed"), "call_crashed"),
+    ],
+    ids=["call-failed", "call-crashed"],
+)
+async def test_cancellation_while_failure_release_is_in_flight_finishes_compensation(
+    clients: AsyncClient, platform_on, monkeypatch,
+    failure: Exception, first_reason: str,
+):
+    org_id, balance_before = await _funded_org(clients)
+    release_commit_reached = asyncio.Event()
+    never_finish_first_release = asyncio.Event()
+    original_commit = AsyncSession.commit
+    original_release = ledger.release
+    gated = False
+    call_id: str | None = None
+
+    async def _fail_relay(*args, **kwargs):
+        raise failure
+
+    async def _tag_first_release(db: AsyncSession, released_call_id: str, **kwargs):
+        if kwargs.get("reason") == first_reason:
+            db.sync_session.info["first_release"] = released_call_id
+        return await original_release(db, released_call_id, **kwargs)
+
+    async def _gate_first_release(db: AsyncSession) -> None:
+        nonlocal gated, call_id
+        first_release = db.sync_session.info.get("first_release")
+        if first_release is not None and not gated:
+            gated = True
+            call_id = first_release
+            release_commit_reached.set()
+            await never_finish_first_release.wait()
+        await original_commit(db)
+
+    monkeypatch.setattr(A, "relay", _fail_relay)
+    monkeypatch.setattr(ledger, "release", _tag_first_release)
+    monkeypatch.setattr(AsyncSession, "commit", _gate_first_release)
+    task = asyncio.create_task(clients.get(
+        f"/call/{EP}?aweme_id=failure-release",
+        headers={"Idempotency-Key": f"cancel-{first_reason}"},
+    ))
+    try:
+        await asyncio.wait_for(release_commit_reached.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+    assert call_id is not None
+    assert await _open_holds(org_id) == []
+    balance_after = (await clients.get(f"/orgs/{org_id}/balance")).json()["balance_micro"]
+    assert balance_after == balance_before
+    releases = await _release_entries(org_id, call_id)
+    assert len(releases) == 1 and releases[0].meta["reason"] == "call_cancelled"
+    assert await _idempotency_claim(f"cancel-{first_reason}") is None


### PR DESCRIPTION
Re-filed from #212 (GitHub closed it when #210's base branch was deleted on merge; a closed PR cannot be retargeted). Content is identical: the pre-4b fix PR mandated by the Stage 4 checkpoint-0 contract, now based on main which contains #210.

## The bug

`asyncio.CancelledError` is a `BaseException`, so `call_tool`'s `except Exception` compensation never ran for a cancelled caller. A client that disconnected after the money reservation left:

- the **hold** open until the lazy reaper (~minutes of a funded org looking broke),
- the **idempotency claim** parked for the full 24 h window - every retry with that key answered 409 for a day,
- the **upstream response** unclosed until GC.

## The fix

One shielded compensation path, `_finish_cancelled_call`: close the upstream response exactly once, release the hold by the pre-minted `call_ref` with ledger reason `call_cancelled`, release the idempotency claim. Invoked from `CancelledError` handlers covering every await after the claim:

- `_await_before_reserve` wraps the 13 awaits between the idempotency claim and `_platform_reserve` (resolve, deny, caps, body read, sandbox branches, secret loads, billed-marketplace classification) - before any money moves, cancellation releases only the claim;
- the reserve call itself (commit-outcome-uncertain window: release by known `call_ref` is idempotent - a committed hold refunds, a rolled-back reserve no-ops, arbitrated by `ledger._claim_hold`'s conditional delete);
- the relay/buffer region, `_record_first_call`, `_platform_settle` on success and on both failure paths (`call_failed_*` / `call_crashed`), and both `_store_idempotent` sites.

The cleanup runs as a task joined through an `asyncio.shield` loop, so anyio's cancellation re-delivery at every await cannot strand compensation halfway. `_cleanup` upholds a must-not-raise invariant; a DB failure during compensation is logged and the committed hold remains durable for the reaper (unchanged outage semantics).

## Intentional behavior changes

Per the refactor plan §0.6 amendment, this list is exhaustive; everything else is behavior-identical.

1. Cancelled metered calls now release immediately with new ledger release reason `call_cancelled` (previously: hold left to the reaper, no release entry until then).
2. Cancelled calls release their idempotency claim immediately (previously: label parked up to 24 h).
3. `request.state.idem_claim` is cleared after `_store_idempotent` instead of before it - identical on all non-cancellation paths (`_store_idempotent` never raises), and it lets a cancellation during the store give the label back.

## Verification

- **E2E, mutation-verified**: all bug-class tests fail at the parent commit (6/7 red on SQLite and Postgres; the 7th is a rolled-back-reserve no-op safety assertion that passes by design).
- `test_cancelling_a_funded_metered_call_releases_every_resource`: real route, blocking provider stream, cancel mid-body → upstream closed exactly once, balance restored, zero holds, exactly one `call_cancelled` release, label immediately reusable, retry is a fresh call.
- `test_cancellation_at_the_reserve_commit_boundary_is_idempotent[committed|rolled-back]`: gated reserve commit, cancel at the uncertain boundary → refund vs no-op, both proven.
- `test_repeated_cancellation_cannot_interrupt_compensation`: gates the release commit and the claim-delete commit, delivers a second and third `task.cancel()` while each is blocked → compensation still completes. Mutation-verified both ways: removing the shield loop fails it, and un-shielding only the claim-release half fails it.
- `test_cancellation_after_claim_before_reserve_releases_the_label`: cancel during resolve → claim row deleted, label reusable.
- `test_cancellation_while_failure_release_is_in_flight_finishes_compensation[call-failed|call-crashed]`: cancel while the failure-path release commit is in flight → exactly one terminal release.
- Full suite 2003 passed + 1 skipped (SQLite); cancellation + pool-discipline + callmatrix 44 passed on Postgres 16; the cancellation file runs in the CI Postgres job. Four snapshots byte-identical; `lint-imports` 5 kept; independent adversarial review (2 rounds) approved.

## Known residuals (reviewed, accepted)

- A cancellation landing inside `_claim_idempotent`'s own commit round-trip can park the label 24 h (row committed, `request.state.idem_claim` never set). Single round-trip window; closable only by releasing by `(membership_id, key)`.
- A cancellation after a settle has committed still releases the pending claim, so a retry pays again for one logical call - the alternative (keeping the claim) is 24 h of 409s.
- Process death / persistent DB failure keeps today's semantics: the committed hold is the durable record, the reaper releases it.
- Cancelled calls write no audit row (same shape as the pre-fix reaper path); the `call_cancelled` ledger reason is the record.
