### PR TITLE
fix(mcp): add Claude connector annotation titles

### DIFF
--- a/docs/CLAUDE-CONNECTOR-SUBMISSION.md
+++ b/docs/CLAUDE-CONNECTOR-SUBMISSION.md
@@ -3,7 +3,7 @@
 This runbook is the owner-facing release gate for Treg's catalog-only Claude connector. Do not
 submit until every required engineering and human check below has passed. Store no reviewer
 password, OAuth code, access token, refresh token, or provider secret in this repository or in test
-evidence.
+evidence. No reviewer passwords, OTPs, or tokens are committed or placed in ordinary submission notes.
 
 ## Directory fields
 
@@ -32,12 +32,16 @@ explicitly granted the corresponding label.
 - [ ] Obtain Owner access to a Claude.ai Team or Enterprise organization. A platform.claude.com API
   organization does not satisfy this requirement.
 - [ ] Approve the name, tagline, categories, catalog-only scope, data-handling answers, and logo.
-- [ ] Create a dedicated reviewer mailbox and a dedicated Treg team owned by it.
-- [ ] Give the reviewer team a populated account, a **$10.00 balance**, and the normal **$5.00 daily
-  cap**. Connect only the provider account(s) required for the acceptance calls.
-- [ ] Put temporary reviewer mailbox credentials only in Anthropic's secure submission portal.
-- [ ] After review, rotate the mailbox password, revoke temporary provider access, and revoke the
-  review OAuth grant.
+- [ ] Choose one reviewer-access option:
+  - **Default:** a reviewer signs up with any verified email. A new Treg team receives **$1.00 in
+    free credit**, requires no payment method, and can immediately use platform-provided catalog
+    endpoints.
+  - **Extended testing:** the reviewer sends Superdesign the exact verified Treg email used for
+    sign-in. Superdesign sends an email-bound invitation to `claude-connector-review-org`, which has
+    **$20.00 in review credit**. The invitation is bound to that email; it is not a universal or
+    shareable code.
+- [ ] After review, revoke the review OAuth grant and any temporary provider access used for
+  acceptance calls.
 
 ## Engineering evidence
 
@@ -58,8 +62,8 @@ Anthropic documents custom and directory connectors as using the same runtime. T
 submission.
 
 1. In Claude.ai, add `https://treg.to/mcp/v2/` as a custom connector.
-2. Sign in with the dedicated reviewer mailbox, select the reviewer team, and verify the displayed
-   identity, team, balance, and daily cap.
+2. Sign in with the verified reviewer email using the selected access option, select the resulting
+   team, and verify the displayed identity, team, balance, and daily cap.
 3. Ask Claude to search Treg for backlink endpoints for `example.com`, compare multiple priced
    options, and stop before making a provider call.
 4. Choose one platform-key-enabled GET/HEAD/OPTIONS endpoint priced below $0.01. Ask Claude to run

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -88,6 +88,8 @@ new directory review approves a contract change:
 - V1 and V2 OAuth audiences do not cross.
 - The feature flag controls the V2 mount, metadata, new grants, call route, and lifespan.
 - V2 directory titles, descriptions, schemas, annotations, and neutral review copy stay under test.
+  Each tool repeats its exact display title in `annotations.title`; Anthropic's submission portal
+  validates the annotation title independently of the top-level tool title.
 
 `tests/test_mcp.py` protects team MCP behavior. `tests/test_mcp_directory.py` protects the V2 surface
 and calls both public URLs with the same inputs to compare search results and prices, endpoint

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -985,16 +985,28 @@ async def my_tools(ctx: Context) -> MyToolsOut:
 # arbitrary team-tool paths.
 # --------------------------------------------------------------------------------------------
 
-_DIRECTORY_READS = ToolAnnotations(
+_DIRECTORY_SEARCH = ToolAnnotations(
+    title="Search Treg Catalog",
+    read_only_hint=True, destructive_hint=False, open_world_hint=False, idempotent_hint=True,
+)
+_DIRECTORY_GET = ToolAnnotations(
+    title="Get Catalog Endpoint",
     read_only_hint=True, destructive_hint=False, open_world_hint=False, idempotent_hint=True,
 )
 _DIRECTORY_OPEN_READ = ToolAnnotations(
+    title="Call a Read Endpoint",
     read_only_hint=True, destructive_hint=False, open_world_hint=True, idempotent_hint=False,
 )
 _DIRECTORY_WRITE = ToolAnnotations(
+    title="Call a Write Endpoint",
     read_only_hint=False, destructive_hint=True, open_world_hint=True, idempotent_hint=False,
 )
+_DIRECTORY_BALANCE = ToolAnnotations(
+    title="Check Treg Balance",
+    read_only_hint=True, destructive_hint=False, open_world_hint=False, idempotent_hint=True,
+)
 _DIRECTORY_ADDITIVE = ToolAnnotations(
+    title="Request a Catalog Capability",
     read_only_hint=False, destructive_hint=False, open_world_hint=False, idempotent_hint=False,
 )
 
@@ -1021,7 +1033,7 @@ directory_mcp = MCPServer(
         "Searches Treg's catalog by capability or task words and returns matching endpoint ids, "
         "providers, prices and measured reliability."
     ),
-    annotations=_DIRECTORY_READS,
+    annotations=_DIRECTORY_SEARCH,
     structured_output=True,
 )
 async def directory_catalog_search(query: str, limit: int = 8) -> SearchOut:
@@ -1035,7 +1047,7 @@ async def directory_catalog_search(query: str, limit: int = 8) -> SearchOut:
         "Returns one catalog endpoint's parameters, provider API documentation, price, example "
         "response and measured reliability, plus comparable providers for the same capability."
     ),
