### PR TITLE
SEO: 5 use-case pages (2026-08-28)

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -418,6 +418,17 @@ branches on the row's `free` flag: `metered_single` states the rate and the mark
 description does not claim "never metered". Both were found the same way as the Semrush one: by
 reading the stock and AI-visibility pages after the tests went green.
 
+**`{cheapest}` is the cheapest of ONE unit, not of the page** (2026-08-28). `_uc_providers` groups
+rows by billing unit and `{cheapest}` expands to `cheapest_by_unit[units[0]]`, whichever unit is
+found first. On a mixed-unit page that is not the lowest number the reader can see: the keyword
+volume job printed "from $0.09" (DataForSEO's flat per-request row) above a table whose first line
+is Serpstat at $0.0005 per keyword, and the LinkedIn profile job printed "from $0.0015" above a
+$0.001 row. The comparison block itself is correct, because it prints a cheapest per unit with the
+units-are-not-interchangeable caveat; only the interpolated lede lies. Both ledes now state the
+rate in prose instead. **Do not write "from {cheapest}" on a page whose providers meter in more
+than one unit**, and read the rendered lede against the rendered table before shipping. Found the
+same way as the two above.
+
 The five flat ad pages predate all of this, keep their URLs and their `build_html.py` ownership, and
 are served first by the same flat handler; `test_legacy_flat_use_case_pages_still_answer` proves a
 rendered job page cannot shadow one. `/use-cases` is the crawlable hub they hang from; before it existed the only link into a spoke

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -4007,6 +4007,255 @@ USE_CASE_PAGES["transcripts-of-x-and-facebook-video-posts"] = {
 }
 
 
+USE_CASE_PAGES["get-a-linkedin-profile"] = {
+    "label": "Get a LinkedIn profile",
+    "sentence": "LinkedIn API and LinkedIn scraper: a person's profile by URL, headline, experience and education",
+    "title": "LinkedIn API: fetch a profile by URL, {n} providers | treg.to",
+    "lede": (
+        "Give your agent a LinkedIn profile URL and get the profile back as data: name, "
+        "headline, location, current role, past roles and education. {n} providers answer "
+        "through one treg.to key, from {cheapest}, each at its own rate with no markup and "
+        "none of them behind a monthly seat. No session cookie of yours, no browser "
+        "extension, no Sales Navigator subscription and no account of yours making the "
+        "request. LinkedIn's own row is here too and it is honest about what it is: it "
+        "returns the profile of the account you connected, and nobody else's."),
+    "prompt": "Using treg, fetch these 40 LinkedIn profile URLs from the cheapest verified "
+              "provider, show me the price per profile first, then give me name, headline, "
+              "current company and years in the current role as a table, and list the URLs "
+              "that came back empty.",
+    "prompt_why": [
+        ("Give the profile URL", "Most rows take the public profile URL or its slug. A name and a company is a different job, and a different page."),
+        ("Say which fields you need", "A full profile is a large object. Naming the columns keeps the table readable and keeps the agent from spending its context on someone's volunteering history."),
+        ("Ask for the price first", "The rates here differ by more than an order of magnitude per profile. treg.to prints the rate before the call, so 40 profiles has a number on it before anything runs."),
+        ("Ask for the misses by name", "Every provider misses some profiles. A list of the URLs that came back empty is worth more than a table that quietly has 34 rows instead of 40."),
+    ],
+    "result_noun": "profile",
+    "result_image": None,
+    "q_cheapest": "Which LinkedIn API is cheapest per profile?",
+    "q_reliable": "Which LinkedIn API is the most reliable?",
+    "q_compare": "How do the LinkedIn providers compare?",
+    "what_is_heading": "What is a LinkedIn API, and why is there no official one?",
+    "what_is": (
+        "A LinkedIn API, as people mean the phrase, returns a person's public profile as "
+        "structured data: headline, location, the roles they have held with dates, and where "
+        "they studied. LinkedIn's official API does not do this. It is an OAuth API for the "
+        "account that authorised it, so it can tell you your own name and email and it cannot "
+        "tell you a stranger's job history; that product does not exist for you. Everything "
+        "else on this page is a third-party provider that reads public profiles with its own "
+        "infrastructure and sells the result per profile. Proxycurl, which was the default "
+        "answer here for years, shut down, which is why the question keeps being asked."),
+    "notes": [
+        "Five third-party rows and one official one, and the official one is a different job. "
+        "LinkedIn's own OAuth row is free, runs on your team's connected account and is never "
+        "metered, and it returns that account's own profile: name, email, member id. It "
+        "cannot fetch a prospect. The other five fetch anyone's public profile and none of "
+        "them uses an account of yours, so no cookie of yours, no extension in your browser "
+        "and no view on your activity log.",
+        "The units differ, so read the rate and the word after it. TikHub bills per "
+        "successful call, ScrapeCreators per call whether or not the profile comes back, "
+        "Bright Data per record delivered, JustOneAPI per success priced in yuan and "
+        "converted, and Fiber per credit for a live fetch. The cheapest claim on this page is "
+        "made inside one unit and never across them. ScrapeCreators, Bright Data, TikHub and "
+        "JustOneAPI have been called live and carry a verified date in the catalog; the Fiber "
+        "row and the LinkedIn OAuth row are documented from the provider's own docs and have "
+        "not been verified through treg.to.",
+        "What nobody can promise is coverage, and this page will not. Each provider reads "
+        "LinkedIn its own way, so a profile one returns in full is one another returns "
+        "thin, and the fields most often missing are exactly the ones people want: the dated "
+        "experience list. The cheap experiment is the honest answer: run the same twenty URLs "
+        "through three rows for a few cents and count who filled the columns you need. "
+        "treg.to shows the rows side by side and the agent picks; it does not route between "
+        "them and it does not fail over.",
+    ],
+    "faq": [
+        ("Is there an official LinkedIn API for other people's profiles?",
+         "No. LinkedIn's OAuth API returns the profile of the member who authorised your app, "
+         "so it answers \"who am I\" and never \"who is this person\". The row on this page "
+         "is that call, marked free and run on your own connection. Everything else here is a "
+         "third party."),
+        ("Will this get my LinkedIn account banned?",
+         "None of the five third-party rows uses an account of yours: no cookie, no session, "
+         "no extension, so there is nothing of yours for LinkedIn to restrict. That is not "
+         "the same as zero risk in general, because the restriction stories in the forum "
+         "include people who were only browsing. The risk these rows remove is the automation "
+         "risk on your own login; the provider carries its own."),
+        ("What replaced Proxycurl?",
+         "Nothing single replaced it. The five third-party rows here are what the catalog "
+         "carries for a person profile by URL, priced per profile with no plan, and the "
+         "honest note is that they are not a drop-in: the field coverage and the freshness "
+         "are each provider's own. Company pages, job changes and people search are separate "
+         "jobs on separate rows."),
+        ("Which provider should my agent use?",
+         "The one whose fields survive your list at a rate that fits the volume. treg.to puts "
+         "the rate, the billing unit and the measured success rate beside each other and the "
+         "agent chooses, or you tell it which to use. treg.to compares; it does not pick for "
+         "you."),
+    ],
+    "voices_intro": (
+        "LinkedIn data is one of the most seeded topics on Reddit: of the ~170 posts read in "
+        "August 2026, one account posted fourteen actor listings in a subreddit it appears to "
+        "run, one promo shipped with its template placeholder still in the body, and one "
+        "seeded thread carried a zero-width space. These five are practitioners, and the last "
+        "one is the reason the page will not claim zero risk."),
+    "voices": [
+        ("An extension got an SDR restricted in days",
+         "My SDR got his account limited after using PhantomBuster for like 3 days.",
+         "r/b2bmarketing, 16 points", "https://www.reddit.com/r/b2bmarketing/comments/1sv9jwv/linkedin_lead_scraping_tools_whats_safe_that_wont/",
+         "That risk is the one thing these rows genuinely remove. A call here runs on the "
+         "provider's infrastructure, not on your seat, so there is no cookie of yours and no "
+         "activity on your account to flag."),
+        ("Being banned is not survivable for some jobs",
+         "I review hundreds of Linkedin profiles a week for a living and it is not viable to be banned from the platform.",
+         "r/apify", "https://www.reddit.com/r/apify/comments/1u7pogx/how_concerned_about_a_linkedin_ban_should_i_be/",
+         "Which is the argument for keeping the fetch off your login entirely. Read the "
+         "profiles through a provider, keep your own account for the human work, and pay per "
+         "profile rather than per seat."),
+        ("The enrichment tools are priced for a different buyer",
+         "Tools like Clay's 'Enrich Profile' feature or APIs like Brightdata feel quite pricey. Any suggestions or alternative approaches?",
+         "r/revops, 5 points", "https://www.reddit.com/r/revops/comments/1i4xwzh/cheapest_way_to_enrich_full_linkedin_profile/",
+         "Bright Data is one of the rows here, at its own per-record rate with nothing added, "
+         "and it is not the cheapest one. The point is the shape: a profile is a call, there "
+         "is no plan to be on, and the rate is printed before the agent spends it."),
+        ("The default answer shut down",
+         "Looking for a good alternative to Proxycurl (they shut down) for B2B sales automation",
+         "r/n8n, 6 points", "https://www.reddit.com/r/n8n/comments/1myqu0v/looking_for_a_good_alternative_to_proxycurl_they/",
+         "This page is five of the alternatives with their prices next to each other. It is "
+         "worth saying that the forum has not moved on to one successor, so the checklist "
+         "that thread asks for, profile plus company plus job changes, is three jobs here and "
+         "three rows."),
+        ("The restriction can arrive with no automation at all",
+         "the funny thing is i wasnt using anything to automate linkedin, just clicking around and opening new tabs",
+         "X, 199 likes", "https://x.com/i/status/2059841283674533977",
+         "Which is why this page says the rows remove the automation risk on your own login "
+         "and stops there. Nothing here makes LinkedIn safer for the account you browse with; "
+         "it just stops needing it."),
+    ],
+    "related": ("Find people by role, company or location",
+                "Enrich a person from an email or LinkedIn URL",
+                "Find professional emails", "Find phone numbers"),
+}
+
+
+USE_CASE_PAGES["find-phone-numbers"] = {
+    "label": "Find phone numbers",
+    "sentence": "Phone number lookup API: a prospect's mobile from a LinkedIn URL or work email",
+    "title": "Phone number lookup API: a mobile from a LinkedIn URL | treg.to",
+    "lede": (
+        "Give your agent a LinkedIn profile URL, a work email or a name and company, and get "
+        "a direct mobile number back where one exists. {n} providers answer through one "
+        "treg.to key, from {cheapest}, each at its own rate with no markup and none of them "
+        "behind a seat or an annual contract. This runs one way only: person to number. It is "
+        "not a reverse lookup, it will not tell you who owns a number you already have, and "
+        "no provider here finds a number for everyone you ask about."),
+    "prompt": "Using treg, find mobile numbers for these 25 LinkedIn URLs, show me the price "
+              "per found number for each provider first, use the cheapest one, then give me a "
+              "table of who was found and who was not, and do not guess a number for anyone "
+              "who came back empty.",
+    "prompt_why": [
+        ("Give the identifier, not the name alone", "Most rows resolve from a LinkedIn URL or a work email. A bare name and company is the weakest input and the one that misses most."),
+        ("Ask for the misses explicitly", "A list of 25 that returns 11 numbers is the normal outcome. The 14 that missed are the information; a table that silently has 11 rows is not."),
+        ("Ask for the price per found number", "The rates here span more than five times per number. treg.to prints each before the call, so 25 people has a worst case before anything runs."),
+        ("Never let the agent infer a number", "A model asked for a phone number will happily produce a plausible one. Say out loud that an empty answer stays empty."),
+    ],
+    "result_noun": "number",
+    "result_image": None,
+    "q_cheapest": "Which phone finder is cheapest per number found?",
+    "q_reliable": "Which phone finder is the most reliable?",
+    "q_compare": "How do the phone finders compare?",
+    "what_is_heading": "What is a phone number lookup API?",
+    "what_is": (
+        "In business-to-business terms it is a call that takes a person, usually as a LinkedIn "
+        "profile URL or a work email, and returns a direct mobile number for them if the "
+        "provider has one. The direction matters: this is person to number. The consumer "
+        "product that goes the other way, number to person, is a different thing entirely and "
+        "is not on this page. Every provider here is assembling the same kind of data from "
+        "the same kinds of sources, which is why the useful question is not who has the best "
+        "database in the abstract but who fills your list, in your countries, this month."),
+    "notes": [
+        "The prices are per number found, and they span the page. Tomba is the cheapest per "
+        "found number, Aviato next, then LeadMagic, Findymail and LeadsForge, which is more "
+        "than five times the cheapest; LeadsForge also has a bulk row at the same rate per "
+        "row. Ocean.io meters in credits and publishes no dollar rate, so the page prints "
+        "none. All of it is the provider's own rate with $0.000 added, from a prepaid balance "
+        "with no minimum.",
+        "Read the miss rule carefully, because it is where the money goes. The rate cards say "
+        "a miss is free, and one row on this page proves it through treg.to: LeadMagic "
+        "reports its own charge back on every call, so a miss settles at zero. The others do "
+        "not report a charge, so the call settles at the catalog rate whether or not a number "
+        "came back. Until that changes, budget the printed rate times every attempt, not "
+        "times the numbers you keep.",
+        "Nobody publishes an honest hit rate, including this page. What the practitioners in "
+        "the forum say instead is that coverage swings by geography and vertical, that a "
+        "provider strong on US technology can be thin on European professional services, and "
+        "that a number being current is not the same as somebody answering it. The cheap "
+        "experiment is the only real answer: run the same twenty rows through three providers "
+        "for a couple of dollars and count. treg.to shows the rates side by side; the agent "
+        "picks, and treg.to never routes or fails over between them.",
+    ],
+    "faq": [
+        ("Can I find out who owns a phone number I already have?",
+         "No. Every row here runs person to number: you give a profile URL, an email or a "
+         "name and company, and get a mobile back. Reverse lookup is a consumer product and a "
+         "different job, and the catalog does not carry it."),
+        ("What hit rate should I expect?",
+         "Nobody on this page will give you a number, and any published match rate you find "
+         "elsewhere was written by whoever is selling. Expect a minority of a cold list to "
+         "resolve, expect it to be worse outside the US, and measure it on your own rows: "
+         "twenty people through three providers costs a couple of dollars."),
+        ("Do I pay for a miss?",
+         "By the providers' rate cards, no. Through treg.to today, only LeadMagic settles a "
+         "miss at zero, because it is the one row that reports its own charge back on the "
+         "call. On the others the call settles at the catalog rate, so budget per attempt."),
+        ("Is a found number safe to call?",
+         "That is your call to make, not the data's. These rows return a number and nothing "
+         "about consent: do not call screening, no suppression list and no country by country "
+         "guidance. Whatever your obligations are under the rules that apply to you, they "
+         "stay yours."),
+    ],
+    "voices_intro": (
+        "This category is the most heavily seeded the loop has read: of the ~380 Reddit and X "
+        "posts read in August 2026 roughly seven in ten were vendor marketing, including a "
+        "ring of six fabricated review subreddits and one post that hid a combining grapheme "
+        "joiner inside half its words. That post was the most quotable in the set, and it is "
+        "not quoted here. These five are practitioners."),
+    "voices": [
+        ("Better data does not make somebody answer",
+         "Post Covid, office lines don't even seem to exist now and connect rates on cell phones are abysmal.",
+         "r/sales, 102 points", "https://www.reddit.com/r/sales/comments/1jfuzv7/cold_calling_is_it_actually_harder_now_or_am_i/",
+         "So this page will not claim to fix connect rates. What a row here can raise is the "
+         "share of your dials that reach a current mobile at all. Whether anyone picks up is "
+         "carrier screening and human behaviour, and no provider sells that."),
+        ("Paying for the data is not the same as the data being right",
+         "The mistake is assuming that paying for contact data means every record will be correct.",
+         "r/RecruitmentAgencies", "https://www.reddit.com/r/RecruitmentAgencies/comments/1v1gi34/best_tools_to_grow_a_recruiting_desk/",
+         "Agreed, and the shape of this page follows from it. Per call pricing means testing "
+         "three providers on your own rows costs less than one seat's first day, which beats "
+         "trusting anyone's accuracy claim, this page's included."),
+        ("It is hard to tell what is good from what is hype",
+         "I've looked at tools like Apollo, ZoomInfo, Lusha, Seamless, Cognism, etc., but it's hard to tell what's good vs hype.",
+         "r/salestechniques, 8 points", "https://www.reddit.com/r/salestechniques/comments/1qi5fx8/b2b_prospecting_tools_that_actually_work_in_europe/",
+         "It is hard because most of what you find when you search is seeded, which the "
+         "research behind this page ran into head first. The answer this page offers is not "
+         "another review: it is the raw result on your own list, for cents, from several "
+         "providers at once."),
+        ("Coverage is a function of where your buyers are",
+         "We tested a few vendors and the data quality changes a lot depending on region. Some are strong in US but weak in Europe.",
+         "r/AppBusiness", "https://www.reddit.com/r/AppBusiness/comments/1s28iwb/what_are_the_best_enrichment_tools_for_mobile/",
+         "No comparison table can tell you which of these is strong in your market, and this "
+         "one does not try. It puts the rates and the billing units side by side so the "
+         "experiment that would tell you is cheap enough to actually run."),
+        ("The ask is plain and nobody answers it plainly",
+         "Basically looking for a reliable provider for cold calling that gives accurate direct dials without breaking the bank.",
+         "r/sales_intelligence", "https://www.reddit.com/r/sales_intelligence/comments/1vh77bm/need_suggestions_on_providers_for_cold_calling/",
+         "The honest version: here are six, here is what each charges per number found, here "
+         "is which one gives you a free miss today, and here is how to test them on twenty of "
+         "your own rows before you commit to any of them."),
+    ],
+    "related": ("Find professional emails", "Check a phone number is real",
+                "Enrich a person from an email or LinkedIn URL", "Get a LinkedIn profile"),
+}
+
+
 # The workflow pages (`/workflows/<slug>`): the sequence a person actually runs, as ONE prompt. A
 # use-case page answers one job; a workflow chains several, with a per-step price pulled live from
 # the catalog and a receipt from a real run. `run` is hand-recorded from that run and dated. A

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -3785,7 +3785,7 @@ USE_CASE_PAGES["app-store-search"] = {
         "two stores are separate shelves here, not two views of one dataset, so ask for both "
         "when you want both."),
     "prompt": "Using treg, search the Apple App Store and Google Play for apps matching "
-              "\"habit tracker\", show me the price per search first, then put the results "
+              "a habit tracker, show me the price per search first, then put the results "
               "from each store in one table with developer, rating, review count and price, "
               "and mark the apps that appear in both.",
     "prompt_why": [
@@ -4014,8 +4014,8 @@ USE_CASE_PAGES["get-a-linkedin-profile"] = {
     "lede": (
         "Give your agent a LinkedIn profile URL and get the profile back as data: name, "
         "headline, location, current role, past roles and education. {n} providers answer "
-        "through one treg.to key, from {cheapest}, each at its own rate with no markup and "
-        "none of them behind a monthly seat. No session cookie of yours, no browser "
+        "through one treg.to key, the cheapest of them a tenth of a cent a profile, each "
+        "at its own rate with no markup and none behind a monthly seat. No session cookie of yours, no browser "
         "extension, no Sales Navigator subscription and no account of yours making the "
         "request. LinkedIn's own row is here too and it is honest about what it is: it "
         "returns the profile of the account you connected, and nobody else's."),
@@ -4213,7 +4213,7 @@ USE_CASE_PAGES["find-phone-numbers"] = {
          "stay yours."),
     ],
     "voices_intro": (
-        "This category is the most heavily seeded the loop has read: of the ~380 Reddit and X "
+        "This is the most heavily seeded category behind any of these pages: of the ~380 Reddit and X "
         "posts read in August 2026 roughly seven in ten were vendor marketing, including a "
         "ring of six fabricated review subreddits and one post that hid a combining grapheme "
         "joiner inside half its words. That post was the most quotable in the set, and it is "
@@ -4253,6 +4253,134 @@ USE_CASE_PAGES["find-phone-numbers"] = {
     ],
     "related": ("Find professional emails", "Check a phone number is real",
                 "Enrich a person from an email or LinkedIn URL", "Get a LinkedIn profile"),
+}
+
+
+USE_CASE_PAGES["keyword-volume-cpc-and-competition"] = {
+    "label": "Keyword volume, CPC and competition",
+    "sentence": "Keyword research API: Google search volume, CPC and competition for a list of keywords",
+    "title": "Keyword research API: Google search volume and CPC | treg.to",
+    "lede": (
+        "Hand your agent a list of keywords and get a figure back for each one: average "
+        "monthly searches, the competition level and the top of page bid range. {n} providers "
+        "answer through one treg.to key: a twentieth of a cent per keyword on the cheapest "
+        "row, a flat rate per request on another, each at the provider's own rate with no markup. Google's own row is free on your connected "
+        "Google Ads account and never metered, and it answers with a number per keyword rather "
+        "than the bucket the Keyword Planner screen shows you. It is the row the research "
+        "behind these pages runs on."),
+    "prompt": "Using treg, get the average monthly searches, competition and top of page bid "
+              "for these 200 keywords in the US in English, show me the price per provider "
+              "first, batch them into as few calls as the provider allows, and sort the table "
+              "by volume with the ones that returned no data listed separately.",
+    "prompt_why": [
+        ("Batch, do not loop", "One row charges a flat rate per request for up to a thousand keywords. Sending them one at a time on that row multiplies the bill by a thousand for the same answer."),
+        ("Name the country and language", "Volume is per market. A keyword measured across everywhere is a number that describes nowhere, and every row here wants the market stated."),
+        ("Ask for the price per provider first", "The rows meter in three different ways: per request, per keyword returned, and free on your own account. treg.to prints each before the call."),
+        ("Keep the empty rows visible", "Google returns nothing for some ordinary words, and a provider that drops them quietly leaves you reading a shorter list than you sent."),
+    ],
+    "result_noun": "keyword",
+    "result_image": None,
+    "q_cheapest": "Which keyword research API is cheapest?",
+    "q_reliable": "Which keyword data provider is the most reliable?",
+    "q_compare": "How do the keyword data providers compare?",
+    "what_is_heading": "What is a keyword research API?",
+    "what_is": (
+        "It is a call that takes a list of keywords and returns what an advertiser's data set "
+        "knows about each one: roughly how many times a month people search it, how "
+        "contested it is, and what advertisers are paying at the top of the page. The reason "
+        "people want it as an API rather than a screen is volume and shape. The Keyword "
+        "Planner screen shows bucketed ranges to accounts that are not spending, its CSV "
+        "export collapses everything to a handful of round numbers, and neither is something "
+        "you can join onto twenty thousand rows. Every provider here answers per keyword, in "
+        "a response an agent can put in a table."),
+    "notes": [
+        "The Google Ads row is free, and it is the real thing. It runs on your team's "
+        "connected Google Ads account, is never metered by treg.to, counts only against the "
+        "developer token's own daily operation limit, and it returns a figure per keyword "
+        "rather than the range the Keyword Planner screen shows. The figure is Google's own "
+        "rounded number and not a raw count. The cost of this row is not money, it is access: "
+        "Google's flow pushes you towards creating a campaign on the way in, and the "
+        "developer token is its own approval.",
+        "The paid rows meter in two different shapes, and the shape decides the bill. "
+        "DataForSEO charges a flat rate per request that covers one keyword or a thousand "
+        "alike, so batching is the whole game; the catalog uses the rate card's price rather "
+        "than the lower one on the public pricing page, because the rate card is what the "
+        "account is actually charged. Serpstat and SE Ranking charge per keyword returned, "
+        "and Serpstat bills its one credit minimum even when a keyword comes back empty. "
+        "Semrush charges API units with no published dollar rate, so the page prints no price "
+        "for it and it runs on your own Semrush plan.",
+        "The numbers will not agree, and no row here is ground truth. Each provider models "
+        "Google's data its own way, so the same keyword comes back with different volumes on "
+        "different rows, and Search Console will show you clicks on queries that none of them "
+        "list at all. The bid range is an estimate of an auction rather than the auction: "
+        "practitioners regularly report paying many times the figure, or a fraction of it. "
+        "Use these fields to rank keywords against each other and take your real cost from "
+        "your own campaign data. treg.to puts the rows side by side; the agent picks, and "
+        "treg.to never routes or fails over between them.",
+    ],
+    "faq": [
+        ("Is this the same data as Google Keyword Planner?",
+         "The Google Ads row is, on your own connected account, and it answers with a figure "
+         "per keyword instead of the range the screen shows. The other rows are each "
+         "provider's own model of the same underlying signal, which is why their numbers "
+         "differ from Google's and from each other."),
+        ("Do I need a Google Ads account?",
+         "Only for the free row, which runs on your own connection and is never metered. The "
+         "paid rows need nothing of yours: they run on treg.to's key and bill from your "
+         "team's prepaid balance at the provider's rate with $0.000 added, so a list of "
+         "keywords does not require a developer token or an ad campaign."),
+        ("Why do the volume numbers differ between providers?",
+         "Because none of them is counting searches. Each one models Google's published "
+         "signal in its own way, and this page will not crown one, because there is no "
+         "ground truth to crown it against. Pull the same list from two rows for a few cents "
+         "and treat the disagreement as the error bar."),
+        ("How much does ten thousand keywords cost?",
+         "It depends entirely on which row and how you batch. A flat per request row covering "
+         "up to a thousand keywords is ten calls; a per keyword row is ten thousand "
+         "chargeable results however you send them; the Google Ads row is free and bounded by "
+         "a daily operation limit instead. treg.to prints each rate before the call so the "
+         "agent can say the number first."),
+    ],
+    "voices_intro": (
+        "SEO tooling threads are seeded on an industrial scale: of the ~180 Reddit and X "
+        "posts read in August 2026, three near identical six week bake off posts landed on "
+        "the same recommendation in the same house style, two subreddits in the results were "
+        "review farms, and one post ran word for word from two different accounts. These "
+        "five are people with a spreadsheet and a problem."),
+    "voices": [
+        ("The screen answers in buckets",
+         "It keeps showing me ranges such as 100-1k. This is very hard for me to guess for any good decision I wish to make.",
+         "r/googleads", "https://www.reddit.com/r/googleads/comments/1dodfc3/how_do_i_see_the_exact_monthly_search_volume/",
+         "The free row on this page is the same Keyword Planner data through the API, and it "
+         "answers with a figure per keyword rather than a range. That figure is Google's own "
+         "rounded number, so treat it as a rank rather than a count."),
+        ("The export rounds everything to nothing",
+         "when i export in CSV it's either 50, 500, 5000 or 50000 for all results",
+         "r/googleads", "https://www.reddit.com/r/googleads/comments/1dz73xx/important_features_missing_from_keyword_planner/",
+         "That is the data quality floor the API is worth having for. Every row here returns "
+         "a per keyword field an agent can sort, join and put in a table, which the export "
+         "cannot give you at any spend level."),
+        ("The bid estimate and the invoice are different numbers",
+         "Keyword planner says Low competition keyword top page bid high range is 0.03 cent. Why am I paying 1.28?",
+         "r/PPC, 8 points", "https://www.reddit.com/r/PPC/comments/1grv58y/google_ads_keyword_planner_says_low_competition/",
+         "No provider on this page fixes that, and any page that says otherwise is selling. "
+         "The bid fields are an estimate of an auction. Use them to rank keywords against one "
+         "another, and take what you actually pay from your own campaign data."),
+        ("Twenty thousand keywords is not a spreadsheet job",
+         "there are like 20,000 keywords, so it's not something a standard VLOOKUP will work for",
+         "r/SEO", "https://www.reddit.com/r/SEO/comments/1dj6b4z/keyword_api_suggestions/",
+         "This is the case per call pricing is for. A flat per request row batches up to a "
+         "thousand keywords at a time, so twenty thousand is twenty calls at a rate printed "
+         "before the first one, with no plan to be on."),
+        ("The tools do not know about traffic you are already getting",
+         "lately we've been seeing a lot of traffic in Google Search Console from keywords that don't even exist in the tools we're using",
+         "r/SEO", "https://www.reddit.com/r/SEO/comments/1ry5v7o/should_i_trust_tools_on_keyword_search_volume/",
+         "Which is the honest limit of every row here. These are models of demand, not "
+         "records of it. Your own Search Console data is the one source that is actually "
+         "counting, and it is a free own account row in this same catalog."),
+    ],
+    "related": ("Keyword ideas from a seed", "Google results for a keyword",
+                "Keywords a domain ranks for", "Keywords a domain bids on"),
 }
 
 

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -3772,6 +3772,241 @@ USE_CASE_PAGES["search-posts-by-keyword"] = {
 }
 
 
+USE_CASE_PAGES["app-store-search"] = {
+    "label": "App store search",
+    "sentence": "App store API: search the Apple App Store and Google Play by keyword, per call",
+    "title": "App store API: search the App Store and Google Play | treg.to",
+    "lede": (
+        "Give your agent a keyword and get the store listing rows back: app name, developer, "
+        "rating, review count, price and the store link, from the Apple App Store and from "
+        "Google Play, both through one treg.to key from {cheapest} a search at the provider's "
+        "own rate with $0.000 added. No Apple developer account, no Play console, no proxy "
+        "pool and no scraper of your own to keep alive when a store changes its markup. The "
+        "two stores are separate shelves here, not two views of one dataset, so ask for both "
+        "when you want both."),
+    "prompt": "Using treg, search the Apple App Store and Google Play for apps matching "
+              "\"habit tracker\", show me the price per search first, then put the results "
+              "from each store in one table with developer, rating, review count and price, "
+              "and mark the apps that appear in both.",
+    "prompt_why": [
+        ("Name both stores", "Apple and Google Play are separate calls with separate app ids and separate rankings. One store is one search; both is two."),
+        ("Say which country", "Store results are per storefront. The US list and the UK list are different lists, and the agent will pick for you if you do not."),
+        ("Ask for the columns", "The rows carry the developer, the rating, the review count, the price and the link. Name the ones you want or the whole listing comes back."),
+        ("Ask for the price first", "treg.to prints the rate before the call, so a hundred keywords across two stores has a number on it before anything runs."),
+    ],
+    "result_noun": "app",
+    "result_image": None,
+    "q_cheapest": "What does an app store search cost?",
+    "q_reliable": "Which store search is the most reliable?",
+    "q_compare": "How do the two stores compare?",
+    "what_is_heading": "What is an app store API?",
+    "what_is": (
+        "An app store API returns what a store's search results page holds, as data: the apps "
+        "matching a keyword, in the store's own order, with the developer, the rating, the "
+        "review count, the price and the listing link. It is not App Store Connect and it is "
+        "not the Google Play Developer API. Those are the accounts you own, and they only "
+        "cover your own apps. It is also not Apple's public iTunes Search endpoint, which is "
+        "free, answers a different query shape, and is not in this catalog. The two rows here "
+        "read the two public stores and relay what the store returned."),
+    "notes": [
+        "One provider serves both stores at one rate. SerpApi runs the Apple App Store engine "
+        "and the Google Play engine at the same flat price per successful search, metered "
+        "from your team's prepaid balance at SerpApi's own rate with $0.000 added, and its "
+        "rate card says a failed or cached search is not billed. Both rows were verified "
+        "against the live API on 2026-07-28. A new team's free dollar is a few dozen searches "
+        "across both stores.",
+        "The two engines take different parameters, and the Play row does two jobs. Apple's "
+        "engine wants a search term; Google Play's wants a query, and the same row answers "
+        "the store charts as well as a keyword search depending on what you send. Read the "
+        "docs linked on each row before an agent loops, because treg.to relays the store's "
+        "own response verbatim and models neither store's API.",
+        "What is not here is the part most people are really after. This is search, not rank "
+        "tracking: nothing stores yesterday's position, and there is no keyword popularity "
+        "index, no download or revenue estimate and no review feed on these two rows. Google "
+        "Play also stops exposing results publicly at shallow depth, which android developers "
+        "have measured for themselves, so a position deeper than the first page or two is not "
+        "a number any public search can honestly return. An agent can rebuild position over "
+        "time by running the same search on a schedule you give it and keeping the results.",
+    ],
+    "faq": [
+        ("Do I need an Apple or Google developer account?",
+         "No. Both rows run on treg.to's own key and bill per successful search from your "
+         "team's balance at SerpApi's rate with no markup. A developer account is for "
+         "publishing apps and reading your own; this reads the public store."),
+        ("Is this App Store Connect or the Play Developer API?",
+         "No. Those two are your own account's APIs and they only see apps you publish: your "
+         "installs, your ratings, your revenue. This page is the public store search, so it "
+         "sees any app but none of the private numbers behind it."),
+        ("Can I track where my app ranks for a keyword over time?",
+         "Your agent can, by running the search on a schedule you set and keeping the "
+         "results. treg.to has no scheduler, no history and no ASO rank tracker. The honest "
+         "limit is depth: the stores expose only so many results, and a rank below that is a "
+         "guess wherever you read it."),
+        ("Can I get reviews, downloads or keyword volume?",
+         "Not from these two rows. They return the search listing and nothing more. The "
+         "catalog carries app review and app data endpoints from other providers on their own "
+         "shelves, and Apple's keyword popularity is a relative index behind an Apple Search "
+         "Ads account, not a search volume figure anyone can resell."),
+    ],
+    "voices_intro": (
+        "App store threads are unusually seeded: of the ~140 Reddit and X posts read in "
+        "August 2026, more than half were builders announcing their own scrapers, one ran the "
+        "same review-scraper copy through seven subreddits, and one post seeded zero-width "
+        "spaces at every paragraph break. These five are developers hitting the wall in "
+        "public."),
+    "voices": [
+        ("Deep store ranks are interpolated, not measured",
+         "The paid SERP APIs go deeper, but tools that don't pay for them and still show you 'rank #63' are interpolating, not measuring.",
+         "r/androiddev, 11 points", "https://www.reddit.com/r/androiddev/comments/1va99d9/psa_google_play_only_exposes_30_search_results/",
+         "That is the honest ceiling and this page will not pretend past it. The rows return "
+         "the store's own results in the store's own order, as deep as the store exposes "
+         "them, and treg.to publishes no rank number of its own."),
+        ("Apple's free endpoint stops answering without notice",
+         "As of this morning (April 16), all my requests to the /search endpoint are returning HTTP 404 Not Found.",
+         "r/iOSProgramming, 11 points", "https://www.reddit.com/r/iOSProgramming/comments/1sn3k1m/itunes_search_api_returning_404_for_search/",
+         "That is Apple's public iTunes Search endpoint, which is free, undocumented in "
+         "practice, and not in this catalog. The rows here are a paid provider's store "
+         "engines, billed only on a successful search, with what the live traffic shows "
+         "rather than an uptime promise."),
+        ("Everything is API first except the store itself",
+         "To have to scrape them from the app store pages when everything else is so API first seems like a miss.",
+         "X, 19 likes", "https://x.com/i/status/2092565867145879853",
+         "Agreed, and that is the whole reason this row exists. The agent sends a keyword and "
+         "a country and gets rows; the scraping, the proxies and the markup changes are the "
+         "provider's problem, at a price printed before the call."),
+        ("The free endpoint carries none of the numbers you want",
+         "the itunes search api does not give downloads, subscriptions, or any financial metrics, and it does not provide subscription pricing either.",
+         "X, 69 likes", "https://x.com/i/status/1994112990866518506",
+         "True, and neither do these rows. Listing price, rating and review count come back; "
+         "installs and revenue do not exist in any public store response, and no provider on "
+         "this page can conjure them."),
+        ("The whole store is bigger than the context window",
+         "welp, even using a 1M token context limit, the data is too large.",
+         "r/shopifyDev, 77 points", "https://www.reddit.com/r/shopifyDev/comments/1o4ugbp/an_analysis_of_15003_apps_in_the_shopify_app_store/",
+         "Which is the argument for asking for columns rather than everything. Say which "
+         "fields a row needs in the prompt, cap the result count, and the agent reads a table "
+         "instead of drowning in a store dump."),
+    ],
+    "related": ("Amazon search and best sellers", "TikTok Shop products and reviews",
+                "Product reviews", "Google results for a keyword"),
+}
+
+
+USE_CASE_PAGES["transcripts-of-x-and-facebook-video-posts"] = {
+    "label": "Transcripts of X and Facebook video posts",
+    "sentence": "Facebook video transcript and X video transcript: the words in a video post, from its URL",
+    "title": "Facebook and X video transcript by URL, per call | treg.to",
+    "lede": (
+        "Paste your agent the URL of a Facebook video post or an X video post and get the "
+        "spoken words back as text, through one treg.to key from {cheapest} a call at the "
+        "provider's own rate with $0.000 added. No download step, no ffmpeg, no Whisper run "
+        "of your own and no developer account on either network. The price is per call, not "
+        "per minute of video, so a fifty minute livestream and a twenty second clip cost the "
+        "same. Public posts only, and a post that has been taken down is gone for everyone."),
+    "prompt": "Using treg, get the transcript of this Facebook video post and this X video "
+              "post, show me the price per call first, then give me the text of each with the "
+              "source link above it, and tell me plainly if either one came back empty.",
+    "prompt_why": [
+        ("Give the post URL, not the video file", "Both rows take the URL of the post. Getting the media off the platform is the part that normally breaks, and it is the provider's job here."),
+        ("Say which network", "Facebook and X are separate rows behind separate calls. One post is one call, on the network the URL belongs to."),
+        ("Ask for the text, not a summary", "The rows return what was said. A summary is the agent's own work afterwards, and it is worth reading the transcript first."),
+        ("Handle the empty case out loud", "A post with no speech, or one the provider cannot reach, comes back with nothing and still costs the call. Tell the agent to say so rather than invent."),
+    ],
+    "result_noun": "transcript",
+    "result_image": None,
+    "q_cheapest": "What does a transcript cost, per network?",
+    "q_reliable": "Which one is the most reliable?",
+    "q_compare": "How do the two networks compare?",
+    "what_is_heading": "What is a Facebook video transcript API?",
+    "what_is": (
+        "It is a call that takes the URL of a video post and returns the words spoken in it as "
+        "text. The hard part was never the speech recognition: it is getting the media out of "
+        "a network that does not want to hand it over. Facebook Reels carry no automatic "
+        "transcription and Facebook blocks the usual downloaders, so the do it yourself path "
+        "runs download, extract audio, transcribe, and falls over at the first step. X posts "
+        "have their own wall around saving the file. Both rows here take the URL and do all "
+        "of it on the provider's side, so your agent gets text and never touches the video."),
+    "notes": [
+        "One provider covers both networks at one rate. ScrapeCreators bills a credit per "
+        "call for the X row and for the Facebook row alike, metered from your team's prepaid "
+        "balance at ScrapeCreators' own rate with $0.000 added. Per call means per call: an "
+        "empty answer is billed the same as a full transcript, so budget the rate times the "
+        "number of posts, not the number of transcripts you keep.",
+        "Neither row has been called live through treg.to yet, and the catalog says so. Both "
+        "carry a documented price and a documented shape from the provider's docs, neither "
+        "has a verified date, and the Facebook row's stored test request does not even name a "
+        "URL. Treat them as documented rather than proven, run one post before an agent runs "
+        "a thousand, and read the docs linked on each row.",
+        "The limits are the platforms', and they are worth saying out loud. Public posts "
+        "only: a friends only, group only or age gated Facebook video is not reachable. A "
+        "deleted post is gone, and no provider recovers it. YouTube transcripts are a "
+        "different and much cheaper shelf with its own page, and TikTok and Instagram "
+        "transcripts are not in the catalog at all. Grok will also transcribe an X video "
+        "inside X if a human is doing it by hand; these rows are for the case where an agent "
+        "needs a hundred of them.",
+    ],
+    "faq": [
+        ("Do I need an X or Facebook developer account?",
+         "No. Both rows run on treg.to's own key and bill per call from your team's balance at "
+         "the provider's rate with no markup. Nothing uses an account of yours, so nothing "
+         "puts one at risk."),
+        ("Does it work on any post?",
+         "Video posts, and public ones. A text post has nothing to transcribe, a private or "
+         "age gated Facebook video is not reachable, and a post that has been removed is gone "
+         "for the provider too. The call still costs its rate when the answer comes back "
+         "empty, which is why the prompt above asks the agent to say so."),
+        ("What about YouTube, TikTok or Instagram?",
+         "YouTube has its own page and its own much cheaper row. TikTok and Instagram video "
+         "transcripts are not in the catalog today, and this page will not pretend otherwise. "
+         "Rumble is there, on its own shelf."),
+        ("Is this cheaper than running Whisper myself?",
+         "That depends on what your time is worth. Whisper is free and the audio is not: the "
+         "download is what fails, and the published attempts at doing this with an agent end "
+         "in blocked downloaders, expired tokens and a fallback to a paid speech API anyway. "
+         "These rows are one call at a printed rate, with no pipeline to maintain."),
+    ],
+    "voices_intro": (
+        "This is a thin corpus honestly reported: of the ~180 Reddit and X posts read in "
+        "August 2026 only about twenty were on the job, and the loudest block of pain "
+        "language in the Facebook dumps came from one bot posting the same six templates. "
+        "These five are people doing it the hard way."),
+    "voices": [
+        ("Facebook Reels have no captions to fall back on",
+         "Facebook blocks most AIs by default, and Reels don't have automatic transcription, so there's no shortcut.",
+         "r/claude, 6 points", "https://www.reddit.com/r/claude/comments/1s22ccw/i_tested_claude_to_see_if_they_could_get_a/",
+         "That is the honest state of Facebook video, and it is why this row exists. The "
+         "shortcut is somebody else's fetch: your agent sends the post URL and reads text "
+         "back, at a rate printed before the call."),
+        ("The agent's problem was the fetch, never the transcription",
+         "It tried again, used yt-dlp, said that it was blocked because FB blocks bots.",
+         "r/claude, 6 points", "https://www.reddit.com/r/claude/comments/1s22ccw/i_tested_claude_to_see_if_they_could_get_a/",
+         "In that thread the model eventually got there through a third party downloader, an "
+         "expired token and a paid speech API, after four nudges. One call replaces the "
+         "chain; what it cannot do is reach a post that is private or gone."),
+        ("Hand typing is the fallback people actually use",
+         "Please note, the transcript may not be 100% accurate as it was typed out by hand.",
+         "r/Superstonk, 6,923 points", "https://www.reddit.com/r/Superstonk/comments/qmnan7/computershare_ama_part_1_video_link_with/",
+         "Machine text is faster and it is not automatically better on accents or crosstalk. "
+         "The useful version is both: get the transcript in a second, then spot check the "
+         "lines you are going to quote against the video."),
+        ("Nobody asked for a summary, they asked what was said",
+         "For those who can't wade through the whole 12 minutes or so, here's a rough and ready transcript.",
+         "X, 6 likes", "https://x.com/i/status/2092561667783573707",
+         "Which is why the prompt on this page asks for the text first. The rows return the "
+         "words; summarising, quoting and pulling a clip out of them is your agent's own work "
+         "afterwards, on data it can show you."),
+        ("A video post with nothing to read",
+         "Finally found a video on Facebook that doesn't have captions or a transcript. WTH.",
+         "X", "https://x.com/i/status/1716876952337068536",
+         "That is the ordinary case on Facebook rather than the unlucky one. The row does not "
+         "read captions off the post, so a video with none is still readable, as long as the "
+         "post is public."),
+    ],
+    "related": ("Get a video's transcript", "Search posts by keyword",
+                "A competitor's recent posts", "Video details, views and stats"),
+}
+
+
 # The workflow pages (`/workflows/<slug>`): the sequence a person actually runs, as ONE prompt. A
 # use-case page answers one job; a workflow chains several, with a per-step price pulled live from
 # the catalog and a receipt from a real run. `run` is hand-recorded from that run and dated. A


### PR DESCRIPTION
Five use-case pages, the next five of the measured-demand worklist in
`loopany/treg-seo-pages/README.md`. 29 of the 34 worklist jobs now have a page; **five remain**:
a company's email format, mine the comments, build a company list by industry/size/tech, job
postings across companies, daily price history.

| Page | Form | Providers | Title term (measured US vol) |
|---|---|---|---|
| `/use-cases/app-store-search` | platforms | SerpApi × 2 stores | `app store api` 140, `google play scraper` 210 |
| `/use-cases/transcripts-of-x-and-facebook-video-posts` | platforms | ScrapeCreators × 2 | `facebook video transcript` 480 |
| `/use-cases/get-a-linkedin-profile` | compare | 6 | `linkedin api` 4,400, `linkedin scraper` 1,000 |
| `/use-cases/find-phone-numbers` | compare | 6 | `phone number lookup api` 90 |
| `/use-cases/keyword-volume-cpc-and-competition` | compare | 5 | `keyword research api` 90, `search volume checker` 390 |

## Where measured demand overrode the worklist term

- **Transcripts.** `facebook video transcript` and `transcribe facebook video` are 480 each against
  `twitter video transcript` at 110, so the page leads with Facebook.
- **LinkedIn.** `linkedin api` 4,400 and `linkedin scraper` 1,000 dwarf the worklist's
  `linkedin scraper api` 90. `linkedin mcp` is 1,300, worth its own page later.
- **Phone.** `phone number lookup` is 673,000/mo and it is **the wrong intent**: consumer reverse
  lookup, number to person, which the catalog does not serve in that direction. The page targets
  the B2B direction only and says so in the H1, the lede and an FAQ.
- **App store.** `app store connect api` 320 and `google play api` 320 are both your-own-apps
  intent, not store search. The page names the distinction rather than harvesting the term.

## Needs a human

- **Misses are billed at the estimate on five of the six phone rows.** `_observed_cost_micro`
  honours a provider's own reported charge for LeadMagic, so a miss settles at zero there. Tomba,
  Findymail, LeadsForge, Aviato and Ocean.io report nothing, so a miss settles at the catalog rate
  even though every one of those rate cards says a miss is free. The page states this plainly
  rather than repeating the rate card. Fixing the parser would let the page say what the vendors
  say.
- **`scrapecreators.x.v1-facebook-post-transcript` has no URL in its stored test request** (only
  `cache_max_age`), and neither transcript row carries a `verified` date. The page ships them as
  documented, not proven, and says so.
- **Unverified rows this run cites:** both ScrapeCreators transcript rows, Fiber AI's LinkedIn
  profile fetch, the LinkedIn OAuth row, Findymail's phone finder, Serpstat and Semrush keyword
  volume.
- **Research finding worth a decision:** almost nobody asks for app-store search by keyword. The
  three jobs developers actually describe are rank tracking, review mining and keyword volume, and
  the catalog carries DataForSEO and Bright Data app rows that no capability maps to. The page is
  honest about the gap; whether the cluster is worth extending is a call, not a loop decision.

## Verification

`tests/test_agent_pages.py` 126 passed. Full suite: 2,068 passed, 1 failed,
`tests/callmatrix/test_matrix.py::test_d3_same_key_with_different_request_is_refused`, which passes
on its own and is unrelated to these changes (this branch touches only `agent_pages.py` and one
docs fragment). All five pages rendered and read as Markdown; four copy bugs fixed from that read,
including `{cheapest}` printing the cheapest of one billing unit as the page's "from" price. That
one is now written up in `docs/context/interface/seo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
