### PR TITLE
feat(mcp): add Claude catalog connector

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -19,6 +19,7 @@ Regenerate via `scripts/build-map.py`.
 | `alembic/env.py` | architecture/data-model.md |
 | `alembic/versions/0001_baseline_current_schema.py` | architecture/data-model.md |
 | `assets/brand/og-card.html` | interface/seo.md |
+| `docs/CLAUDE-CONNECTOR-SUBMISSION.md` | architecture/mcp-oauth.md |
 | `dsh/cordis.patch.yml` | interface/skill.md |
 | `dsh/index.js` | interface/skill.md |
 | `examples/proxy-demo/server.js` | architecture/local-proxy.md |
@@ -33,6 +34,7 @@ Regenerate via `scripts/build-map.py`.
 | `scripts/catalog_drift.py` | architecture/catalog.md |
 | `scripts/catalog_ingest.py` | architecture/catalog.md |
 | `scripts/catalog_validate.py` | architecture/catalog.md |
+| `scripts/dev-local.sh` | ops/deploy.md |
 | `scripts/dump_surface.py` | architecture/composition.md |
 | `scripts/minimax_plugin.py` | interface/skill.md |
 | `src/treg/__main__.py` | ops/deploy.md |
@@ -158,6 +160,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/timeutil.py` | architecture/data-model.md, interface/api.md |
 | `src/treg/web/adtrack.js` | architecture/ads-conversions.md |
 | `src/treg/web/catalog.css` | interface/seo.md |
+| `src/treg/web/claude-connector.html` | architecture/mcp-oauth.md |
 | `src/treg/web/connect-demo.html` | architecture/mcp-oauth.md |
 | `src/treg/web/index.html` | interface/dashboard.md, interface/landing-sandbox.md, interface/onboarding.md, interface/seo.md |
 | `src/treg/web/install.sh` | interface/landing-sandbox.md |
@@ -188,7 +191,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `__init__.py`, `teams.py`, `__init__.py`, `test_import_lightness.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
-| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `connect-demo.html` |
+| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md` |
 | `architecture/money.md` | `ledger.py`, `models.py`, `billing.py`, `billing.py`, `referrals.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `referrals.py`, `api.py`, `signup.py`, `admin.py`, `billing.py`, `orgs.py`, `referrals.py` |
 | `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `signup.py`, `teams.py`, `access.py`, `session.py`, `auth.py`, `orgs.py`, `resources.py`, `db.py`, `test_router_dependencies.py` |
 | `architecture/proxy-model.md` | `proxy.py`, `api.py` |
@@ -205,5 +208,5 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `index.html`, `landing.html`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `render.yaml` |
+| `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -177,6 +177,9 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/vendor/README.md` | interface/dashboard.md |
 | `src/treg/web/vendor/vue-3.5.41.global.prod.js` | interface/dashboard.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
+| `tests/test_marketplace_call.py` | architecture/mcp-oauth.md |
+| `tests/test_mcp.py` | architecture/mcp-oauth.md |
+| `tests/test_mcp_directory.py` | architecture/mcp-oauth.md |
 | `tests/test_router_dependencies.py` | architecture/multi-tenancy.md |
 
 ## Fragment → sources
@@ -191,7 +194,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `__init__.py`, `teams.py`, `__init__.py`, `test_import_lightness.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
-| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md` |
+| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
 | `architecture/money.md` | `ledger.py`, `models.py`, `billing.py`, `billing.py`, `referrals.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `referrals.py`, `api.py`, `signup.py`, `admin.py`, `billing.py`, `orgs.py`, `referrals.py` |
 | `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `signup.py`, `teams.py`, `access.py`, `session.py`, `auth.py`, `orgs.py`, `resources.py`, `db.py`, `test_router_dependencies.py` |
 | `architecture/proxy-model.md` | `proxy.py`, `api.py` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ This file orients an AI agent (Claude Code, Codex, Cursor, …) working in this 
 - Run `uv run pytest -q` before and after changes; keep it green (add tests for new behavior).
 - Keep changes minimal and scoped; match the surrounding style.
 - When you change a subsystem, update its `docs/context/` fragment in the same change.
+- When `/mcp/`, `/mcp/v2/`, or shared MCP code changes, review both MCP surfaces. Preserve the
+  documented differences, run the paired MCP contract tests, and update
+  `docs/context/architecture/mcp-oauth.md` when the contract changes.
 - Commits follow Conventional Commits (`feat(scope): …`, `fix: …`, `docs: …`); one logical change per
   commit. PRs should say what changed and why, and note which fragments were updated.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ the command line **and** treg's tools. Other agents: `npx skills add superdesign
 See [docs/CLAUDE-PLUGIN.md](docs/CLAUDE-PLUGIN.md). MiniMax Code / MiniMax Agent users: the same
 skill ships via the MiniMax Plugin Marketplace ([docs/MINIMAX-PLUGIN.md](docs/MINIMAX-PLUGIN.md)).
 
+### Claude.ai connector
+
+The Claude Connectors Directory surface is `https://treg.to/mcp/v2/`. It exposes only curated
+catalog endpoints and separates read calls from write calls so Claude receives accurate safety
+signals. The existing `/mcp/` surface remains available for catalog endpoints, team-owned tools,
+and imported skills. See the [MCP and OAuth architecture](docs/context/architecture/mcp-oauth.md)
+for the boundary and implementation, and the
+[submission runbook](docs/CLAUDE-CONNECTOR-SUBMISSION.md) for release gates.
+
 ## Call a tool you don't have a key for
 
 The catalog is grouped by what endpoints **do**: keyword and rank tracking, backlinks and authority,

--- a/docs/CLAUDE-CONNECTOR-SUBMISSION.md
+++ b/docs/CLAUDE-CONNECTOR-SUBMISSION.md
@@ -1,0 +1,96 @@
+# Claude Connectors Directory — submission runbook
+
+This runbook is the owner-facing release gate for Treg's catalog-only Claude connector. Do not
+submit until every required engineering and human check below has passed. Store no reviewer
+password, OAuth code, access token, refresh token, or provider secret in this repository or in test
+evidence.
+
+## Directory fields
+
+| Field | Submission value |
+|---|---|
+| Name | Treg |
+| Tagline | Live data and APIs for Claude, without API keys |
+| Categories | Data; Sales and marketing; Productivity |
+| Publisher | Superdesign |
+| Transport | Streamable HTTP |
+| Server URL | `https://treg.to/mcp/v2/` |
+| Authentication | OAuth DCR/CIMD with S256 PKCE |
+| Documentation | `https://treg.to/connectors/claude` |
+| Privacy | `https://treg.to/privacy` |
+| Support | `https://treg.to/support` |
+| Logo | `plugin/assets/logo.png` (1024×1024 marketplace logo) |
+| Allowed link URIs | None |
+| Availability | Immediately after directory approval |
+
+Describe Treg as a **third-party/community connector published by Superdesign**. Do not call the
+listing official, Anthropic-built, Anthropic-approved, verified, or certified unless Anthropic has
+explicitly granted the corresponding label.
+
+## Owner prerequisites
+
+- [ ] Obtain Owner access to a Claude.ai Team or Enterprise organization. A platform.claude.com API
+  organization does not satisfy this requirement.
+- [ ] Approve the name, tagline, categories, catalog-only scope, data-handling answers, and logo.
+- [ ] Create a dedicated reviewer mailbox and a dedicated Treg team owned by it.
+- [ ] Give the reviewer team a populated account, a **$10.00 balance**, and the normal **$5.00 daily
+  cap**. Connect only the provider account(s) required for the acceptance calls.
+- [ ] Put temporary reviewer mailbox credentials only in Anthropic's secure submission portal.
+- [ ] After review, rotate the mailbox password, revoke temporary provider access, and revoke the
+  review OAuth grant.
+
+## Engineering evidence
+
+- [ ] Full automated suite passes, including the exact six-tool contract, annotations, schemas,
+  method separation, catalog-only resolution, OAuth version isolation, transport protections,
+  pricing, metering, audit, idempotency, and error attribution.
+- [ ] MCP Inspector connects to `https://treg.to/mcp/v2/`, authenticates, lists exactly the six
+  expected tools, and successfully invokes each tool.
+- [ ] The deployed connector emits `claude-connector` attribution for catalog provider calls.
+- [ ] The legacy `https://treg.to/mcp/` contract remains unchanged.
+- [ ] Save dated, secret-free evidence: test output, Inspector result, endpoint ids, expected/actual
+  balance deltas, audit ids, and screenshots with private values redacted.
+
+## Mandatory production custom-connector test
+
+Anthropic documents custom and directory connectors as using the same runtime. This test blocks
+submission.
+
+1. In Claude.ai, add `https://treg.to/mcp/v2/` as a custom connector.
+2. Sign in with the dedicated reviewer mailbox, select the reviewer team, and verify the displayed
+   identity, team, balance, and daily cap.
+3. Ask Claude to search Treg for backlink endpoints for `example.com`, compare multiple priced
+   options, and stop before making a provider call.
+4. Choose one platform-key-enabled GET/HEAD/OPTIONS endpoint priced below $0.01. Ask Claude to run
+   it; verify success without a write confirmation and record the exact balance and audit delta.
+5. Choose one non-mutating POST-based search endpoint below $0.01. Ask Claude to run it; verify that
+   Claude presents its write approval, approve it, then record success and the exact delta.
+6. Ask Claude to check `balance`, then submit a clearly labelled test `catalog_request`.
+7. Verify the tool list contains only `catalog_search`, `catalog_get`, `catalog_call_read`,
+   `catalog_call_write`, `balance`, and `catalog_request`. Create or use a same-named team tool and
+   verify it cannot shadow the catalog endpoint.
+8. Disconnect the connector, reconnect it, and complete OAuth again.
+9. Smoke-test the same account in Claude Code and Claude Desktop. Record mobile as tested only if it
+   was actually tested.
+
+For each step record pass/fail, UTC time, surface, endpoint id, expected charge, actual charge, and
+the corresponding audit id. Never paste raw provider responses containing personal data into the
+submission packet.
+
+## Submission and review
+
+- [ ] Owner reviews the complete field set, evidence, data-handling answers, and attestations.
+- [ ] Submit from the Claude.ai organization's settings, not the API Console organization.
+- [ ] Keep `/mcp/v2/` and its tool names stable during review.
+- [ ] Forward reviewer feedback to engineering. Owner approves material scope, copy, security, or
+  branding changes before resubmission.
+- [ ] Verify the live listing, its links, OAuth flow, logo, community/verification label, and tool
+  set before approving an announcement.
+
+## Monitoring and rollback
+
+For seven days after publication, review `claude-connector` traffic and Anthropic's health view
+daily; review weekly afterward. Track OAuth failures, 401/403/421 rates, tool errors, provider error
+rates, latency, spend, insufficient-balance refusals, and usage. Rollback is additive: unmount or
+disable `/mcp/v2/`; do not change `/mcp/`. Existing v2 grants then remain stored but cannot reach an
+active v2 resource.

--- a/docs/CLAUDE-CONNECTOR-SUBMISSION.md
+++ b/docs/CLAUDE-CONNECTOR-SUBMISSION.md
@@ -46,8 +46,9 @@ explicitly granted the corresponding label.
   pricing, metering, audit, idempotency, and error attribution.
 - [ ] MCP Inspector connects to `https://treg.to/mcp/v2/`, authenticates, lists exactly the six
   expected tools, and successfully invokes each tool.
-- [ ] The deployed connector emits `claude-connector` attribution for catalog provider calls.
-- [ ] The legacy `https://treg.to/mcp/` contract remains unchanged.
+- [ ] The deployed connector emits `claude-connector` attribution for catalog searches, requests,
+  details, balance reads, and provider calls.
+- [ ] The existing team MCP contract at `https://treg.to/mcp/` remains unchanged.
 - [ ] Save dated, secret-free evidence: test output, Inspector result, endpoint ids, expected/actual
   balance deltas, audit ids, and screenshots with private values redacted.
 

--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -79,7 +79,7 @@ route cannot silently expand the dataplane. Role separation is preparatory in st
 `all` role is deployed.
 
 `TREG_CLAUDE_CONNECTOR_ENABLED=true` adds `/mcp/v2` and starts its lifespan. When the flag is false
-or missing, only the legacy `/mcp` mount starts. The nested V2 mount is registered first so the
+or missing, only the team `/mcp` mount starts. The nested V2 mount is registered first so the
 parent `/mcp` mount cannot consume it.
 
 When V2 is enabled, `NormalizeDirectoryMCPPath` rewrites the exact `/mcp/v2` path to `/mcp/v2/`

--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -30,8 +30,9 @@ related:
 attaches concern routers at compatibility-sensitive registration points, and calls the factory once at
 EOF so the deployed `treg.api:app` import path remains the default `all` role.
 
-The factory owns concrete assembly: the three pure-ASGI middleware registrations, five exception handlers,
-static mounts, optional MCP mount and lifespan, GET-to-HEAD widening, the OpenAPI wrapper that hides
+The factory owns concrete assembly: the three core pure-ASGI middleware registrations, the optional
+V2 path normalizer, five exception handlers, static mounts, optional MCP mounts and lifespans,
+GET-to-HEAD widening, the OpenAPI wrapper that hides
 implied HEAD operations, shared HTTP client creation, startup work, shutdown drains, and the Ads
 conversion worker. Registration order is compatibility behavior. The four stage-0 snapshots stay
 byte-identical for `role="all"` unless that composition intentionally changes.
@@ -80,6 +81,10 @@ route cannot silently expand the dataplane. Role separation is preparatory in st
 `TREG_CLAUDE_CONNECTOR_ENABLED=true` adds `/mcp/v2` and starts its lifespan. When the flag is false
 or missing, only the legacy `/mcp` mount starts. The nested V2 mount is registered first so the
 parent `/mcp` mount cannot consume it.
+
+When V2 is enabled, `NormalizeDirectoryMCPPath` rewrites the exact `/mcp/v2` path to `/mcp/v2/`
+before route matching. Claude can remove the final slash from a custom-connector URL. Both spellings
+must stay on the V2 transport and OAuth audience.
 
 ## Route cloning
 

--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -62,9 +62,9 @@ Every created app exposes `app.state.role_manifest` with explicit `routes`, `bac
 
 | Role | HTTP routes and mounts | Background tasks | Startup checks |
 |---|---|---|---|
-| `all` | The complete existing surface, including `/run`, static files, and `/mcp` | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client, MCP lifespan |
-| `dataplane` | `/call/{rest:path}`, the `/mcp` mount, and its RFC 9728 resource-metadata route; no `/run`, static files, docs, or OpenAPI | None | DB init, provider-tool backfill, HTTP client, MCP lifespan |
-| `control` | Everything except the calling surface (`/call/{rest:path}`, `/mcp`, and its resource metadata); includes `/run` and static files | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client |
+| `all` | The complete surface, including `/run`, static files, `/mcp`, and the flagged `/mcp/v2` | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client, enabled MCP lifespans |
+| `dataplane` | `/call/{rest:path}`, `/catalog/call/{rest:path}`, MCP mounts, and their resource metadata; no `/run`, static files, docs, or OpenAPI | None | DB init, provider-tool backfill, HTTP client, enabled MCP lifespans |
+| `control` | Everything except the calling surfaces; includes OAuth issuance, `/run`, and static files | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client |
 
 MCP is calling traffic (the refactor plan's role table assigns `mcp.py` to the dataplane), so a future
 dataplane deployment serves agents on both entry points. OAuth token issuance - consent pages and the
@@ -76,6 +76,10 @@ tokens, while both roles share its signing-key validation through `domain.identi
 owner. App creation fails on an unclassified, stale, duplicate, or multiply-owned key, so adding a
 route cannot silently expand the dataplane. Role separation is preparatory in stage 1; only the
 `all` role is deployed.
+
+`TREG_CLAUDE_CONNECTOR_ENABLED=true` adds `/mcp/v2` and starts its lifespan. When the flag is false
+or missing, only the legacy `/mcp` mount starts. The nested V2 mount is registered first so the
+parent `/mcp` mount cannot consume it.
 
 ## Route cloning
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -144,12 +144,14 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
 - **`ToolRequest`** — a "the catalog doesn't have X" report (`POST /tool-requests`, open + per-IP
   rate-limited): `capability` (the headline, ≤200 chars), `query` (the search that came up empty —
   auto-filled by agents, the dedup/priority signal), `note`, `contact`, `source` (`web` | `cli` |
-  `mcp` | `api`), `status` (`open` | `done` | `dismissed`, flipped by hand), and **nullable**
+  `mcp` | `claude-connector` | `api`), `status` (`open` | `done` | `dismissed`, flipped by hand), and
+  **nullable**
   `org_id`/`user_email` — identity is attribution when the caller happens to have one, never a
   requirement, because the usual filer is an agent with zero results and no token. Reviewed by
   querying the table; a Slack notifier may hang off the insert later, but the row is the record.
 - **`SearchMiss`** — a catalog search that returned **nothing**: `query` (capped to 300 chars),
-  `source` (`api` — the HTTP route serving web + CLI + raw API — or `mcp`), `created_at`. The demand
+  `source` (`api` for the HTTP route that serves web + CLI + raw API; `mcp` for the team MCP; or
+  `claude-connector` for V2), `created_at`. The demand
   signal one step before a `ToolRequest`: most agents that miss never file, so the query text is all
   they leave. Written fire-and-forget through `audit.record_search_miss` (dropped rows cost
   analytics, never a search) from both search paths — `GET /catalog/search` and the in-process MCP

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -29,6 +29,21 @@ Protocol. Both use one deployment, database, and enforcement layer:
 - `/mcp/v2/` is the catalog-only Claude directory surface. It cannot list or call arbitrary
   team-owned tools, including a team tool whose name matches a catalog endpoint.
 
+## Why V2 exists
+
+The legacy `/mcp/` must keep its general `call` tool because existing users use it for catalog
+endpoints, team-owned tools, and imported skills. Treg cannot reliably classify the side effects of
+an arbitrary private tool, so that surface cannot give Claude a precise read-versus-write safety
+signal without breaking its existing contract.
+
+V2 keeps `/mcp/` unchanged and exposes a narrower directory boundary. It accepts only curated
+catalog ids and splits calls by the HTTP method stored in the catalog. Claude can therefore treat
+GET, HEAD, and OPTIONS as reads and request approval for POST, PUT, PATCH, and DELETE. Both surfaces
+still use the same internal credential, policy, metering, audit, and relay machinery.
+
+The two version labels describe different things. `/mcp/v2/` is Treg's second MCP transport
+surface. **Connector release V1** is the first product release submitted to Claude's directory.
+
 `NormalizeDirectoryMCPPath` makes `/mcp/v2` and `/mcp/v2/` the same V2 resource. This is required
 because a real Claude custom-connector flow removed the trailing slash. Without normalization, the
 request can fall through to the legacy `/mcp` mount and receive the wrong OAuth resource identity.

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -273,16 +273,16 @@ challenge scopes while omitting the RFC 8707 `resource` parameter. In that case,
 `_effective_mcp_resource` selects the V2 audience. An explicit resource always wins, and all other
 requests keep the V1 default.
 
-**The audience set is canonical + legacy** (`mcp_resource_audiences()`: `public_url` plus
-`config.PUBLIC_HOST_ALIASES` — the treg.superdesign.dev → treg.to move, SYMMETRIC so grants
-minted on either name survive a `TREG_PUBLIC_URL` flip in either direction). A pre-move grant carries
-the old resource URL as its audience for its whole lifetime, because refresh reissues the audience
-that was consented to (`row.resource`); validating against the canonical URL alone would 401 every
-pre-move grant with refresh unable to recover. The transport validates via `read_access_token_any`,
-and `/oauth/token` treats the two names as the same resource (`routers.auth._same_mcp_resource`).
-Slash-variant spellings are healed by `normalize_resource()` at every store/mint/compare site:
-authorize accepts `…/mcp` via a forgiving compare, and a token whose audience kept that spelling
-would fail the exact audience match forever.
+**Each MCP version has its own audience set.** `mcp_resource_audiences(version)` includes the
+configured `public_url` plus `config.PUBLIC_HOST_ALIASES` for that version. This is symmetric so a
+grant survives a host change or rollback. Host and trailing-slash aliases can normalize within V1 or
+within V2, but they never cross versions. A V1 token fails on `/mcp/v2/`, and a V2 token fails on
+`/mcp/`.
+
+A grant keeps its consented audience for its lifetime because refresh reissues `row.resource`.
+`read_access_token_any` validates against the selected version, `_same_mcp_resource` accepts aliases
+only when both values resolve to that version, and `normalize_resource()` heals slash spellings at
+each store, mint, and comparison point.
 
 ## Two doors in, one row out
 

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -9,7 +9,9 @@ sources:
   - src/treg/domain/identity/mcp_oauth.py
   - src/treg/domain/identity/session.py
   - src/treg/routers/auth.py