-    annotations=_DIRECTORY_READS,
+    annotations=_DIRECTORY_GET,
     structured_output=True,
 )
 async def directory_catalog_get(endpoint_id: str, ctx: Context) -> CatalogGetOut:
@@ -1103,7 +1115,7 @@ async def directory_catalog_call_write(
     name="balance",
     title="Check Treg Balance",
     description="Returns the connected team's Treg balance, in-flight holds, team and identity.",
-    annotations=_DIRECTORY_READS,
+    annotations=_DIRECTORY_BALANCE,
     structured_output=True,
 )
 async def directory_balance(ctx: Context) -> BalanceOut:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -347,6 +347,7 @@ async def test_every_tool_declares_what_it_can_do(clients):
     ann = {t.name: t.annotations for t in await server.list_tools()}
     assert set(ann) == {"catalog_search", "catalog_get", "call", "balance", "my_tools",
                         "catalog_request"}
+    assert all(a.title is None for a in ann.values())
     for name in ("catalog_search", "catalog_get", "balance", "my_tools"):
         a = ann[name]
         assert a and a.read_only_hint is True, name

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -182,7 +182,7 @@ async def test_v2_declares_exact_directory_contract():
         "catalog_search", "catalog_get", "catalog_call_read", "catalog_call_write", "balance",
         "catalog_request",
     ]
-    assert {name: tool.title for name, tool in tools.items()} == {
+    expected_titles = {
         "catalog_search": "Search Treg Catalog",
         "catalog_get": "Get Catalog Endpoint",
         "catalog_call_read": "Call a Read Endpoint",
@@ -190,6 +190,8 @@ async def test_v2_declares_exact_directory_contract():
         "balance": "Check Treg Balance",
         "catalog_request": "Request a Catalog Capability",
     }
+    assert {name: tool.title for name, tool in tools.items()} == expected_titles
+    assert {name: tool.annotations.title for name, tool in tools.items()} == expected_titles
     assert "my_tools" not in tools and "call" not in tools
     assert "method" not in tools["catalog_call_read"].input_schema["properties"]
     assert "method" not in tools["catalog_call_write"].input_schema["properties"]
@@ -277,11 +279,18 @@ async def test_v2_serializes_the_scanner_facing_contract(clients):
         assert initialized.status_code == 200
         listed = await _rpc(client, "tools/list", token=token)
     tools = {tool["name"]: tool for tool in listed.json()["result"]["tools"]}
-    assert set(tools) == {
-        "catalog_search", "catalog_get", "catalog_call_read", "catalog_call_write", "balance",
-        "catalog_request",
+    expected_titles = {
+        "catalog_search": "Search Treg Catalog",
+        "catalog_get": "Get Catalog Endpoint",
+        "catalog_call_read": "Call a Read Endpoint",
+        "catalog_call_write": "Call a Write Endpoint",
+        "balance": "Check Treg Balance",
+        "catalog_request": "Request a Catalog Capability",
     }
+    assert set(tools) == set(expected_titles)
+    assert {name: tool["annotations"]["title"] for name, tool in tools.items()} == expected_titles
     assert tools["catalog_call_read"]["annotations"] == {
+        "title": "Call a Read Endpoint",
         "readOnlyHint": True, "destructiveHint": False, "idempotentHint": False,
         "openWorldHint": True,
     }


### PR DESCRIPTION
## Summary

- add `annotations.title` to the exact six `/mcp/v2/` tools using the same reviewed display titles already present at the top level
- preserve the V2 tool names, top-level titles, descriptions, schemas, and safety hints, while asserting the V1 annotation contract remains unchanged
- replace the dedicated reviewer mailbox/account flow with the default $1 self-signup option and the email-bound $20 extended-review invitation option

## Anthropic portal evidence

The production Anthropic submission portal discovered all six `/mcp/v2/` tools and displayed their names, but reported `Missing annotations: title` for every tool. This hotfix adds the exact annotation titles the scanner requires:

- `catalog_search`: Search Treg Catalog
- `catalog_get`: Get Catalog Endpoint
- `catalog_call_read`: Call a Read Endpoint
- `catalog_call_write`: Call a Write Endpoint
- `balance`: Check Treg Balance
- `catalog_request`: Request a Catalog Capability

Both the in-memory six-tool manifest and the scanner-facing serialized `tools/list` response are covered by exact-title assertions.

## Test results

- Baseline `uv run pytest -q`: `2037 passed, 1 skipped, 68 failed` in `137.67s`; all 68 failures were the known hosted SEO-page 404 cluster under the local public URL.
- Focused `TREG_PUBLIC_URL=https://treg.to uv run --frozen pytest -q tests/test_mcp.py tests/test_mcp_directory.py tests/test_marketplace_call.py`: `199 passed` in `19.65s`.
- Final `TREG_PUBLIC_URL=https://treg.to uv run --frozen pytest -q`: `2105 passed, 1 skipped` in `139.83s`.
- Context drift check maps `src/treg/mcp.py` to `docs/context/architecture/mcp-oauth.md`; that fragment was reviewed and updated. Context index regeneration produced no additional diff.
- `uv.lock` is unchanged.

## Reviewer-flow documentation

The submission runbook now documents:

- default access through any verified email, with a new Treg team's $1 free credit, no payment method, and immediate platform-provided catalog access
- extended testing through an invitation bound to the reviewer's exact verified Treg email for `claude-connector-review-org`, which has $20 review credit
- reviewer passwords, OTPs, and tokens are not committed or placed in ordinary submission notes

The invitation is explicitly documented as email-bound, not universal or shareable.

## Rollout

No migration or data backfill is required. Deploy through the normal application rollout after merge; the change only adds V2 annotation-title fields and does not alter the V1 surface. No production deployment is part of this PR.