+  - src/treg/web/claude-connector.html
   - src/treg/web/connect-demo.html
+  - docs/CLAUDE-CONNECTOR-SUBMISSION.md
 related:
   - architecture/auth-secrets.md
   - architecture/proxy-model.md
@@ -19,11 +21,21 @@ related:
 
 # MCP
 
-Everything else in treg is reached by a CLI or an HTTP call. This is the door an **assistant** comes
-through: ChatGPT, Claude Code, Cursor, or anything else that speaks the Model Context Protocol. It is
-mounted at `/mcp/` on the same app, so there is one deployment, one database and one set of rules.
+Everything else in treg is reached by a CLI or an HTTP call. These are the doors an **assistant**
+comes through: ChatGPT, Claude, Claude Code, Cursor, or anything else that speaks the Model Context
+Protocol. Both use one deployment, database, and enforcement layer:
 
-## Six tools, and why only six
+- `/mcp/` keeps the legacy catalog, team-tool, and imported-skill behavior.
+- `/mcp/v2/` is the catalog-only Claude directory surface. It cannot list or call arbitrary
+  team-owned tools, including a team tool whose name matches a catalog endpoint.
+
+## Claude connector feature flag
+
+`TREG_CLAUDE_CONNECTOR_ENABLED` defaults to `false`. When false, V2 is not mounted, its lifespan does
+not start, V2 resource metadata and new V2 grants are refused, and the catalog-only call route returns
+404. The legacy `/mcp/` surface does not depend on this flag.
+
+## Legacy `/mcp/`: six tools
 
 | Tool | Job |
 |---|---|

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -253,6 +253,11 @@ A test asserts that calling without it raises rather than defaulting to permissi
 that is valid, well-formed and silently useless — the failure then surfaces at the first tool call as
 "not signed in", pointing the reader at authentication when the problem was the audience.
 
+V2 advertises `treg:directory` as a fallback resource marker. Hosted Claude can preserve the V2
+challenge scopes while omitting the RFC 8707 `resource` parameter. In that case,
+`_effective_mcp_resource` selects the V2 audience. An explicit resource always wins, and all other
+requests keep the V1 default.
+
 **The audience set is canonical + legacy** (`mcp_resource_audiences()`: `public_url` plus
 `config.PUBLIC_HOST_ALIASES` — the treg.superdesign.dev → treg.to move, SYMMETRIC so grants
 minted on either name survive a `TREG_PUBLIC_URL` flip in either direction). A pre-move grant carries

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -29,6 +29,10 @@ Protocol. Both use one deployment, database, and enforcement layer:
 - `/mcp/v2/` is the catalog-only Claude directory surface. It cannot list or call arbitrary
   team-owned tools, including a team tool whose name matches a catalog endpoint.
 
+`NormalizeDirectoryMCPPath` makes `/mcp/v2` and `/mcp/v2/` the same V2 resource. This is required
+because a real Claude custom-connector flow removed the trailing slash. Without normalization, the
+request can fall through to the legacy `/mcp` mount and receive the wrong OAuth resource identity.
+
 ## Claude connector feature flag
 
 `TREG_CLAUDE_CONNECTOR_ENABLED` defaults to `false`. When false, V2 is not mounted, its lifespan does
@@ -375,18 +379,25 @@ perfectly while every tool still forwarded the raw bearer and got "not signed in
 
 ## Sign-in mid-authorization
 
-A signed-out visitor to `/oauth/authorize` has the destination parked in a short-lived cookie and
-resumed at the **dashboard**, which is the one point every browser sign-in door ends at. It stores a
-relative path and honours only `/oauth/authorize`, so it cannot become a general "send me anywhere
-after login" primitive.
+A signed-out visitor to `/oauth/authorize` has the destination parked in a short-lived HttpOnly
+cookie and is redirected to `/?signin=oauth`. The dashboard opens the existing sign-in modal with
+generic connection copy, removes the query parameter from the visible URL, and does not create a
+sandbox session. The query parameter is only a UI cue; it contains no OAuth request data. Google,
+GitHub, and email-code sign-in all return to the dashboard, which resumes the parked authorization
+request. The cookie stores a relative path and honours only `/oauth/authorize`, so it cannot become a
+general "send me anywhere after login" primitive.
 
 ## `/connect-demo`
 
 A page that pretends to be someone else's app and runs the whole flow — register, consent popup,
 token exchange, tool calls. It uses only public endpoints; being served from treg's domain gives it
-nothing. It exists because a failure inside ChatGPT surfaces as a shrug, and it earned itself
-immediately: it found that browsers were refused outright (`"*"` is not a wildcard in the SDK's
-origin check) and that consent failed intermittently on `Origin: null`.
+nothing. `TREG_CONNECT_DEMO_ENABLED` gates both the page and its callback and defaults to `false`, so
+production should return 404. The local development script enables it; staging can enable it
+explicitly for tests. The browser holds working tokens in tab-local session storage for the demo,
+but the visible log shows only `[received]` and never displays a token prefix. Disconnect revokes the
+grant and clears the stored tokens. The page exists because a failure inside an agent client surfaces
+as a shrug, and it earned itself immediately: it found that browsers were refused outright (`"*"` is
+not a wildcard in the SDK's origin check) and that consent failed intermittently on `Origin: null`.
 
 ## What is deliberately NOT here
 

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -12,6 +12,9 @@ sources:
   - src/treg/web/claude-connector.html
   - src/treg/web/connect-demo.html
   - docs/CLAUDE-CONNECTOR-SUBMISSION.md
+  - tests/test_mcp.py
+  - tests/test_mcp_directory.py
+  - tests/test_marketplace_call.py
 related:
   - architecture/auth-secrets.md
   - architecture/proxy-model.md
@@ -25,13 +28,13 @@ Everything else in treg is reached by a CLI or an HTTP call. These are the doors
 comes through: ChatGPT, Claude, Claude Code, Cursor, or anything else that speaks the Model Context
 Protocol. Both use one deployment, database, and enforcement layer:
 
-- `/mcp/` keeps the legacy catalog, team-tool, and imported-skill behavior.
+- `/mcp/` is the team MCP surface. It keeps its catalog, team-tool, and imported-skill behavior.
 - `/mcp/v2/` is the catalog-only Claude directory surface. It cannot list or call arbitrary
   team-owned tools, including a team tool whose name matches a catalog endpoint.
 
 ## Why V2 exists
 
-The legacy `/mcp/` must keep its general `call` tool because existing users use it for catalog
+The team `/mcp/` must keep its general `call` tool because existing users use it for catalog
 endpoints, team-owned tools, and imported skills. Treg cannot reliably classify the side effects of
 an arbitrary private tool, so that surface cannot give Claude a precise read-versus-write safety
 signal without breaking its existing contract.
@@ -46,15 +49,53 @@ surface. **Connector release V1** is the first product release submitted to Clau
 
 `NormalizeDirectoryMCPPath` makes `/mcp/v2` and `/mcp/v2/` the same V2 resource. This is required
 because a real Claude custom-connector flow removed the trailing slash. Without normalization, the
-request can fall through to the legacy `/mcp` mount and receive the wrong OAuth resource identity.
+request can fall through to the team `/mcp` mount and receive the wrong OAuth resource identity.
 
 ## Claude connector feature flag
 
 `TREG_CLAUDE_CONNECTOR_ENABLED` defaults to `false`. When false, V2 is not mounted, its lifespan does
 not start, V2 resource metadata and new V2 grants are refused, and the catalog-only call route returns
-404. The legacy `/mcp/` surface does not depend on this flag.
+404. The team `/mcp/` surface does not depend on this flag.
 
-## Legacy `/mcp/`: six tools
+## MCP surface maintenance contract
+
+The two public surfaces have different contracts, but they must not have different implementations
+of shared behavior.
+
+| Area | Must stay shared | Intentional difference |
+|---|---|---|
+| catalog search | loading, ranking, price view, observed data, near misses | next-call guidance and event source |
+| endpoint details | the `/catalog/endpoints/{id}` route and error shape | client attribution |
+| calls | request assembly, credentials, policy, limits, idempotency, relay, errors, metering, audit | team MCP accepts team tools; V2 accepts catalog ids only and splits read/write methods |
+| balance | team selection, grant labels, balance route, error shape | client attribution |
+| catalog requests | `/tool-requests`, rate limit, field limits, caller IP | event source and client attribution |
+| transport | host checks, compression, cache headers, eager auth, static capabilities | V2 has a separate audience, metadata path, scope marker, and Claude browser origin |
+| lifecycle | the transport factory and `mcp_lifespan` | V2 mount and lifespan depend on its feature flag |
+
+`_SurfacePolicy` contains the small set of values that can differ inside shared tool behavior. Public
+tool registrations remain separate because their names, descriptions, input schemas, and safety
+annotations are public contracts. `build_mcp_app` refuses a server and OAuth resource-version pair
+that names different surfaces.
+
+When either MCP surface or shared MCP code changes, review both surfaces. The tests must compare the
+shared behavior and must also prove the listed differences. Keep these V2 properties fixed unless a
+new directory review approves a contract change:
+
+- `/mcp/v2/` is the stable URL, and `/mcp/v2` resolves to the same resource.
+- The tool list has exactly six tools.
+- V2 accepts catalog ids only. It does not list or call arbitrary team tools or passthrough paths.
+- Read and write calls stay separate, and their annotations match their method classes.
+- V1 and V2 OAuth audiences do not cross.
+- The feature flag controls the V2 mount, metadata, new grants, call route, and lifespan.
+- V2 directory titles, descriptions, schemas, annotations, and neutral review copy stay under test.
+
+`tests/test_mcp.py` protects team MCP behavior. `tests/test_mcp_directory.py` protects the V2 surface
+and calls both public URLs with the same inputs to compare search results and prices, endpoint
+details, balance, catalog-call results, errors, catalog-only hints, and client attribution.
+`tests/test_marketplace_call.py` proves that the catalog-only API route cannot be shadowed by a
+same-named team tool. A change is incomplete if only one relevant MCP test file is reviewed.
+
+## Team MCP at `/mcp/`: six tools
 
 | Tool | Job |
 |---|---|
@@ -92,8 +133,9 @@ nothing upstream, nothing spent), so it stays closed-world and non-destructive. 
 `X-Forwarded-For` — the in-process relay would otherwise collapse every MCP caller into one
 rate-limit bucket. `catalog_search`'s zero-result hint names it, so an agent that just searched
 and found nothing can file the gap in the same session — and the miss itself is logged as a
-`SearchMiss` row (`audit.record_search_miss`, `source="mcp"`): this tool reads the catalog
-in-process, so the HTTP route's own miss logging never sees an MCP agent's empty search.
+`SearchMiss` row (`audit.record_search_miss`, `source="mcp"` on the team MCP and
+`source="claude-connector"` on V2): this tool reads the catalog in-process, so the HTTP route's own
+miss logging never sees an MCP agent's empty search.
 
 ## In-process, not over the network
 
@@ -101,8 +143,9 @@ Tools reach the rest of treg through `httpx.ASGITransport` against our own app �
 through the real routes, without a socket. That matters because the enforcement rules (deny rules,
 capability pins, per-member tool access, the credential ladder, metering) live in those routes. A
 second path that "just read the database" would be a second implementation of every one of them,
-drifting quietly. The in-process client stamps `X-Treg-Client: mcp` (attribution, never a gate), so
-MCP traffic is distinguishable from unreported CLI traffic in the audit trail and analytics.
+drifting quietly. The in-process client stamps `X-Treg-Client: mcp` for the team MCP and
+`X-Treg-Client: claude-connector` for V2 (attribution, never a gate), so each MCP surface is
+distinguishable from unreported CLI traffic and from the other MCP surface.
 
 The catalog is the one exception: read straight from `catalog_store`, which is already parsed in
 memory, so a search answers in about a millisecond. That is a **speed** choice, not a permission one.

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -110,6 +110,14 @@ concurrency limit, and `llms.txt` says so. `tests/test_call_pool_discipline.py` 
 orgs resolve independently and may reuse a tool name or upstream host; `call_tool` then loads only
 same-org secrets. After resolution `call_tool` runs `_enforce_daily_cap` (the per-user daily usage cap —
 429 when over; `-1`/default is a no-op, so the hot path adds no query for unmetered members). Two shapes:
+
+`* /catalog/call/{rest:path}` is the narrower entrance used by catalog-only MCP surfaces.
+`call_catalog_endpoint` sets `request.state.catalog_only` and then enters the same `call_tool`
+implementation. Resolution accepts only an exact catalog endpoint id and does not call `_resolve_call`,
+so a private team tool or arbitrary passthrough path cannot shadow the catalog entry. Everything after
+catalog resolution stays shared: credentials, ACLs, deny rules, caps, cancellation cleanup, metering,
+audit, idempotency, and faithful relay.
+
 - **URL-passthrough (agent-native):** `rest` is the real upstream URL (`/call/https://api.intercom.io/me`).
   `_normalize_scheme()` restores the `https://` a path param collapses to `https:/`. The tool is resolved
   by **host** (`_host_of()` = `urlsplit(...).netloc`, matched against the indexed `Tool.host`) then the

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -319,7 +319,8 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   wants, so no signup wall. The miss itself is also logged as a `SearchMiss` row (fire-and-forget
   via `audit.record_search_miss`, from this route and from the MCP `catalog_search` tool alike) —
   most missing agents never file a request, and the queries they leave behind are what
-  `scripts/usage_report.py` reports as un-served demand.
+  `scripts/usage_report.py` reports as un-served demand. MCP rows use `mcp` for the team MCP and
+  `claude-connector` for V2, so reports can separate the two surfaces.
 - **Auth — three identity doors** (all resolve to a user via the shared `_find_or_create_user`, so
   first-proof = registration — the **user only, no auto personal org**; a brand-new user lands with zero
   teams and names their first via the mandatory welcome / `treg org create`): **GitHub** — `auth_github` (`GET /auth/github`,

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -582,6 +582,11 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   `sqlalchemy.exc.TimeoutError`) rather than a 30 s wait and an anonymous 500. A **platform binding** carries no `secret_id`
   (its value comes from settings at relay time), so secret-loading now skips `secret_id is None`. Detail
   in [proxy-model](../architecture/proxy-model.md).
+  `call_catalog_endpoint` (`* /catalog/call/{rest:path}`, hidden from public OpenAPI) is the narrower
+  internal entrance used by catalog-only MCP surfaces: it requires an exact catalog id and skips
+  `_resolve_call`, so an exact same-named team tool cannot shadow the catalog endpoint. From the
+  credential ladder onward it delegates to `call_tool`, retaining provider/user credentials, ACLs,
+  deny rules, caps, metering, audit, idempotency and faithful relay.
 
 ## Schemas
 Pydantic input models: `UserIn`, `OrgIn` / `InviteIn` / `AcceptIn`, `EmailStartIn` / `EmailVerifyIn`,
@@ -647,7 +652,9 @@ why that widening must be kept out of the schema.
 treg is an OAuth authorization server for its own MCP endpoint. Detail in
 `architecture/mcp-oauth.md`; this is the surface.
 
-    GET  /.well-known/oauth-protected-resource      what guards /mcp/ (served at BOTH lookup paths)
+    GET  /.well-known/oauth-protected-resource      what guards /mcp/ (served at BOTH v1 lookup paths)
+    GET  /.well-known/oauth-protected-resource/mcp/v2
+                                                    distinct metadata for /mcp/v2/
     GET  /.well-known/oauth-authorization-server    endpoints, S256, DCR + CIMD support
     POST /oauth/register                            dynamic client registration (RFC 7591)
     GET  /oauth/authorize                           the consent screen (JSON with Accept: application/json)
@@ -657,9 +664,11 @@ treg is an OAuth authorization server for its own MCP endpoint. Detail in
     GET  /oauth/grants                              live (non-retired, non-expired) grant families
     POST /oauth/grants/{family}/team                move family authority to another member team
     POST /mcp/                                      the MCP transport itself
+    POST /mcp/v2/                                   catalog-only Claude directory transport
 
     GET  /connect-demo                              a page that pretends to be an MCP client
     GET  /connect-demo/callback                     its OAuth callback
+    GET  /connectors/claude                         setup, scope, pricing, data flow and removal docs
 
 `/call/` gained one thing for this: a metered response now carries `X-Treg-Cost-Micro`, so a caller
 can report what it spent instead of diffing the balance. Absent on an unmetered call — a team's own

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -670,6 +670,10 @@ treg is an OAuth authorization server for its own MCP endpoint. Detail in
     GET  /connect-demo/callback                     its OAuth callback
     GET  /connectors/claude                         setup, scope, pricing, data flow and removal docs
 
+The V2 metadata and transport routes are available only when
+`TREG_CLAUDE_CONNECTOR_ENABLED=true`. The metadata route returns 404 when V2 is disabled. New V2
+OAuth grants and catalog-only calls are also refused.
+
 `/call/` gained one thing for this: a metered response now carries `X-Treg-Cost-Micro`, so a caller
 can report what it spent instead of diffing the balance. Absent on an unmetered call — a team's own
 key is not ours to bill, and `0` would read as "free".

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -68,6 +68,12 @@ loaded, so this makes rendering consistent for everyone), `--r:14 / --rb:9`, a `
 shared `.btn` / `.iconbtn` height so controls align. The logged-out `/` is now the **landing + sandbox
 studio** (see [landing-sandbox](landing-sandbox.md)), not a login box; sign-in is a modal.
 
+An OAuth authorization that needs sign-in redirects to `/?signin=oauth`. The dashboard reads this as
+a UI cue, removes it from the visible URL, and opens the same modal with generic connection copy. It
+does not create a sandbox session. The protected OAuth return path stays in an HttpOnly cookie, so
+GitHub, Google, and email-code sign-in all resume the same authorization flow without putting OAuth
+request data in the URL.
+
 The **authed** shell is sidebar-first. The **top bar** is just brand + search. The **left sidebar**
 stacks: (top) an **org block** — role + team name — that on click opens a switcher **dropdown** where
 each team carries its own **⚙ Settings** (`orgSettings` → switch into it, then open its settings) and

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -70,9 +70,10 @@ studio** (see [landing-sandbox](landing-sandbox.md)), not a login box; sign-in i
 
 An OAuth authorization that needs sign-in redirects to `/?signin=oauth`. The dashboard reads this as
 a UI cue, removes it from the visible URL, and opens the same modal with generic connection copy. It
-does not create a sandbox session. The protected OAuth return path stays in an HttpOnly cookie, so
-GitHub, Google, and email-code sign-in all resume the same authorization flow without putting OAuth
-request data in the URL.
+does not create a sandbox session. During this flow the modal hides the agent/CLI token fallback,
+because that token does not create the browser session required to resume authorization. The
+protected OAuth return path stays in an HttpOnly cookie, so GitHub, Google, and email-code sign-in all
+resume the same authorization flow without putting OAuth request data in the URL.
 
 The **authed** shell is sidebar-first. The **top bar** is just brand + search. The **left sidebar**
 stacks: (top) an **org block** — role + team name — that on click opens a switcher **dropdown** where

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -144,6 +144,10 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
 - `proxy_ssrf_check` (`TREG_PROXY_SSRF_CHECK`) — the **call-time SSRF guard** on the proxy: resolve the
   upstream host and refuse an internal/private target. **On by default**; only the test suite disables it
   (its upstream is an in-process ASGI transport, not real DNS).
+- `claude_connector_enabled` (`TREG_CLAUDE_CONNECTOR_ENABLED`) — enables the catalog-only Claude
+  connector at `/mcp/v2/`. The default is false. Keep it false during normal deployment. Set it to
+  true for a controlled test window. Set it back to false to disable V2 without changing the existing
+  `/mcp/` connector.
 - `intercom_app_id` / `intercom_secret` (`TREG_INTERCOM_APP_ID` / `TREG_INTERCOM_SECRET`) — support
   chat via the **Intercom Messenger** (treg's own workspace). Empty app_id = the widget is OFF
   everywhere — `/meta`

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -9,6 +9,7 @@ sources:
   - src/treg/db.py
   - src/treg/email.py
   - src/treg/audit.py
+  - scripts/dev-local.sh
   - render.yaml
 related:
   - architecture/data-model.md
@@ -148,6 +149,10 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
   connector at `/mcp/v2/`. The default is false. Keep it false during normal deployment. Set it to
   true for a controlled test window. Set it back to false to disable V2 without changing the existing
   `/mcp/` connector.
+- `connect_demo_enabled` (`TREG_CONNECT_DEMO_ENABLED`) — enables the developer OAuth test page and
+  callback at `/connect-demo`. The default is false, and both routes return 404 when it is false. The
+  local development script enables it. Staging can enable it explicitly for controlled tests; leave
+  it false in production.
 - `intercom_app_id` / `intercom_secret` (`TREG_INTERCOM_APP_ID` / `TREG_INTERCOM_SECRET`) — support
   chat via the **Intercom Messenger** (treg's own workspace). Empty app_id = the widget is OFF
   everywhere — `/meta`

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -31,7 +31,7 @@ DEV_HOME="$ROOT/scripts/.dev-home"         # sandbox HOME for the dev CLI
 
 DEV_KEYS="$DEV_HOME/dev-keys.env"           # stable dev-only Fernet + session keys, minted once —
                                             # without them every --reload restart drops sessions/secrets
-SERVER_ENV="TREG_EMAIL_DEV_MODE=true TREG_DATABASE_URL=sqlite+aiosqlite:///$DEV_DB"
+SERVER_ENV="TREG_EMAIL_DEV_MODE=true TREG_CONNECT_DEMO_ENABLED=true TREG_DATABASE_URL=sqlite+aiosqlite:///$DEV_DB"
 SERVER_CMD="cd $ROOT && set -a && . $DEV_KEYS && set +a && env $SERVER_ENV uv run python -m treg --reload"
 
 ensure_dev_keys() {

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -210,6 +210,7 @@ from .routers.auth import (
     _cli_states,
     _client_ip,
     _find_or_create_user,
+    _effective_mcp_resource,
     _live_invite_by_email_token,
     _login_page_html,
     _norm_pair_code,

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -4213,6 +4213,8 @@ async def call_catalog_endpoint(
     db: AsyncSession = Depends(get_session),
 ):
     """Call one catalog endpoint through the same policy, billing, audit, and relay path as /call."""
+    if not get_settings().claude_connector_enabled:
+        raise HTTPException(status_code=404, detail="Claude catalog connector is not enabled")
     request.state.catalog_only = True
     return await call_tool(rest, request, caller, db)
 

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -3751,7 +3751,8 @@ async def call_tool(
     # valid percent-escapes, so the original bytes travel through to the upstream one-to-one.
     raw_path = request.scope.get("raw_path")
     if raw_path:
-        _, sep, raw_rest = raw_path.decode("ascii", "replace").partition("/call/")
+        call_prefix = "/catalog/call/" if getattr(request.state, "catalog_only", False) else "/call/"
+        _, sep, raw_rest = raw_path.decode("ascii", "replace").partition(call_prefix)
         if sep:
             rest = raw_rest
     # The caller's tags, parsed ONCE and read by everything below — the budgets, the ledger, the
@@ -3794,18 +3795,29 @@ async def call_tool(
     drop_params: set[str] = set()
     mk: MarketplaceCall | None = None
     own_tool_miss: dict | None = None
-    try:
-        tool, upstream_url = await _await_before_reserve(
-            _resolve_call(rest, caller, db), request, call_ref)
-    except HTTPException as exc:
-        # Not a tool → maybe a marketplace endpoint id (`treg call tikhub.tiktok.video.comments`).
-        # Only the 404 falls through, so an org tool with the same name always wins.
-        ep = _catalog_endpoint_for(rest) if exc.status_code == 404 else None
+    catalog_only = bool(getattr(request.state, "catalog_only", False))
+    if catalog_only:
+        # This reviewed surface accepts only a catalog id. A same-named team tool cannot shadow it.
+        ep = _catalog_endpoint_for(rest)
         if ep is None:
-            raise
-        if (isinstance(exc.detail, dict)
-                and str(exc.detail.get("hint", "")).startswith("your org has tool ")):
-            own_tool_miss = exc.detail
+            raise HTTPException(status_code=404, detail=(
+                f"unknown catalog endpoint {rest!r} — use catalog_search for a valid endpoint id"))
+    else:
+        try:
+            tool, upstream_url = await _await_before_reserve(
+                _resolve_call(rest, caller, db), request, call_ref)
+        except HTTPException as exc:
+            # Not a tool → maybe a marketplace endpoint id (`treg call tikhub.tiktok.video.comments`).
+            # Only the 404 falls through, so an org tool with the same name always wins.
+            ep = _catalog_endpoint_for(rest) if exc.status_code == 404 else None
+            if ep is None:
+                raise
+            if (isinstance(exc.detail, dict)
+                    and str(exc.detail.get("hint", "")).startswith("your org has tool ")):
+                own_tool_miss = exc.detail
+        else:
+            ep = None
+    if ep is not None:
         try:
             mk = await _await_before_reserve(
                 _resolve_marketplace_call(ep, request, caller, db), request, call_ref)
@@ -4187,6 +4199,22 @@ async def call_tool(
         request.state.idem_claim = None
     response.headers["X-Treg-Call-Id"] = call_ref
     return response
+
+
+@app.api_route(
+    "/catalog/call/{rest:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
+    include_in_schema=False,
+)
+async def call_catalog_endpoint(
+    rest: str,
+    request: Request,
+    caller: Caller = Depends(require_member),
+    db: AsyncSession = Depends(get_session),
+):
+    """Call one catalog endpoint through the same policy, billing, audit, and relay path as /call."""
+    request.state.catalog_only = True
+    return await call_tool(rest, request, caller, db)
 
 
 # ---- server-side CLI execution (Tier 0 `treg run`) ---------------------------------------

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -693,7 +693,7 @@ router.routes.extend(web_routes.catalog_pages_router.routes)
 TOOLREQ_HIT_NS = "toolreq"
 TOOLREQ_RATE_MAX = 10          # filings per IP per window
 TOOLREQ_RATE_WINDOW_S = 3600   # 1 hour
-TOOLREQ_SOURCES = {"web", "cli", "mcp", "api"}
+TOOLREQ_SOURCES = {"web", "cli", "mcp", "claude-connector", "api"}
 
 
 class ToolRequestIn(BaseModel):
@@ -701,7 +701,7 @@ class ToolRequestIn(BaseModel):
     query: str = ""          # the catalog search that came up empty (agents auto-fill this)
     note: str = ""
     contact: str = ""        # optional reach-back; free text, unverified
-    source: str = "web"      # web | cli | mcp | api
+    source: str = "web"      # web | cli | mcp | claude-connector | api
 
 
 @app.post("/tool-requests", include_in_schema=False)

--- a/src/treg/application/auth.py
+++ b/src/treg/application/auth.py
@@ -697,7 +697,10 @@ def _wrong_resource(resource: str) -> str | None:
         return None
     canonical = mcp_oauth.mcp_resource_url()
     # Host aliases and slash variants stay valid within one surface. V1 and V2 stay distinct.
-    if mcp_oauth.mcp_resource_version(resource) is not None:
+    version = mcp_oauth.mcp_resource_version(resource)
+    if version == "v2" and not get_settings().claude_connector_enabled:
+        return "the Claude catalog connector is not enabled on this deployment"
+    if version is not None:
         return None
     return (f"this server issues tokens for {canonical} or {mcp_oauth.mcp_resource_url('v2')} only "
             "— use the `resource` value from "

--- a/src/treg/application/auth.py
+++ b/src/treg/application/auth.py
@@ -707,6 +707,15 @@ def _wrong_resource(resource: str) -> str | None:
             f"/.well-known/oauth-protected-resource")
 
 
+def _effective_mcp_resource(resource: str, scope: str) -> str:
+    """Use an explicit resource, or the V2 scope marker when hosted Claude omits it."""
+    if resource:
+        return mcp_oauth.normalize_resource(resource)
+    requested_scopes = set((scope or "").split())
+    version = "v2" if mcp_oauth.DIRECTORY_SCOPE in requested_scopes else "v1"
+    return mcp_oauth.mcp_resource_url(version)
+
+
 def _same_mcp_resource(a: str, b: str) -> bool:
     """Whether two `resource` values name this same MCP server. Exact match, slash-variant match,
     or BOTH normalize into the canonical+legacy audience set — the domain move renamed the
@@ -750,7 +759,7 @@ def _redirect_refusal(error: str, description: str) -> OAuthServerError:
 
 async def prepare_oauth_authorization(
     *, client_id: str, redirect_uri: str, response_type: str, code_challenge: str,
-    code_challenge_method: str, resource: str, session_cookie: str,
+    code_challenge_method: str, resource: str, scope: str, session_cookie: str,
 ) -> OAuthAuthorizationView | None:
     async with database.session_maker() as db:
         client = await _authorize_request(
@@ -764,7 +773,8 @@ async def prepare_oauth_authorization(
             raise _redirect_refusal(
                 "invalid_request", "PKCE with code_challenge_method=S256 is required",
             )
-        if (bad_target := _wrong_resource(resource)) is not None:
+        effective_resource = _effective_mcp_resource(resource, scope)
+        if (bad_target := _wrong_resource(effective_resource)) is not None:
             raise _redirect_refusal("invalid_target", bad_target)
 
         user = await _user_from_session(session_cookie, db)
@@ -810,7 +820,8 @@ async def approve_oauth_authorization(
         if decision != "allow":
             # Cancel is a real answer and the client is entitled to hear it, rather than hang.
             raise _redirect_refusal("access_denied", "the user declined")
-        if (bad_target := _wrong_resource(resource)) is not None:
+        effective_resource = _effective_mcp_resource(resource, scope)
+        if (bad_target := _wrong_resource(effective_resource)) is not None:
             raise _redirect_refusal("invalid_target", bad_target)
         if not code_challenge or code_challenge_method != "S256":
             raise _redirect_refusal(
@@ -829,7 +840,7 @@ async def approve_oauth_authorization(
         code = OAuthCode(
             code=_secrets.token_urlsafe(32), client_id=client.client_id, user_id=user.id, org_id=org_id,
             redirect_uri=redirect_uri, code_challenge=code_challenge,
-            resource=mcp_oauth.normalize_resource(resource) if resource else mcp_oauth.mcp_resource_url(),
+            resource=effective_resource,
             scope=scope,
             expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
             + timedelta(seconds=AUTH_CODE_TTL_S))

--- a/src/treg/application/auth.py
+++ b/src/treg/application/auth.py
@@ -696,11 +696,11 @@ def _wrong_resource(resource: str) -> str | None:
     if not resource:
         return None
     canonical = mcp_oauth.mcp_resource_url()
-    # The legacy hosts' resource URLs stay valid: a pre-move client discovered its `resource` from
-    # the old domain's metadata and will keep sending it for the lifetime of the grant.
-    if any(resource.rstrip("/") == aud.rstrip("/") for aud in mcp_oauth.mcp_resource_audiences()):
+    # Host aliases and slash variants stay valid within one surface. V1 and V2 stay distinct.
+    if mcp_oauth.mcp_resource_version(resource) is not None:
         return None
-    return (f"this server issues tokens for {canonical} only — use the `resource` value from "
+    return (f"this server issues tokens for {canonical} or {mcp_oauth.mcp_resource_url('v2')} only "
+            "— use the `resource` value from "
             f"/.well-known/oauth-protected-resource")
 
 
@@ -712,8 +712,9 @@ def _same_mcp_resource(a: str, b: str) -> bool:
     na, nb = mcp_oauth.normalize_resource(a), mcp_oauth.normalize_resource(b)
     if a == b or na == nb:
         return True
-    auds = mcp_oauth.mcp_resource_audiences()
-    return na in auds and nb in auds
+    a_version = mcp_oauth.mcp_resource_version(na)
+    b_version = mcp_oauth.mcp_resource_version(nb)
+    return a_version is not None and a_version == b_version
 
 
 async def _authorize_request(client_id: str, redirect_uri: str, response_type: str,

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -97,6 +97,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/legal.css', ('GET',), 'legal_css'),
     ('/terms', ('GET',), 'terms_page'),
     ('/privacy', ('GET',), 'privacy_page'),
+    ('/connectors/claude', ('GET',), 'claude_connector_page'),
     ('/adtrack.js', ('GET',), 'adtrack_js'),
     ('/resources', ('GET',), 'resources_page'),
     ('/usecase.css', ('GET',), 'usecase_css'),
@@ -240,9 +241,13 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
 })
 _DATAPLANE_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ("/call/{rest:path}", ("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"), "call_tool"),
+    ("/catalog/call/{rest:path}",
+     ("DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"),
+     "call_catalog_endpoint"),
     # MCP is calling traffic, so its mount and its RFC 9728 resource metadata belong to the
     # dataplane. Token issuance (consent, /oauth/*) stays on control; the dataplane only validates.
     ('/.well-known/oauth-protected-resource/mcp', ('GET',), 'oauth_protected_resource'),
+    ('/.well-known/oauth-protected-resource/mcp/v2', ('GET',), 'oauth_protected_resource_v2'),
 })
 
 ROLE_BACKGROUND_TASKS: dict[AppRole, tuple[str, ...]] = {
@@ -415,7 +420,7 @@ def _lifespan(api_module, role: AppRole):
             if role == "control" or _mcp is None:
                 yield
             else:
-                async with _mcp.mcp_lifespan():
+                async with _mcp.all_mcp_lifespans():
                     yield
         finally:
             if ads_task is not None:
@@ -457,6 +462,8 @@ def create_app(role: AppRole = "all") -> FastAPI:
     _install_head_and_openapi(app)
 
     if role != "control" and _mcp is not None:
+        # Register the nested mount first so the /mcp parent does not consume it.
+        app.mount("/mcp/v2", _mcp.directory_mcp_app)
         app.mount("/mcp", _mcp.mcp_app)
 
     startup_checks = list(ROLE_STARTUP_CHECKS[role])

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -419,8 +419,11 @@ def _lifespan(api_module, role: AppRole):
         try:
             if role == "control" or _mcp is None:
                 yield
-            else:
+            elif get_settings().claude_connector_enabled:
                 async with _mcp.all_mcp_lifespans():
+                    yield
+            else:
+                async with _mcp.mcp_lifespan():
                     yield
         finally:
             if ads_task is not None:
@@ -462,8 +465,9 @@ def create_app(role: AppRole = "all") -> FastAPI:
     _install_head_and_openapi(app)
 
     if role != "control" and _mcp is not None:
-        # Register the nested mount first so the /mcp parent does not consume it.
-        app.mount("/mcp/v2", _mcp.directory_mcp_app)
+        if get_settings().claude_connector_enabled:
+            # Register the nested mount first so the /mcp parent does not consume it.
+            app.mount("/mcp/v2", _mcp.directory_mcp_app)
         app.mount("/mcp", _mcp.mcp_app)
 
     startup_checks = list(ROLE_STARTUP_CHECKS[role])

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -466,6 +466,8 @@ def create_app(role: AppRole = "all") -> FastAPI:
 
     if role != "control" and _mcp is not None:
         if get_settings().claude_connector_enabled:
+            # Claude can remove the final slash. Normalize before the parent V1 mount can match.
+            app.add_middleware(_mcp.NormalizeDirectoryMCPPath)
             # Register the nested mount first so the /mcp parent does not consume it.
             app.mount("/mcp/v2", _mcp.directory_mcp_app)
         app.mount("/mcp", _mcp.mcp_app)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -248,6 +248,11 @@ class Settings(BaseSettings):
     # surface before its production Inspector and custom-connector gates have passed.
     claude_connector_enabled: bool = False
 
+    # Browser-only OAuth/MCP test harness. It handles real grants and therefore belongs on local
+    # and staging deployments, not on the public product surface. Explicitly enable it where an
+    # engineer is testing the protocol end to end.
+    connect_demo_enabled: bool = False
+
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.
     public_url: str = "https://treg.to"

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -244,6 +244,10 @@ class Settings(BaseSettings):
     # default; the test suite disables it (its upstream is an in-process ASGI transport, not real DNS).
     proxy_ssrf_check: bool = True
 
+    # Additive Claude directory MCP. Default OFF so deploying code cannot publish a new connector
+    # surface before its production Inspector and custom-connector gates have passed.
+    claude_connector_enabled: bool = False
+
     # treg's own public base URL — used to build the OAuth callback (must be whitelisted in the
     # provider's OAuth app). Self-hosting? Set TREG_PUBLIC_URL to your deployment's URL.
     public_url: str = "https://treg.to"

--- a/src/treg/domain/identity/mcp_oauth.py
+++ b/src/treg/domain/identity/mcp_oauth.py
@@ -45,6 +45,19 @@ ACCESS_TTL_SECONDS = 3600
 
 REFRESH_TTL_S = 30 * 24 * 3600   # a connector the user still uses keeps working for a month
 
+# Hosted Claude can preserve requested scopes while omitting RFC 8707 `resource`. This V2-only
+# marker selects the directory audience in that case; it grants no additional API permission.
+DIRECTORY_SCOPE = "treg:directory"
+BASE_SCOPES = ["treg:catalog", "treg:call", "treg:read"]
+
+
+def scopes_for_resource(version: str = "v1") -> list[str]:
+    if version == "v1":
+        return [*BASE_SCOPES]
+    if version == "v2":
+        return [*BASE_SCOPES, DIRECTORY_SCOPE]
+    raise ValueError(f"unknown MCP resource version {version!r}")
+
 # Marks a token as an MCP access token and nothing else. treg already mints session cookies and
 # identity tokens with the same HMAC construction, so without a type marker a session cookie would
 # validate here (and vice versa) — one class of token would silently become another, which is a
@@ -135,7 +148,7 @@ def protected_resource_metadata(version: str = "v1") -> dict:
     return {
         "resource": mcp_resource_url(version),
         "authorization_servers": [base],
-        "scopes_supported": ["treg:catalog", "treg:call", "treg:read"],
+        "scopes_supported": scopes_for_resource(version),
         "bearer_methods_supported": ["header"],
         "resource_documentation": f"{base}/llms.txt",
     }
@@ -159,7 +172,7 @@ def authorization_server_metadata() -> dict:
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["none"],
-        "scopes_supported": ["treg:catalog", "treg:call", "treg:read"],
+        "scopes_supported": scopes_for_resource("v2"),
         # ChatGPT sends an HTTPS metadata URL as its client_id instead of registering. Advertising
         # this does not replace `registration_endpoint` above — Claude Code and most other clients
         # register dynamically, and supporting only one of the two would lock the others out.

--- a/src/treg/domain/identity/mcp_oauth.py
+++ b/src/treg/domain/identity/mcp_oauth.py
@@ -68,7 +68,15 @@ def _unb64(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
-def mcp_resource_url() -> str:
+def _mcp_path(version: str) -> str:
+    if version == "v1":
+        return "mcp/"
+    if version == "v2":
+        return "mcp/v2/"
+    raise ValueError(f"unknown MCP resource version {version!r}")
+
+
+def mcp_resource_url(version: str = "v1") -> str:
     """The canonical identifier for the thing being protected — our MCP endpoint.
 
     Must match what clients send as `resource`, byte for byte, because that string is what ends up in
@@ -76,16 +84,26 @@ def mcp_resource_url() -> str:
     is mounted at `/mcp` and served at `/mcp/`, and a client that resolves the metadata will use the
     form we publish here.
     """
-    return urljoin(get_settings().public_url.rstrip("/") + "/", "mcp/")
+    return urljoin(get_settings().public_url.rstrip("/") + "/", _mcp_path(version))
 
 
-def mcp_resource_audiences() -> set[str]:
+def mcp_resource_audiences(version: str = "v1") -> set[str]:
     """Every audience an access token may legitimately carry: the canonical resource URL plus every
     reference-deployment alias. A grant keeps the audience that was consented to for its whole
     lifetime — refresh reissues `row.resource` — so validating against the canonical URL alone
     would 401 every pre-move grant forever, with refresh unable to recover. SYMMETRIC on purpose:
     grants minted on treg.to must equally survive a TREG_PUBLIC_URL rollback to the old name."""
-    return {mcp_resource_url(), *(f"https://{h}/mcp/" for h in PUBLIC_HOST_ALIASES)}
+    path = _mcp_path(version)
+    return {mcp_resource_url(version), *(f"https://{h}/{path}" for h in PUBLIC_HOST_ALIASES)}
+
+
+def mcp_resource_version(resource: str) -> str | None:
+    """Return the MCP surface named by a host or slash variant, without crossing versions."""
+    value = (resource or "").rstrip("/")
+    for version in ("v1", "v2"):
+        if any(value == audience.rstrip("/") for audience in mcp_resource_audiences(version)):
+            return version
+    return None
 
 
 def normalize_resource(resource: str) -> str:
@@ -93,28 +111,29 @@ def normalize_resource(resource: str) -> str:
     `mcp_resource_audiences()`; anything else passes through untouched. Authorization accepts
     `…/mcp` via a forgiving compare, but a token whose audience is stored with that spelling would
     fail the exact audience match forever — so every store/mint/compare site normalizes first."""
-    r = (resource or "").rstrip("/")
-    for aud in mcp_resource_audiences():
-        if r == aud.rstrip("/"):
-            return aud
+    version = mcp_resource_version(resource)
+    if version is not None:
+        for audience in mcp_resource_audiences(version):
+            if resource.rstrip("/") == audience.rstrip("/"):
+                return audience
     return resource
 
 
-def read_access_token_any(token: str) -> dict | None:
+def read_access_token_any(token: str, version: str = "v1") -> dict | None:
     """`read_access_token` against each legitimate audience — the resource-server-side companion to
     `mcp_resource_audiences()`."""
-    for aud in mcp_resource_audiences():
+    for aud in mcp_resource_audiences(version):
         claims = read_access_token(token, expected_audience=aud)
         if claims is not None:
             return claims
     return None
 
 
-def protected_resource_metadata() -> dict:
+def protected_resource_metadata(version: str = "v1") -> dict:
     """`/.well-known/oauth-protected-resource` — "who guards this, and what may you ask for?"."""
     base = get_settings().public_url.rstrip("/")
     return {
-        "resource": mcp_resource_url(),
+        "resource": mcp_resource_url(version),
         "authorization_servers": [base],
         "scopes_supported": ["treg:catalog", "treg:call", "treg:read"],
         "bearer_methods_supported": ["header"],

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -1260,12 +1260,14 @@ class RequireAuthForProtectedTools:
         return None             # a live access token, or a per-org token the tool validates itself
 
     async def _challenge(self, send, *, invalid: bool = False) -> None:
+        from . import mcp_oauth
+
         base = get_settings().public_url.rstrip("/")
         suffix = "/mcp/v2" if self.resource_version == "v2" else ""
         meta = f"{base}/.well-known/oauth-protected-resource{suffix}"
         # The spec SHOULDs a `scope` in the challenge so a client requests the right scopes up front,
         # least-privilege, without a second round-trip. These match scopes_supported in the metadata.
-        scope = "treg:catalog treg:call treg:read"
+        scope = " ".join(mcp_oauth.scopes_for_resource(self.resource_version))
         if invalid:
             # RFC 6750 §3.1: the expired/invalid-token challenge. `error="invalid_token"` is the
             # machine-readable cue on which an OAuth client runs its refresh grant instead of

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -956,6 +956,7 @@ directory_mcp = MCPServer(
         "catalog_get returns parameters, provider documentation, price and reliability; "
         "catalog_call_read and catalog_call_write execute the selected endpoint."
     ),
+    middleware=[_StaticSurfaceCapabilities()],
 )
 
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -1136,6 +1136,24 @@ def _allowed_origins() -> list[str]:
     return sorted(dict.fromkeys(origins))
 
 
+class NormalizeDirectoryMCPPath:
+    """Make the directory transport accept its URL with or without the final slash.
+
+    Starlette mounts match ``/mcp/v2/`` but not the exact no-slash path. Hosted Claude removes the
+    slash before its first POST, so the request otherwise falls through to the legacy ``/mcp``
+    mount, discovers V1 OAuth metadata, obtains a V1 token, and then receives a 404. Rewriting the
+    ASGI path before route matching keeps both spellings on the same V2 transport and audience.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and scope.get("path") == "/mcp/v2":
+            scope = dict(scope, path="/mcp/v2/", raw_path=b"/mcp/v2/")
+        return await self.app(scope, receive, send)
+
+
 class RequireAuthForProtectedTools:
     """Answer 401 with `WWW-Authenticate` for any uncredentialed MCP request — eager, not lazy.
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -2,10 +2,10 @@
 
 A coding agent reaches treg through the CLI, and the skill tells it which commands to run. An agent
 inside ChatGPT or a Codex plugin has no CLI, and telling it to install one is where the visitor
-leaves. This module is the other door: five tools over MCP, so an agent can search the catalog, read
+leaves. This module is the other door: six tools over MCP, so an agent can search the catalog, read
 a price and make the call without anything being installed first.
 
-**Five tools, not 2,600.** The catalog stays *data* — one tool searches it, one reads an entry, one
+**Six tools, not 2,600.** The catalog stays *data* — one tool searches it, one reads an entry, one
 calls an endpoint. Exposing every endpoint as its own MCP tool would flood the model's context with
 2,600 schemas and make the catalog unusable, which is the opposite of the point.
 
@@ -39,6 +39,7 @@ import json
 import logging
 import os
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl, urlsplit
 
@@ -71,6 +72,27 @@ _CALLS = ToolAnnotations(read_only_hint=False, destructive_hint=True, open_world
 # route cheap enough to be the honest choice.
 _INTERNAL_BASE = "http://treg.internal"
 _TIMEOUT = httpx.Timeout(120.0, connect=5.0)
+
+
+@dataclass(frozen=True)
+class _SurfacePolicy:
+    """The small set of values that may differ between the two public MCP surfaces."""
+
+    client_name: str
+    event_source: str
+    next_call: str
+
+
+_TEAM_SURFACE = _SurfacePolicy(
+    client_name="mcp",
+    event_source="mcp",
+    next_call="call(...)"
+)
+_DIRECTORY_SURFACE = _SurfacePolicy(
+    client_name="claude-connector",
+    event_source="claude-connector",
+    next_call="catalog_call_read(...) or catalog_call_write(...), based on the documented method",
+)
 
 
 class _StaticSurfaceCapabilities:
@@ -520,6 +542,12 @@ async def _whose_grant(client: httpx.AsyncClient, slug: str | None, *, oauth: bo
     structured_output=True
 )
 async def catalog_search(query: str, limit: int = 8) -> SearchOut:
+    return await _catalog_search_impl(query, limit, surface=_TEAM_SURFACE)
+
+
+async def _catalog_search_impl(
+    query: str, limit: int = 8, *, surface: _SurfacePolicy
+) -> SearchOut:
     cat = catalog_store.load()
     limit = max(1, min(limit, 25))
     # Score, then let the evidence break the ties. Token scoring produces ties by the dozen — every
@@ -562,7 +590,7 @@ async def catalog_search(query: str, limit: int = 8) -> SearchOut:
         # Same miss log as GET /catalog/search (see models.SearchMiss) — this tool reads the catalog
         # in-process, so the HTTP route's logging never sees an MCP agent's empty search.
         if query.strip():
-            audit.record_search_miss(query=query.strip(), source="mcp")
+            audit.record_search_miss(query=query.strip(), source=surface.event_source)
         # the zero-result answer carries the rows that JUST missed the gate and which words they
         # missed — the caller is an LLM, and told exactly what to drop it re-queries correctly
         near = catalog_store.near_misses(query, cat)
@@ -582,7 +610,8 @@ async def catalog_search(query: str, limit: int = 8) -> SearchOut:
                 "requests steer which provider gets added next"
             )
     else:
-        out["next"] = "catalog_get(endpoint_id) for parameters and the exact price, then call(...)"
+        out["next"] = ("catalog_get(endpoint_id) for parameters and the exact price, then "
+                       f"{surface.next_call}")
     return out
 
 
@@ -598,6 +627,14 @@ async def catalog_search(query: str, limit: int = 8) -> SearchOut:
     structured_output=True
 )
 async def catalog_request(capability: str, ctx: Context, note: str = "") -> RequestOut:
+    return await _catalog_request_impl(
+        capability, ctx, note, surface=_TEAM_SURFACE,
+    )
+
+
+async def _catalog_request_impl(
+    capability: str, ctx: Context, note: str = "", *, surface: _SurfacePolicy
+) -> RequestOut:
     """Relays to POST /tool-requests so the rate limiting, field caps and attribution live in one
     place; the bearer (when the session has one) turns into who-asked on the stored row."""
     token = _bearer(ctx)
@@ -605,9 +642,11 @@ async def catalog_request(capability: str, ctx: Context, note: str = "") -> Requ
     # making the per-IP rate limit a single global bucket — forward the edge's X-Forwarded-For
     # so the API's limiter sees the real caller.
     xff = (ctx.headers or {}).get("x-forwarded-for") or (ctx.headers or {}).get("X-Forwarded-For") or ""
-    async with _api(token) as client:
+    api_context = (_api(token) if surface is _TEAM_SURFACE
+                   else _api(token, client_name=surface.client_name))
+    async with api_context as client:
         r = await client.post("/tool-requests", json={
-            "capability": capability, "note": note, "source": "mcp"},
+            "capability": capability, "note": note, "source": surface.event_source},
             headers={"X-Forwarded-For": xff} if xff else {})
     return _body(r)
 
@@ -623,10 +662,18 @@ async def catalog_request(capability: str, ctx: Context, note: str = "") -> Requ
     structured_output=True
 )
 async def catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
+    return await _catalog_get_impl(endpoint_id, ctx, surface=_TEAM_SURFACE)
+
+
+async def _catalog_get_impl(
+    endpoint_id: str, ctx: Context, *, surface: _SurfacePolicy
+) -> CatalogGetOut:
     """Goes through the HTTP route rather than the store: that route attaches the observed
     reliability figures and the capability siblings, and those come from the database."""
     token = _bearer(ctx)
-    async with _api(token) as client:
+    api_context = (_api(token) if surface is _TEAM_SURFACE
+                   else _api(token, client_name=surface.client_name))
+    async with api_context as client:
         r = await client.get(f"/catalog/endpoints/{endpoint_id}")
     if r.status_code == 404:
         cat = catalog_store.load()
@@ -686,7 +733,7 @@ async def call(endpoint_id: str, params: dict | list | None = None,
     return await _call_impl(
         endpoint_id, params=params, method=method, idempotency_key=idempotency_key,
         query=query, body=body, headers=headers, content_type=content_type, ctx=ctx,
-        catalog_only=False, client_name="mcp", allowed_methods=None,
+        catalog_only=False, surface=_TEAM_SURFACE, allowed_methods=None,
     )
 
 
@@ -694,8 +741,9 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
                      method: str | None = None, idempotency_key: str | None = None,
                      query: dict | None = None, body: dict | list | str | None = None,
                      headers: dict | None = None, content_type: str | None = None,
-                     ctx: Context = None, *, catalog_only: bool, client_name: str,
-                     allowed_methods: frozenset[str] | None) -> CallOut:
+                     ctx: Context = None, *, catalog_only: bool,
+                     allowed_methods: frozenset[str] | None,
+                     surface: _SurfacePolicy) -> CallOut:
     token = _bearer(ctx) if ctx else ""
     if not token:
         return _need_token()
@@ -786,10 +834,10 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
                 ctype = "text/plain"
         extra_headers["content-type"] = ctype
 
-    # Keep the legacy call shape intact for integrations/tests that wrap `_api(token)`. The v2
+    # Keep the existing team-MCP call shape intact for integrations/tests that wrap `_api(token)`. The V2
     # connector opts into its own attribution header without changing the established surface.
-    api_context = (_api(token) if client_name == "mcp"
-                   else _api(token, client_name=client_name))
+    api_context = (_api(token) if surface is _TEAM_SURFACE
+                   else _api(token, client_name=surface.client_name))
     async with api_context as client:
         # Resolve the team the same way `balance`/`my_tools` do BEFORE spending anything: a
         # multi-team identity token otherwise reaches /call and bounces off its raw
@@ -874,10 +922,16 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
     structured_output=True
 )
 async def balance(ctx: Context) -> BalanceOut:
+    return await _balance_impl(ctx, surface=_TEAM_SURFACE)
+
+
+async def _balance_impl(ctx: Context, *, surface: _SurfacePolicy) -> BalanceOut:
     token = _bearer(ctx)
     if not token:
         return _need_token()
-    async with _api(token) as client:
+    api_context = (_api(token) if surface is _TEAM_SURFACE
+                   else _api(token, client_name=surface.client_name))
+    async with api_context as client:
         org_id, slug, problem = await _resolve_org(client)
         if problem:
             return problem
@@ -926,7 +980,7 @@ async def my_tools(ctx: Context) -> MyToolsOut:
 
 
 # --------------------------------------------------------------------------------------------
-# Directory-reviewed catalog surface. Additive: the legacy `mcp` server above stays byte-for-byte
+# Directory-reviewed catalog surface. Additive: the team `mcp` server above stays byte-for-byte
 # compatible for clients that rely on `call` + `my_tools`; this server deliberately cannot resolve
 # arbitrary team-tool paths.
 # --------------------------------------------------------------------------------------------
@@ -971,7 +1025,7 @@ directory_mcp = MCPServer(
     structured_output=True,
 )
 async def directory_catalog_search(query: str, limit: int = 8) -> SearchOut:
-    return await catalog_search(query, limit)
+    return await _catalog_search_impl(query, limit, surface=_DIRECTORY_SURFACE)
 
 
 @directory_mcp.tool(
@@ -985,7 +1039,7 @@ async def directory_catalog_search(query: str, limit: int = 8) -> SearchOut:
     structured_output=True,
 )
 async def directory_catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
-    return await catalog_get(endpoint_id, ctx)
+    return await _catalog_get_impl(endpoint_id, ctx, surface=_DIRECTORY_SURFACE)
 
 
 @directory_mcp.tool(
@@ -1010,7 +1064,7 @@ async def directory_catalog_call_read(
 ) -> CallOut:
     return await _call_impl(
         endpoint_id, params=params, idempotency_key=idempotency_key, query=query, headers=headers,
-        ctx=ctx, catalog_only=True, client_name="claude-connector",
+        ctx=ctx, catalog_only=True, surface=_DIRECTORY_SURFACE,
         allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
     )
 
@@ -1040,7 +1094,7 @@ async def directory_catalog_call_write(
     return await _call_impl(
         endpoint_id, params=params, idempotency_key=idempotency_key, query=query, body=body,
         headers=headers, content_type=content_type, ctx=ctx, catalog_only=True,
-        client_name="claude-connector",
+        surface=_DIRECTORY_SURFACE,
         allowed_methods=frozenset({"POST", "PUT", "PATCH", "DELETE"}),
     )
 
@@ -1053,7 +1107,7 @@ async def directory_catalog_call_write(
     structured_output=True,
 )
 async def directory_balance(ctx: Context) -> BalanceOut:
-    return await balance(ctx)
+    return await _balance_impl(ctx, surface=_DIRECTORY_SURFACE)
 
 
 @directory_mcp.tool(
@@ -1067,7 +1121,9 @@ async def directory_balance(ctx: Context) -> BalanceOut:
     structured_output=True,
 )
 async def directory_catalog_request(capability: str, ctx: Context, note: str = "") -> RequestOut:
-    return await catalog_request(capability, ctx, note)
+    return await _catalog_request_impl(
+        capability, ctx, note, surface=_DIRECTORY_SURFACE,
+    )
 
 
 # --------------------------------------------------------------------------------------------
@@ -1106,7 +1162,7 @@ def _allowed_hosts() -> list[str]:
     return sorted(dict.fromkeys(hosts))
 
 
-def _allowed_origins() -> list[str]:
+def _allowed_origins(resource_version: str = "v1") -> list[str]:
     """Which `Origin` headers the transport will answer to.
 
     `"*"` is NOT a wildcard here — the SDK compares origins literally, and only a `:*` port suffix is
@@ -1129,9 +1185,13 @@ def _allowed_origins() -> list[str]:
     origins += [f"http://localhost:{p}" for p in ("8000", "18790")]
     origins += [f"http://127.0.0.1:{p}" for p in ("8000", "18790")]
     origins += ["http://localhost", "http://127.0.0.1"]
-    # Claude's hosted custom/directory connector UI. Exact, never a wildcard; the transport still
-    # rejects every other browser origin.
-    origins += ["https://claude.ai"]
+    if resource_version == "v2":
+        # Claude's hosted custom/directory connector UI. Exact, never a wildcard; the transport
+        # still rejects every other browser origin. This permission belongs to V2 only: adding the
+        # directory connector must not widen the team MCP surface.
+        origins += ["https://claude.ai"]
+    elif resource_version != "v1":
+        raise ValueError(f"unknown MCP resource version {resource_version!r}")
     origins += [o.strip() for o in os.environ.get("TREG_MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
     return sorted(dict.fromkeys(origins))
 
@@ -1140,7 +1200,7 @@ class NormalizeDirectoryMCPPath:
     """Make the directory transport accept its URL with or without the final slash.
 
     Starlette mounts match ``/mcp/v2/`` but not the exact no-slash path. Hosted Claude removes the
-    slash before its first POST, so the request otherwise falls through to the legacy ``/mcp``
+    slash before its first POST, so the request otherwise falls through to the team ``/mcp``
     mount, discovers V1 OAuth metadata, obtains a V1 token, and then receives a 404. Rewriting the
     ASGI path before route matching keeps both spellings on the same V2 transport and audience.
     """
@@ -1346,12 +1406,15 @@ def build_mcp_app(*, server: MCPServer | None = None, resource_version: str = "v
     to stream, and skipping SSE framing is most of the speed.
     """
     server = server or mcp
+    if (server is mcp and resource_version != "v1") or \
+            (server is directory_mcp and resource_version != "v2"):
+        raise ValueError("the MCP server and resource version do not name the same public surface")
     transport = server.streamable_http_app(
         streamable_http_path="/", stateless_http=True, json_response=True,
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
             allowed_hosts=_allowed_hosts(),
-            allowed_origins=_allowed_origins(),
+            allowed_origins=_allowed_origins(resource_version),
         ),
     )
     # Wrapped HERE, not around the module-level value, so a caller that builds its own app gets the

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -327,7 +327,8 @@ def _oauth_claims(token: str) -> dict | None:
     """
     from .domain.identity import mcp_oauth
 
-    return mcp_oauth.read_access_token_any(token)
+    return (mcp_oauth.read_access_token_any(token, "v1")
+            or mcp_oauth.read_access_token_any(token, "v2"))
 
 
 def _need_token() -> dict:
@@ -388,7 +389,7 @@ async def _internal_auth(token: str) -> dict[str, str]:
 
 
 @asynccontextmanager
-async def _api(token: str):
+async def _api(token: str, *, client_name: str = "mcp"):
     """An in-process client bound to treg's own ASGI app, carrying the caller's identity."""
     from .api import app  # deferred: bootstrap imports THIS module while assembling api:app
 
@@ -398,7 +399,7 @@ async def _api(token: str):
         timeout=_TIMEOUT,
         # X-Treg-Client is attribution, not auth: without it every MCP-originated call lands
         # in the audit trail as client="", indistinguishable from unreported CLI traffic.
-        headers={**await _internal_auth(token), "X-Treg-Client": "mcp"},
+        headers={**await _internal_auth(token), "X-Treg-Client": client_name},
     ) as client:
         yield client
 
@@ -682,6 +683,19 @@ async def call(endpoint_id: str, params: dict | list | None = None,
                query: dict | None = None, body: dict | list | str | None = None,
                headers: dict | None = None, content_type: str | None = None,
                ctx: Context = None) -> CallOut:  # type: ignore[assignment]
+    return await _call_impl(
+        endpoint_id, params=params, method=method, idempotency_key=idempotency_key,
+        query=query, body=body, headers=headers, content_type=content_type, ctx=ctx,
+        catalog_only=False, client_name="mcp", allowed_methods=None,
+    )
+
+
+async def _call_impl(endpoint_id: str, params: dict | list | None = None,
+                     method: str | None = None, idempotency_key: str | None = None,
+                     query: dict | None = None, body: dict | list | str | None = None,
+                     headers: dict | None = None, content_type: str | None = None,
+                     ctx: Context = None, *, catalog_only: bool, client_name: str,
+                     allowed_methods: frozenset[str] | None) -> CallOut:
     token = _bearer(ctx) if ctx else ""
     if not token:
         return _need_token()
@@ -692,10 +706,11 @@ async def call(endpoint_id: str, params: dict | list | None = None,
     # could see and never call — which is how this gap was found.
     cat = catalog_store.load()
     ep = cat.by_id.get(endpoint_id)
-    if ep is None and "/" not in endpoint_id:
+    if ep is None and (catalog_only or "/" not in endpoint_id):
         near = catalog_store.near_ids(endpoint_id, cat)
         return {"error": f"unknown endpoint {endpoint_id!r}",
                 "hint": ("did you mean " + ", ".join(near) + "?" if near else
+                         "use catalog_search for a catalog endpoint id" if catalog_only else
                          "use catalog_search for a catalog id, or my_tools then "
                          "'<tool-name>/<path>' for one of this team's own tools"),
                 "did_you_mean": near}
@@ -704,6 +719,12 @@ async def call(endpoint_id: str, params: dict | list | None = None,
     # mismatch, so making `body` just work beats asking the caller to repeat what the catalog knows.
     method = (method or (ep.get("method") if ep else None)
               or ("POST" if body is not None else "GET")).upper()
+    if allowed_methods is not None and method not in allowed_methods:
+        expected = "GET, HEAD or OPTIONS" if "GET" in allowed_methods else "POST, PUT, PATCH or DELETE"
+        return {"error": f"{endpoint_id} is {method}; this tool accepts only {expected} endpoints",
+                "endpoint_id": endpoint_id,
+                "hint": ("use catalog_call_read for safe-method endpoints" if "GET" not in allowed_methods
+                         else "use catalog_call_write for unsafe-method endpoints")}
     reads_query = method in ("GET", "HEAD", "DELETE")
     # A LIST is a legitimate body, not a mistake. DataForSEO — the largest provider in the catalog at
     # 217 endpoints — takes an ARRAY of task objects on every one of its `live` POST routes, so a
@@ -765,7 +786,11 @@ async def call(endpoint_id: str, params: dict | list | None = None,
                 ctype = "text/plain"
         extra_headers["content-type"] = ctype
 
-    async with _api(token) as client:
+    # Keep the legacy call shape intact for integrations/tests that wrap `_api(token)`. The v2
+    # connector opts into its own attribution header without changing the established surface.
+    api_context = (_api(token) if client_name == "mcp"
+                   else _api(token, client_name=client_name))
+    async with api_context as client:
         # Resolve the team the same way `balance`/`my_tools` do BEFORE spending anything: a
         # multi-team identity token otherwise reaches /call and bounces off its raw
         # "choose an org (send X-Treg-Org)" 400 — a header hint an MCP caller cannot act on.
@@ -802,7 +827,8 @@ async def call(endpoint_id: str, params: dict | list | None = None,
                 kw["content"] = the_body.encode()
             else:
                 kw["json"] = the_body
-        r = await client.request(method, f"/call/{endpoint_id}", **kw)
+        route = "/catalog/call" if catalog_only else "/call"
+        r = await client.request(method, f"{route}/{endpoint_id}", **kw)
 
     out: dict[str, Any] = {"status": r.status_code, "endpoint_id": endpoint_id, "body": _body(r)}
     if r.headers.get("X-Treg-Idempotent-Replay") == "true":
@@ -900,6 +926,150 @@ async def my_tools(ctx: Context) -> MyToolsOut:
 
 
 # --------------------------------------------------------------------------------------------
+# Directory-reviewed catalog surface. Additive: the legacy `mcp` server above stays byte-for-byte
+# compatible for clients that rely on `call` + `my_tools`; this server deliberately cannot resolve
+# arbitrary team-tool paths.
+# --------------------------------------------------------------------------------------------
+
+_DIRECTORY_READS = ToolAnnotations(
+    read_only_hint=True, destructive_hint=False, open_world_hint=False, idempotent_hint=True,
+)
+_DIRECTORY_OPEN_READ = ToolAnnotations(
+    read_only_hint=True, destructive_hint=False, open_world_hint=True, idempotent_hint=False,
+)
+_DIRECTORY_WRITE = ToolAnnotations(
+    read_only_hint=False, destructive_hint=True, open_world_hint=True, idempotent_hint=False,
+)
+_DIRECTORY_ADDITIVE = ToolAnnotations(
+    read_only_hint=False, destructive_hint=False, open_world_hint=False, idempotent_hint=False,
+)
+
+directory_mcp = MCPServer(
+    name="treg",
+    title="Treg",
+    description=(
+        "Search and call Treg's curated catalog of external data APIs, with price and reliability "
+        "information available before a call."
+    ),
+    instructions=(
+        "This connector exposes Treg catalog endpoints only. catalog_search finds endpoint ids; "
+        "catalog_get returns parameters, provider documentation, price and reliability; "
+        "catalog_call_read and catalog_call_write execute the selected endpoint."
+    ),
+)
+
+
+@directory_mcp.tool(
+    name="catalog_search",
+    title="Search Treg Catalog",
+    description=(
+        "Searches Treg's catalog by capability or task words and returns matching endpoint ids, "
+        "providers, prices and measured reliability."
+    ),
+    annotations=_DIRECTORY_READS,
+    structured_output=True,
+)
+async def directory_catalog_search(query: str, limit: int = 8) -> SearchOut:
+    return await catalog_search(query, limit)
+
+
+@directory_mcp.tool(
+    name="catalog_get",
+    title="Get Catalog Endpoint",
+    description=(
+        "Returns one catalog endpoint's parameters, provider API documentation, price, example "
+        "response and measured reliability, plus comparable providers for the same capability."
+    ),
+    annotations=_DIRECTORY_READS,
+    structured_output=True,
+)
+async def directory_catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
+    return await catalog_get(endpoint_id, ctx)
+
+
+@directory_mcp.tool(
+    name="catalog_call_read",
+    title="Call a Read Endpoint",
+    description=(
+        "Calls a catalog endpoint whose documented HTTP method is GET, HEAD or OPTIONS. The "
+        "endpoint must come from catalog_search; catalog_get supplies its provider API documentation, "
+        "parameters and price. A successful call may deduct that displayed price from the team's "
+        "Treg balance."
+    ),
+    annotations=_DIRECTORY_OPEN_READ,
+    structured_output=True,
+)
+async def directory_catalog_call_read(
+    endpoint_id: str,
+    params: dict | None = None,
+    idempotency_key: str | None = None,
+    query: dict | None = None,
+    headers: dict | None = None,
+    ctx: Context = None,  # type: ignore[assignment]
+) -> CallOut:
+    return await _call_impl(
+        endpoint_id, params=params, idempotency_key=idempotency_key, query=query, headers=headers,
+        ctx=ctx, catalog_only=True, client_name="claude-connector",
+        allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
+    )
+
+
+@directory_mcp.tool(
+    name="catalog_call_write",
+    title="Call a Write Endpoint",
+    description=(
+        "Calls a catalog endpoint whose documented HTTP method is POST, PUT, PATCH or DELETE. The "
+        "endpoint must come from catalog_search; catalog_get supplies its provider API documentation, "
+        "parameters and price. The provider may create, change or delete external data, and a "
+        "successful call may deduct the displayed price from the team's Treg balance."
+    ),
+    annotations=_DIRECTORY_WRITE,
+    structured_output=True,
+)
+async def directory_catalog_call_write(
+    endpoint_id: str,
+    params: dict | list | None = None,
+    idempotency_key: str | None = None,
+    query: dict | None = None,
+    body: dict | list | str | None = None,
+    headers: dict | None = None,
+    content_type: str | None = None,
+    ctx: Context = None,  # type: ignore[assignment]
+) -> CallOut:
+    return await _call_impl(
+        endpoint_id, params=params, idempotency_key=idempotency_key, query=query, body=body,
+        headers=headers, content_type=content_type, ctx=ctx, catalog_only=True,
+        client_name="claude-connector",
+        allowed_methods=frozenset({"POST", "PUT", "PATCH", "DELETE"}),
+    )
+
+
+@directory_mcp.tool(
+    name="balance",
+    title="Check Treg Balance",
+    description="Returns the connected team's Treg balance, in-flight holds, team and identity.",
+    annotations=_DIRECTORY_READS,
+    structured_output=True,
+)
+async def directory_balance(ctx: Context) -> BalanceOut:
+    return await balance(ctx)
+
+
+@directory_mcp.tool(
+    name="catalog_request",
+    title="Request a Catalog Capability",
+    description=(
+        "Records a request for a provider or capability that is missing from Treg's catalog. "
+        "This creates a request in Treg and does not call an external provider or spend balance."
+    ),
+    annotations=_DIRECTORY_ADDITIVE,
+    structured_output=True,
+)
+async def directory_catalog_request(capability: str, ctx: Context, note: str = "") -> RequestOut:
+    return await catalog_request(capability, ctx, note)
+
+
+# --------------------------------------------------------------------------------------------
 # Mounting
 # --------------------------------------------------------------------------------------------
 
@@ -958,6 +1128,9 @@ def _allowed_origins() -> list[str]:
     origins += [f"http://localhost:{p}" for p in ("8000", "18790")]
     origins += [f"http://127.0.0.1:{p}" for p in ("8000", "18790")]
     origins += ["http://localhost", "http://127.0.0.1"]
+    # Claude's hosted custom/directory connector UI. Exact, never a wildcard; the transport still
+    # rejects every other browser origin.
+    origins += ["https://claude.ai"]
     origins += [o.strip() for o in os.environ.get("TREG_MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()]
     return sorted(dict.fromkeys(origins))
 
@@ -982,8 +1155,9 @@ class RequireAuthForProtectedTools:
     everything below.
     """
 
-    def __init__(self, app):
+    def __init__(self, app, *, resource_version: str = "v1"):
         self.app = app
+        self.resource_version = resource_version
 
     async def __call__(self, scope, receive, send):
         if scope["type"] != "http" or scope.get("method") != "POST":
@@ -1021,8 +1195,7 @@ class RequireAuthForProtectedTools:
 
         return await self.app(scope, replay, send)
 
-    @staticmethod
-    def _auth_verdict(scope, body: bytes) -> str | None:
+    def _auth_verdict(self, scope, body: bytes) -> str | None:
         """None = pass through. "missing" = no credential. "invalid" = a DEAD access token.
 
         **Eager, not lazy.** Every treg tool needs auth, so there is nothing to browse anonymously —
@@ -1063,14 +1236,14 @@ class RequireAuthForProtectedTools:
             return "missing"
         from .domain.identity import mcp_oauth
         if mcp_oauth.looks_like_access_token(token) and \
-                mcp_oauth.read_access_token_any(token) is None:
+                mcp_oauth.read_access_token_any(token, self.resource_version) is None:
             return "invalid"
         return None             # a live access token, or a per-org token the tool validates itself
 
-    @staticmethod
-    async def _challenge(send, *, invalid: bool = False) -> None:
+    async def _challenge(self, send, *, invalid: bool = False) -> None:
         base = get_settings().public_url.rstrip("/")
-        meta = f"{base}/.well-known/oauth-protected-resource"
+        suffix = "/mcp/v2" if self.resource_version == "v2" else ""
+        meta = f"{base}/.well-known/oauth-protected-resource{suffix}"
         # The spec SHOULDs a `scope` in the challenge so a client requests the right scopes up front,
         # least-privilege, without a second round-trip. These match scopes_supported in the metadata.
         scope = "treg:catalog treg:call treg:read"
@@ -1138,7 +1311,7 @@ class NoTransformResponses:
         return await self.app(scope, receive, send_stamped)
 
 
-def build_mcp_app():
+def build_mcp_app(*, server: MCPServer | None = None, resource_version: str = "v1"):
     """A fresh ASGI app for the MCP transport.
 
     A factory rather than a bare module-level value because each call builds its own session
@@ -1151,7 +1324,8 @@ def build_mcp_app():
     would need sticky routing; `json_response` because these are request/response tools with nothing
     to stream, and skipping SSE framing is most of the speed.
     """
-    transport = mcp.streamable_http_app(
+    server = server or mcp
+    transport = server.streamable_http_app(
         streamable_http_path="/", stateless_http=True, json_response=True,
         transport_security=TransportSecuritySettings(
             enable_dns_rebinding_protection=True,
@@ -1176,11 +1350,13 @@ def build_mcp_app():
     # too; gzip sits between so challenges and answers alike are origin-encoded.
     from starlette.middleware.gzip import GZipMiddleware
 
-    return NoTransformResponses(GZipMiddleware(RequireAuthForProtectedTools(transport),
+    return NoTransformResponses(GZipMiddleware(RequireAuthForProtectedTools(
+                                                   transport, resource_version=resource_version),
                                                minimum_size=1024))
 
 
 mcp_app = build_mcp_app()
+directory_mcp_app = build_mcp_app(server=directory_mcp, resource_version="v2")
 
 
 @asynccontextmanager
@@ -1194,3 +1370,11 @@ async def mcp_lifespan(target=None):
         inner = inner.app
     async with inner.router.lifespan_context(inner):
         yield
+
+
+@asynccontextmanager
+async def all_mcp_lifespans():
+    """Start both mounted transports; Starlette does not run mounted-app lifespans itself."""
+    async with mcp_lifespan(mcp_app):
+        async with mcp_lifespan(directory_mcp_app):
+            yield

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1005,7 +1005,7 @@ class ToolRequest(SQLModel, table=True):
     query: str = Field(default="")
     note: str = Field(default="")
     contact: str = Field(default="")  # optional reach-back (email/handle); free text, unverified
-    source: str = Field(default="web", index=True)  # web | cli | mcp | api
+    source: str = Field(default="web", index=True)  # web | cli | mcp | claude-connector | api
     status: str = Field(default="open", index=True)  # open | done | dismissed — flipped by hand
     created_at: datetime = Field(default_factory=_now, index=True)
 
@@ -1025,5 +1025,6 @@ class SearchMiss(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     query: str  # the search text that matched nothing, capped by the writer
-    source: str = Field(default="api", index=True)  # api (HTTP /catalog/search: web + CLI) | mcp
+    # api (HTTP /catalog/search: web + CLI) | mcp | claude-connector
+    source: str = Field(default="api", index=True)
     created_at: datetime = Field(default_factory=_now, index=True)

--- a/src/treg/routers/auth.py
+++ b/src/treg/routers/auth.py
@@ -811,6 +811,7 @@ def _consent_page(*, client_name: str, client_uri: str, user_email: str, teams: 
 
 
 _wrong_resource = auth_use_cases._wrong_resource
+_effective_mcp_resource = auth_use_cases._effective_mcp_resource
 _same_mcp_resource = auth_use_cases._same_mcp_resource
 
 
@@ -866,6 +867,7 @@ async def oauth_authorize(
             code_challenge=code_challenge,
             code_challenge_method=code_challenge_method,
             resource=resource,
+            scope=scope,
             session_cookie=treg_session,
         )
     except auth_use_cases.OAuthServerError as exc:

--- a/src/treg/routers/auth.py
+++ b/src/treg/routers/auth.py
@@ -1002,6 +1002,8 @@ async def oauth_protected_resource():
 @app.get("/.well-known/oauth-protected-resource/mcp/v2", include_in_schema=False)
 async def oauth_protected_resource_v2():
     """Protected-resource metadata for the catalog-only connector."""
+    if not get_settings().claude_connector_enabled:
+        raise HTTPException(status_code=404, detail="Claude catalog connector is not enabled")
     return JSONResponse(mcp_oauth.protected_resource_metadata("v2"),
                         headers={"Cache-Control": "public, max-age=3600"})
 

--- a/src/treg/routers/auth.py
+++ b/src/treg/routers/auth.py
@@ -875,7 +875,8 @@ async def oauth_authorize(
         # query the sign-in page would have to understand — the first version invented that
         # convention and nothing implemented it, so the user signed in and landed on the dashboard
         # with the authorization silently dropped.
-        resp = RedirectResponse("/", status_code=302)
+        # The query is only a UI cue. The validated request stays in the HttpOnly return cookie.
+        resp = RedirectResponse("/?signin=oauth", status_code=302)
         _remember_oauth_return(resp, request)
         return resp
 

--- a/src/treg/routers/auth.py
+++ b/src/treg/routers/auth.py
@@ -999,6 +999,13 @@ async def oauth_protected_resource():
                         headers={"Cache-Control": "public, max-age=3600"})
 
 
+@app.get("/.well-known/oauth-protected-resource/mcp/v2", include_in_schema=False)
+async def oauth_protected_resource_v2():
+    """Protected-resource metadata for the catalog-only connector."""
+    return JSONResponse(mcp_oauth.protected_resource_metadata("v2"),
+                        headers={"Cache-Control": "public, max-age=3600"})
+
+
 @app.get("/.well-known/oauth-authorization-server", include_in_schema=False)
 async def oauth_authorization_server():
     """How to get a token: the authorize and token endpoints, S256, and that we accept both dynamic

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2441,6 +2441,7 @@ _SITEMAP_PAGES: tuple[tuple[str, str, str], ...] = (
     ("/resources", "resources.html", "0.8"),
     ("/vendor-listing", "vendor-listing.md", "0.5"),
     ("/support", "support.html", "0.4"),
+    ("/connectors/claude", "claude-connector.html", "0.6"),
     ("/terms", "terms.html", "0.2"),
     ("/privacy", "privacy.html", "0.2"),
     # The outcome pages. Listed WITHOUT a trailing slash on purpose: `/use-cases/<slug>/` 307s to
@@ -2670,6 +2671,12 @@ async def privacy_page():
     (Google requires a reachable privacy policy carrying the Limited Use disclosure), so this path
     is effectively public API — don't rename it without updating the provider consoles."""
     return _legal_page("privacy.html")
+
+
+@app.get("/connectors/claude", include_in_schema=False)
+async def claude_connector_page():
+    """Setup, scope, billing, privacy, and removal instructions for the Claude connector."""
+    return _legal_page("claude-connector.html")
 
 
 @app.get("/adtrack.js", include_in_schema=False)

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2790,12 +2790,16 @@ async def connect_demo_page():
     browser before trusting it inside ChatGPT, where a failure surfaces as a shrug rather than an
     error message.
     """
+    if not get_settings().connect_demo_enabled:
+        raise HTTPException(status_code=404, detail="connect demo is not enabled")
     return _legal_page("connect-demo.html")
 
 
 @app.get("/connect-demo/callback", include_in_schema=False)
 async def connect_demo_callback():
     """Where treg sends the browser back. Hands the code to the opener and closes."""
+    if not get_settings().connect_demo_enabled:
+        raise HTTPException(status_code=404, detail="connect demo is not enabled")
     return _legal_page("connect-demo-callback.html")
 
 

--- a/src/treg/web/claude-connector.html
+++ b/src/treg/web/claude-connector.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Treg connector for Claude</title>
+<meta name="description" content="Connect Claude to Treg's curated catalog of live data and APIs without sharing API keys with Claude."/>
+<link rel="canonical" href="{BASE}/connectors/claude"/>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist+Pixel&family=DM+Mono:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/legal.css"/>
+</head>
+<body>
+<div class="topbar"><div class="in">
+  <a class="brand" href="/"><span class="glyph">▚</span> treg</a>
+  <span class="sp"></span>
+  <a class="nav on" href="/connectors/claude">Claude connector</a>
+  <a class="nav" href="/pricing">pricing</a>
+  <a class="nav" href="/support">support</a>
+</div></div>
+
+<div class="page"><div class="doc">
+  <div class="eyebrow">Community connector</div>
+  <h1>Treg for Claude</h1>
+  <div class="stamp"><span>Published by Superdesign</span><span>Catalog-only V1</span></div>
+
+  <div class="summary">
+    <h2>Live data and APIs for Claude, without API keys</h2>
+    <p>Treg lets Claude find and call endpoints from Treg's curated catalog. It is a third-party
+    community connector published by Superdesign; it is not an Anthropic product or a claim of
+    Anthropic verification.</p>
+  </div>
+
+  <h2 class="sec" id="setup"><span class="n">01</span>Connect</h2>
+  <ol>
+    <li>In Claude, open <b>Settings → Connectors</b> and choose Treg from the directory.</li>
+    <li>Choose <b>Connect</b>. Claude opens Treg's OAuth consent page.</li>
+    <li>Sign in to Treg, select the team Claude may use, review the requested access, and approve.</li>
+  </ol>
+  <p>While the directory listing is under review, the same connector can be tested as a custom
+  connector using <code>{BASE}/mcp/v2/</code>. Authentication uses OAuth with PKCE; do not paste a
+  Treg token or provider API key into Claude.</p>
+
+  <h2 class="sec" id="scope"><span class="n">02</span>V1 scope and tools</h2>
+  <p>This version exposes the curated Treg catalog only. It cannot list or invoke team-owned tools,
+  imported skills, arbitrary URLs, or arbitrary HTTP methods.</p>
+  <ul>
+    <li><code>catalog_search</code> and <code>catalog_get</code> find endpoints and show their input,
+    authentication, method, and price.</li>
+    <li><code>catalog_call_read</code> invokes only catalog entries declared as GET, HEAD, or OPTIONS.</li>
+    <li><code>catalog_call_write</code> invokes only catalog entries declared as POST, PUT, PATCH, or
+    DELETE. Claude controls its confirmation experience for these potentially mutating calls.</li>
+    <li><code>balance</code> reports the selected team's prepaid balance and daily usage.</li>
+    <li><code>catalog_request</code> records a request for a missing capability; it does not call a
+    provider or change provider data.</li>
+  </ul>
+
+  <h2 class="sec" id="pricing"><span class="n">03</span>Pricing and limits</h2>
+  <p>Searching and inspecting the catalog is free. Before a metered call, Treg returns the endpoint's
+  USD price. Calls served with Treg's platform credential debit the selected team's prepaid balance;
+  calls using your own connected provider credential follow the provider's own billing as well.
+  Your team's balance and daily cap are enforced before calls. See the current <a href="/pricing">pricing</a>
+  page and the endpoint detail shown in Claude before proceeding.</p>
+
+  <h2 class="sec" id="data"><span class="n">04</span>Data flow and security</h2>
+  <p>Claude sends the chosen endpoint id and request inputs to Treg. Treg resolves the curated entry,
+  applies the selected team's access rules and spending limits, injects the applicable credential
+  server-side, and relays the request to that endpoint's provider. The provider response is returned
+  to Claude without reshaping it. Provider credentials are never returned to Claude.</p>
+  <p>Treg records call metadata needed for metering, audit, reliability, and support. Provider request
+  and response data necessarily pass through Treg to complete the call. Read the full
+  <a href="/privacy">privacy policy</a> for retention, processors, and account-data rights.</p>
+
+  <h2 class="sec" id="disconnect"><span class="n">05</span>Disconnect and revoke</h2>
+  <p>Disconnect Treg from Claude in <b>Settings → Connectors</b>. To revoke the underlying authorization
+  from Treg as well, sign in to Treg and remove the Claude grant from the connected-apps area, or ask
+  <a href="/support">support</a> to revoke it. Disconnecting does not delete your Treg team, balance,
+  provider connections, or audit history.</p>
+
+  <h2 class="sec" id="support"><span class="n">06</span>Support</h2>
+  <p>For setup, billing, privacy, security, or endpoint problems, visit <a href="/support">Treg support</a>
+  or email <a href="mailto:jason@superdesign.dev">jason@superdesign.dev</a>. Include the endpoint id,
+  approximate time, and the error text, but never send passwords, OAuth codes, tokens, or API keys.</p>
+</div>
+
+<nav class="toc">
+  <a href="#setup">Connect</a><a href="#scope">V1 scope</a><a href="#pricing">Pricing</a>
+  <a href="#data">Data flow</a><a href="#disconnect">Disconnect</a><a href="#support">Support</a>
+</nav></div>
+
+<footer><div class="foot-in">
+  <span class="brand"><span class="glyph">▚</span> treg</span><span class="muted">— by Superdesign</span>
+  <span class="sp"></span><a href="/support">support</a><a href="/privacy">privacy</a>
+  <a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">github ↗</a>
+</div></footer>
+</body>
+</html>

--- a/src/treg/web/claude-connector.html
+++ b/src/treg/web/claude-connector.html
@@ -24,7 +24,7 @@
 <div class="page"><div class="doc">
   <div class="eyebrow">Community connector</div>
   <h1>Treg for Claude</h1>
-  <div class="stamp"><span>Published by Superdesign</span><span>Catalog-only V1</span></div>
+  <div class="stamp"><span>Published by Superdesign</span><span>Connector release V1</span></div>
 
   <div class="summary">
     <h2>Live data and APIs for Claude, without API keys</h2>
@@ -41,9 +41,10 @@
   </ol>
   <p>While the directory listing is under review, the same connector can be tested as a custom
   connector using <code>{BASE}/mcp/v2/</code>. Authentication uses OAuth with PKCE; do not paste a
-  Treg token or provider API key into Claude.</p>
+  Treg token or provider API key into Claude. The <code>v2</code> in this URL identifies Treg's
+  restricted MCP transport; it is separate from connector release V1.</p>
 
-  <h2 class="sec" id="scope"><span class="n">02</span>V1 scope and tools</h2>
+  <h2 class="sec" id="scope"><span class="n">02</span>Connector V1 scope and tools</h2>
   <p>This version exposes the curated Treg catalog only. It cannot list or invoke team-owned tools,
   imported skills, arbitrary URLs, or arbitrary HTTP methods.</p>
   <ul>
@@ -86,7 +87,7 @@
 </div>
 
 <nav class="toc">
-  <a href="#setup">Connect</a><a href="#scope">V1 scope</a><a href="#pricing">Pricing</a>
+  <a href="#setup">Connect</a><a href="#scope">Connector V1 scope</a><a href="#pricing">Pricing</a>
   <a href="#data">Data flow</a><a href="#disconnect">Disconnect</a><a href="#support">Support</a>
 </nav></div>
 

--- a/src/treg/web/connect-demo.html
+++ b/src/treg/web/connect-demo.html
@@ -170,8 +170,7 @@ async function exchange(code) {
   document.querySelectorAll(".tool").forEach((b) => (b.disabled = false));
   $("btnRefresh").disabled = false; $("btnDisconnect").disabled = false; $("btnCall").disabled = false;
   log("token received", { token_type: body.token_type, expires_in: body.expires_in,
-                          access_token: body.access_token.slice(0, 24) + "…",
-                          refresh_token: body.refresh_token.slice(0, 12) + "…" });
+                          access_token: "[received]", refresh_token: "[received]" });
 }
 
 let rpcId = 0;

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -3887,7 +3887,7 @@ treg login</pre></div>
         <div class="field"><input v-model="codeInput" inputmode="numeric" placeholder="6-digit code" @keyup.enter="emailVerify"/></div>
         <button class="btn primary" style="width:100%" @click="emailVerify" :disabled="busy">{{busy?'Verifying…':'Sign in'}}</button>
       </div>
-      <details style="margin-top:12px;text-align:left">
+      <details v-if="!oauthSignin" style="margin-top:12px;text-align:left">
         <summary class="sub" style="cursor:pointer;text-align:center">or paste an org token (agents &amp; CLI)</summary>
         <div class="field" style="margin-top:8px"><input v-model="tokenInput" type="password" placeholder="X-Treg-Token" @keyup.enter="addToken(tokenInput)"/></div>
         <button class="btn" style="width:100%" @click="addToken(tokenInput)" :disabled="busy">{{busy?'Checking…':'Sign in with token'}}</button>

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -3868,8 +3868,9 @@ treg login</pre></div>
     <div class="lc-modal" role="dialog" aria-modal="true" aria-label="Sign in">
       <button class="cls" @click="demo.signin=false" aria-label="Close">✕</button>
       <div style="font-size:26px">▚</div>
-      <h2 style="margin:8px 0 2px;font-family:var(--mono)">{{invitePrefill?'Accept your invite':(shareGate?'Sign in to view it':(publicCatalog?'Start calling':'Make it yours'))}}</h2>
-      <p v-if="invitePrefill" class="sub">Sign in with <b>{{invitePrefill}}</b> and you'll drop straight into the team.</p>
+      <h2 style="margin:8px 0 2px;font-family:var(--mono)">{{oauthSignin?'Sign in to continue connecting Treg':(invitePrefill?'Accept your invite':(shareGate?'Sign in to view it':(publicCatalog?'Start calling':'Make it yours')))}}</h2>
+      <p v-if="oauthSignin" class="sub">After sign-in, review the requested access before you approve it.</p>
+      <p v-else-if="invitePrefill" class="sub">Sign in with <b>{{invitePrefill}}</b> and you'll drop straight into the team.</p>
       <p v-else-if="shareGate" class="sub">You'll land on “{{shareGate.name}}” right after.</p>
       <!-- The default line is the SANDBOX's ("bring it into a real account"), which is nonsense to
            someone who arrived on a catalog page from a search result and has no sandbox. -->
@@ -3909,7 +3910,7 @@ createApp({
       // unauthenticated, so the same marketplace views render for a signed-out visitor — that is
       // what makes the catalog indexable without maintaining a second copy of the UI. Everything
       // that needs a session (org switcher, vault, activity, team, try-it) is hidden on `authed`.
-      publicCatalog:false,
+      publicCatalog:false, oauthSignin:false,
       cfg, tokenInput:'', busy:false, loginErr:'', addOrg:false, orgMenu:false, orgMenuStyle:null,
       emailInput:'', codeInput:'', emailStage:false, devCode:'', pendingInvites:[], invitePrefill:'', inviteChoice:false, inviteBusy:false,
       inviteSel:{}, inviteLinkOrg:null, inviteErr:'',  // multi-select accept: checked ids, the org_id the clicked email link was for, partial-failure note
@@ -6259,8 +6260,9 @@ createApp({
     // Invite-link params, parsed BEFORE the session check: ?invite_org= arrives freshly signed in
     // from the email link's POST-confirm; ?invite= is the legacy code path (prefilled login).
     const qs = new URLSearchParams(location.search);
-    const linkOrg = qs.get('invite_org'), inv = qs.get('invite');
-    if(linkOrg || inv || qs.get('invite_expired')){ history.replaceState(null,'',location.pathname+location.hash); }  // strip one-shot params so reload/share doesn't replay them
+    const linkOrg = qs.get('invite_org'), inv = qs.get('invite'), oauthSignin = qs.get('signin')==='oauth';
+    this.oauthSignin=oauthSignin;
+    if(linkOrg || inv || qs.get('invite_expired') || oauthSignin){ history.replaceState(null,'',location.pathname+location.hash); }  // strip one-shot params so reload/share doesn't replay them
     if(linkOrg){ this.inviteLinkOrg=parseInt(linkOrg,10)||null; }
     // A shared detail deep link (/app/skills/<x>, /app/tools/<x>) — from the URL itself, or stashed
     // before an OAuth hop (the callback always lands on /app, which would otherwise drop the path).
@@ -6324,8 +6326,9 @@ createApp({
       // renders blank in an incognito window.
       if(catRoute.slug) this.openPlatform(catRoute.slug, true); else { this.view='connections'; this.loadConnections(); }
       return; }
-    if(!inv && !linkOrg && !route && !qs.get('invite_expired') && !qs.get('ref')){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door. `ref` is NOT a plain visit: it is a use-case page's CTA (/app?ref=p1), and bouncing that visitor to the front door throws away the page they arrived on — on a paid click, the one we bought.
+    if(!inv && !linkOrg && !route && !qs.get('invite_expired') && !qs.get('ref') && !oauthSignin){ location.replace('/'); return; }  // logged-out plain visit → the marketing landing owns the front door. `ref` is NOT a plain visit: it is a use-case page's CTA (/app?ref=p1), and bouncing that visitor to the front door throws away the page they arrived on — on a paid click, the one we bought.
     if(route){ this.shareGate=route; this.demo.signin=true; }  // shared link while logged out: the focused gate (no sandbox mint, no tour); after sign-in the boot lands on it (email verify reloads in place; OAuth restores via the treg-next stash)
+    else if(oauthSignin) this.demo.signin=true;     // OAuth already has a pending return cookie; open login directly and do not mint a sandbox
     else this.sbxInit();                            // other logged-out flows → the in-app landing + sign-in modal
     if(inv){ this.invitePrefill=inv; this.emailInput=inv; this.emailStage=false; this.demo.signin=true; }  // legacy code link while logged out: prefill + open sign-in; the invite auto-accepts after login (maybeOnboard)
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,9 @@ os.environ["TREG_EMAIL_DEV_MODE"] = "true"  # tests need the returned OTP code (
 os.environ["TREG_RESEND_API_KEY"] = ""  # never fire a real Resend send from the test suite (send_otp/send_invite skip when empty)
 os.environ["TREG_RUN_ALLOWED_BINS"] = "sh,echo,true,false,cat,sleep,treg-nonexistent-bin-xyz"  # allow the test CLIs for --server run tests
 os.environ["TREG_PROXY_SSRF_CHECK"] = "false"
+# The production default is OFF. The established connector tests and committed route snapshots test
+# the enabled product surface; dedicated tests below also prove the disabled deployment shape.
+os.environ["TREG_CLAUDE_CONNECTOR_ENABLED"] = "true"
 # Blank every registry credential so the suite NEVER inherits a developer's real .env. Settings
 # reads .env, and a real env var beats it — so without this, a machine with Google/X/LinkedIn
 # credentials configured runs a different suite than CI, and provider tests pass or fail depending

--- a/tests/snapshots/composition.json
+++ b/tests/snapshots/composition.json
@@ -24,6 +24,11 @@
   "middleware": [
     {
       "args": [],
+      "class": "treg.mcp.NormalizeDirectoryMCPPath",
+      "kwargs": {}
+    },
+    {
+      "args": [],
       "class": "treg.api._BodyDecodeMiddleware",
       "kwargs": {}
     },

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -601,6 +601,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "claude_connector_page",
+    "path": "/connectors/claude"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "adtrack_js",
     "path": "/adtrack.js"
   },
@@ -689,6 +698,15 @@
     ],
     "name": "oauth_protected_resource",
     "path": "/.well-known/oauth-protected-resource"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
+    "name": "oauth_protected_resource_v2",
+    "path": "/.well-known/oauth-protected-resource/mcp/v2"
   },
   {
     "kind": "APIRoute",
@@ -1836,10 +1854,30 @@
   {
     "kind": "APIRoute",
     "methods": [
+      "DELETE",
+      "GET",
+      "HEAD",
+      "OPTIONS",
+      "PATCH",
+      "POST",
+      "PUT"
+    ],
+    "name": "call_catalog_endpoint",
+    "path": "/catalog/call/{rest:path}"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
       "POST"
     ],
     "name": "run_tool_server",
     "path": "/run"
+  },
+  {
+    "kind": "Mount",
+    "methods": [],
+    "name": null,
+    "path": "/mcp/v2"
   },
   {
     "kind": "Mount",

--- a/tests/test_app_roles.py
+++ b/tests/test_app_roles.py
@@ -15,6 +15,7 @@ from treg.bootstrap import create_app
 
 _SNAPSHOT = Path(__file__).parent / "snapshots" / "routes.json"
 _CALL_ROUTE = "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT /call/{rest:path}"
+_CATALOG_CALL_ROUTE = "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT /catalog/call/{rest:path}"
 
 
 def _all_routes() -> list[str]:
@@ -32,7 +33,10 @@ _ALL_ROUTES = _all_routes()
 # MCP is calling traffic: the dataplane owns its mount and its RFC 9728 resource metadata.
 _DATAPLANE_ONLY = (
     _CALL_ROUTE,
+    _CATALOG_CALL_ROUTE,
     "GET,HEAD /.well-known/oauth-protected-resource/mcp",
+    "GET,HEAD /.well-known/oauth-protected-resource/mcp/v2",
+    "MOUNT /mcp/v2",
     "MOUNT /mcp",
 )
 _DATAPLANE_ROUTES = [route for route in _ALL_ROUTES if route in _DATAPLANE_ONLY]

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -27,6 +27,7 @@ def test_oauth_entry_opens_the_existing_sign_in_modal_without_minting_a_sandbox(
     assert "else if(oauthSignin) this.demo.signin=true" in INDEX
     assert "Sign in to continue connecting Treg" in INDEX
     assert "After sign-in, review the requested access before you approve it." in INDEX
+    assert '<details v-if="!oauthSignin" style="margin-top:12px;text-align:left">' in INDEX
 
 
 # Every <template> open/close, because only a balanced count locates the view boundaries: the file

--- a/tests/test_dashboard_markup.py
+++ b/tests/test_dashboard_markup.py
@@ -22,6 +22,13 @@ TUTORIAL = (Path(api.__file__).parent / "web" / "tutorial.html").read_text(encod
 SHARED_DIALOGS = ["tokenAsk", "capAsk", "resPick"]
 
 
+def test_oauth_entry_opens_the_existing_sign_in_modal_without_minting_a_sandbox():
+    assert "qs.get('signin')==='oauth'" in INDEX
+    assert "else if(oauthSignin) this.demo.signin=true" in INDEX
+    assert "Sign in to continue connecting Treg" in INDEX
+    assert "After sign-in, review the requested access before you approve it." in INDEX
+
+
 # Every <template> open/close, because only a balanced count locates the view boundaries: the file
 # nests plain `v-if`/`v-for` templates inside views, and each of those closes with a `</template>`
 # that would otherwise be read as closing the view. (Corollary: don't write a literal `<template`

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -120,6 +120,22 @@ async def test_tier1_registered_tool_wins(clients: AsyncClient):
     assert (await _telemetry(clients))["tool_name"] == "our-tikhub"
 
 
+async def test_catalog_only_route_cannot_be_shadowed_by_same_named_team_tool(clients: AsyncClient):
+    """The directory route resolves the curated id directly; legacy `/call` still gives an exact
+    same-named team tool precedence, preserving both contracts at once."""
+    sid = (await clients.post("/secrets", json={"name": "own-key", "value": "OWN"})).json()["id"]
+    await clients.post("/tools", json={"name": EP, "base_url": "http://upstream", "secret_id": sid})
+    await clients.post("/secrets", json={"name": "tikhub", "value": "CATALOG"})
+
+    legacy = await clients.get(f"/call/{EP}?aweme_id=7")
+    directory = await clients.get(f"/catalog/call/{EP}?aweme_id=7")
+
+    assert legacy.status_code == 200 and legacy.json()["auth"] == "Bearer OWN"
+    assert directory.status_code == 200
+    assert directory.json()["auth"] == "Bearer CATALOG"
+    assert directory.json()["raw_path"] == EP_PATH
+
+
 async def test_tier3_no_credential_is_an_actionable_404(clients: AsyncClient):
     """With tier 4 OFF (the default — no provider allow-listed), the ladder still dead-ends here."""
     r = await clients.get(f"/call/{EP}?aweme_id=7")

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -1,0 +1,172 @@
+"""The Claude directory MCP is catalog-only and OAuth-isolated from the legacy MCP."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from treg import mcp, mcp_oauth
+
+pytestmark = pytest.mark.anyio
+
+MCP_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+
+
+@asynccontextmanager
+async def directory_session():
+    fresh = mcp.build_mcp_app(server=mcp.directory_mcp, resource_version="v2")
+    host = FastAPI()
+    host.mount("/mcp/v2", fresh)
+    async with mcp.mcp_lifespan(fresh):
+        async with AsyncClient(transport=ASGITransport(app=host),
+                               base_url="http://localhost") as client:
+            yield client
+
+
+async def _rpc(client: AsyncClient, method: str, params=None, token: str | None = None):
+    headers = dict(MCP_HEADERS)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    body = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        body["params"] = params
+    return await client.post("http://localhost/mcp/v2/", json=body, headers=headers)
+
+
+async def test_v2_declares_exact_directory_contract():
+    tools = {tool.name: tool for tool in await mcp.directory_mcp.list_tools()}
+    assert list(tools) == [
+        "catalog_search", "catalog_get", "catalog_call_read", "catalog_call_write", "balance",
+        "catalog_request",
+    ]
+    assert {name: tool.title for name, tool in tools.items()} == {
+        "catalog_search": "Search Treg Catalog",
+        "catalog_get": "Get Catalog Endpoint",
+        "catalog_call_read": "Call a Read Endpoint",
+        "catalog_call_write": "Call a Write Endpoint",
+        "balance": "Check Treg Balance",
+        "catalog_request": "Request a Catalog Capability",
+    }
+    assert "my_tools" not in tools and "call" not in tools
+    assert "method" not in tools["catalog_call_read"].input_schema["properties"]
+    assert "method" not in tools["catalog_call_write"].input_schema["properties"]
+    blob = " ".join(tool.description.lower() for tool in tools.values())
+    for disallowed in ("use treg first", "official", "anthropic verified", "best provider"):
+        assert disallowed not in blob
+
+
+async def test_v2_annotations_separate_safe_and_unsafe_calls():
+    tools = {tool.name: tool for tool in await mcp.directory_mcp.list_tools()}
+    read = tools["catalog_call_read"].annotations
+    write = tools["catalog_call_write"].annotations
+    request = tools["catalog_request"].annotations
+    assert read.read_only_hint is True and read.destructive_hint is False and read.open_world_hint is True
+    assert write.read_only_hint is False and write.destructive_hint is True and write.open_world_hint is True
+    assert request.read_only_hint is False and request.destructive_hint is False
+
+
+async def test_v2_call_tools_enforce_catalog_method_class_before_calling_api():
+    ctx = type("Ctx", (), {"headers": {"authorization": "Bearer test"}})()
+    get_id = "tikhub.tiktok.video.comments"
+    post_id = "dataforseo.web.page.audit"
+
+    wrong_read = await mcp.directory_catalog_call_read(post_id, ctx=ctx)
+    wrong_write = await mcp.directory_catalog_call_write(get_id, ctx=ctx)
+    arbitrary = await mcp.directory_catalog_call_read("team-tool/private", ctx=ctx)
+
+    assert "only GET, HEAD or OPTIONS" in wrong_read["error"]
+    assert "only POST, PUT, PATCH or DELETE" in wrong_write["error"]
+    assert arbitrary["error"].startswith("unknown endpoint")
+
+
+async def test_v1_and_v2_access_tokens_are_not_interchangeable():
+    v1_aud = mcp_oauth.mcp_resource_url("v1")
+    v2_aud = mcp_oauth.mcp_resource_url("v2")
+    v1 = mcp_oauth.make_access_token(user_id=1, org_id=1, audience=v1_aud)
+    v2 = mcp_oauth.make_access_token(user_id=1, org_id=1, audience=v2_aud)
+
+    assert mcp_oauth.read_access_token_any(v1, "v1") is not None
+    assert mcp_oauth.read_access_token_any(v1, "v2") is None
+    assert mcp_oauth.read_access_token_any(v2, "v2") is not None
+    assert mcp_oauth.read_access_token_any(v2, "v1") is None
+    assert mcp_oauth.mcp_resource_version(v1_aud.rstrip("/")) == "v1"
+    assert mcp_oauth.mcp_resource_version(v2_aud.rstrip("/")) == "v2"
+
+
+async def test_v2_transport_challenges_with_v2_metadata():
+    async with directory_session() as client:
+        response = await _rpc(client, "tools/list")
+    assert response.status_code == 401
+    challenge = response.headers["www-authenticate"]
+    assert "/.well-known/oauth-protected-resource/mcp/v2" in challenge
+    assert response.headers["cache-control"] == "no-store, no-transform"
+
+
+async def test_v2_serializes_the_scanner_facing_contract(clients):
+    token = (await clients.post("/users", json={"email": "directory-list@superdesign.dev"})).json()["token"]
+    async with directory_session() as client:
+        initialized = await _rpc(client, "initialize", {
+            "protocolVersion": "2025-06-18", "capabilities": {},
+            "clientInfo": {"name": "scanner", "version": "1"},
+        }, token)
+        assert initialized.status_code == 200
+        listed = await _rpc(client, "tools/list", token=token)
+    tools = {tool["name"]: tool for tool in listed.json()["result"]["tools"]}
+    assert set(tools) == {
+        "catalog_search", "catalog_get", "catalog_call_read", "catalog_call_write", "balance",
+        "catalog_request",
+    }
+    assert tools["catalog_call_read"]["annotations"] == {
+        "readOnlyHint": True, "destructiveHint": False, "idempotentHint": False,
+        "openWorldHint": True,
+    }
+    assert tools["catalog_call_write"]["annotations"]["destructiveHint"] is True
+    assert "method" not in tools["catalog_call_read"]["inputSchema"]["properties"]
+    assert "method" not in tools["catalog_call_write"]["inputSchema"]["properties"]
+
+
+async def test_transports_reject_the_other_mcp_versions_token():
+    v1 = mcp_oauth.make_access_token(user_id=1, org_id=1,
+                                     audience=mcp_oauth.mcp_resource_url("v1"))
+    v2 = mcp_oauth.make_access_token(user_id=1, org_id=1,
+                                     audience=mcp_oauth.mcp_resource_url("v2"))
+    async with directory_session() as client:
+        assert (await _rpc(client, "tools/list", token=v1)).status_code == 401
+        assert (await _rpc(client, "tools/list", token=v2)).status_code == 200
+
+    legacy = mcp.build_mcp_app(resource_version="v1")
+    host = FastAPI()
+    host.mount("/mcp", legacy)
+    async with mcp.mcp_lifespan(legacy):
+        async with AsyncClient(transport=ASGITransport(app=host),
+                               base_url="http://localhost") as client:
+            body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+            wrong = await client.post("http://localhost/mcp/", json=body,
+                                      headers={**MCP_HEADERS, "Authorization": f"Bearer {v2}"})
+            right = await client.post("http://localhost/mcp/", json=body,
+                                      headers={**MCP_HEADERS, "Authorization": f"Bearer {v1}"})
+    assert wrong.status_code == 401
+    assert right.status_code == 200
+
+
+async def test_claude_origin_is_explicitly_allowed_and_unknown_origins_are_not():
+    origins = mcp._allowed_origins()
+    assert origins.count("https://claude.ai") == 1
+    assert "https://attacker.example" not in origins
+
+    token = mcp_oauth.make_access_token(user_id=1, org_id=1,
+                                        audience=mcp_oauth.mcp_resource_url("v2"))
+    async with directory_session() as client:
+        body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        allowed = await client.post("http://localhost/mcp/v2/", json=body, headers={
+            **MCP_HEADERS, "Authorization": f"Bearer {token}", "Origin": "https://claude.ai",
+        })
+        blocked = await client.post("http://localhost/mcp/v2/", json=body, headers={
+            **MCP_HEADERS, "Authorization": f"Bearer {token}",
+            "Origin": "https://attacker.example",
+        })
+    assert allowed.status_code == 200
+    assert blocked.status_code == 403

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -101,11 +101,44 @@ async def test_v2_feature_flag_enables_mount_metadata_and_resource(monkeypatch):
         async with AsyncClient(transport=ASGITransport(app=enabled),
                                base_url="http://registry") as client:
             metadata = await client.get("/.well-known/oauth-protected-resource/mcp/v2")
+            body = {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+                "protocolVersion": "2025-06-18", "capabilities": {},
+                "clientInfo": {"name": "slash-test", "version": "1"},
+            }}
+            challenges = [
+                await client.post(path, json=body, headers=MCP_HEADERS)
+                for path in ("/mcp/v2", "/mcp/v2/")
+            ]
         assert metadata.status_code == 200
         assert metadata.json()["resource"].endswith("/mcp/v2/")
+        for challenge in challenges:
+            assert challenge.status_code == 401
+            assert "/.well-known/oauth-protected-resource/mcp/v2" in \
+                challenge.headers["www-authenticate"]
 
         resource = mcp_oauth.mcp_resource_url("v2")
         assert treg_api._wrong_resource(resource) is None
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_v2_no_slash_path_rejects_a_v1_token_with_the_v2_challenge(monkeypatch):
+    """Claude strips the final slash. That spelling must never fall through to the V1 mount."""
+    monkeypatch.setenv("TREG_CLAUDE_CONNECTOR_ENABLED", "true")
+    get_settings.cache_clear()
+    try:
+        enabled = create_app("all")
+        token = mcp_oauth.make_access_token(
+            user_id=1, org_id=1, audience=mcp_oauth.mcp_resource_url("v1"))
+        async with AsyncClient(transport=ASGITransport(app=enabled),
+                               base_url="http://registry") as client:
+            response = await client.post("/mcp/v2", json={
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+            }, headers={**MCP_HEADERS, "Authorization": f"Bearer {token}"})
+        assert response.status_code == 401
+        assert 'error="invalid_token"' in response.headers["www-authenticate"]
+        assert "/.well-known/oauth-protected-resource/mcp/v2" in \
+            response.headers["www-authenticate"]
     finally:
         get_settings.cache_clear()
 

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -227,6 +227,7 @@ async def test_v2_transport_challenges_with_v2_metadata():
     assert response.status_code == 401
     challenge = response.headers["www-authenticate"]
     assert "/.well-known/oauth-protected-resource/mcp/v2" in challenge
+    assert mcp_oauth.DIRECTORY_SCOPE in challenge
     assert response.headers["cache-control"] == "no-store, no-transform"
 
 

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -36,6 +36,24 @@ async def _rpc(client: AsyncClient, method: str, params=None, token: str | None 
     return await client.post("http://localhost/mcp/v2/", json=body, headers=headers)
 
 
+async def _modern_rpc(client: AsyncClient, method: str, params=None,
+                      token: str = "opaque-test-token"):
+    body_params = dict(params or {})
+    body_params["_meta"] = {
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {"name": "directory-test", "version": "1"},
+    }
+    return await client.post("http://localhost/mcp/v2/", json={
+        "jsonrpc": "2.0", "id": 1, "method": method, "params": body_params,
+    }, headers={
+        **MCP_HEADERS,
+        "Authorization": f"Bearer {token}",
+        "MCP-Protocol-Version": "2026-07-28",
+        "MCP-Method": method,
+    })
+
+
 async def test_v2_declares_exact_directory_contract():
     tools = {tool.name: tool for tool in await mcp.directory_mcp.list_tools()}
     assert list(tools) == [
@@ -56,6 +74,24 @@ async def test_v2_declares_exact_directory_contract():
     blob = " ".join(tool.description.lower() for tool in tools.values())
     for disallowed in ("use treg first", "official", "anthropic verified", "best provider"):
         assert disallowed not in blob
+
+
+async def test_v2_does_not_advertise_or_serve_change_subscriptions():
+    async with directory_session() as client:
+        discovered = await _modern_rpc(client, "server/discover")
+        listened = await _modern_rpc(client, "subscriptions/listen", {
+            "notifications": {"toolsListChanged": True},
+        })
+
+    assert discovered.status_code == 200, discovered.text
+    capabilities = discovered.json()["result"]["capabilities"]
+    assert capabilities["tools"]["listChanged"] is False
+    assert capabilities["prompts"]["listChanged"] is False
+    assert capabilities["resources"] == {"listChanged": False, "subscribe": False}
+    assert listened.status_code == 404, listened.text
+    assert listened.json()["error"] == {
+        "code": -32601, "message": "Method not found", "data": "subscriptions/listen",
+    }
 
 
 async def test_v2_annotations_separate_safe_and_unsafe_calls():

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -7,8 +7,12 @@ from contextlib import asynccontextmanager
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from starlette.routing import Mount
 
+from treg import api as treg_api
 from treg import mcp, mcp_oauth
+from treg.bootstrap import create_app
+from treg.config import Settings, get_settings
 
 pytestmark = pytest.mark.anyio
 
@@ -52,6 +56,58 @@ async def _modern_rpc(client: AsyncClient, method: str, params=None,
         "MCP-Protocol-Version": "2026-07-28",
         "MCP-Method": method,
     })
+
+
+async def test_v2_feature_flag_defaults_off(monkeypatch):
+    monkeypatch.delenv("TREG_CLAUDE_CONNECTOR_ENABLED", raising=False)
+    assert Settings(_env_file=None).claude_connector_enabled is False
+
+
+async def test_v2_feature_flag_disables_mount_metadata_grants_and_catalog_route(
+    monkeypatch, clients,
+):
+    monkeypatch.setenv("TREG_CLAUDE_CONNECTOR_ENABLED", "false")
+    get_settings.cache_clear()
+    try:
+        disabled = create_app("all")
+        mounts = [route.path for route in disabled.routes if isinstance(route, Mount)]
+        assert "/mcp" in mounts
+        assert "/mcp/v2" not in mounts
+
+        async with AsyncClient(transport=ASGITransport(app=disabled),
+                               base_url="http://registry") as client:
+            metadata = await client.get("/.well-known/oauth-protected-resource/mcp/v2")
+        assert metadata.status_code == 404
+        assert "not enabled" in metadata.json()["detail"]
+
+        resource = mcp_oauth.mcp_resource_url("v2")
+        assert "not enabled" in treg_api._wrong_resource(resource)
+
+        direct = await clients.get("/catalog/call/tikhub.tiktok.video.comments?aweme_id=7")
+        assert direct.status_code == 404
+        assert "not enabled" in direct.json()["detail"]
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_v2_feature_flag_enables_mount_metadata_and_resource(monkeypatch):
+    monkeypatch.setenv("TREG_CLAUDE_CONNECTOR_ENABLED", "true")
+    get_settings.cache_clear()
+    try:
+        enabled = create_app("all")
+        mounts = [route.path for route in enabled.routes if isinstance(route, Mount)]
+        assert mounts.index("/mcp/v2") < mounts.index("/mcp")
+
+        async with AsyncClient(transport=ASGITransport(app=enabled),
+                               base_url="http://registry") as client:
+            metadata = await client.get("/.well-known/oauth-protected-resource/mcp/v2")
+        assert metadata.status_code == 200
+        assert metadata.json()["resource"].endswith("/mcp/v2/")
+
+        resource = mcp_oauth.mcp_resource_url("v2")
+        assert treg_api._wrong_resource(resource) is None
+    finally:
+        get_settings.cache_clear()
 
 
 async def test_v2_declares_exact_directory_contract():

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -1,7 +1,8 @@
-"""The Claude directory MCP is catalog-only and OAuth-isolated from the legacy MCP."""
+"""The Claude directory MCP is catalog-only and OAuth-isolated from the team MCP."""
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 
 import pytest
@@ -30,14 +31,46 @@ async def directory_session():
             yield client
 
 
-async def _rpc(client: AsyncClient, method: str, params=None, token: str | None = None):
+@asynccontextmanager
+async def paired_mcp_session():
+    """Serve both public MCP surfaces on one app for direct contract comparisons."""
+    team = mcp.build_mcp_app(resource_version="v1")
+    directory = mcp.build_mcp_app(server=mcp.directory_mcp, resource_version="v2")
+    host = FastAPI()
+    host.mount("/mcp/v2", directory)
+    host.mount("/mcp", team)
+    async with mcp.mcp_lifespan(team):
+        async with mcp.mcp_lifespan(directory):
+            async with AsyncClient(transport=ASGITransport(app=host),
+                                   base_url="http://localhost") as client:
+                yield client
+
+
+async def _rpc(client: AsyncClient, method: str, params=None, token: str | None = None,
+               extra_headers: dict | None = None, *, path: str = "/mcp/v2/"):
     headers = dict(MCP_HEADERS)
     if token:
         headers["Authorization"] = f"Bearer {token}"
+    headers.update(extra_headers or {})
     body = {"jsonrpc": "2.0", "id": 1, "method": method}
     if params is not None:
         body["params"] = params
-    return await client.post("http://localhost/mcp/v2/", json=body, headers=headers)
+    return await client.post(path, json=body, headers=headers)
+
+
+async def _call_tool(client: AsyncClient, name: str, args: dict, token: str,
+                     extra_headers: dict | None = None, *, path: str = "/mcp/v2/") -> dict:
+    await _rpc(client, "initialize", {
+        "protocolVersion": "2025-06-18", "capabilities": {},
+        "clientInfo": {"name": "directory-test", "version": "1"},
+    }, token, extra_headers, path=path)
+    response = await _rpc(client, "tools/call", {"name": name, "arguments": args},
+                          token, extra_headers, path=path)
+    payload = response.json()
+    content = (payload.get("result") or {}).get("content") or []
+    if content and content[0].get("type") == "text":
+        return json.loads(content[0]["text"])
+    return payload
 
 
 async def _modern_rpc(client: AsyncClient, method: str, params=None,
@@ -160,6 +193,9 @@ async def test_v2_declares_exact_directory_contract():
     assert "my_tools" not in tools and "call" not in tools
     assert "method" not in tools["catalog_call_read"].input_schema["properties"]
     assert "method" not in tools["catalog_call_write"].input_schema["properties"]
+    for tool in tools.values():
+        assert tool.output_schema and tool.output_schema.get("properties")
+        assert not tool.output_schema.get("required")
     blob = " ".join(tool.description.lower() for tool in tools.values())
     for disallowed in ("use treg first", "official", "anthropic verified", "best provider"):
         assert disallowed not in blob
@@ -254,6 +290,226 @@ async def test_v2_serializes_the_scanner_facing_contract(clients):
     assert "method" not in tools["catalog_call_write"]["inputSchema"]["properties"]
 
 
+async def test_v2_shared_catalog_details_balance_and_guidance_work_end_to_end(clients):
+    token = clients.headers["X-Treg-Token"]
+    async with directory_session() as client:
+        search = await _call_tool(client, "catalog_search", {"query": "tiktok comments"}, token)
+        endpoint = await _call_tool(client, "catalog_get", {
+            "endpoint_id": "tikhub.tiktok.video.comments",
+        }, token)
+        balance = await _call_tool(client, "balance", {}, token)
+
+    assert search["results"] and search["results"][0].get("usd_per_call") is not None
+    assert "catalog_call_read" in search["next"]
+    assert "catalog_call_write" in search["next"]
+    assert "then call(...)" not in search["next"]
+    assert endpoint["endpoint"]["id"] == "tikhub.tiktok.video.comments"
+    assert endpoint["endpoint"].get("cost")
+    assert balance["team"] and balance["balance_micro"] is not None
+
+
+async def test_team_and_directory_catalog_search_results_and_prices_match(clients):
+    token = clients.headers["X-Treg-Token"]
+    args = {"query": "tiktok comments", "limit": 5}
+    async with paired_mcp_session() as client:
+        team = await _call_tool(client, "catalog_search", args, token, path="/mcp/")
+        directory = await _call_tool(client, "catalog_search", args, token)
+
+    team_shared = {key: value for key, value in team.items() if key != "next"}
+    directory_shared = {key: value for key, value in directory.items() if key != "next"}
+    assert team_shared == directory_shared
+    assert team["results"] and all("usd_per_call" in row for row in team["results"])
+    assert team["next"].endswith("then call(...)")
+    assert "catalog_call_read" in directory["next"]
+    assert "catalog_call_write" in directory["next"]
+
+
+async def test_team_and_directory_endpoint_details_and_balance_match(clients):
+    token = clients.headers["X-Treg-Token"]
+    endpoint_args = {"endpoint_id": "tikhub.tiktok.video.comments"}
+    async with paired_mcp_session() as client:
+        team_endpoint = await _call_tool(
+            client, "catalog_get", endpoint_args, token, path="/mcp/",
+        )
+        directory_endpoint = await _call_tool(client, "catalog_get", endpoint_args, token)
+        team_balance = await _call_tool(client, "balance", {}, token, path="/mcp/")
+        directory_balance = await _call_tool(client, "balance", {}, token)
+
+    assert team_endpoint == directory_endpoint
+    assert team_endpoint["endpoint"]["id"] == endpoint_args["endpoint_id"]
+    assert team_endpoint["endpoint"]["cost"] == directory_endpoint["endpoint"]["cost"]
+    assert team_balance == directory_balance
+
+
+async def test_team_and_directory_catalog_call_results_match_except_attribution(clients):
+    from treg import audit
+
+    await clients.post("/secrets", json={"name": "tikhub", "value": "PAIRED-KEY"})
+    token = clients.headers["X-Treg-Token"]
+    args = {
+        "endpoint_id": "tikhub.tiktok.video.comments",
+        "params": {"aweme_id": "7"},
+        "headers": {"X-Paired-Test": "same"},
+    }
+    async with paired_mcp_session() as client:
+        team = await _call_tool(client, "call", args, token, path="/mcp/")
+        directory = await _call_tool(client, "catalog_call_read", args, token)
+    await audit.drain()
+
+    assert team == directory
+    assert team["status"] == 200
+    assert team["body"]["auth"] == "Bearer PAIRED-KEY"
+    assert team["body"]["headers"]["x-paired-test"] == "same"
+    rows = (await clients.get("/calls")).json()
+    assert {row["client"] for row in rows} == {"mcp", "claude-connector"}
+
+
+async def test_team_and_directory_catalog_call_errors_match_or_keep_the_documented_boundary(clients):
+    token = clients.headers["X-Treg-Token"]
+    ambiguous = {
+        "endpoint_id": "tikhub.tiktok.video.comments",
+        "params": {"aweme_id": "7"},
+        "query": {"aweme_id": "7"},
+    }
+    unknown = {"endpoint_id": "not.a.catalog.endpoint"}
+    async with paired_mcp_session() as client:
+        team_ambiguous = await _call_tool(client, "call", ambiguous, token, path="/mcp/")
+        directory_ambiguous = await _call_tool(
+            client, "catalog_call_read", ambiguous, token,
+        )
+        team_unknown = await _call_tool(client, "call", unknown, token, path="/mcp/")
+        directory_unknown = await _call_tool(client, "catalog_call_read", unknown, token)
+
+    assert team_ambiguous == directory_ambiguous
+    assert "query string" in team_ambiguous["error"]
+    assert team_unknown["error"] == directory_unknown["error"]
+    assert team_unknown["did_you_mean"] == directory_unknown["did_you_mean"]
+    assert "my_tools" in team_unknown["hint"]
+    assert "my_tools" not in directory_unknown["hint"]
+    assert "catalog endpoint id" in directory_unknown["hint"]
+
+
+async def test_v2_search_and_catalog_request_keep_directory_attribution(clients):
+    from sqlmodel import select
+
+    from treg import audit
+    from treg.db import session_maker
+    from treg.models import SearchMiss, ToolRequest
+
+    token = clients.headers["X-Treg-Token"]
+    async with directory_session() as client:
+        miss = await _call_tool(client, "catalog_search", {
+            "query": "zzzz-directory-only-miss",
+        }, token)
+        request = await _call_tool(client, "catalog_request", {
+            "capability": "directory attribution test",
+        }, token)
+    await audit.drain()
+
+    assert miss["count"] == 0
+    assert request["status"] == "received"
+    async with session_maker() as db:
+        search_row = (await db.execute(select(SearchMiss))).scalars().one()
+        request_row = (await db.execute(select(ToolRequest))).scalars().one()
+    assert search_row.source == "claude-connector"
+    assert request_row.source == "claude-connector"
+
+
+async def test_v2_catalog_call_uses_shared_credentials_headers_errors_and_audit(clients):
+    from treg import audit
+
+    await clients.post("/secrets", json={"name": "tikhub", "value": "DIRECTORY-KEY"})
+    token = clients.headers["X-Treg-Token"]
+    async with directory_session() as client:
+        result = await _call_tool(client, "catalog_call_read", {
+            "endpoint_id": "tikhub.tiktok.video.comments",
+            "params": {"aweme_id": "7"},
+            "headers": {"X-Test-Header": "kept", "X-Treg-Token": "blocked"},
+        }, token, {"X-Treg-Meta": "customer=directory_test"})
+    await audit.drain()
+
+    assert result["status"] == 200
+    assert result["body"]["auth"] == "Bearer DIRECTORY-KEY"
+    assert result["body"]["headers"]["x-test-header"] == "kept"
+    assert result["body"]["headers"].get("x-treg-token") != "blocked"
+    assert "cost_usd" not in result or result["cost_usd"] is None
+    row = (await clients.get("/calls")).json()[0]
+    assert row["client"] == "claude-connector"
+    assert row["tags"] == {"customer": "directory_test"}
+
+
+async def test_v2_metering_and_idempotency_use_the_shared_money_path(clients, monkeypatch):
+    monkeypatch.setenv("TREG_PLATFORM_KEY_TIKHUB", "DIRECTORY-PLATFORM-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub")
+    get_settings.cache_clear()
+    try:
+        org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+
+        async def current_balance() -> int:
+            body = (await clients.get(f"/orgs/{org_id}/balance")).json()
+            return body["balance_micro"]
+
+        token = clients.headers["X-Treg-Token"]
+        args = {
+            "endpoint_id": "tikhub.tiktok.video.comments",
+            "params": {"aweme_id": "7"},
+            "idempotency_key": "directory-one-call",
+        }
+        before = await current_balance()
+        async with directory_session() as client:
+            first = await _call_tool(client, "catalog_call_read", args, token)
+            second = await _call_tool(client, "catalog_call_read", args, token)
+        after = await current_balance()
+
+        assert first["status"] == 200 and first["cost_usd"] > 0
+        assert second["status"] == 200 and second["replayed"] is True
+        assert second["body"] == first["body"]
+        assert before - after == round(first["cost_usd"] * 1_000_000)
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_v2_write_call_and_insufficient_balance_errors_use_shared_behavior(
+    clients, monkeypatch,
+):
+    from sqlmodel import select
+
+    from treg.db import session_maker
+    from treg.models import Org
+
+    await clients.post("/secrets", json={"name": "dataforseo", "value": "user:password"})
+    token = clients.headers["X-Treg-Token"]
+    async with directory_session() as client:
+        write = await _call_tool(client, "catalog_call_write", {
+            "endpoint_id": "dataforseo.web.page.audit",
+            "body": [{"url": "https://example.com"}],
+        }, token)
+    assert write["status"] == 200
+    assert json.loads(write["body"]["body"]) == [{"url": "https://example.com"}]
+
+    monkeypatch.setenv("TREG_PLATFORM_KEY_TIKHUB", "DIRECTORY-PLATFORM-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub")
+    get_settings.cache_clear()
+    try:
+        org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+        async with session_maker() as db:
+            org = (await db.execute(select(Org).where(Org.id == org_id))).scalar_one()
+            org.balance_micro = 0
+            db.add(org)
+            await db.commit()
+        async with directory_session() as client:
+            refused = await _call_tool(client, "catalog_call_read", {
+                "endpoint_id": "tikhub.tiktok.video.comments",
+                "params": {"aweme_id": "7"},
+            }, token)
+        blob = json.dumps(refused)
+        assert refused["status"] == 402
+        assert "topup_url" not in blob and "http://" not in blob and "https://" not in blob
+        assert "not enough for this call" in refused["hint"]
+    finally:
+        get_settings.cache_clear()
+
+
 async def test_transports_reject_the_other_mcp_versions_token():
     v1 = mcp_oauth.make_access_token(user_id=1, org_id=1,
                                      audience=mcp_oauth.mcp_resource_url("v1"))
@@ -263,10 +519,10 @@ async def test_transports_reject_the_other_mcp_versions_token():
         assert (await _rpc(client, "tools/list", token=v1)).status_code == 401
         assert (await _rpc(client, "tools/list", token=v2)).status_code == 200
 
-    legacy = mcp.build_mcp_app(resource_version="v1")
+    team_mcp = mcp.build_mcp_app(resource_version="v1")
     host = FastAPI()
-    host.mount("/mcp", legacy)
-    async with mcp.mcp_lifespan(legacy):
+    host.mount("/mcp", team_mcp)
+    async with mcp.mcp_lifespan(team_mcp):
         async with AsyncClient(transport=ASGITransport(app=host),
                                base_url="http://localhost") as client:
             body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
@@ -279,9 +535,11 @@ async def test_transports_reject_the_other_mcp_versions_token():
 
 
 async def test_claude_origin_is_explicitly_allowed_and_unknown_origins_are_not():
-    origins = mcp._allowed_origins()
-    assert origins.count("https://claude.ai") == 1
-    assert "https://attacker.example" not in origins
+    v1_origins = mcp._allowed_origins("v1")
+    v2_origins = mcp._allowed_origins("v2")
+    assert "https://claude.ai" not in v1_origins
+    assert v2_origins.count("https://claude.ai") == 1
+    assert "https://attacker.example" not in v2_origins
 
     token = mcp_oauth.make_access_token(user_id=1, org_id=1,
                                         audience=mcp_oauth.mcp_resource_url("v2"))
@@ -296,3 +554,28 @@ async def test_claude_origin_is_explicitly_allowed_and_unknown_origins_are_not()
         })
     assert allowed.status_code == 200
     assert blocked.status_code == 403
+
+
+async def test_team_mcp_does_not_inherit_the_claude_origin_permission():
+    token = mcp_oauth.make_access_token(user_id=1, org_id=1,
+                                        audience=mcp_oauth.mcp_resource_url("v1"))
+    team_mcp = mcp.build_mcp_app(resource_version="v1")
+    host = FastAPI()
+    host.mount("/mcp", team_mcp)
+    async with mcp.mcp_lifespan(team_mcp):
+        async with AsyncClient(transport=ASGITransport(app=host),
+                               base_url="http://localhost") as client:
+            response = await client.post("/mcp/", json={
+                "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+            }, headers={
+                **MCP_HEADERS, "Authorization": f"Bearer {token}",
+                "Origin": "https://claude.ai",
+            })
+    assert response.status_code == 403
+
+
+def test_transport_factory_refuses_a_server_audience_mismatch():
+    with pytest.raises(ValueError, match="same public surface"):
+        mcp.build_mcp_app(server=mcp.directory_mcp, resource_version="v1")
+    with pytest.raises(ValueError, match="same public surface"):
+        mcp.build_mcp_app(server=mcp.mcp, resource_version="v2")

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -17,6 +17,7 @@ import time
 import pytest
 
 from treg import mcp, mcp_oauth, session
+from treg.config import Settings, get_settings
 
 # The MCP transport helpers live with the MCP tests; a token is only interesting here because it can
 # drive a tool, so reuse them rather than keeping a second copy that can drift.
@@ -51,6 +52,11 @@ async def test_v2_metadata_names_only_the_directory_resource(clients):
     assert response.json()["resource"] == mcp_oauth.mcp_resource_url("v2")
     assert response.json()["resource"].endswith("/mcp/v2/")
     assert response.json()["resource"] != mcp_oauth.mcp_resource_url("v1")
+
+
+async def test_connect_demo_defaults_off(monkeypatch):
+    monkeypatch.delenv("TREG_CONNECT_DEMO_ENABLED", raising=False)
+    assert Settings(_env_file=None).connect_demo_enabled is False
 
 
 async def test_authorization_server_metadata_offers_only_safe_choices(clients):
@@ -889,6 +895,7 @@ async def test_a_signed_out_user_is_returned_to_the_consent_screen(clients):
     clients.cookies.clear()
     sent_away = await clients.get("/oauth/authorize", params=params, follow_redirects=False)
     assert sent_away.status_code == 302
+    assert sent_away.headers["location"] == "/?signin=oauth"
     parked = (sent_away.cookies.get("treg_oauth_return") or "").strip('"')
     assert parked.startswith("/oauth/authorize?"), f"nothing was parked: {parked!r}"
     assert params["client_id"] in parked, "the parked destination must be THIS request"
@@ -899,6 +906,28 @@ async def test_a_signed_out_user_is_returned_to_the_consent_screen(clients):
     back = await clients.get("/app", follow_redirects=False)
     assert back.status_code == 302, "the dashboard must resume the parked authorization"
     assert back.headers["location"].startswith("/oauth/authorize?")
+
+
+async def test_connect_demo_is_explicitly_enabled_and_never_displays_token_prefixes(
+    monkeypatch, clients,
+):
+    monkeypatch.setenv("TREG_CONNECT_DEMO_ENABLED", "false")
+    get_settings.cache_clear()
+    try:
+        assert (await clients.get("/connect-demo")).status_code == 404
+        assert (await clients.get("/connect-demo/callback")).status_code == 404
+
+        monkeypatch.setenv("TREG_CONNECT_DEMO_ENABLED", "true")
+        get_settings.cache_clear()
+        page = await clients.get("/connect-demo")
+        callback = await clients.get("/connect-demo/callback")
+        assert page.status_code == callback.status_code == 200
+        assert 'access_token: "[received]"' in page.text
+        assert 'refresh_token: "[received]"' in page.text
+        assert "body.access_token.slice" not in page.text
+        assert "body.refresh_token.slice" not in page.text
+    finally:
+        get_settings.cache_clear()
 
 
 async def test_the_parked_destination_cannot_be_used_as_an_open_redirect(clients):

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -45,6 +45,14 @@ async def test_the_metadata_is_served_at_BOTH_lookup_paths(clients):
     assert a.json() == b.json()
 
 
+async def test_v2_metadata_names_only_the_directory_resource(clients):
+    response = await clients.get("/.well-known/oauth-protected-resource/mcp/v2")
+    assert response.status_code == 200
+    assert response.json()["resource"] == mcp_oauth.mcp_resource_url("v2")
+    assert response.json()["resource"].endswith("/mcp/v2/")
+    assert response.json()["resource"] != mcp_oauth.mcp_resource_url("v1")
+
+
 async def test_authorization_server_metadata_offers_only_safe_choices(clients):
     """OAuth 2.1 drops the implicit grant, and `plain` PKCE makes the challenge equal to the secret —
     anyone who sees the authorization request could redeem the code. Offering either would be a
@@ -362,6 +370,36 @@ async def test_the_whole_flow_end_to_end(clients):
     claims = mcp._oauth_claims(access)
     assert claims is not None, "the MCP server must accept what we just issued"
     assert claims["org"] == org_id, "the token spends from the team the human picked"
+
+
+async def test_v2_dcr_flow_mints_only_a_v2_audience(clients):
+    """The directory resource reuses DCR, PKCE and the team picker, but not the legacy audience."""
+    client_id = await _register(clients)
+    _, org_id = await _signed_in(clients, "oauth-v2@superdesign.dev")
+    verifier, challenge = _pkce()
+    resource = mcp_oauth.mcp_resource_url("v2")
+    params = {"client_id": client_id, "redirect_uri": "https://client.test/cb",
+              "response_type": "code", "code_challenge": challenge,
+              "code_challenge_method": "S256", "state": "v2", "resource": resource,
+              "scope": "treg:call"}
+
+    shown = await clients.get("/oauth/authorize", params=params,
+                              headers={"Accept": "application/json"})
+    assert shown.status_code == 200
+    assert any(team["org_id"] == org_id for team in shown.json()["teams"])
+    approved = await clients.post("/oauth/authorize", data={**params, "org_id": org_id},
+                                  follow_redirects=False)
+    assert approved.status_code == 302
+    code = approved.headers["location"].split("code=")[1].split("&")[0]
+    token = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier, "resource": resource,
+    })
+    assert token.status_code == 200, token.text
+    access = token.json()["access_token"]
+    assert mcp_oauth.read_access_token_any(access, "v2") is not None
+    assert mcp_oauth.read_access_token_any(access, "v1") is None
 
 
 async def test_a_code_can_be_redeemed_only_ONCE(clients):

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -16,6 +16,7 @@ import time
 
 import pytest
 
+from treg import api as treg_api
 from treg import mcp, mcp_oauth, session
 from treg.config import Settings, get_settings
 
@@ -33,6 +34,7 @@ async def test_protected_resource_metadata_names_the_mcp_endpoint(clients):
     assert r.status_code == 200
     body = r.json()
     assert body["resource"] == mcp_oauth.mcp_resource_url()
+    assert mcp_oauth.DIRECTORY_SCOPE not in body["scopes_supported"]
     assert body["resource"].endswith("/mcp/"), "the trailing slash is part of the identifier"
     assert body["authorization_servers"], "a client must be told who issues tokens for us"
 
@@ -52,6 +54,7 @@ async def test_v2_metadata_names_only_the_directory_resource(clients):
     assert response.json()["resource"] == mcp_oauth.mcp_resource_url("v2")
     assert response.json()["resource"].endswith("/mcp/v2/")
     assert response.json()["resource"] != mcp_oauth.mcp_resource_url("v1")
+    assert mcp_oauth.DIRECTORY_SCOPE in response.json()["scopes_supported"]
 
 
 async def test_connect_demo_defaults_off(monkeypatch):
@@ -69,6 +72,7 @@ async def test_authorization_server_metadata_offers_only_safe_choices(clients):
     assert "plain" not in body["code_challenge_methods_supported"]
     assert body["authorization_endpoint"].endswith("/oauth/authorize")
     assert body["token_endpoint"].endswith("/oauth/token")
+    assert mcp_oauth.DIRECTORY_SCOPE in body["scopes_supported"]
 
 
 async def test_metadata_advertises_BOTH_ways_for_a_client_to_identify_itself(clients):
@@ -406,6 +410,41 @@ async def test_v2_dcr_flow_mints_only_a_v2_audience(clients):
     access = token.json()["access_token"]
     assert mcp_oauth.read_access_token_any(access, "v2") is not None
     assert mcp_oauth.read_access_token_any(access, "v1") is None
+
+
+async def test_v2_scope_selects_v2_when_claude_omits_the_resource(clients):
+    """Hosted Claude omitted RFC 8707 resource but kept the V2 challenge scopes in production."""
+    client_id = await _register(clients)
+    _, org_id = await _signed_in(clients, "oauth-v2-no-resource@superdesign.dev")
+    verifier, challenge = _pkce()
+    scope = " ".join(mcp_oauth.scopes_for_resource("v2"))
+    params = {
+        "client_id": client_id, "redirect_uri": "https://client.test/cb",
+        "response_type": "code", "code_challenge": challenge,
+        "code_challenge_method": "S256", "state": "v2-no-resource", "scope": scope,
+    }
+
+    shown = await clients.get("/oauth/authorize", params=params,
+                              headers={"Accept": "application/json"})
+    assert shown.status_code == 200
+    approved = await clients.post("/oauth/authorize", data={**params, "org_id": org_id},
+                                  follow_redirects=False)
+    assert approved.status_code == 302
+    code = approved.headers["location"].split("code=")[1].split("&")[0]
+    token = await clients.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": "https://client.test/cb", "client_id": client_id,
+        "code_verifier": verifier,
+    })
+    assert token.status_code == 200, token.text
+    access = token.json()["access_token"]
+    assert mcp_oauth.read_access_token_any(access, "v2") is not None
+    assert mcp_oauth.read_access_token_any(access, "v1") is None
+
+
+def test_explicit_resource_wins_over_the_v2_scope_marker():
+    v1 = mcp_oauth.mcp_resource_url("v1")
+    assert treg_api._effective_mcp_resource(v1, mcp_oauth.DIRECTORY_SCOPE) == v1
 
 
 async def test_a_code_can_be_redeemed_only_ONCE(clients):


### PR DESCRIPTION
## What this does

Adds a feature-flagged, catalog-only MCP surface at /mcp/v2/ for the Claude Connectors Directory. It exposes six reviewed tools with a clear read/write split, uses a distinct OAuth resource and token audience, and keeps the existing /mcp/ surface unchanged.

The change also adds the Claude connector documentation and submission runbook, protects the V1/V2 shared catalog behavior with contract tests, and keeps team-owned tools unavailable from V2.

## Safety and rollout

- TREG_CLAUDE_CONNECTOR_ENABLED defaults to false.
- V2 accepts only curated catalog endpoint IDs. It does not accept arbitrary URLs, methods, paths, or team-tool names.
- Read calls allow GET, HEAD, and OPTIONS. Write calls allow POST, PUT, PATCH, and DELETE.
- Calls retain the existing credential ladder, ACL and deny rules, caps, metering, audit, idempotency, and relay behavior.
- V1 and V2 OAuth audiences are isolated.
- The connect demo is disabled by default, and connector sign-in hides the organization-token login option.

## How it was tested

- Rebases cleanly onto origin/main at ddf5211.
- Full suite: TREG_PUBLIC_URL=https://treg.to uv run --frozen pytest -q — 2105 passed, 1 skipped.
- Focused connector, GTM catalog, OAuth, marketplace, dashboard, and surface tests — 400 passed.
- MCP Inspector passed against staging, including OAuth, six-tool discovery, V1/V2 audience isolation, origin controls, gzip, cache headers, and successful read/write provider calls.
- Claude.ai custom connector passed OAuth, tool discovery, catalog search/details, balance, read/write confirmation, disconnect, and reconnect checks on staging.

Production deployment and Claude directory submission remain separate release gates.

## Checklist

- [x] Full test suite passes locally
- [x] Added or updated behavior tests
- [x] Updated the relevant docs/context fragments
- [x] No secrets or uv.lock changes in the diff