### PR TITLE
seo: link the orphan hubs from every surface, cross-link tools/jobs/workflows, pricing titles, IndexNow

### DIFF
--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -117,3 +117,6 @@ Each factory call must produce an independent app whose dependency overrides bel
 at the new FastAPI instance, and rebuilds its request handler. This also avoids the internal
 `_IncludedRouter` wrapper added by the current FastAPI `include_router()` implementation, which would
 otherwise change route inspection and the committed surface snapshot.
+
+Public routes added since: `/{INDEXNOW_KEY}.txt` (`indexnow_key`, `routers/web.py`) — the IndexNow
+key file; listed in the ownership table beside `/sitemap.xml`. See `interface/seo.md` § IndexNow.

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -7,8 +7,12 @@ sources:
   - src/treg/agent_pages.py
   - src/treg/web/robots.txt
   - src/treg/web/catalog.css
+  - src/treg/web/usecase.css
   - src/treg/web/index.html
   - src/treg/web/landing.html
+  - src/treg/web/llms.txt
+  - src/treg/endpoint_stats.py
+  - scripts/indexnow_submit.py
   - src/treg/web/support.html
   - assets/brand/og-card.html
 related:
@@ -488,7 +492,7 @@ What links what now, and where it is generated:
 
 | From | To | Where |
 |---|---|---|
-| footer of every server-rendered page (Explore / Build / Company columns; the nav is unchanged by request) | `/use-cases`, `/workflows`, `/agents/claude-code` | `_page()` in `routers/web.py` |
+| footer of every server-rendered page (Explore / Build / Company columns; the nav is unchanged by request) | `/use-cases`, `/workflows`, `/agents/claude-code` — **hosted only**: those pages 404 on a self-hosted registry, so the links are gated by `_hosted()` (the landing wraps them in `<!--hosted-->` markers the route strips off-host) | `_page()` in `routers/web.py` |
 | the landing footer (`landing.html`; the public catalog SPA has no footer and links the hubs from its prerender) | same three | hand-kept markup, so `test_every_surface_links_the_three_hubs` walks `/` and `/catalog` |
 | `/catalog` prerender | both hubs, in a sentence | `catalog_index` |
 | `/tools/<provider>` "Used in" | every job page whose capabilities the provider answers | `_jobs_by_provider()`, cached per process from `USE_CASE_PAGES` × the catalog |
@@ -503,20 +507,23 @@ workflow is cross-linked the moment it is routed, and nothing is listed by hand.
 The non-brand queries that reach the site are "{provider} api pricing" phrasings ("linkedin api
 pricing", "1688 api pricing" — the one non-brand click in 28 days), not "api for agents". So:
 
-- `/tools/<provider>` titles lead with it: `{Provider} API pricing per call: from $0.0245 | treg.to`
-  (falls back to `{Provider} API pricing per call | treg.to` past 65 characters; own-account
-  providers keep the MCP title). The kicker carries the measured line — calls observed, ok rate,
-  median latency — read through `_observed_or_empty` like the job pages; it is the one fact a
-  vendor's own pricing page cannot print.
+- `/tools/<provider>` titles lead with it: `{Provider} API pricing: from $0.00245/result, no signup | treg.to`
+  (the price label carries its own billing unit, so the copy never says "per call" beside it;
+  falls back to `{Provider} API pricing: from $X | treg.to` past 65 characters; own-account
+  providers keep the MCP title). The kicker carries the measured line — calls observed, ok rate
+  weighted by each endpoint's DECIDED calls (`decided` in `endpoint_stats`, 2xx + 5xx, never the
+  4xx-inclusive `samples`), median of the endpoint `p50_ms` medians — read through
+  `_observed_or_empty` like the job pages; it is the one fact a vendor's own pricing page cannot
+  print.
 - compare-form job titles get `, from $X` appended when the hand-written title carries no price and
   the result stays within `_TITLE_MAX` (65); " compared" is dropped to make room.
 
 ### IndexNow
 
 `/{INDEXNOW_KEY}.txt` serves the IndexNow key (not a secret: the protocol only checks the key is
-served from the host named in the submission). `scripts/indexnow_submit.py` reads the live sitemap
-and pushes every URL to `api.indexnow.org` (Bing, Yandex, Seznam, Naver share the feed) and pings
-Google's sitemap endpoint. Google's own resubmission goes through Search Console
+served from the host named in the submission), on every host, since IndexNow is generic.
+`scripts/indexnow_submit.py` reads the live sitemap and pushes every URL to `api.indexnow.org`
+(Bing, Yandex, Seznam, Naver share the feed). Google retired its sitemap ping; its resubmission goes through Search Console
 (`google-search-console.x.webmasters-sitemaps-submit` in the catalog, owner OAuth). The route is
 registered in `bootstrap.py`'s ownership table like every other public route.
 

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -488,8 +488,8 @@ What links what now, and where it is generated:
 
 | From | To | Where |
 |---|---|---|
-| nav + footer of every server-rendered page | `/use-cases`, `/workflows`, `/agents/claude-code` | `_page()` in `routers/web.py` |
-| the landing and the public catalog (`landing.html`, `index.html` pubnav) | same three | hand-kept markup, so `test_every_surface_links_the_three_hubs` walks `/` and `/catalog` |
+| footer of every server-rendered page (Explore / Build / Company columns; the nav is unchanged by request) | `/use-cases`, `/workflows`, `/agents/claude-code` | `_page()` in `routers/web.py` |
+| the landing footer (`landing.html`; the public catalog SPA has no footer and links the hubs from its prerender) | same three | hand-kept markup, so `test_every_surface_links_the_three_hubs` walks `/` and `/catalog` |
 | `/catalog` prerender | both hubs, in a sentence | `catalog_index` |
 | `/tools/<provider>` "Used in" | every job page whose capabilities the provider answers | `_jobs_by_provider()`, cached per process from `USE_CASE_PAGES` × the catalog |
 | `/use-cases/<job>` "Run the full sequence" | every workflow with a step on one of the job's capabilities | `_workflows_by_capability()`, cached from `WORKFLOWS[*].steps` |

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -523,3 +523,13 @@ registered in `bootstrap.py`'s ownership table like every other public route.
 Tests: `test_every_surface_links_the_three_hubs`, `test_provider_page_names_the_jobs_it_serves`,
 `test_job_page_names_the_workflows_that_chain_it`, `test_compare_titles_carry_the_cheapest_price`,
 `test_provider_title_leads_with_pricing`, `test_indexnow_key_is_served_from_the_root`.
+
+### Agent pages name the workflows
+
+`/agents/<agent>` (and its `.md` twin) carries a **Workflows** section listing every entry in
+`agent_pages.WORKFLOWS` with its step count, between "The menu" and the category sections. Before
+this the workflow pages were reachable from `/workflows` alone. `AGENTS["grok-bot"]` also carries
+three Grok-Bot-specific FAQ entries (lead generation, research, what it cannot do yet) because
+"grok bot lead generation" is the one emerging term in the outbound research that passed all seven
+gates; the use-case map lives in `marketing/rebuild/06-grok-bot-use-cases.md`. Test:
+`test_agent_pages_name_the_workflows`.

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -474,3 +474,52 @@ and the schema all state them and had drifted apart (2,617/42 and ~2,600/~48). N
 shows the **whole** catalog, not the sum of its tiles: a tile counts only its browse surface, so the
 account/utility endpoints — real inventory, listed on each shelf page — are excluded from tile counts
 by `catalog_store.HIDDEN_KINDS`.
+
+## Discovery — the hubs are linked, not just listed
+
+Search Console on 2026-08-27 showed the 38 job pages, `/workflows` and `/agents` at zero
+impressions, and URL inspection answered "URL is unknown to Google" for
+`/use-cases/find-professional-emails` and `/workflows/find-and-verify-a-lead-list`. They were in
+the sitemap and linked from nothing: the landing linked `/catalog` and `/resources` only, `/catalog`
+linked `/tools/*` only, `/resources` linked the five outcome pages only — and those five were the
+only non-homepage URLs with impressions. A sitemap is not a crawl path.
+
+What links what now, and where it is generated:
+
+| From | To | Where |
+|---|---|---|
+| nav + footer of every server-rendered page | `/use-cases`, `/workflows`, `/agents/claude-code` | `_page()` in `routers/web.py` |
+| the landing and the public catalog (`landing.html`, `index.html` pubnav) | same three | hand-kept markup, so `test_every_surface_links_the_three_hubs` walks `/` and `/catalog` |
+| `/catalog` prerender | both hubs, in a sentence | `catalog_index` |
+| `/tools/<provider>` "Used in" | every job page whose capabilities the provider answers | `_jobs_by_provider()`, cached per process from `USE_CASE_PAGES` × the catalog |
+| `/use-cases/<job>` "Run the full sequence" | every workflow with a step on one of the job's capabilities | `_workflows_by_capability()`, cached from `WORKFLOWS[*].steps` |
+| `llms.txt` | the three indexes, with the `.md` twins | hand-kept |
+
+Both reverse indexes are derived from the same tables the pages render from, so a new job or
+workflow is cross-linked the moment it is routed, and nothing is listed by hand.
+
+### Titles: the pricing intent
+
+The non-brand queries that reach the site are "{provider} api pricing" phrasings ("linkedin api
+pricing", "1688 api pricing" — the one non-brand click in 28 days), not "api for agents". So:
+
+- `/tools/<provider>` titles lead with it: `{Provider} API pricing per call: from $0.0245 | treg.to`
+  (falls back to `{Provider} API pricing per call | treg.to` past 65 characters; own-account
+  providers keep the MCP title). The kicker carries the measured line — calls observed, ok rate,
+  median latency — read through `_observed_or_empty` like the job pages; it is the one fact a
+  vendor's own pricing page cannot print.
+- compare-form job titles get `, from $X` appended when the hand-written title carries no price and
+  the result stays within `_TITLE_MAX` (65); " compared" is dropped to make room.
+
+### IndexNow
+
+`/{INDEXNOW_KEY}.txt` serves the IndexNow key (not a secret: the protocol only checks the key is
+served from the host named in the submission). `scripts/indexnow_submit.py` reads the live sitemap
+and pushes every URL to `api.indexnow.org` (Bing, Yandex, Seznam, Naver share the feed) and pings
+Google's sitemap endpoint. Google's own resubmission goes through Search Console
+(`google-search-console.x.webmasters-sitemaps-submit` in the catalog, owner OAuth). The route is
+registered in `bootstrap.py`'s ownership table like every other public route.
+
+Tests: `test_every_surface_links_the_three_hubs`, `test_provider_page_names_the_jobs_it_serves`,
+`test_job_page_names_the_workflows_that_chain_it`, `test_compare_titles_carry_the_cheapest_price`,
+`test_provider_title_leads_with_pricing`, `test_indexnow_key_is_served_from_the_root`.

--- a/marketing/_research-ai-outbound-playbook-2026-08-27.md
+++ b/marketing/_research-ai-outbound-playbook-2026-08-27.md
@@ -1,0 +1,204 @@
+# AI outbound in 2026 — the playbook people run, what Reddit asks, and what treg.to should publish
+
+Research date: 2026-08-27. Sources: X (OpenCLI, 6 queries + threads of @itsalexvacca, @fivosaresti, @IAmAaronWill, @aryanXmahajan), Reddit (OpenCLI, 6 queries, 12 threads read with comments), YouTube (yt-dlp, 5 queries, 8 full transcripts), web (8 playbook articles incl. Eric Nowoslawski / Explorium / SyncGTM / Salesforge / Koka Sexton / Yalc / SalesRobot / Growth Unhinged). LinkedIn covered via the web playbooks and the LinkedIn-specific X/YouTube systems (the LinkedIn MCP isn't configured on this machine).
+
+---
+
+## 1. The system everyone runs (the 2026 skeleton)
+
+Eight YouTube systems, eight web playbooks and the top X operators converge on the same nine steps. Where they disagree is the orchestrator, not the shape.
+
+| Step | What it is | Who says it | Tools they name |
+|---|---|---|---|
+| 0. Context layer | ICP, exclusions, offer, email framework in a `CLAUDE.md` (<250 lines) + `icp/`, `messaging/` markdown | SyncGTM, Salesforge, Growth Unhinged, Lead Gen Jay ("strategy skill runs before scraping") | Claude Code, Notion |
+| 1. Signal in | Hiring (esp. SDR/AE/VP Sales), funding, job/leadership change, tech-stack change, news, site visitors, LinkedIn engagement | Everyone. "Outbound stopped paying for volume, started paying for homework" | PredictLeads, Clay, RB2B, Apify LinkedIn Jobs, Crustdata |
+| 2. Small list | 50–250 (Growth Unhinged), 300–1,000 (SyncGTM), 20–30 accounts (Koka). Lists < 30 days old | @itsalexvacca: "write the entry rule first — 5 to 10 signals must be true" | Apollo search (via Apify because "export is too expensive"), Sales Nav |
+| 3. Qualify before you spend | AI yes/no + reason; drops ~40% of list, "2–3x reply rate" | Lead Gen Jay, Apollo, Explorium scoring weights | Claude/GPT |
+| 4. Waterfall enrich + verify | 6 providers vs 1 = 50–70% → 85–95% email coverage; verify everything; bounce < 1% | SyncGTM, Eric N., Reddit | Findymail, Hunter, LeadMagic, Anymail, MillionVerifier |
+| 5. Research → one-signal personalization | Scrape site/posts → LLM abstract → LLM **fills a fixed template**, never writes whole emails (A/B-ability). ≤85 words, no links in email 1 | Saraev, Clarence Nap, SyncGTM. Dissent: Marc ("hyper-personalization can backfire") | Perplexity Sonar ("way cheaper than a Clay agent"), Firecrawl, Exa |
+| 6. Send from real infra, never from the agent | Secondary domains, SPF/DKIM/DMARC, 2–4 week warmup, 30–40/inbox/day, cancel a domain at < 0.7% reply | Every source | Instantly, Smartlead, Lemlist, Email Bison |
+| 7. LinkedIn inside the caps | 100 invites / rolling 7 days, 20–25/day, new accounts 5–10/day for 4 weeks, note < 300 chars, acceptance > 25–40% or you're throttled. Comment-first warming is the 2026 move; browser-click automation gets whole user bases banned | Yalc, SalesRobot, Saraev | PhantomBuster, HeyReach, Unipile API, Claude-in-Chrome |
+| 8. Reply classification, human conversation | interested / not now / OOO / referral / unsubscribe / angry → tag CRM, pause sequence. Reply within a minute "≈4x conversion" | Explorium, Yalc, Saraev | Claude, Supabase vectors |
+| 9. Weekly loop | Reply rate by segment, top/bottom first lines, 20–50 simultaneous tests, control inboxes to tell "me vs the platform" | Eric N., SyncGTM, r/Coldemailing | Sheets/Supabase |
+
+**The orchestrator war (this is the story for treg.to):**
+- **n8n/Make** (Saraev ×2, Clarence Nap, three of the Reddit "my system" posts) — visual, Sheets as the database, polling loops for async scrapers.
+- **Claude Code + skills** (Lead Gen Jay, @fivosaresti "we took every UI out of our outbound stack", @itsalexvacca "21 MCP connections run our GTM from one terminal", Eric N. "2M lines in 45 days") — the fastest-growing camp. Lead Gen Jay explicitly built a "Clay killer" = Perplexity + Claude + own DB. Growth Unhinged: mature teams are moving **MCP → API/CLI** because MCP is 10–32x more expensive in tokens.
+- **Claude Cowork + vendor MCPs** (Automate with Marc, the $10K LinkedIn video) — Apollo/Clay/HubSpot/Lemlist connectors, no code.
+- **All-in-one** (Apollo, AI SDRs) — Reddit is openly hostile: "AI SDR is a bullshit category, $45M later still can't sell"; "over half of buyers churn inside 90 days".
+
+**What Clay's moat actually is, in the operators' own words:** Eric Nowoslawski keeps Clay for "150+ pre-negotiated data providers — one datapoint from HG Insights without an HG contract" and "automatic API queuing/rate-limit handling across 50 tables". r/gtmengineering: "Clay is great because of their data sources all coming together in one place… what data sources do you use?" That is, word for word, the catalog's pitch — one token, many providers, per-call, no contracts — and Clay's price ("exorbitant", "50–70% cheaper" is the winning alt pitch) is the wedge.
+
+**Numbers that recur** (vendor benchmarks, quote with attribution): cold-email reply 5.1% (2024) → 3.43% (2026, Woodpecker); signal-triggered 4–8% vs generic 1–3%; the 5% who personalize every email get 17–18%; LinkedIn reply 10.3% vs email 5.1% (Expandi); Gmail spam-complaint cap 0.3% and it's **cumulative**, "one bad AI blast poisons a domain you warmed for months"; B2B data decays ~2%/month; Apollo rows: ~66% have LinkedIn URL, ~77% have email, ~25% of sites unscrapable, so plan 10K rows → ~2K deliverable.
+
+**Copy-paste assets the sources already show (we can do these better with real calls):**
+- SyncGTM's `CLAUDE.md` ICP block and 3-line email framework (hook/problem/CTA, ≤85 words).
+- Explorium's `SCORING_WEIGHTS` dict (funding_90d 30, sales_hiring_spike 25, eng_hiring_spike 20, intent 20, technographic 15, leadership_change 10; threshold 40).
+- Saraev's icebreaker prompt ("Spartan, paraphrase never quote, shorten company names, never 'love your website'") and his few-shot layout.
+- Clarence Nap's hiring-signal template ("Saw you've got some SDR roles open…").
+- Koka's two-sentence signal email ("Saw your comment on the pipeline-velocity post this week. Are you solving that now, or researching how others handle it?").
+- SalesRobot's five LinkedIn scripts (connect / follow-up / job change / funding / post engagement).
+- Eric N.'s Friday domain-health cron and "guess 6 permutations → verify → keep the valid one" email finder.
+- Explorium's `0 2 * * * claude -p "…"` cron pattern and reply-classification JSON schema.
+
+---
+
+## 2. What Reddit is actually asking (ranked)
+
+1. **"Is cold email / outbound still working in 2026?"** — 6+ threads; r/LeadGeneration's top thread (282 comments). Answer people upvote: yes, for Google-Maps-scraped local businesses without a website, 100–200 personalized emails → 3–5 replies; "anyone can blast 10k, few can send 500 hyper-relevant ones".
+2. **"How do I make AI emails not sound like AI?"** — 5 threads. Best answer (r/SaaS, 363 pts): feed 50+ hand-written examples, "copy style not content", < 100 words, pre-filter generic LinkedIn posts, A/B the prompt (30% swing). "Identical sentence rhythm across 1,800 emails — nobody replies to tell you, they just stop replying."
+3. **"Do AI SDRs actually book meetings?"** — 5 threads; deeply skeptical. One honest founder funnel: 1,842 contacts → 11.6% reply → 52 booked → 31 held. "The tool is 30%. The list filter and the first line are the other 70%."
+4. **"Which tool do I start with — enrichment, scoring or sequencing?"** — "Everyone wants to automate a process they have no idea how to do without AI." Answer: source → enrich → qualify → CRM check → draft → human review → send → track; do 20 by hand first.
+5. **"Is Clay worth it / cheaper Clay alternative?"** — 3 threads, 40–63 comments each; purely price-driven ("the pricing disturbs me the most"; GTM lead at a $200M-ARR company: "way overpriced").
+6. **"Which data source is accurate — Apollo, Clay, Sales Nav, ZoomInfo?"** — "Apollo is honestly trash, under 10% valid phone numbers"; "ZoomInfo and Apollo lack up-to-date email verification and proper buying signals… I was learning to build middleware myself with Claude and n8n."
+7. **"Where do I store leads between n8n runs?"** — dedicated thread; both big n8n posts use Google Sheets as the source of truth.
+8. **"How do I handle replies — classify or keep human?"** — 3 threads.
+9. **"Which sender accepts CSV with custom variables?"** / **"How do I verify emails inside the workflow?"** — 2 each.
+10. **"Can you share the JSON?"** — asked ~7× in one thread; the "DM me" non-answer is resented. **Actually shipping the workflow is the whole differentiator.**
+11. **"How many LinkedIn accounts / per-seat cost?"** — HeyReach $590/mo/sender vs Unipile €5/account.
+12. **"How do I tell whether a reply-rate drop is me or Google/Microsoft?"** — the control-inbox answer.
+13. "How do I find clients for my n8n/automation agency?" (924-pt r/AI_Agents thread) — the freelancer audience is huge and broke.
+
+Pain points with the loudest quotes: saturation ("reply rates 3–5% → 1–2% because everyone runs the same stack sending 'hi {firstName} I noticed {scraped_intent_signal}'"), domain burn, tool sprawl ("so many tools… confused which to start with"), Clay cost, data rot, and Reddit's own vendor pollution ("it is his vibecoded SaaS and he's namedropping it here").
+
+---
+
+## 3. Where treg.to fits — the gaps nobody explains how to fetch
+
+The web playbooks all say "go get X data" and stop. Checked against the catalog today:
+
+| The playbook says | Nobody says how | treg.to has it (cheapest working option, no key needed) |
+|---|---|---|
+| "Posted SDR/BDR roles in last 90 days" | ✗ | `apify.linkedin.search.jobs` $0.001 · `leadmagic.x.jobs-search-v3` $0.025 · `predictleads.companies.job_openings` $0.04 |
+| "Raised Series B/C in last 18 months" | ✗ | `aviato.companies.funding_rounds` $0.01 · `predictleads.companies.financing_events` $0.04 · `predictleads.financing.discover` (who-just-raised feed) |
+| "Doesn't yet use Salesforce" | ✗ | `tomba.companies.tech_stack` $0.0089 · `predictleads.technologies.users` (reverse lookup) $0.04 |
+| "Research their last 3 LinkedIn posts" | ✗ | `tikhub.x.linkedin-web-v2-get-user-posts` $0.001 · `scrapecreators.linkedin.user.profile` $0.00188 (1,997 samples, 99.9%) |
+| "Who engaged with the competitor's post" | ✗ | `scrapecreators.x.v1-linkedin-post` $0.00188 (likes, comments) — partial |
+| "Scrape X + LinkedIn with Apify, Claude scores each lead" (@IAmAaronWill) | — | `scrapecreators.x.user.posts` $0.00188 · `tikhub.x.user.posts` $0.001 |
+| "Find the VP Sales at each company" | — | `icypeas.people.search` $0.00038 · `findymail.search.employees` $0.0198 · `leadmagic.x.role-finder` $0.05 |
+| Waterfall email finder | — | tomba $0.0089 → icypeas $0.019 → findymail $0.0198 → hunter $0.0245 → leadsforge/leadmagic $0.025 (6 providers, one token) |
+| Verify before send | — | icypeas $0.0019 · leadmagic $0.00625 (2,997 samples) · hunter $0.01225 |
+| Google Maps "niche + city, no website" | — | `dataforseo.x.business-data-business-listings-search-live` $0.013 |
+| Scrape the prospect's website → markdown | ✗ | **Catalog gap.** Nothing Firecrawl/Jina-shaped; `dataforseo.x.on-page-content-parsing` is the nearest. Worth a `catalog_request`, because 3 of 8 YouTube systems have this step. |
+| Website visitor de-anonymization | ✗ | Not in catalog (RB2B/Warmly); leave to own-key tools. |
+
+Caveats to keep the pages honest (CLAUDE.md rules): treg **compares** these providers side by side, it does not waterfall/route automatically — the article's script does the waterfall in 6 lines, which is exactly the point. Findymail/Fiber misses bill at full rate until `_observed_cost_micro` is fixed (see memory) — say "a miss costs nothing" only for providers where it's true.
+
+---
+
+## 4. Articles to write on treg.to (copy, paste, run)
+
+Format rule for every one: the article **is** a runnable file. One `SKILL.md` or one bash/Python script that calls `/call/` with a treg token, real endpoint ids, real prices, a real run's output pasted in, and the tuned prompt inline. This answers Reddit's #10 ("share the JSON") in a way vendors refuse to. Each should end with the exact cost of the run shown.
+
+**Tier 1 — matches the biggest asked questions and the strongest catalog coverage**
+
+0. **"The join problem, solved with three catalog calls"** — the framing from Akshay Pachaar's Seltz-sponsored X Article *Build a Multi-Agent GTM Intelligence System* (Aug 24, 172 likes / 28K views; [blog mirror](https://blog.dailydoseofds.com/p/build-a-multi-agent-gtm-intelligence)): the trigger (new VP, funding closed) and the person's record live in different places, so a snippet-returning search API forces search → fetch → parse per company and per person; a full-record API turns the join into a merge. Three agents: Signal Hunter (news) → People Enricher (career record) → Outreach Strategist (merge, rank, first line). Rebuild it on `predictleads.financing.discover` / `apollo.companies.news` for the trigger, `icypeas.people.search` + `scrapecreators.linkedin.user.profile` for the record, `tikhub` posts for the hook — **with prices**, which Seltz's piece never shows. Keep their honest "when to chain with open web search" section; ours is "when to use your own key".
+
+1. **"The Clay-free waterfall: find and verify a work email across 6 providers for $0.01–0.025"** — the `email.find` cascade (tomba → icypeas → findymail → hunter → leadmagic), verify, stop at first hit. Reddit #5/#6/#9; the "150 providers behind one key" moat, done in a 40-line script. Compare to Clay credits per row. Reuses the shipped `/use-cases/lead-enrichment-for-ai-agents/` proof.
+2. **"Hiring-signal outbound in one SKILL.md: companies that posted SDR roles this week → the VP Sales → verified email → templated first line"** — Clarence Nap's $35K/mo system, rebuilt on `apify.linkedin.search.jobs` + `icypeas.people.search` + email waterfall + Saraev's icebreaker prompt. The single most-cited signal across all sources.
+3. **"Who just raised: a Monday cron that pulls last week's funding rounds and writes the entry-rule scorecard"** — `predictleads.financing.discover` / `aviato` + Explorium's scoring weights as a real Python dict + `0 2 * * * claude -p`. @itsalexvacca's "write the entry rule first" as the frame.
+4. **"Score before you send: the 40-line lead qualifier (and why it 2–3x'd replies while dropping 40% of the list)"** — Lead Gen Jay's qualification prompt + tech-stack check (`tomba.companies.tech_stack`) + LinkedIn profile pull; output a yes/no/reason CSV. Reddit #2/#4.
+5. **"LinkedIn post → first line: personalize 500 emails from each prospect's last 3 posts for under a dollar"** — the r/SaaS 363-pt method (`tikhub` posts $0.001 + GPT-4o-mini + "copy style not content" with 25+ examples). Pure copy-paste; the generic-post pre-filter included.
+
+5b. **"Stack the signals: the $0→$2M compliance playbook, as a scoring script"** — from [@pierreeliottlal's post](https://x.com/pierreeliottlal/status/2092548845255209294) (Gojiberry founder, Aug 26: 203 likes, 30K views, **549 bookmarks**). A GDPR/SOC 2 vendor's whole GTM: (1) keywords buyers engage with when compliance becomes urgent, (2) monitor ICP people engaging with that content, (3) filter role/size/geo, (4) enrich, (5) contact while fresh, (6) monitor competitor company pages, founders, salespeople, employees — ICP engagers there are the warmest, (7) monitor Seed/Series A raises because questionnaires follow growth, (8) **stack**: fit → +topic engagement → +follows competitor → +just raised = call now. "Fit tells you who CAN buy, intent tells you who might buy NOW." Ours: the stack as an additive score with real calls behind each term — `predictleads.financing.discover` (7), `scrapecreators.x.v1-linkedin-post` engagers on competitor posts (6, partial), `tikhub` person posts (2, partial), `icypeas.people.search` + waterfall (3–4). Honest gap: keyword-level LinkedIn engagement monitoring (step 2) isn't in the catalog — file it; Gojiberry's moat is exactly that feed.
+
+6. **"Local-business outbound that still works in 2026: Google Maps → no website → owner email → 100 a day"** — the r/LeadGeneration top answer, on `dataforseo` business listings + email find. Cheap, beginner, huge Reddit audience.
+7. **"The 2026 outbound stack, mapped: what each tool does, which ones are one API call, and what it costs per lead"** — the nine-layer breakdown (@itsalexvacca's frame) with a price-per-1,000-leads table computed from the catalog. The comparison page Reddit #4/#6 keep asking for; honest about what treg doesn't do (send, warm, de-anon).
+8. **"n8n vs Claude Code for outbound: the same hiring-signal pipeline built both ways"** — the orchestrator war, one HTTP node vs one skill, MCP vs CLI token cost. Growth Unhinged's "MCP → CLI" data point.
+9. **"Where to store leads between runs: SQLite + a dedupe key, in 20 lines"** — Reddit #7; answers the "never re-contact the same lead" problem every system hits.
+10. **"Reply classifier: six labels, one prompt, webhook to your sequencer"** — Explorium's schema, as a runnable script. Reddit #8.
+
+**Tier 3 — LinkedIn and X specifically**
+
+11. **"The comment-first LinkedIn play: pull the engagers on three competitor posts, score them, connect to 20 a day"** — `scrapecreators.x.v1-linkedin-post` + profile pull + SalesRobot's scripts + the 100/week caps stated plainly. Honest that treg reads LinkedIn; sending stays in HeyReach/Unipile/your hands.
+12. **"Score X followers as leads: scrape a competitor's audience's posts, let Claude rank them, DM the top 50"** — @IAmAaronWill's viral inbound/outbound split on `scrapecreators.x.user.posts`.
+13. **"Control inboxes: a 12-line weekly check that tells you whether Google moved or you did"** — the r/Coldemailing insight nobody has written up; pulls per-domain reply rates from Instantly/Smartlead as own-key tools.
+
+**Don't write:** "best AI SDR tools 2026" listicles (the audience distrusts the category and it's vendor-saturated), anything promising automatic routing/failover, "how to X with ChatGPT" (dead per the pSEO teardown), and PDF-style "ultimate guides" — Lead Gen Jay's audience calls the perceived value of those "trash".
+
+**Distribution loop:** each article's script doubles as (a) a `SKILL.md` installable via `install.sh`, (b) the answer to the matching Reddit thread (post the actual JSON/script — the one thing OPs there never do), (c) an X post in the @fivosaresti "here's the cheat sheet" format, which is what performs in this niche.
+
+---
+
+## 5. Where articles of that quality live (and what to copy from each)
+
+Searched X Articles, the web and GitHub for the hands-on, code-included, honest-caveat shape of the Seltz piece. Four publisher shapes exist; none is written from the "many providers, one token, per-call price" angle.
+
+**A. Sponsored newsletter walkthroughs (the Seltz shape).** Daily Dose of DS (Avi Chawla + Akshay Pachaar, 100K+ readers) runs a *[Hands-on] … explained with code* series where a vendor sponsors one build: Seltz (GTM), Mistral OCR, "Audio RAG with 200x cheaper vector DB", "Semantic code navigation cuts agent tokens 36%", "Query billion-row Postgres". Format: problem framing → 3-agent architecture → CrewAI/MCP code → Streamlit demo → Lightning Studio repo → "when to use something else" → "thanks to X for sponsoring". Akshay's follow-up tweet ("I just built my own multi-agent GTM research assistant — it finds the reason to reach out before it writes a single message", 87 likes) is the distribution post. **Action:** price the slot; the brief writes itself from article #0.
+
+**B. Vendor engineering blogs with real code.**
+- Firecrawl — *How to Build an AI SDR that Researches Companies in Real Time* (Jun 2026): Python, four stages (search → schema extract → write → batch to 50 concurrent), Pydantic schema, cites Belkins/Woodpecker with links and flags vendor-sourced stats as "directional". Also *Bulk Sales Lead Extractor in Python*, *Complete Guide to Data Enrichment*, n8n templates. This is the bar for code quality.
+- Explorium — *How to build an Outbound Agent with Claude Code* (May 2026): CLAUDE.md, researcher + writer agents, five-stage pipeline, 8-point production audit (HMAC, DLQ, ICP gating), 30/60/90 roadmap, G2 quotes against Apollo/Clay ("credits per row vary 100% from stated"). Heavier on positioning; its "$18K SDR → $200 agent" framing is the one being shared.
+- FoxReach — *How to Build an AI SDR: 2026 Build Guide*: the 8-stage closed loop table (source → enrich → research → draft → send → triage → hand off → feedback); "you own the brain, rent the hands"; sending backend as typed tools with JSON schemas. Best architecture prose of the set.
+- The Signal Club's Eric Nowoslawski profile, SyncGTM, Salesforge (already in §1) — operator-voice, fewer code blocks.
+
+**C. Open-source GTM skill packs for Claude Code (the fastest-moving shape).**
+| Repo | ★ | What it is | Why it matters |
+|---|---|---|---|
+| `gtmagents/gtm-agents` | 393 | Claude Code plugin marketplace of GTM agents; "generate 100 leads in 5 minutes" use-case docs | The distribution model — a `/plugin marketplace add`; treg's `skill.md` could ship as one |
+| `oneshot-agent/oneshot-gtm` | 308 | GTM agent for technical founders, pay-per-result, signed receipts, CLI + local dashboard | Pay-per-result is our billing story told by someone else |
+| `Othmane-Khadri/YALC-the-GTM-operating-system` | 288 | "The open-source Clay alternative": MIT, CLI-first, runs in Claude Code, enrichment and workflows in markdown you own, "you pay providers direct" | **Directly adjacent.** YALC 1.0 needs a key per provider; treg is one token for all of them. A "run YALC on treg" article or PR is the highest-leverage integration on this list |
+| `AIDevGTM/gtm-cofounder` | 248 | #1 Product of the Day; strategy-side skills (positioning, first users, pricing) | Not data; skip |
+| `LeadMagic/gtm-skills` | 45 | 206 SKILL.md skills incl. `outbound-stack`, `prospecting-stack`, `rb2b-outbound-triggers`, `cold-email-strategy`, with QA scripts | LeadMagic is a catalog provider (`leadmagic.people.email.find`, 3,130 samples). Their skills call LeadMagic directly; a fork that calls `/call/` gets a waterfall for free |
+
+**D. The X Article format itself.** Long-form X Articles with a code walkthrough and a "here's the cheat sheet" hook are what perform in this niche this month: @fivosaresti (Claude Code outbound cheat sheet), @itsalexvacca (nine-layer GTM stack, 21 MCPs), @harsehaj ("how I built an SEO/AEO blog engine" as a Browserbase intern, 1,199 likes), @_avichawla ("Cut agent tokens 2.7x", 165K views). The pattern: one specific build, numbers, a diagram, the repo link, an honest limits section.
+
+**What none of them do, which is our opening:** show the price of every call, compare providers for the same step side by side, and let the reader run it without signing up for four vendors. Every article above ends with "get an API key from X, Y and Z".
+
+---
+
+## 6. What to do with it — one build, five outputs
+
+The principle: **build one recipe for real, get a receipt, then reuse that single run everywhere.** The receipt (the terminal showing three `/call/`s, their prices, the merged output) is the asset nobody else in §5 can produce, because they don't have per-call prices or six providers behind one token.
+
+### The build (week 1): the join-problem recipe, run for real
+- One `SKILL.md` + one script: Signal Hunter (`predictleads.financing.discover` or `apify.linkedin.search.jobs`) → People Enricher (`icypeas.people.search` → `scrapecreators.linkedin.user.profile` → email waterfall → verify) → Strategist (merge, rank, one-signal first line with Saraev's prompt).
+- Run it on 20 real companies. Save: the exact commands, every call's price, total cost, the ranked output, what missed. That run is the receipt.
+- Fix or caveat before publishing: the Findymail/Fiber miss-billing (say "a miss costs nothing" only where true); file `catalog_request` for website→markdown scraping so the recipe can research a homepage.
+
+### Output 1 — X (Jason's account first, @treg second)
+| Post | Format | Model it copies |
+|---|---|---|
+| **The join problem, with a receipt** | X Article + hook tweet: "Cold outreach fails on timing, not wording. The trigger and the person live in different records. Here's the join in 3 calls, $0.04 per lead, receipt attached." Terminal screenshot of the run, diagram of the three agents, repo link, honest "when to use your own key" | Akshay's Seltz piece; @fivosaresti's cheat-sheet close ("bookmark + send to your team") |
+| **The price-receipt series** (weekly) | One image: one outbound step, all providers side by side — price, measured success %, median ms, samples. "Email verification: 5 providers, $0.0019 to $0.0123, which one your agent should pick." No other account can post this table | @itsalexvacca's nine-layer stack, made numeric |
+| **Value replies with the script** | Reply to the viral outbound posts (@IAmAaronWill's inbound/outbound split, @itsalexvacca's entry rule, @aryanXmahajan's AI SDR) with the 10-line version that does their step, prices inline. The paused "X value replies" loop is the vehicle | The one thing Reddit OPs won't do: share the actual code |
+| **"Clay's moat in 40 lines"** | Quote Eric N.'s "150 pre-negotiated providers" line, show the waterfall script, the cost per row vs Clay credits | The Clay-alternative threads (40–63 comments each) |
+| **YALC-on-treg** | Joint announce with the YALC maintainer once the PR lands: "the open-source Clay alternative now runs on one token" | Open-source cross-post; both audiences |
+
+Rules from the teardown: first tweet carries the number and the receipt, not the pitch; never claim routing; "genuinely" is fine, em-dashes are the tell.
+
+**The format that gets bookmarked** (Pierre's post, 549 bookmarks on 203 likes): a named outcome in line one ("$0 to $2M ARR with one play"), a concrete niche so it feels real (GDPR/SOC 2 → US companies), eight numbered steps, one thought per line, no image, the product named once in the last three lines, "try it free" as a self-reply. Bookmarks, not likes, are the metric for playbook posts — write for the save.
+
+### Output 2 — treg.to articles: a `/recipes/` shelf
+- **Page type:** `/recipes/<slug>`, server-rendered from the catalog like `/use-cases/` (`agent_pages.py` `_USE_CASES` pattern, so a new recipe lands in the sitemap for free). Prices and success rates pulled live from the catalog, so the page never goes stale.
+- **Fixed anatomy** (copy Firecrawl's rigor, Akshay's framing, FoxReach's loop table): (1) the Reddit question, quoted; (2) the join — which records live where; (3) the calls, with a provider table for each step; (4) the receipt — a real run, total cost; (5) the prompt, inline; (6) "when to use your own key / when to use open web search"; (7) install: `treg skill install <slug>` or the `SKILL.md` download.
+- **Order of publication** = §4 Tier 1: join problem → email waterfall → hiring signal → who-just-raised cron → lead qualifier → LinkedIn posts → first line. One a week; the daily "treg.to SEO pages" loop keeps shipping catalog pages underneath.
+- **Agent × recipe pages** already have the machinery (`/for/claude-code`, `/for/cursor` agent pages): each recipe gets an install block per agent, which is Pipedream's "agent × platform" win without the empty matrix.
+- Each recipe also lands in `src/treg/web/skill.md` / `llms.txt` as a one-line "recipes" index — agent-facing files are the front door.
+
+### Output 3 — distribution beyond our own channels
+- **Sponsor the Daily Dose of DS slot.** The brief is article #0; ask for the same anatomy (3 agents, CrewAI or Claude Agent SDK, Streamlit, hosted repo) with treg as the retrieval tool. Fits the creator-sponsorship criteria (workflow builders, rank on views).
+- **YALC PR:** a treg provider adapter so "you pay providers direct" becomes "one token". Highest-leverage integration found; 288★, MIT, runs in Claude Code.
+- **Fork `LeadMagic/gtm-skills` `prospecting-stack`** to call `/call/` — LeadMagic is already a catalog provider, so this is a waterfall upgrade of their own skill; offer it upstream.
+- **List treg in `gtmagents/gtm-agents`** as a marketplace plugin (`skill.md` already exists).
+- **Answer the five Reddit threads** (r/MarketingAutomation "where to start", r/gtmengineering Clay alternatives ×2, r/n8n "where to store leads", r/SaaS personalization) with the recipe script, not a link — via the paused Reddit karma loop, one value comment per thread.
+
+### Sequence
+Week 1 build + receipt → week 2 X Article + recipe page #1 + YALC PR opened → week 3 price-receipt series starts, Reddit answers, DDoDS outreach → weekly thereafter one recipe, one receipt image, replies as they come. Measure with the existing GSC+Ads loop: impressions on `/recipes/`, first-call rate from those pages (the funnel still needs instrumenting — see memory).
+
+---
+
+## 7. Measured: where this fits the SEO strategy (DataForSEO via the catalog, 2026-08-27, ~$0.16)
+
+Full table and linking map: `marketing/rebuild/00-strategy.md`. Drafts: `marketing/rebuild/01–05`.
+
+**Winnable, worth a page:** "clay alternative(s)" 480+480/mo, CPC $36.72, **KD 0** (SERP = listicles, an r/gtmengineering thread, an HN "should I build one" post) · "clay pricing" 1,900 (KD 3) · "clay api" 390 · "gtm engineering / gtm engineer" 3,600 LOW competition, untargeted by anyone in our sources · "gojiberry ai" 1,600 + "trigify" 720 + "teamfluence" 90 — the no-API subscription LinkedIn-intent tools have real brand volume · "ai sdr" 1,900 (−46% YoY, CPC $92) with "ai sdr open source" showing a bare GitHub repo at #1 · "linkedin scraper" 1,000 / "linkedin profile scraper" 210 / "linkedin post scraper" 110.
+
+**Dead:** "rebuild clay", "build your own clay", "clay clone", "signal based outbound" (10), "waterfall enrichment api" (10), "open source clay alternative" (10), and every "{x} api" phrasing except "email verification api" (210). Same lesson as the memory note: buyers type "scraper", "alternative", "pricing", "vs".
+
+**The shelf:** `/rebuild/` — Rebuild Clay (clay alternative + pricing + api + waterfall) · Rebuild Gojiberry/Trigify (LinkedIn intent, with the keyword-monitoring gap stated) · Build your own AI SDR (the loop; sending stays in your sequencer) · The GTM engineering stack, priced (the 3,600 term) · The join problem (repurposed; doubles as the X Article and the DDoDS brief). Every page is a recipe with a run receipt; every existing use-case page links to the rebuild that extends it, and every rebuild's provider table links back to the catalog comparison pages.
+
+---
+
+## Raw material
+Scratchpad: `x_opencli.txt`, `x_threads.txt`, `x_users.txt`, `reddit.txt`, `reddit_threads.txt`, `yt/*.txt` (8 transcripts), `c_p1..8.md` (web pages). Agent Reach v1.5.0 is current.

--- a/marketing/rebuild/00-strategy.md
+++ b/marketing/rebuild/00-strategy.md
@@ -1,0 +1,64 @@
+# "Rebuild X" — the outbound cluster, measured
+
+Research: `marketing/_research-ai-outbound-playbook-2026-08-27.md`. Volumes: DataForSEO Google Ads, US, pulled 2026-08-27 through the catalog (`dataforseo.google.keywords.volume`, one $0.09 call for 100 terms; SERPs $0.002 each). KD from `dataforseo.google.keywords.ideas`.
+
+## What the numbers say
+
+| Term | Vol/mo | CPC | Comp | Read |
+|---|---|---|---|---|
+| gtm engineer / gtm engineering | 3,600 | $9.32 | LOW | Biggest informational term in the set; nobody in our sources targets it |
+| crustdata | 2,400 | $31.43 | LOW | Brand; has an API. Comparison mention only |
+| ai sdr | 1,900 | $92.30 | MED | −46% YoY. Category distrust on Reddit. Target with "build your own", not a listicle |
+| clay pricing | 1,900 | $4.45 | MED | KD 3. The cost-per-row page, not the alternative page |
+| ai lead generation (+ tools) | 1,600 + 480 | $54 / $47 | MED / LOW | Head terms; the recipes shelf as a whole targets these |
+| gojiberry ai | 1,600 | $3.48 | MED | The no-API, subscription-only LinkedIn-intent tool. "gojiberry" (110K) is the fruit |
+| trigify | 720 | $3.54 | MED | Same category, same page |
+| clay alternative(s) | 480 + 480 | $36.72 | MED | **KD 0.** SERP = listicles + r/gtmengineering + HN "should I build one" |
+| zoominfo / apollo alternative | 480 / 390 | $58 / $54 | MED | Mention inside the Clay page; don't build separate pages yet |
+| clay api | 390 | $4.38 | LOW | Developers looking for what Clay doesn't sell |
+| intent data / providers | 390 / 210 | $151 / $146 | MED | Bombora's SERP; enterprise buyers. One section, not a page |
+| buying signals / intent signals | 260 / 170 | $12 / $71 | LOW / MED | The "stack the signals" page |
+| clay vs apollo / zoominfo | 260 / 140 | $45 / $23 | MED | Comparison rows inside the Clay page |
+| email verification api | 210 | $20.73 | LOW | Already a catalog page (`Email verification API: {n} verifiers compared`) — link to it |
+| linkedin scraper / profile scraper / post scraper | 1,000 / 210 / 110 | $21 / $12 / $13 | MED | Scraper wording wins again. The LinkedIn-intent page carries these |
+| waterfall enrichment | 140 | $26 | MED | SERP is Clay, Apollo, ZoomInfo, FullEnrich, Hunter — every vendor explains it, none prices it |
+| predictleads / teamfluence / seltz ai | 170 / 90 / 50 | — | — | Mention as providers / comparisons |
+
+**Dead, don't target:** "rebuild clay", "build your own clay", "clay clone", "cheap clay alternative", "signal based outbound" (10), "waterfall enrichment api" (10), "open source clay alternative" (10 — but its SERP is where YALC, OpenClay, Eigent live, so the Clay page should say "open source" once), every "{thing} api" phrasing except email verification. Buyers type "scraper", "alternative", "pricing", "vs".
+
+## The cluster
+
+Five pages, one shelf (`/rebuild/`), one repurposed article, and links from the five live use-case pages.
+
+| # | Page | Primary term | Secondary | File |
+|---|---|---|---|---|
+| 1 | Rebuild Clay | clay alternative (480, KD 0) | clay pricing, clay api, clay vs apollo, waterfall enrichment, open source clay alternative | `01-rebuild-clay.md` |
+| 2 | Rebuild Gojiberry / Trigify (LinkedIn intent) | gojiberry ai (1,600) | trigify, teamfluence, linkedin post scraper, buying signals, intent signals | `02-rebuild-linkedin-intent.md` |
+| 3 | Rebuild an AI SDR | ai sdr (1,900) | ai sdr tools, ai sdr open source, build ai sdr | `03-rebuild-ai-sdr.md` |
+| 4 | The GTM engineering stack, priced | gtm engineering (3,600, LOW) | gtm engineer, gtm agent, outbound agent | `04-gtm-engineering-stack.md` |
+| 5 | The join problem (repurposed) | — (editorial; the X Article + DDoDS shape) | intent signals, hiring signals | `05-join-problem.md` |
+
+Every page is a **recipe** — a runnable script with real endpoint ids, real prices and a run receipt — and every page says plainly what treg does not do (send, warm, route, de-anonymize) and where the catalog has a gap.
+
+## Linking map (existing → new, new → existing)
+
+| Existing page | Link to | Anchor |
+|---|---|---|
+| `/use-cases/lead-enrichment-for-ai-agents/` (p2) | Rebuild Clay | "the same waterfall, as a Clay replacement" |
+| `/use-cases/company-research-for-ai-agents/` (p5) | Rebuild Clay · Join problem | "funding + people in one pass" |
+| `/use-cases/social-creator-trends` (p3) | Rebuild LinkedIn intent | "the same post/profile tools, pointed at buyers" |
+| `/use-cases/company-buying-signals` (p5) | Rebuild LinkedIn intent · Rebuild AI SDR | "signals → outreach" |
+| Catalog pages: Email finder API / Email verification API / People search API / Person & company enrichment API | Rebuild Clay | provider tables cite them |
+| Agent pages (`/for/claude-code`, `/for/cursor`, Claude MCP) | every rebuild page | install block per agent |
+| `skill.md`, `llms.txt` | `/rebuild/` index | one line: "recipes that rebuild Clay, Gojiberry, an AI SDR on the catalog" |
+
+Reverse links: each rebuild page's provider table links to the matching catalog comparison page; each "what we don't do" section links to the use-case page that covers the adjacent job.
+
+## Honesty rules carried into every draft
+
+- treg **compares** providers; the script does the waterfall. Never "routes", never "fails over".
+- Findymail/Fiber misses bill at full rate until `_observed_cost_micro` is fixed — "a miss costs nothing" only for providers where it's measured true (tomba, hunter, leadmagic).
+- Catalog gaps stated on the page: website → markdown scraping; keyword-level LinkedIn engagement monitoring; the *likers* of a post (the post endpoint returns commenters with URLs and only a like count); visitor de-anonymization; sending.
+- Scripts use the real parameter shapes from `catalog get` (checked 2026-08-27 for tomba, findymail, hunter, leadsforge, leadmagic, icypeas people search, scrapecreators post). Icypeas's email finder/verifier are async and stay out of sync loops. Response paths (`.data.email`, `.contact.email`, `.items[0]`) still need confirming against a live run before publish.
+- Vendor benchmarks cited as vendor benchmarks (Woodpecker 3.43%, Expandi 10.3%, Instantly 17–18%).
+- No Clay price numbers we haven't verified; use their public credit model and the G2 quote Explorium cites ("stated 11 credits/row, actual 25").

--- a/marketing/rebuild/01-rebuild-clay.md
+++ b/marketing/rebuild/01-rebuild-clay.md
@@ -78,7 +78,7 @@ Run it over a CSV and you have Clay's "Find work email" waterfall column. Add th
 ## Where Clay is still the right buy
 
 - You want a spreadsheet, not a script. The table is genuinely good.
-- You need Claygent-style "read the website and answer a question per row." The catalog has no website-to-markdown tool today (a `catalog_request` is open); use Firecrawl or Perplexity on your own key for that step.
+- You need Claygent-style "read the website and answer a question per row." The catalog has no raw website-to-markdown tool; it does have named-field extraction by domain (`branddev.brand.ai.query`, $0.025), which covers the structured half. For free-text reading use Firecrawl or Perplexity on your own key.
 - You run 50 tables unattended and want Clay's queueing and rate-limit handling. Here, that's your job.
 - Open-source route: YALC (MIT, CLI-first, runs in Claude Code) does the orchestration half; it still needs a key per provider, which is the half this page replaces.
 
@@ -86,7 +86,7 @@ Run it over a CSV and you have Clay's "Find work email" waterfall column. Add th
 
 ```bash
 curl -fsSL https://treg.to/install.sh | sh     # adds skill.md to Claude Code / Cursor
-treg skill install rebuild-clay                  # the waterfall as a SKILL.md
+# the waterfall script above is the recipe; a packaged skill is not published yet
 ```
 
 Related: [Find and verify decision-makers from one agent prompt](/use-cases/lead-enrichment-for-ai-agents/) · [Email finder API: 6 providers compared](/catalog/email-finder-api) · [Email verification API: 3 verifiers compared](/catalog/email-verification-api) · [Research any company list without buying a database](/use-cases/company-research-for-ai-agents/)

--- a/marketing/rebuild/01-rebuild-clay.md
+++ b/marketing/rebuild/01-rebuild-clay.md
@@ -1,0 +1,92 @@
+---
+page_id: r1
+slug: /rebuild/clay/
+seo_title: "Clay Alternative: Rebuild the Waterfall in 40 Lines | treg.to"           # 58
+meta_description: "Rebuild Clay's enrichment waterfall on six email providers with one token. Per-call prices, a real run receipt, and the honest list of what Clay still does better."  # 158
+h1: "Rebuild Clay: the enrichment waterfall, priced per call"
+seo_terms:
+  primary: "clay alternative"            # 480/mo, CPC $36.72, KD 0
+  secondary:
+    - "clay pricing"                     # 1,900
+    - "clay api"                         # 390
+    - "clay vs apollo"                   # 260
+    - "waterfall enrichment"             # 140
+    - "open source clay alternative"     # 10, but the SERP is the builders
+capabilities: [people.email.find, people.email.verify, people.search, companies.enrich, companies.tech_stack]
+links_out: [/use-cases/lead-enrichment-for-ai-agents/, /use-cases/company-research-for-ai-agents/, catalog:email-finder-api, catalog:email-verification-api, catalog:people-search-api]
+links_in: [p2, p5, catalog:email-finder-api, /for/claude-code]
+status: draft 2026-08-27 · needs a real run receipt before publish
+---
+
+# Rebuild Clay: the enrichment waterfall, priced per call
+
+Clay's moat, in the words of the agency that runs 250 Clay tables at once: "150-plus pre-negotiated data providers — one datapoint from HG Insights without an HG contract." That is the part people pay for. The visual table is the wrapper.
+
+This page rebuilds that part. One token, six email-finding providers, a verifier, a people search and a tech-stack check, called in order until one answers. Forty lines. Every call has a price on it before you run it.
+
+It does not rebuild the table, the Claygent research column, or the 150 integrations. The last section says exactly where Clay is still the right buy.
+
+## What a Clay row actually costs
+
+Clay bills in credits, and the credit cost of a row depends on which providers the waterfall touches. Users report the gap between stated and actual: "Per-row credit cost can vary 100% from stated amounts (e.g., stated 11 credits/row, actual 25)" — a verified G2 review. r/gtmengineering's most-commented threads this year are "cost-effective alternatives to Clay" (50+ comments) and a founder whose last ten customers "migrated from Clay" because the alternative was "50 to 70% cheaper."
+
+The per-call version has no credit. A found email is one price; a verification is another; you see both before the call.
+
+| Step | Providers, one token | Price per call | Measured |
+|---|---|---|---|
+| Find a work email (name + domain) | tomba → icypeas → findymail → hunter → leadsforge → leadmagic | $0.0089 → $0.019 → $0.0198 → $0.0245 → $0.0245 → $0.025 | hunter 5,206 calls · leadmagic 3,130 · tomba 445 (98%) |
+| Verify it | icypeas → leadmagic → hunter | $0.0019 → $0.00625 → $0.01225 | leadmagic 2,997 calls, 100% |
+| Find the person by title | icypeas.people.search → findymail.search.employees | $0.00038 → $0.0198 | icypeas 347 calls |
+| Tech stack by domain | tomba.companies.tech_stack | $0.0089 | 8 calls |
+| Company profile | scrapecreators LinkedIn company page | $0.00188 | 754 calls, 100% |
+
+Typical case, first or second provider hits: **$0.01–0.03 per verified email**. Every finder in the loop documents a miss as free, and for tomba, hunter, leadmagic and leadsforge we have watched the credit counter confirm it. One caveat from our own ledger: treg currently meters findymail (and Fiber) at the full rate whether or not the call hits, until the cost parser for those providers is fixed — budget findymail rungs as if every call were a hit.
+
+## The script
+
+```bash
+# waterfall.sh — find + verify one work email across five sync providers, cheapest first, stop at first hit
+NAME="$1"; DOMAIN="$2"; FIRST="${NAME%% *}"; LAST="${NAME#* }"
+try() { EMAIL=$(eval "$2" | jq -r "$3 // empty"); [ -n "$EMAIL" ] && VIA="$1"; }
+try tomba     "treg call tomba.people.email.find --query domain=$DOMAIN --query 'full_name=$NAME'"                                   '.data.email'
+[ -z "$EMAIL" ] && try findymail "treg call findymail.search.name --method POST --data '{\"name\":\"$NAME\",\"domain\":\"$DOMAIN\"}'" '.contact.email'
+[ -z "$EMAIL" ] && try hunter    "treg call hunter.people.email.find --query domain=$DOMAIN --query 'full_name=$NAME'"                '.data.email'
+[ -z "$EMAIL" ] && try leadsforge "treg call leadsforge.people.email.find --method POST --data '{\"firstName\":\"$FIRST\",\"lastName\":\"$LAST\",\"companyDomain\":\"$DOMAIN\"}'" '.email'
+[ -z "$EMAIL" ] && try leadmagic "treg call leadmagic.people.email.find --method POST --data '{\"full_name\":\"$NAME\",\"domain\":\"$DOMAIN\"}'" '.email'
+[ -z "$EMAIL" ] && { echo "miss"; exit 1; }
+STATUS=$(treg call leadmagic.people.email.verify --method POST --data "{\"email\":\"$EMAIL\"}" | jq -r '.email_status')
+echo "$EMAIL  $STATUS  via $VIA"
+```
+
+Each provider has its own parameter shape — two take a query string, three take a JSON body — which is exactly the tedium Clay's waterfall column hides. `treg catalog get <endpoint>` prints the exact input, the response path and the price. Icypeas is left out of the sync loop because its finder and verifier are async (submit, then read the result by id); add it as the sixth rung with `icypeas.bulk.search` when you run lists. The loop is the whole product: treg shows the providers side by side with price and success rate — **the script picks the order; treg does not route or fail over on its own.**
+
+Run it over a CSV and you have Clay's "Find work email" waterfall column. Add the people search in front and you have the "Find people at company" column. Add the tech-stack call and you have the "Uses Salesforce?" filter.
+
+## The run receipt
+
+> `[to be pasted from the real run before publish: 50 contacts from a Series-B SaaS list — N found on provider 1, N on provider 2…, N verified deliverable, total $X.XX, wall time]`
+
+## Clay vs Apollo vs this
+
+| | Clay | Apollo | Per-call catalog |
+|---|---|---|---|
+| Data | 150+ providers behind credits | One provider's database ("under 10% valid phone numbers in our industry" — r/n8n) | 6 email finders, 3 verifiers, 11 company-search providers, each priced |
+| Pricing unit | Credits, monthly plan | Seats + credits; export is "too expensive," so people scrape it via Apify | Per call, prepaid balance, $1.00 free |
+| Orchestration | The table, Claygent, integrations | The app | Your script, n8n, or Claude Code — the catalog is only the data layer |
+| Where it wins | Non-technical teams, edge cases, 50 tables running unattended | Search graph for building TAM | Anyone who already runs their outbound from code or an agent |
+
+## Where Clay is still the right buy
+
+- You want a spreadsheet, not a script. The table is genuinely good.
+- You need Claygent-style "read the website and answer a question per row." The catalog has no website-to-markdown tool today (a `catalog_request` is open); use Firecrawl or Perplexity on your own key for that step.
+- You run 50 tables unattended and want Clay's queueing and rate-limit handling. Here, that's your job.
+- Open-source route: YALC (MIT, CLI-first, runs in Claude Code) does the orchestration half; it still needs a key per provider, which is the half this page replaces.
+
+## Install
+
+```bash
+curl -fsSL https://treg.to/install.sh | sh     # adds skill.md to Claude Code / Cursor
+treg skill install rebuild-clay                  # the waterfall as a SKILL.md
+```
+
+Related: [Find and verify decision-makers from one agent prompt](/use-cases/lead-enrichment-for-ai-agents/) · [Email finder API: 6 providers compared](/catalog/email-finder-api) · [Email verification API: 3 verifiers compared](/catalog/email-verification-api) · [Research any company list without buying a database](/use-cases/company-research-for-ai-agents/)

--- a/marketing/rebuild/02-rebuild-linkedin-intent.md
+++ b/marketing/rebuild/02-rebuild-linkedin-intent.md
@@ -1,0 +1,92 @@
+---
+page_id: r2
+slug: /rebuild/linkedin-intent-signals/
+seo_title: "Gojiberry & Trigify, Rebuilt: LinkedIn Intent From $0.002 a Post | treg.to"   # 66 → trim to "Rebuild Gojiberry: LinkedIn Intent Signals From $0.002 | treg.to"
+meta_description: "Gojiberry, Trigify and Teamfluence sell LinkedIn intent as a subscription with no API. Here is the same loop — competitor-post engagers, profile pull, funding check — as a script with prices."  # 178 → trim
+h1: "Rebuild Gojiberry: LinkedIn intent signals, per post, per profile"
+seo_terms:
+  primary: "gojiberry ai"                # 1,600/mo
+  secondary:
+    - "trigify"                          # 720
+    - "teamfluence"                      # 90
+    - "linkedin post scraper"            # 110
+    - "linkedin profile scraper"         # 210
+    - "buying signals"                   # 260
+    - "intent signals"                   # 170
+capabilities: [linkedin.post, linkedin.user.profile, linkedin.user.posts, people.search, people.email.find, companies.funding]
+links_out: [/use-cases/company-buying-signals/, /use-cases/social-creator-trends/, /rebuild/clay/, /rebuild/ai-sdr/]
+links_in: [p3, p5, /for/claude-code]
+status: draft 2026-08-27 · one honest gap stated (keyword-level monitoring) · needs a run receipt
+---
+
+# Rebuild Gojiberry: LinkedIn intent signals, per post, per profile
+
+A GDPR/SOC 2 vendor went from $0 to $2M ARR on one LinkedIn play, per its founder's post this week (549 bookmarks): watch who in your ICP engages with compliance content and with your competitors' posts, enrich them, contact them while the signal is fresh, and stack the signals — fit, plus topic engagement, plus follows a competitor, plus just raised. "Fit tells you who CAN buy. Intent tells you who might buy NOW."
+
+Gojiberry, Trigify and Teamfluence sell that loop as a subscription. None of them sells an API. This page is the loop as a script, with a price on each step, and one part it can't do yet, stated plainly.
+
+## The loop, step by step
+
+| Step (Pierre's playbook) | Call | Price | Measured |
+|---|---|---|---|
+| 6. Who commented on a competitor's post | `scrapecreators.x.v1-linkedin-post` — commenters with profile URLs, plus the like count | $0.00188 | 21 calls, 100% |
+| 2/4. Who they are — title, company, tenure | `scrapecreators.linkedin.user.profile` | $0.00188 | 1,997 calls, 99.9% |
+| 2. What they've been saying | `tikhub.x.linkedin-web-v2-get-user-posts` — a person's recent posts | $0.001 | 78 calls, 100% |
+| 3. Filter to ICP (role, size, geo) | `scrapecreators.x.v1-linkedin-company` — headcount, industry | $0.00188 | 754 calls, 100% |
+| 7. Did the company just raise | `aviato.companies.funding_rounds` · `predictleads.companies.financing_events` | $0.01 · $0.04 | 7 · 228 calls |
+| 4. Email + verify | the [Clay waterfall](/rebuild/clay/) | $0.01–0.03 | — |
+
+Per engager, fully enriched with a funding check: **about $0.05**. A hundred engagers on three competitor posts: about $5, and you own the list.
+
+## The script
+
+```bash
+# commenters.sh — everyone who commented on a post, scored against the ICP
+POST_URL="$1"
+treg call scrapecreators.x.v1-linkedin-post --query "url=$POST_URL" \
+  | jq -r '.comments[].linkedinUrl' | sort -u > commenters.txt
+
+while read -r P; do
+  PROFILE=$(treg call scrapecreators.linkedin.user.profile --query "url=$P")
+  TITLE=$(echo "$PROFILE" | jq -r '.headline'); CO=$(echo "$PROFILE" | jq -r '.current_company.url')
+  COMPANY=$(treg call scrapecreators.x.v1-linkedin-company --query "url=$CO")
+  SIZE=$(echo "$COMPANY" | jq -r '.employee_count'); DOMAIN=$(echo "$COMPANY" | jq -r '.website')
+  RAISED=$(treg call aviato.companies.funding_rounds --query "domain=$DOMAIN" | jq -r '.rounds[0].date // ""')
+  echo -e "$P\t$TITLE\t$SIZE\t$RAISED"
+done < commenters.txt > scored.tsv
+```
+
+Commenters, not likers: the post endpoint returns each commenter's name and profile URL but only a *count* of reactions. Commenters are the stronger signal anyway — a comment is a sentence of intent, a like is a thumb — but if you need the likers list, that is PhantomBuster/Vayne territory on your own key.
+
+Then the stack, as a score, not a vibe:
+
+```python
+score  = 10 if fits_icp(title, size, geo) else 0          # fit
+score += 15 if engaged_with_topic_post else 0             # step 2
+score += 20 if engaged_with_competitor_post else 0        # step 6
+score += 30 if raised_within_days(RAISED, 180) else 0     # step 7
+# >= 50 → "call them now" (Pierre's step 8)
+```
+
+## The honest gap
+
+Pierre's step 2 — **monitor everyone in your ICP engaging with content around keywords** — is a keyword-level feed across all of LinkedIn. That feed is what Gojiberry and Trigify actually are. The catalog can read the engagers on posts you name (yours, a competitor's, an industry account's) but cannot search LinkedIn by topic today. A `catalog_request` for it is open. Until then, curate 20–30 source posts a week by hand; three competitor pages plus two industry voices covered the vendor in Pierre's story.
+
+Also not here: sending. LinkedIn caps sit at ~100 invites per rolling week, 20–25 a day, and browser-click automation gets whole user bases banned. Send by hand, or through HeyReach/Unipile on your own key. The catalog reads; it does not press the button.
+
+## The run receipt
+
+> `[three competitor posts → N unique engagers → N ICP fits → N with a raise in 180 days → N verified emails, total $X.XX]`
+
+## Gojiberry vs Trigify vs this
+
+| | Gojiberry | Trigify | Per-call catalog |
+|---|---|---|---|
+| Keyword monitoring across LinkedIn | Yes | Yes | No (gap stated above) |
+| Engagers on named posts | Likers + commenters | Likers + commenters | Commenters, $0.00188 per post; likers are a gap |
+| Profile + company + funding enrichment | Bundled | Bundled | $0.002 + $0.002 + $0.01, itemized |
+| API | No | No | Everything is an API |
+| Pricing | Subscription | Subscription | Per call, prepaid |
+| Sending | Built in | Built in | Not here, by design |
+
+Related: [Company data and buying signals](/use-cases/company-buying-signals/) · [Rebuild Clay](/rebuild/clay/) · [Rebuild an AI SDR](/rebuild/ai-sdr/) · [Social & creator tools](/use-cases/social-creator-trends/)

--- a/marketing/rebuild/02-rebuild-linkedin-intent.md
+++ b/marketing/rebuild/02-rebuild-linkedin-intent.md
@@ -68,9 +68,9 @@ score += 30 if raised_within_days(RAISED, 180) else 0     # step 7
 # >= 50 → "call them now" (Pierre's step 8)
 ```
 
-## The honest gap
+## The honest scope (corrected after review, 2026-08-28)
 
-Pierre's step 2 — **monitor everyone in your ICP engaging with content around keywords** — is a keyword-level feed across all of LinkedIn. That feed is what Gojiberry and Trigify actually are. The catalog can read the engagers on posts you name (yours, a competitor's, an industry account's) but cannot search LinkedIn by topic today. A `catalog_request` for it is open. Until then, curate 20–30 source posts a week by hand; three competitor pages plus two industry voices covered the vendor in Pierre's story.
+Pierre's step 2, monitoring everyone in your ICP who engages with content around keywords, is a keyword-level feed across all of LinkedIn; that feed is what Gojiberry and Trigify actually are. The catalog gets most of the way there with two calls the first draft of this page wrongly called gaps: `scrapecreators.x.v1-linkedin-search-posts` finds public posts by keyword through Google's index (621 calls measured, 99.7% ok, $0.00188, `date_posted=last-week`), and `aviato.linkedin.post.reactions` lists a post's reactors by URN ($0.02 per success, 100 per page; JustOneAPI is the sibling at $0.03). So the honest pipeline is: scheduled keyword search over public posts → reactions and comments per post → profile → ICP filter → funding check. What it is not: LinkedIn's own feed, private posts, or a real-time stream. Say that on the page.
 
 Also not here: sending. LinkedIn caps sit at ~100 invites per rolling week, 20–25 a day, and browser-click automation gets whole user bases banned. Send by hand, or through HeyReach/Unipile on your own key. The catalog reads; it does not press the button.
 
@@ -82,8 +82,8 @@ Also not here: sending. LinkedIn caps sit at ~100 invites per rolling week, 20�
 
 | | Gojiberry | Trigify | Per-call catalog |
 |---|---|---|---|
-| Keyword monitoring across LinkedIn | Yes | Yes | No (gap stated above) |
-| Engagers on named posts | Likers + commenters | Likers + commenters | Commenters, $0.00188 per post; likers are a gap |
+| Keyword monitoring across LinkedIn | Their own feed | Their own feed | Public posts via Google's index, $0.00188 a search, scheduled by you |
+| Engagers on named posts | Likers + commenters | Likers + commenters | Commenters $0.00188 per post; reactors $0.02 per page of 100 |
 | Profile + company + funding enrichment | Bundled | Bundled | $0.002 + $0.002 + $0.01, itemized |
 | API | No | No | Everything is an API |
 | Pricing | Subscription | Subscription | Per call, prepaid |

--- a/marketing/rebuild/03-rebuild-ai-sdr.md
+++ b/marketing/rebuild/03-rebuild-ai-sdr.md
@@ -1,0 +1,84 @@
+---
+page_id: r3
+slug: /rebuild/ai-sdr/
+seo_title: "Build Your Own AI SDR: Open Source, Priced Per Lead | treg.to"     # 58
+meta_description: "An AI SDR is a loop: signal, list, enrich, research, draft, send, triage. Here is the open-source version with treg as the data layer — every call priced, sending left to your sequencer."  # 176 → trim
+h1: "Build your own AI SDR: the open-source loop, with prices"
+seo_terms:
+  primary: "ai sdr"                      # 1,900/mo, −46% YoY, CPC $92
+  secondary:
+    - "ai sdr tools"                     # 210
+    - "ai sdr open source"               # SERP is a bare GitHub repo at #1
+    - "build ai sdr"
+    - "outbound agent"                   # 70
+capabilities: [jobs.search, companies.funding, people.search, people.email.find, people.email.verify, linkedin.user.posts]
+links_out: [/rebuild/clay/, /rebuild/linkedin-intent-signals/, /use-cases/company-buying-signals/, /use-cases/lead-enrichment-for-ai-agents/]
+links_in: [p2, p5, /for/claude-code, /for/cursor]
+status: draft 2026-08-27 · needs a run receipt
+---
+
+# Build your own AI SDR: the open-source loop, with prices
+
+"AI SDR is a bullshit category, $45M later, still can't sell" is a top post on r/salesdevelopment this month. The complaint is specific: the funded products send from burned domains, personalize from scraped bios, and "over half of buyers churn inside 90 days." One founder who dogfoods his own: 1,842 contacts → 11.6% reply → 52 booked → 31 held. "The tool is maybe 30% of this. The list filter and the first line are the other 70%."
+
+So this page is the 70%. It is the AI SDR as a loop you own — the shape every serious build guide converges on — with treg as the data layer and your existing sequencer as the hands. It is not a product that sends.
+
+## The loop
+
+| Stage | What runs | Data layer call | Price |
+|---|---|---|---|
+| Signal | Companies that posted SDR/AE roles this week, or raised in 90 days | `apify.linkedin.search.jobs` · `predictleads.financing.discover` | $0.001 · $0.04 |
+| List | The VP Sales / Head of RevOps at each | `icypeas.people.search` | $0.00038 |
+| Enrich + verify | Work email, waterfall, then verify | [the Clay waterfall](/rebuild/clay/) | $0.01–0.03 |
+| Research | Their last three posts; the company page | `tikhub…get-user-posts` · `scrapecreators.x.v1-linkedin-company` | $0.001 · $0.00188 |
+| Draft | Claude fills a fixed template (never writes the whole email) | your model | — |
+| Send + sequence | Instantly / Smartlead / Lemlist, your key | own tool via treg, never metered | — |
+| Triage | Six labels: interested / not now / OOO / referral / unsubscribe / angry | your model | — |
+| Feedback | Reply rate by segment, weekly | Sheets / SQLite | — |
+
+**About $0.05 per fully researched lead.** The $18K/month SDR vs $200/month agent framing that vendors use is theirs; ours is that the data for a lead costs less than a nickel and you can see it before you spend it.
+
+## The script (the first four stages)
+
+```bash
+# sdr-signal.sh — hiring-signal list for one week
+treg call apify.linkedin.search.jobs --query 'title=Sales Development Representative' --query 'posted=week' \
+  | jq -r '.[] | .company_domain' | sort -u > companies.txt
+
+while read -r D; do
+  P=$(treg call icypeas.people.search --method POST --data "{\"query\":{\"currentCompanyWebsite\":{\"include\":[\"$D\"]},\"currentJobTitle\":{\"include\":[\"VP Sales\",\"Head of Sales\",\"CRO\"]}},\"pagination\":{\"size\":1}}" | jq -c '.items[0]')
+  NAME=$(echo "$P" | jq -r '.firstname + " " + .lastname'); LI=$(echo "$P" | jq -r '.linkedinUrl')
+  EMAIL=$(./waterfall.sh "$NAME" "$D")                 # from /rebuild/clay
+  POSTS=$(treg call tikhub.x.linkedin-web-v2-get-user-posts --query "url=$LI" | jq -r '[.posts[:3][].text] | join(" | ")')
+  echo -e "$D\t$NAME\t$EMAIL\t$POSTS"
+done < companies.txt > leads.tsv
+```
+
+## The first line (the part that decides the 70%)
+
+The rules that operators agree on, from 24M+ sends of teardown material:
+
+- One signal per email. "Saw you've got two SDR roles open" beats a paragraph about their mission.
+- The LLM fills a template; it does not compose. Otherwise you can't A/B anything.
+- Feed it 25+ of your own hand-written emails and say "copy style, not content."
+- Under 85 words. No link in email one. No "hope this finds you well."
+- Openers that are an *inference* ("two SDR roles plus an enablement hire in one month reads like a ramp problem, not headcount") outperform scraped facts, because scraped facts read as scraped.
+
+```
+System: You write the first line of a cold email. Input: a hiring signal and the prospect's last three posts.
+Output one sentence, under 25 words, that infers what the signal means for them. Never quote a post. Never say "I noticed."
+Examples: [your 25 real first lines]
+```
+
+## What this does not do
+
+- **Send.** Deliverability is domains, warmup, 30–40 per inbox per day, and cancelling a domain under 0.7% reply. That is Instantly/Smartlead's job; connect yours as an own-key tool and the calls are never metered.
+- **De-anonymize site visitors.** RB2B / Warmly, own key.
+- **Read a prospect's website.** The catalog has no page-to-markdown tool yet (request open). Firecrawl on your own key for that stage.
+- **Route between providers.** The script picks the order; treg shows the options.
+
+## The run receipt
+
+> `[one week of SDR postings → N companies → N VP-level contacts → N verified emails → N first lines, total $X.XX]`
+
+Related: [Rebuild Clay](/rebuild/clay/) · [Rebuild Gojiberry](/rebuild/linkedin-intent-signals/) · [Company data and buying signals](/use-cases/company-buying-signals/) · [Find and verify decision-makers](/use-cases/lead-enrichment-for-ai-agents/)

--- a/marketing/rebuild/03-rebuild-ai-sdr.md
+++ b/marketing/rebuild/03-rebuild-ai-sdr.md
@@ -74,7 +74,7 @@ Examples: [your 25 real first lines]
 
 - **Send.** Deliverability is domains, warmup, 30–40 per inbox per day, and cancelling a domain under 0.7% reply. That is Instantly/Smartlead's job; connect yours as an own-key tool and the calls are never metered.
 - **De-anonymize site visitors.** RB2B / Warmly, own key.
-- **Read a prospect's website.** The catalog has no page-to-markdown tool yet (request open). Firecrawl on your own key for that stage.
+- **Read a prospect's website as free text.** The catalog extracts named fields from a site by domain (`branddev.brand.ai.query`, $0.025) but has no raw page-to-markdown tool; Firecrawl on your own key for prose.
 - **Route between providers.** The script picks the order; treg shows the options.
 
 ## The run receipt

--- a/marketing/rebuild/04-gtm-engineering-stack.md
+++ b/marketing/rebuild/04-gtm-engineering-stack.md
@@ -1,0 +1,63 @@
+---
+page_id: r4
+slug: /rebuild/gtm-engineering-stack/
+seo_title: "GTM Engineering Stack 2026: Nine Layers, Priced Per Call | treg.to"     # 61
+meta_description: "What a GTM engineer actually runs in 2026 — signal, list, enrich, research, write, send, LinkedIn, triage, analytics — with the tools per layer and what each call costs."  # 168 → trim
+h1: "The GTM engineering stack, priced"
+seo_terms:
+  primary: "gtm engineering"             # 3,600/mo, LOW competition, CPC $9.32
+  secondary:
+    - "gtm engineer"                     # 3,600
+    - "gtm agent"                        # 170
+    - "outbound agent"                   # 70
+    - "clay vs apollo"                   # 260
+capabilities: [all outbound capabilities]
+links_out: [/rebuild/clay/, /rebuild/linkedin-intent-signals/, /rebuild/ai-sdr/, /use-cases/lead-enrichment-for-ai-agents/, /use-cases/company-research-for-ai-agents/]
+links_in: [/resources, /for/claude-code, skill.md]
+status: draft 2026-08-27 · price table to be regenerated from the catalog at build time
+---
+
+# The GTM engineering stack, priced
+
+"GTM engineer" is the job that appeared when outbound moved from seats to scripts. The stack has settled into nine layers; an agency that runs outbound for 100+ AI companies describes it as "21 MCP connections from one Claude Code terminal." What no stack post shows is the price of each layer per lead. This one does, from the catalog's measured rate card, with the honest column for what still needs a subscription.
+
+## The nine layers
+
+| Layer | Job | Subscription tools people name | Per-call, one token | Per lead |
+|---|---|---|---|---|
+| 1. Signal | Who's in market this week | PredictLeads, Common Room, RB2B, Warmly, Gojiberry, Trigify | job postings `apify.linkedin.search.jobs`; funding `aviato` / `predictleads`; post engagers `scrapecreators` | $0.001–0.04 |
+| 2. List | The right person at each account | Apollo, Sales Nav, Crustdata, Prospeo | `icypeas.people.search`, `findymail.search.employees`, `leadmagic.x.role-finder` | $0.0004–0.05 |
+| 3. Enrich | Verified email, phone, firmographics | Clay, FullEnrich, ZoomInfo | six email finders + three verifiers ([the waterfall](/rebuild/clay/)) | $0.01–0.03 |
+| 4. Research | What they said, what they run | Firecrawl, Exa, Perplexity, Claygent | LinkedIn posts `tikhub`, company page `scrapecreators`, tech stack `tomba` | $0.001–0.009 · website scrape: gap |
+| 5. Write | The first line and the sequence | Claude, GPT | your model | — |
+| 6. Send | Domains, warmup, rotation, replies | Instantly, Smartlead, Lemlist, Email Bison | own-key tool, never metered | — |
+| 7. LinkedIn | Connect, message, inside 100/week | HeyReach, Expandi, Unipile, PhantomBuster | read-only here; send on your key | — |
+| 8. Triage | Classify replies, pause, hand off | Claude | your model | — |
+| 9. Analytics | Reply rate by segment, domain health | Sheets, Supabase | own-key Search Console / Ads when the loop includes SEO | — |
+
+**Data layers 1–4 together: roughly $0.02–0.10 per fully researched lead**, visible before the call. Layers 5–9 are where the money and the risk live, and the catalog does not pretend to own them.
+
+## The orchestrator question
+
+Three camps, all using the same data layer:
+
+- **n8n / Make** — visual, Sheets as the database, polling loops for async scrapers. The Reddit "here's my system" posts.
+- **Claude Code + skills** — the fastest-growing. "We took every UI out of our outbound stack," says one agency; Growth Unhinged reports mature teams moving MCP → CLI because MCP costs 10–32x the tokens. YALC (MIT) is the open-source Clay of this camp.
+- **Cowork + vendor MCPs** — Apollo, Clay, HubSpot, Lemlist connectors, no code.
+
+The catalog is the same in all three: `treg call` from a shell, an HTTP node in n8n, or the MCP server in Claude Code. Pick by what your team can debug at 2am.
+
+## The rules the operators agree on
+
+- Write the entry rule before you buy a tool: how many signals must be true, and how recent, before an account enters a send. Five to ten.
+- Micro-campaigns of 50–250 contacts, lists under 30 days old.
+- Qualify before you spend on enrichment; it drops ~40% of the list and doubles replies.
+- One signal per email. The LLM fills a template.
+- Cancel a domain at <0.7% reply. Keep two control inboxes running a known-good sequence so you can tell whether Google moved or you did.
+- LinkedIn: 100 invites per rolling week, comment-first warming, acceptance above 25–40% or you're throttled.
+
+## What this stack does not include
+
+Sending, warming, visitor de-anonymization, website-to-markdown (catalog request open), keyword-level LinkedIn monitoring (same). Anyone selling "one agent does all nine layers" is selling layers 5–9 on a data layer they don't price.
+
+Related recipes: [Rebuild Clay](/rebuild/clay/) · [Rebuild Gojiberry](/rebuild/linkedin-intent-signals/) · [Build your own AI SDR](/rebuild/ai-sdr/) · [The join problem](/rebuild/join-problem/)

--- a/marketing/rebuild/05-join-problem.md
+++ b/marketing/rebuild/05-join-problem.md
@@ -1,0 +1,69 @@
+---
+page_id: r5
+slug: /rebuild/join-problem/
+seo_title: "The Join Problem: Signal + Person in Three Calls | treg.to"       # 55
+meta_description: "Cold outreach fails on timing, not wording. The trigger and the person live in different records. Here is the join — funding feed, people search, profile — as three priced calls."  # 176 → trim
+h1: "The join problem: find the trigger and the person in one pass"
+seo_terms:
+  primary: "intent signals"              # 170 — editorial page; distribution is X Article + newsletter, not search
+  secondary:
+    - "buying signals"                   # 260
+    - "hiring signals"
+    - "company funding data"
+capabilities: [companies.funding, jobs.search, people.search, linkedin.user.profile, people.email.find]
+links_out: [/use-cases/company-research-for-ai-agents/, /rebuild/clay/, /rebuild/ai-sdr/]
+links_in: [p5, /rebuild/gtm-engineering-stack/]
+repurposed_from: "Akshay Pachaar / Daily Dose of DS, 'Build a Multi-Agent GTM Intelligence System' (Seltz-sponsored, 2026-08-24) — framing credited; pipeline rebuilt on the catalog with prices"
+status: draft 2026-08-27 · this is also the X Article and the DDoDS sponsorship brief
+---
+
+# The join problem: find the trigger and the person in one pass
+
+Most teams wait nine months after a lost deal to reach out again. The right moment isn't on the calendar. It's when something changed — a new VP joined, a round closed, a leadership hire landed in the right function.
+
+The problem, as a recent walkthrough on Daily Dose of DS put it, is that the signal and the person don't live in the same place. "Who just joined" is a people record. "What the company announced" is a news record. A search API returns snippets of each, so an agent has to search, fetch, parse, and repeat for every person and every company before it can answer "who should I email today, and why."
+
+That is the join problem. This page does the join with three calls, and prints what each one cost.
+
+## Three agents, three calls
+
+| Agent | Job | Call | Price | Measured |
+|---|---|---|---|---|
+| Signal Hunter | Trigger events at target companies in a window | `predictleads.financing.discover` (who just raised) · `apify.linkedin.search.jobs` (who's hiring) · `apollo.companies.news` | $0.04 · $0.001 · $0.026 | 228 · 92 · 1 |
+| People Enricher | The full record of the person the trigger names, or the person the role implies | `icypeas.people.search` → `scrapecreators.linkedin.user.profile` | $0.00038 → $0.00188 | 347 · 1,997 (99.9%) |
+| Outreach Strategist | Merge, rank, one-signal first line | your model over two complete records | — | — |
+
+Neither of the first two fetches a second page. The join in agent three is a merge across two full records, not a reconstruction from fragments. **Per ranked contact, about $0.045.**
+
+## The script
+
+```bash
+# join.sh — last 7 days of raises → the revenue leader at each → ranked
+treg call predictleads.financing.discover --query 'days=7' --query 'min_amount=5000000' \
+  | jq -c '.data[] | {domain:.attributes.domain, amount:.attributes.amount, date:.attributes.date}' > raises.jsonl
+
+while read -r R; do
+  D=$(echo "$R" | jq -r .domain)
+  P=$(treg call icypeas.people.search --method POST --data "{\"query\":{\"currentCompanyWebsite\":{\"include\":[\"$D\"]},\"currentJobTitle\":{\"include\":[\"VP Sales\",\"CRO\",\"Head of Revenue\"]}},\"pagination\":{\"size\":1}}" | jq -c '.items[0]')
+  PROF=$(treg call scrapecreators.linkedin.user.profile --query "url=$(echo "$P" | jq -r .linkedinUrl)")
+  jq -n --argjson r "$R" --argjson p "$P" --argjson prof "$PROF" '{trigger:$r, person:$p, record:$prof}'
+done < raises.jsonl > joined.jsonl
+```
+
+Then the strategist, which needs no retrieval:
+
+```
+For each record in joined.jsonl: rank by (amount, days since raise, seniority, tenure < 6 months).
+Write one first line, under 25 words, that infers what the raise means for this person's next quarter.
+Never say "congrats on the raise." Output JSON: {rank, domain, name, first_line, why}.
+```
+
+## When to chain with open web search
+
+The walkthrough this page credits was honest about its retrieval tool's limits, and the same honesty applies here. For the single most senior executive at a company, a plain web search is often the stronger first call; the catalog's people search is strongest at the director and VP layer below. For discovery — "which companies should I even target" — use search or the funding feed, then the catalog for depth on each. And for reading a company's own site, the catalog has no page-to-markdown tool yet; Firecrawl or Perplexity on your own key covers that stage.
+
+## The run receipt
+
+> `[7 days of raises ≥ $5M → N companies → N revenue leaders found → N profiles → top 10 ranked with first lines, total $X.XX, N minutes]`
+
+Related: [Research any company list without buying a database](/use-cases/company-research-for-ai-agents/) · [Rebuild Clay](/rebuild/clay/) · [Build your own AI SDR](/rebuild/ai-sdr/)

--- a/marketing/rebuild/06-grok-bot-use-cases.md
+++ b/marketing/rebuild/06-grok-bot-use-cases.md
@@ -37,8 +37,9 @@ real run.
 - `/agents/*` pages (all five) gain a **Workflows** section listing every workflow with its step
   count, plus the `.md` twin. `/agents/grok-bot` now links the lead-gen workflow directly.
 - `AGENTS["grok-bot"].faq` gains three Grok-specific entries: lead generation (points at the
-  workflow), research (the jobs by category), and what it cannot do yet (no sending, no LinkedIn
-  topic search, no likers, no page-to-markdown).
+  workflow), research (the jobs by category), and what it cannot do yet (no sending; LinkedIn post
+  search is public posts via Google's index, reactions come a page at a time; website reading is
+  named-field extraction, not raw markdown).
 
 ## Provider note — why the X-complaint recipe is not a workflow yet
 

--- a/marketing/rebuild/06-grok-bot-use-cases.md
+++ b/marketing/rebuild/06-grok-bot-use-cases.md
@@ -1,0 +1,59 @@
+---
+page_id: r6
+slug: /agents/grok-bot (existing) + /workflows/* (existing structure)
+seo_terms:
+  primary: "grok bot lead generation"     # null volume = too new to measure (Grok Bot shipped 2026-08-11); passes all 7 emerging-term gates
+  secondary:
+    - "grok bot use cases"                 # live autocomplete #3 for "grok bot "
+    - "grok bot for sales"
+    - "grok bot research"
+status: agent page extended 2026-08-28 (workflows section + 3 Grok-specific FAQ entries). The X-complaint recipe below stays a draft — see the provider note.
+---
+
+# Grok Bot use cases, mapped onto the structure that exists
+
+The site already has the right containers. Every Grok Bot use case is either a **job** (one call,
+`/use-cases/<job>`, listed on `/agents/grok-bot` under "The menu" with a category prompt) or a
+**workflow** (several jobs, one prompt, a receipt, `/workflows/<slug>`, now listed on every agent
+page under "Workflows"). Nothing new to build for the map itself; the work is which workflows get a
+real run.
+
+## The map
+
+| Use case people ask for (X, this week) | Structure | Jobs it chains | Run status |
+|---|---|---|---|
+| **Lead generation** — "find customers with Grok Bot" (@luismbat 4.5M views, @kristaletz 2.85M) | workflow | companies.search → people.search → people.email.find → people.email.verify → companies.news | **Live**: `/workflows/find-and-verify-a-lead-list`, receipt 2026-08-26, $3.62 / 50 companies |
+| Lead generation from X complaints — "people complaining about competitors / looking for an alternative" (the @luismbat recipe, Amplemarket in the enrich slot) | workflow | x.search.posts → x.user.profile → people.email.find → people.email.verify | **Draft, blocked**: see provider note |
+| Prospect research — funding, headcount, hiring, tech stack, news by domain | jobs | companies.enrich · companies.funding · companies.jobs · companies.tech_stack · companies.news | Live as jobs; the join-problem workflow (`05-join-problem.md`) needs its run |
+| People research — profile, recent posts, work email | jobs | linkedin.user.profile · linkedin.user.posts · people.email.find | Live as jobs |
+| Market research — who is hiring, what employees say, competitor ads | jobs (category "Market research" prompt already on the agent page) | jobs.search · employee reviews · ads.library | Live as jobs |
+| SEO research — keyword volume, who ranks, Search Console | jobs (category "Search & rankings") | keywords.volume · serp.organic · search-console.performance | Live as jobs |
+| Creator / social research — creators by keyword, a video's comments, a post's engagers | jobs (category "Social listening") | creators.search · youtube.comments · linkedin.post | Live as jobs |
+| Directory business — "curated data on a website" (@startupideaspod, 104K views) | workflow candidate | local businesses by keyword+location → reviews → enrich | Not run |
+| Review intelligence — a business's reviews, reply to your own | jobs | reviews · google-business-profile | Live as jobs |
+
+## What shipped today (in the discovery PR)
+
+- `/agents/*` pages (all five) gain a **Workflows** section listing every workflow with its step
+  count, plus the `.md` twin. `/agents/grok-bot` now links the lead-gen workflow directly.
+- `AGENTS["grok-bot"].faq` gains three Grok-specific entries: lead generation (points at the
+  workflow), research (the jobs by category), and what it cannot do yet (no sending, no LinkedIn
+  topic search, no likers, no page-to-markdown).
+
+## Provider note — why the X-complaint recipe is not a workflow yet
+
+Ran step 1 today: `tikhub.x.twitter-web-fetch-search-timeline` with `"looking for an alternative
+to" hubspot`, `search_type=Latest`, $0.001. Five posts came back, dated 2016–2024 (not latest),
+four of them vendors promoting HubSpot alternatives. A receipt built on that would say "5 posts,
+0 buyers". Either the provider's Latest mode is not latest, or the complaint phrasing needs the
+X API's recent search (`x.x.search-posts-recent`, own key, 44% observed ok rate). Re-run with a
+narrower query and the X-API sibling before writing the page; if it still returns vendors, the
+honest version of this workflow starts from competitor-post **commenters** on LinkedIn instead.
+
+## The emerging-term page
+
+"grok bot lead generation" has no measured volume yet (17 days old) and a soft SERP (x.ai
+announcement, a day-old YouTube, an r/AI_Agents thread, two setup guides). The page that targets it
+is **the existing lead-list workflow**, retitled for the term when it has an agent-specific
+rendering, or the X Article in `marketing/_grok-bot-treg-2026-08-28.md` linking to it. Day-7 /
+day-21 on exact-head position; autocomplete rechecked weekly.

--- a/marketing/rebuild/BUILD-PLAN.md
+++ b/marketing/rebuild/BUILD-PLAN.md
@@ -83,3 +83,26 @@ Format rules from the teardown: number and receipt in the first line, product na
 ## Sequence, compressed
 
 Decisions → rebase → runs 1–4 (parallel with catalog fixes) → port + tests → wiring + docs → publish one, then one a week → distribution cadence → day-30 review.
+
+## Corrections from the independent Codex review (2026-08-28, task_123bcea8fb2b, 20 findings)
+
+Accepted and applied to the drafts:
+
+- **Not gaps after all.** `scrapecreators.x.v1-linkedin-search-posts` (public posts by keyword, Google-indexed) and `aviato.linkedin.post.reactions` (reactors by post URN) exist; `branddev.brand.ai.query` does named-field extraction from a website. The two `catalog_request`s in §2 are withdrawn; the Gojiberry page and the Grok Bot FAQ now describe the real scope (public posts, paged reactions, structured website extraction, no raw markdown).
+- **Free-miss evidence.** Only Hunter and LeadMagic misses are derived by the ledger (`api.py`); Tomba, Findymail and Fiber misses settle at the estimate, and the live workflow's receipt already says so for Tomba. Budget all three at the estimate; say "documented" vs "observed" on the page. The "$0.01–0.03 per verified email" claim is unproven until a receipt; Tomba + Findymail + verify is about $0.035 today.
+- **Capability ids in the drafts are wrong** (`linkedin.post`, `jobs.search`, `companies.funding`). Derive every workflow step's capability from the chosen endpoint's catalog entry (`companies.funding_rounds`, `linkedin.search.posts`, `linkedin.post.reactions`, …); `test_every_workflow_step_capability_and_endpoint_exist` enforces it.
+- **Parameter shapes in the scripts are guessed** for Apify jobs (POST JSON `jobTitles`, `postedLimit`, a `maxItems` / `maxTotalChargeUsd` cap; rows carry no `company_domain`), Icypeas people search (`leads[]`, `profileUrl`), PredictLeads financing (`type`, `location`, `page`, `limit`; domains under `included`; `effective_date`, `amount_normalized`) and Aviato funding (`website`, `perPage`, `page`; `fundingRounds[].announcedOn`). Every script gets a one-row smoke run before it is quoted.
+- **`treg skill install rebuild-clay` does not exist.** Removed from the Clay draft; a packaged skill is a separate deliverable.
+- **Bare "treg" and em/en dashes in reader copy** violate CLAUDE.md and `test_no_em_dashes_in_the_hand_written_copy`; strip at port time (the shipped FAQ copy is already clean).
+- **Slugs.** The drafts link `/rebuild/...` and two non-existent use-case paths; the live ones are `/use-cases/social-trend-research-for-ai-agents` and `/use-cases/company-research-for-ai-agents`. Freeze the slug map before porting; add an internal-link 200 test (the sitemap walk does not check outbound links).
+
+Accepted, changes the plan:
+
+- **D1(a) is not a shipping option as written.** The `WORKFLOWS` renderer and `tests/test_agent_pages.py` require a dated run, `rows_in`, a row-outcome CSV under `src/treg/workflow_runs/`, a narrative, ≥4 failure modes, exactly 4 FAQ entries and 4 related labels. Aggregate-only receipts mean changing the renderer, spec, docs and tests together as a contract change, or shipping D1(b) with the anonymised CSV. Decision still Jason's; the default flips to D1(b).
+- **The renderer has no slot for the drafts' comparison tables, first-line rules or stack layers**; `seo_title`/`meta_description`/`h1` in the frontmatter are ignored. Port by a field-by-field matrix into the fixed sections, or extend the renderer with tested optional sections first.
+- **`once` cannot price a multi-provider waterfall or three named source posts.** The cardinality model is one call or `rows_in` calls per endpoint. Either store `calls_by_endpoint` in the run block (docs + tests) or constrain the first pages to workflows the model can express.
+- **Order after the crawl gate:** Clay first (or the existing lead-list workflow retitled toward "clay pricing"), a dedicated GTM page second only once it has a page type with its own title and canonical (`/resources` is one static file), Gojiberry third, AI SDR later, the join problem as distribution content.
+- **Measurement already exists:** every workflow CTA carries `/app?ref=wf-<slug>` and `sitetrack.js` records pageviews and first-touch UTM/referrer. Persist the `ref` through signup instead of adding a new `src` parameter; gate on indexed → non-brand impressions/position → CTA-to-first-call → clicks, separately.
+- **Branch note (§1) was stale** the moment the discovery branch was cut from main; the plan names branches by role now, not by name.
+
+Already done in PR #234 before the review landed: the crawl gate (hub links from the indexed pages, reverse indexes, `/catalog` prerender), the existing workflow used as the pilot and linked from every agent page, and the wiring tests in `tests/test_seo.py`.

--- a/marketing/rebuild/BUILD-PLAN.md
+++ b/marketing/rebuild/BUILD-PLAN.md
@@ -1,0 +1,85 @@
+# Build plan — the outbound cluster on treg.to
+
+Scope: the five drafts in this folder, the X distribution, the integrations, and the measurement loop. Ordered by dependency; each step names its file, its test, and the decision it needs.
+
+## 0. Decisions before code (Jason)
+
+| # | Decision | Default if unanswered |
+|---|---|---|
+| D1 | **Receipt policy.** (a) aggregate receipt only — counts + cost, no CSV, no per-row; (b) current spec — aggregate + anonymised row-outcome CSV; (c) no receipts — publish as prompt + live-price step table, use-case style | (a). Honest, no person data, still a run behind it |
+| D2 | **Page type.** Port into `agent_pages.WORKFLOWS` (gets the hub, `.md` twin, HowTo schema, tests for free) vs a new "recipe" type | WORKFLOWS. Don't add a fourth generator |
+| D3 | **Slugs.** `/workflows/rebuild-clay` etc. vs job-phrased slugs (`/workflows/find-and-verify-a-lead-list` style) | Job-phrased slug, "Rebuild Clay" in the H1/title. Slugs are forever; brand names aren't |
+| D4 | Sponsor the Daily Dose of DS slot (budget) | Ask for the rate; decide after step 5 ships |
+
+## 1. Branch hygiene (30 min)
+
+- This worktree is 245 commits behind `origin/main`; `/workflows`, `/tools`, `/agents`, `/pricing` exist only on main. **Rebase `seo/pages-2026-08-24` onto main** before touching `agent_pages.py`.
+- Commit the untracked research + drafts as docs (`marketing/`), separate from code.
+- Run `bash .agents/skills/tools-registry-context/scripts/drift.sh` at the end of every code step; `docs/context/interface/seo.md` is the fragment that moves.
+
+## 2. Catalog prerequisites (1–2 days, mostly waiting)
+
+| Item | Why | Where |
+|---|---|---|
+| Fix `_observed_cost_micro` for findymail / fiber | drafts say "a miss is free"; the ledger bills the miss | `src/treg/…` per memory note; money code — ledger rules apply |
+| `catalog_request`: website → markdown | 3 of 8 systems have the step; the AI SDR and Clay pages state it as a gap until it lands | catalog |
+| `catalog_request`: LinkedIn post *likers* and keyword-level engagement search | the Gojiberry page's two stated gaps | catalog |
+| Confirm response paths | `.data.email`, `.contact.email`, `.items[0]`, `.comments[].linkedinUrl` — read from `catalog get` examples, not yet exercised | one call each |
+
+None of these block writing; they change what the pages are allowed to claim.
+
+## 3. The runs (½ day each, 5 pages)
+
+For each draft: run the script on a small real input, record the aggregate receipt per D1, keep the CSV local. Order = expected search value:
+
+1. Rebuild Clay — 50 contacts through the waterfall. Receipt: found per rung, verified, total.
+2. Build your own AI SDR — one week of SDR postings → VP-level contacts → verified emails. (Reuses 1.)
+3. The join problem — 7 days of raises ≥ $5M → revenue leader → profile. (Reuses 1.)
+4. Rebuild Gojiberry — three competitor posts → commenters → ICP fit → raise check.
+5. GTM stack — no run; the price table is generated from the catalog at build time.
+
+Budget: under $10 total at catalog prices. Every run's receipt line goes into the page's `run` block with a date.
+
+## 4. Port to `WORKFLOWS` (1 day)
+
+- One dict per slug in `agent_pages.WORKFLOWS`: `sentence`, `title`, `lede`, `prompt`, `prompt_why` (4), `steps` as `(name, capability, ask, endpoint, why)`, `once`, `run`.
+- Capabilities must exist (`test_every_workflow_step_capability_and_endpoint_exist`); every step links to its use-case page via `USE_CASES` by capability or falls back to the agent-page anchor.
+- **Strip every em-dash** — `test_workflow_copy_has_no_em_dashes` will fail the drafts as written. Also the brand rule: treg.to, never bare "treg" in copy.
+- No routing claims anywhere; "the script picks the order" sentence stays.
+- The GTM-stack page is not a workflow (no run). Ship it as a `/resources` entry or the intro of the `/workflows` hub — decide in D2's spirit: no new page type.
+
+## 5. Wiring (½ day)
+
+| From | To | Mechanism |
+|---|---|---|
+| `/workflows` hub | 4 new + 1 existing | already spreads from `WORKFLOWS`; sitemap and `.md` twins follow |
+| 5 outcome pages (`marketing/landing/0*.md` → `usecase-*.html`) | the workflow that extends each | one "Run the full sequence" link block; rebuild with `marketing/landing/build.py` |
+| 38 job pages | the workflows that use their capability | reverse index: for each capability in a workflow's steps, add a "Used in" line on the job page — generated, not hand-written |
+| `/tools/<provider>` | workflows that call that provider | same reverse index by endpoint |
+| `/agents/*` | `/workflows` | one line in the install block |
+| `llms.txt`, `skill.md` | `/workflows` | one line each; these are the front door |
+| `docs/context/interface/seo.md` | the new pages | drift.sh will flag it |
+
+Tests: `tests/test_seo.py` walks every sitemap entry for 200; add the four workflow slugs to the served-with-crawler-essentials test.
+
+## 6. Distribution (rolling, starts when page 1 is live)
+
+| Week | X (Jason's account) | Elsewhere |
+|---|---|---|
+| Page 1 live | The join-problem X Article + hook tweet with the receipt screenshot | Reddit: the r/gtmengineering Clay-alternative threads, script not link (weekly loop, u/jzdesign rules) |
+| +1 | Price-receipt image #1: email verification, 3 providers | Open the YALC PR (treg provider adapter); list in `gtmagents/gtm-agents` |
+| +2 | "Clay's moat in 40 lines" | Fork `LeadMagic/gtm-skills` `prospecting-stack` to `/call/`; offer upstream |
+| +3 | Price-receipt #2: email finders, 6 providers | DDoDS brief sent (D4) |
+| weekly after | one receipt image, replies via the @treg_ai loop ("when unsure, skip") | — |
+
+Format rules from the teardown: number and receipt in the first line, product named once at the end, "try free" as a self-reply, write for the bookmark.
+
+## 7. Measurement (from day 1)
+
+- Search Console impressions/clicks on `/workflows/*` and the linked job pages, weekly, via the existing GSC + Ads loop (own-key, free).
+- First-call rate from those pages — still uninstrumented (memory: the funnel gap). Minimum: a `?src=workflow-<slug>` on the install CTA and a count in the audit log.
+- Review at day 30: keep the shelf if any page has impressions on its primary term; otherwise fold the copy into the job pages and stop adding workflows.
+
+## Sequence, compressed
+
+Decisions → rebase → runs 1–4 (parallel with catalog fixes) → port + tests → wiring + docs → publish one, then one a week → distribution cadence → day-30 review.

--- a/scripts/indexnow_submit.py
+++ b/scripts/indexnow_submit.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Push every URL in the live sitemap to IndexNow, and ping Google with the sitemap.
+
+IndexNow is one POST for up to 10,000 URLs; Bing, Yandex, Seznam and Naver share the feed, so one
+submission reaches all of them. Google does not take IndexNow — it gets the sitemap ping, and the
+Search Console sitemap resubmission is done through the catalog (`google-search-console.x.webmasters-
+sitemaps-submit`) because it needs the property owner's OAuth.
+
+Run after a deploy that adds or retitles pages:
+
+    uv run --frozen python scripts/indexnow_submit.py            # the live site
+    uv run --frozen python scripts/indexnow_submit.py --base https://staging.example
+
+Exit code is non-zero when IndexNow rejects the batch (422 = key file not reachable on the host).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+KEY = "7c2e4a91b5d3f8e6treg2026"  # must match INDEXNOW_KEY in src/treg/routers/web.py
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="https://treg.to")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    base = args.base.rstrip("/")
+    host = re.sub(r"^https?://", "", base)
+
+    with urllib.request.urlopen(f"{base}/sitemap.xml", timeout=30) as r:
+        urls = re.findall(r"<loc>([^<]+)</loc>", r.read().decode())
+    print(f"{len(urls)} URLs in {base}/sitemap.xml")
+
+    with urllib.request.urlopen(f"{base}/{KEY}.txt", timeout=30) as r:
+        served = r.read().decode().strip()
+    if served != KEY:
+        print(f"key file mismatch: {served!r} != {KEY!r}", file=sys.stderr)
+        return 2
+
+    if args.dry_run:
+        print("dry run — not submitting")
+        return 0
+
+    body = json.dumps({"host": host, "key": KEY, "keyLocation": f"{base}/{KEY}.txt", "urlList": urls}).encode()
+    req = urllib.request.Request("https://api.indexnow.org/IndexNow", data=body,
+                                 headers={"Content-Type": "application/json; charset=utf-8"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as r:
+            print(f"IndexNow: HTTP {r.status}")
+    except urllib.error.HTTPError as e:  # noqa: PERF203
+        print(f"IndexNow rejected the batch: HTTP {e.code} {e.read().decode()[:200]}", file=sys.stderr)
+        return 1
+
+    ping = f"https://www.google.com/ping?sitemap={base}/sitemap.xml"
+    try:
+        with urllib.request.urlopen(ping, timeout=30) as r:
+            print(f"Google sitemap ping: HTTP {r.status}")
+    except urllib.error.HTTPError as e:  # noqa: PERF203
+        # Google retired the ping endpoint for some properties; the Search Console resubmission
+        # is the reliable path and is done separately.
+        print(f"Google sitemap ping: HTTP {e.code} (use the Search Console sitemaps API)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/indexnow_submit.py
+++ b/scripts/indexnow_submit.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Push every URL in the live sitemap to IndexNow, and ping Google with the sitemap.
+"""Push every URL in the live sitemap to IndexNow.
 
 IndexNow is one POST for up to 10,000 URLs; Bing, Yandex, Seznam and Naver share the feed, so one
-submission reaches all of them. Google does not take IndexNow — it gets the sitemap ping, and the
-Search Console sitemap resubmission is done through the catalog (`google-search-console.x.webmasters-
-sitemaps-submit`) because it needs the property owner's OAuth.
+submission reaches all of them. Google does not take IndexNow and retired its sitemap ping; its
+resubmission goes through Search Console via the catalog (`google-search-console.x.webmasters-
+sitemaps-submit`), which needs the property owner's OAuth.
 
 Run after a deploy that adds or retitles pages:
 
@@ -56,14 +56,11 @@ def main() -> int:
         print(f"IndexNow rejected the batch: HTTP {e.code} {e.read().decode()[:200]}", file=sys.stderr)
         return 1
 
-    ping = f"https://www.google.com/ping?sitemap={base}/sitemap.xml"
-    try:
-        with urllib.request.urlopen(ping, timeout=30) as r:
-            print(f"Google sitemap ping: HTTP {r.status}")
-    except urllib.error.HTTPError as e:  # noqa: PERF203
-        # Google retired the ping endpoint for some properties; the Search Console resubmission
-        # is the reliable path and is done separately.
-        print(f"Google sitemap ping: HTTP {e.code} (use the Search Console sitemaps API)")
+    # Google retired its sitemap ping endpoint (June 2023); the only supported path is Search
+    # Console, which needs the property owner's OAuth. Through the catalog:
+    #   treg call google-search-console.x.webmasters-sitemaps-submit --method PUT \
+    #     --query siteUrl=sc-domain:treg.to --query feedpath=https://treg.to/sitemap.xml
+    print("Google: resubmit through Search Console (google-search-console.x.webmasters-sitemaps-submit)")
     return 0
 
 

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2701,9 +2701,10 @@ AGENTS["grok-bot"] = {
          "below is one call, priced per call."),
         ("What can it not do yet?",
          "It does not send anything: email goes through your sequencer and LinkedIn through your "
-         "own account, on your own key. It cannot search LinkedIn by topic or list a post's likers, "
-         "and it has no page-to-markdown scraper today, so reading a prospect's website is a job for "
-         "a tool you already have. The catalog says so on the page rather than pretending."),
+         "own account, on your own key. LinkedIn post search covers public posts through Google's "
+         "index rather than LinkedIn's own feed, and a post's reactions come back a page at a time. "
+         "There is no raw page-to-markdown scraper; website reading is a named-field extraction by "
+         "domain. The catalog says what each tool covers on the page rather than pretending."),
         ("Is treg.to free to use in Grok Bot?",
          "Adding it is free and every new team starts with $1.00 of calls. After that, each call is "
          "metered from the team's prepaid balance at the provider's own rate, with no markup and no "

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -2686,6 +2686,24 @@ AGENTS["grok-bot"] = {
     "install_image_bar": "Grok Bot  ·  Plugins",
     "install_image_caption": "Steps 1 and 2: Plugins in the sidebar, search treg, Add.",
     "faq": [
+        ("Can Grok Bot do lead generation with this?",
+         "Yes, and it is the sequence most people ask for first. A research bot or a sales bot in "
+         "Grok Bot can browse, but browsing is not data. With the plugin it can build a company "
+         "list by industry, size or funding, find the decision maker at each one, find and verify a "
+         "work email, and pull a recent news event for the opener. The whole sequence is on the "
+         "workflows page above with the receipt from a real run. Each step is priced before the bot "
+         "spends, and a miss on a per-success provider costs nothing."),
+        ("What research can a Grok Bot do with the catalog?",
+         "Company research: funding rounds, headcount, job postings, tech stack and recent news by "
+         "domain. People research: a LinkedIn profile, a person's recent posts, their work email. "
+         "Market research: who is hiring for a role this month, what employees say about a company, "
+         "which ads a competitor is running, keyword volumes and who ranks. Every job on the menu "
+         "below is one call, priced per call."),
+        ("What can it not do yet?",
+         "It does not send anything: email goes through your sequencer and LinkedIn through your "
+         "own account, on your own key. It cannot search LinkedIn by topic or list a post's likers, "
+         "and it has no page-to-markdown scraper today, so reading a prospect's website is a job for "
+         "a tool you already have. The catalog says so on the page rather than pretending."),
         ("Is treg.to free to use in Grok Bot?",
          "Adding it is free and every new team starts with $1.00 of calls. After that, each call is "
          "metered from the team's prepaid balance at the provider's own rate, with no markup and no "

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -88,6 +88,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/llms.txt', ('GET',), 'llms_txt'),
     ('/robots.txt', ('GET',), 'robots_txt'),
     ('/sitemap.xml', ('GET',), 'sitemap_xml'),
+    ('/7c2e4a91b5d3f8e6treg2026.txt', ('GET',), 'indexnow_key'),
     ('/install.sh', ('GET',), 'install_sh'),
     ('/selfhost.sh', ('GET',), 'selfhost_sh'),
     ('/quickstart.md', ('GET',), 'quickstart_md'),

--- a/src/treg/domain/catalog/stats.py
+++ b/src/treg/domain/catalog/stats.py
@@ -171,7 +171,7 @@ async def observed(
             # be tested against `decided`, not total traffic: four 422s plus one 405 previously
             # published the outcome of that ONE decided call as 0%, violating both the evidence
             # and privacy reasons for having the floor.
-            out[ep_id] = {"samples": n, "ok_rate": None,
+            out[ep_id] = {"samples": n, "decided": decided, "ok_rate": None,
                           "p50_ms": None, "p95_ms": None, "last_ok_days": None,
                           "hit_rate": hit_rate, "hit_samples": hit_decided}
             continue
@@ -179,6 +179,9 @@ async def observed(
         enough_latency = len(ms) >= MIN_SAMPLES
         out[ep_id] = {
             "samples": n,
+            # `decided` is the denominator of ok_rate (2xx + 5xx). Anything aggregating rates
+            # across endpoints must weight by this, not by `samples`, which still counts 4xx.
+            "decided": decided,
             "ok_rate": round(ok / decided, 4) if decided else None,
             # A rate may rest on five decided calls while only one succeeded. Calling that single
             # duration p50 AND p95 dresses one observation up as a distribution, so latency has
@@ -189,7 +192,7 @@ async def observed(
             "hit_rate": hit_rate, "hit_samples": hit_decided,
         }
     for ep_id in ids:                # an endpoint nobody has called says so, rather than vanishing
-        out.setdefault(ep_id, {"samples": 0, "ok_rate": None,
+        out.setdefault(ep_id, {"samples": 0, "decided": 0, "ok_rate": None,
                                "p50_ms": None, "p95_ms": None, "last_ok_days": None,
                                "hit_rate": None, "hit_samples": 0})
     return out

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2130,10 +2130,13 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
         # The title leads with the pricing intent: Search Console shows "{provider} api pricing" is
         # what reaches these pages ("linkedin api pricing", "1688 api pricing" — the site's one
         # non-brand click), and the number is the part no vendor page prints.
-        title = (f"{display} API pricing per call: from {cheapest} | treg.to" if cheapest
+        # `cheapest` already names its unit ("$0.00245/result"), so the title does not say "per
+        # call" beside it — a per-result price is not a per-call one.
+        title = (f"{display} API pricing: from {cheapest}, no signup | treg.to" if cheapest
                  else f"{display} API pricing per call, no signup | treg.to")
         if len(title) > _TITLE_MAX:
-            title = f"{display} API pricing per call | treg.to"
+            title = (f"{display} API pricing: from {cheapest} | treg.to" if cheapest
+                     else f"{display} API pricing per call | treg.to")
         desc = (f"{display} API pricing, per call, with no {display} signup: {len(eps)} tools "
                 f"{'from ' + cheapest + ' ' if cheapest else ''}through one treg.to key or MCP server"
                 f"{' — ' + measured if measured else ''}. Use it from Claude Code, ChatGPT or any agent.")

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -144,6 +144,10 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
     def navlink(href: str, label: str, extra: str = "") -> str:
         cur = ' aria-current="page"' if href == nav_current else ""
         return f'<a href="{href}"{cur}{extra}>{label}</a>'
+    # The job, workflow and agent pages exist on the hosted deployment only (`_hosted`): a
+    # self-hosted registry must not put three 404s in its own footer.
+    hub_links = ('<a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a>'
+                 '<a href="/agents/claude-code">Agents</a>' if _hosted() else "")
     return HTMLResponse(f"""<!doctype html>
 <html lang="en">
 <head>
@@ -193,8 +197,7 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
     </div>
     <nav class="foot-cols" aria-label="Site">
       <div class="foot-col"><div class="lab">Explore</div>
-        <a href="/catalog">Catalog</a><a href="/use-cases">Use cases</a
-        ><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a></div>
+        <a href="/catalog">Catalog</a>{hub_links}</div>
       <div class="foot-col"><div class="lab">Build</div>
         <a href="/tutorial">Docs</a><a href="/docs">API</a><a href="/llms.txt">llms.txt</a
         ><a href="{_GH}" target="_blank" rel="noopener">GitHub ↗</a></div>
@@ -346,9 +349,11 @@ async def catalog_index():
                  # The two hubs are linked from HERE as well as the nav: this prerender is the page
                  # Google crawls most, and before this line the job and workflow pages were reachable
                  # only from the sitemap — "URL is unknown to Google" on every one of them.
-                 + '<p>Looking for a job rather than a platform? <a href="/use-cases">The use cases</a> '
-                   'compare the providers that do one job, and <a href="/workflows">the workflows</a> '
-                   'chain several jobs into one prompt with the price of each step.</p>'
+                 + ('<p>Looking for a job rather than a platform? <a href="/use-cases">The use cases</a> '
+                    'compare the providers that do one job, <a href="/workflows">the workflows</a> '
+                    'chain several jobs into one prompt with the price of each step, and '
+                    '<a href="/agents/claude-code">the agent pages</a> show the whole menu for one '
+                    'agent.</p>' if _hosted() else "")
                  + "".join(sections)
                  + f"<h2>The providers</h2><p>{len(prov_rows)} vendors serve this catalog, each "
                    f"with its own page: {prov_links}</p>")
@@ -1913,9 +1918,13 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
     # thing a vendor's own pricing page cannot print, and it goes above the fold for that reason.
     obs = await _observed_or_empty(db, [e["id"] for e in eps])
     o_samples = sum(int(o.get("samples") or 0) for o in obs.values())
-    o_ok = [o for o in obs.values() if o.get("samples") and o.get("ok_rate") is not None]
-    o_ok_rate = (sum(o["ok_rate"] * o["samples"] for o in o_ok) / sum(o["samples"] for o in o_ok)) if o_ok else None
-    o_p50s = sorted(o["p50"] for o in obs.values() if o.get("p50"))
+    # The provider-wide rate weights each endpoint's published rate by the calls that DECIDED it
+    # (2xx + 5xx). `samples` still counts callers' 4xx, so weighting by it would let one team's
+    # malformed requests drag a healthy provider down. Latency is the median of the endpoint
+    # medians that cleared the successful-sample floor; `p50_ms` is the key endpoint_stats emits.
+    o_ok = [o for o in obs.values() if o.get("ok_rate") is not None and (o.get("decided") or 0) > 0]
+    o_ok_rate = (sum(o["ok_rate"] * o["decided"] for o in o_ok) / sum(o["decided"] for o in o_ok)) if o_ok else None
+    o_p50s = sorted(o["p50_ms"] for o in obs.values() if o.get("p50_ms"))
     o_p50 = o_p50s[len(o_p50s) // 2] if o_p50s else None
     measured = ""
     if o_samples:
@@ -1943,7 +1952,7 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
             "from then on, through one treg.to token. Calls on your own connection are never metered."
             if is_oauth else
             f"{_esc_html(blurb)} {len(eps)} tools for your agent through one treg.to key, priced "
-            f"per call{' from ' + _esc_html(cheapest) if cheapest else ''}, with no {esc_d} signup.")
+            f"at the provider's own rate{' from ' + _esc_html(cheapest) if cheapest else ''}, with no {esc_d} signup.")
     hero = (
         '<div class="hero"><div class="wrap">'
         '<div class="trust" style="margin:0 0 18px"><a href="/">treg.to</a> / '
@@ -2142,7 +2151,7 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
                     f"<h2>Jobs {esc_d} does, compared with the other providers</h2>"
                     '<div class="cards">'
                     + "".join(f'<a class="card" href="/use-cases/{_esc_html(js)}"><h3>{_esc_html(jsent)}</h3>'
-                              f"<p>Every provider that does this job, side by side: price per call, "
+                              f"<p>Every provider that does this job, side by side: price per billing unit, "
                               f"measured success rate and speed.</p></a>" for js, jsent in used_in)
                     + "</div></div></section>")
 
@@ -2158,14 +2167,16 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
         # non-brand click), and the number is the part no vendor page prints.
         # `cheapest` already names its unit ("$0.00245/result"), so the title does not say "per
         # call" beside it — a per-result price is not a per-call one.
+        # `cheapest` carries its own billing unit ("$0.00245/result", "$0.0089/call"), so the copy
+        # never says "per call" next to it: a per-result or per-success rate is not a per-call one.
         title = (f"{display} API pricing: from {cheapest}, no signup | treg.to" if cheapest
-                 else f"{display} API pricing per call, no signup | treg.to")
+                 else f"{display} API pricing, no signup | treg.to")
         if len(title) > _TITLE_MAX:
             title = (f"{display} API pricing: from {cheapest} | treg.to" if cheapest
-                     else f"{display} API pricing per call | treg.to")
-        desc = (f"{display} API pricing, per call, with no {display} signup: {len(eps)} tools "
+                     else f"{display} API pricing | treg.to")
+        desc = (f"{display} API pricing at the provider's own rate, with no {display} signup: {len(eps)} tools "
                 f"{'from ' + cheapest + ' ' if cheapest else ''}through one treg.to key or MCP server"
-                f"{' — ' + measured if measured else ''}. Use it from Claude Code, ChatGPT or any agent.")
+                f"{', ' + measured if measured else ''}. Use it from Claude Code, ChatGPT or any agent.")
 
     ld = [
         {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
@@ -2430,6 +2441,9 @@ async def landing(request: Request, treg_session: str = Cookie(default=""),
         # would tell crawlers its front page really lives on treg.to.
         html = page.read_text(encoding="utf-8").replace(
             "{BASE}", get_settings().public_url.rstrip("/"))
+        # The footer's hub links point at hosted-only pages; a self-hosted landing drops them.
+        if not _hosted():
+            html = re.sub(r"<!--hosted-->.*?<!--/hosted-->", "", html, flags=re.S)
         resp = HTMLResponse(html, headers={"Cache-Control": "no-cache"})
         if ref:
             _remember_referral(resp, request, ref)

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -629,6 +629,11 @@ async def agent_page(request: Request, agent: str):
     if as_md:
         md = [f"# {title}", "", definition, "", f"## Install in {name}", ""]
         md += [f"{i}. {html_mod.unescape(st)}" for i, st in enumerate(steps_text, 1)]
+        if agent_pages.WORKFLOWS:
+            md += ["", f"## Sequences {name} can run from one prompt", ""]
+            md += [f"- [{wspec['sentence']}]({base}/workflows/{ws}), {len(wspec.get('steps', ()))} steps, "
+                   f"each priced, with the receipt from a real run"
+                   for ws, wspec in agent_pages.WORKFLOWS.items()]
         md += ["", f"## What {name} can do now", "",
                "One row per job. Prices are the provider's own rate with $0.000 markup; rows marked FREE run on your own account and are never metered.", ""]
         for category, prompt, rows in menu:
@@ -762,6 +767,21 @@ async def agent_page(request: Request, agent: str):
         f'<div class="cards">{"".join(cards)}</div>'
         f'<p style="margin-top:20px"><a href="/catalog">Browse all {n} endpoints &rarr;</a> &middot; '
         f'<a href="/use-cases">read the job guides &rarr;</a></p></div></section>'
+
+        # The workflows: several jobs from the menu chained into one prompt, each with a receipt from
+        # a real run. Linked from every agent page so the page that describes what an agent can do
+        # also names the sequences it can run; before this the workflow pages were reachable from
+        # the hub alone.
+        + (f'<section id="workflows"><div class="wrap"><div class="seclab">Workflows</div>'
+           f'<h2>Sequences {_esc_html(name)} can run from one prompt</h2>'
+           '<p>Several jobs from the menu, chained. Each step is priced from the catalog and the page '
+           'prints the receipt from a real run, not a rate card.</p><div class="cards">'
+           + "".join(f'<a class="card" href="/workflows/{_esc_html(ws)}"><h3>{_esc_html(wspec["sentence"])}</h3>'
+                     f'<p>{len(wspec.get("steps", ()))} steps, each a metered call, with the price shown before '
+                     f'{_esc_html(name)} spends it.</p></a>'
+                     for ws, wspec in agent_pages.WORKFLOWS.items())
+           + f'</div><p style="margin-top:20px"><a href="/workflows">All workflows &rarr;</a></p></div></section>'
+           if agent_pages.WORKFLOWS else "")
 
         + "".join(sections)
 

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -115,6 +115,10 @@ def _serp_desc(text: str, limit: int = 155) -> str:
     return cut[:cut.rfind(" ")].rstrip(",;:") + "."
 
 
+# Google prints about 60 characters of a title; tests/test_agent_pages.py holds every page to 65.
+_TITLE_MAX = 65
+
+
 def _page(title: str, description: str, path: str, body: str, ld: list[dict],
           *, nav_current: str = "", head_extra: str = "", css: str = "catalog.css") -> HTMLResponse:
     """The shared shell for every server-rendered page. One place that owns <title>, the meta
@@ -174,7 +178,9 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
   <a class="brand" href="/"><span class="glyph">▚</span> treg</a>
   <div class="links">
     {navlink("/catalog", "Catalog")}
-    {navlink("/tutorial", "Tutorial")}
+    {navlink("/use-cases", "Use cases")}
+    {navlink("/workflows", "Workflows")}
+    {navlink("/tutorial", "Tutorial", ' class="hidem"')}
     {navlink("/docs", "API")}
     <a class="hidem" href="{_GH}" target="_blank" rel="noopener">GitHub ↗</a>
     <a class="candy" href="/app?ref={ref}">Start free</a>
@@ -186,7 +192,8 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
     <div class="brand"><span class="glyph">▚</span> treg</div>
     <span style="font-family:var(--mono);font-size:12px">· 100% open source</span>
     <span class="sp"></span>
-    <a href="/catalog">catalog</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a
+    <a href="/catalog">catalog</a><a href="/use-cases">use cases</a><a href="/workflows">workflows</a
+    ><a href="/agents/claude-code">agents</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a
     ><a href="{_GH}" target="_blank" rel="noopener">github ↗</a><a href="/docs">api</a
     ><a href="/terms">terms</a><a href="/privacy">privacy</a>
   </div>
@@ -330,6 +337,12 @@ async def catalog_index():
                  + f'<p class="lede">{total_eps:,} endpoints across {len(rows)} platforms and '
                    f"{len(providers)} providers — every tool your agent can call through one key, "
                    "priced up front and billed per call, with no provider signup.</p>"
+                 # The two hubs are linked from HERE as well as the nav: this prerender is the page
+                 # Google crawls most, and before this line the job and workflow pages were reachable
+                 # only from the sitemap — "URL is unknown to Google" on every one of them.
+                 + '<p>Looking for a job rather than a platform? <a href="/use-cases">The use cases</a> '
+                   'compare the providers that do one job, and <a href="/workflows">the workflows</a> '
+                   'chain several jobs into one prompt with the price of each step.</p>'
                  + "".join(sections)
                  + f"<h2>The providers</h2><p>{len(prov_rows)} vendors serve this catalog, each "
                    f"with its own page: {prov_links}</p>")
@@ -495,6 +508,47 @@ def _use_case_caps(label: str) -> tuple[str, ...]:
             if lbl == label:
                 return caps
     return ()
+
+
+# ---- the reverse index: which job pages use a provider, which workflows use a job -------------
+#
+# Every job page already links DOWN to the catalog and every workflow step links down to its job
+# page. Nothing linked UP: a provider page did not name the jobs it serves, and a job page did not
+# name the workflows that chain it. The result was measurable — the 38 job pages and both workflow
+# pages had zero impressions and "URL is unknown to Google", while /tools/<provider> (linked from
+# /catalog) was indexed. These two indexes are computed once per process from the same tables the
+# pages render from, so a new job or workflow is cross-linked the moment it is routed.
+
+@lru_cache(maxsize=1)
+def _jobs_by_provider() -> dict[str, list[tuple[str, str]]]:
+    """provider service -> [(job slug, job sentence)], for every job whose capabilities the
+    provider answers. Ordered by the job table so the list reads the way the hub does."""
+    cat = catalog_store.load()
+    out: dict[str, list[tuple[str, str]]] = {}
+    for slug, spec in agent_pages.USE_CASE_PAGES.items():
+        provs = {e["provider"] for cid in _use_case_caps(spec["label"])
+                 for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS}
+        for p in provs:
+            out.setdefault(p, []).append((slug, spec["sentence"]))
+    return out
+
+
+@lru_cache(maxsize=1)
+def _workflows_by_capability() -> dict[str, list[tuple[str, str]]]:
+    """capability id -> [(workflow slug, workflow sentence)] for every workflow with a step on it."""
+    out: dict[str, list[tuple[str, str]]] = {}
+    for slug, spec in agent_pages.WORKFLOWS.items():
+        for _name, cid, *_rest in spec.get("steps", ()):
+            out.setdefault(cid, []).append((slug, spec["sentence"]))
+    return out
+
+
+def _workflows_for_caps(caps: tuple[str, ...]) -> list[tuple[str, str]]:
+    seen: dict[str, str] = {}
+    for cid in caps:
+        for slug, sentence in _workflows_by_capability().get(cid, ()):
+            seen.setdefault(slug, sentence)
+    return list(seen.items())
 
 
 def _menu_rows(cat, category: str, jobs) -> list[dict]:
@@ -892,6 +946,7 @@ async def use_case_job_page(request: Request, job: str,
     eps = [e for cid in caps for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
     if not eps:
         raise HTTPException(status_code=404, detail="no endpoints for this job")
+    job_workflows = _workflows_for_caps(caps)
     obs = await _observed_or_empty(observations, [e["id"] for e in eps])
     provs = _uc_providers(cat, eps, obs)
 
@@ -943,6 +998,17 @@ async def use_case_job_page(request: Request, job: str,
     title = spec.get("title", "{sentence}: {n} providers | treg.to").format(
         sentence=spec["sentence"], n=n, agent=agent_name,
         cheapest=money(headline["usd"]) if headline else free_words)
+    # The number goes in the title. Search Console shows the pricing phrasing is what reaches this
+    # site, and a title that already names the cheapest price is the one fact a vendor's own page
+    # cannot carry. Only the compare form has a price to name; a hand-written title that already
+    # carries one is left alone.
+    if form == "compare" and headline and "$" not in title and title.endswith(" | treg.to"):
+        head = title[: -len(" | treg.to")]
+        if head.endswith(" compared"):  # "5 verifiers compared" -> "5 verifiers, from $0.0019"
+            head = head[: -len(" compared")]
+        priced = f"{head}, from {money(headline['usd'])} | treg.to"
+        if len(priced) <= _TITLE_MAX:
+            title = priced
     lede = spec["lede"].format(n=n, agent=agent_name,
                                cheapest=money(headline["usd"]) if headline else free_words)
     bits_desc = [spec["sentence"] + "."]
@@ -1287,6 +1353,12 @@ async def use_case_job_page(request: Request, job: str,
 
         + (f'<section id="related"><div class="wrap"><div class="seclab">Related</div>'
            f'<h2>Other jobs your agent can do</h2><div class="cards">{related}</div></div></section>' if related else "")
+        + (f'<section id="workflows"><div class="wrap"><div class="seclab">Run the full sequence</div>'
+           f'<h2>Workflows that use this job</h2><div class="cards">'
+           + "".join(f'<a class="card" href="/workflows/{_esc_html(ws)}"><h3>{_esc_html(wsent)}</h3>'
+                     f'<p>One prompt, every step priced, with the receipt from a real run.</p></a>'
+                     for ws, wsent in job_workflows)
+           + '</div></div></section>' if job_workflows else "")
         + _COPY_JS)
     ld = [
         {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
@@ -1758,9 +1830,10 @@ details.tl li small{color:var(--muted)}
 
 
 @app.get("/tools/{service}", include_in_schema=False)
-async def tools_provider(service: str):
-    """One provider's public page, in the use-case pages' skin (usecase.css): hero on the measured
-    "{provider} mcp" term, the agent->treg->provider flow, setup (agent one-liner first), a prompt
+async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
+    """One provider's public page, in the use-case pages' skin (usecase.css): hero on the two
+    measured terms — "{provider} api pricing" (what Search Console shows people typing) and
+    "{provider} mcp" — the agent->treg->provider flow, setup (agent one-liner first), a prompt
     to try, why-treg cards, EVERY tool grouped by platform, alternatives and an FAQ that also
     feeds the FAQPage JSON-LD. The signed-in twin stays at /app/marketplace/<service>."""
     cat = catalog_store.load()
@@ -1810,6 +1883,22 @@ async def tools_provider(service: str):
     sample_eps = sorted([e for e in eps if e["verified"]], key=lambda e: len(e["id"])) or eps
     sample_id = sample_eps[0]["id"]
     badge = "YOUR ACCOUNT" if is_oauth else "NO SIGNUP"
+    # The measured line: what treg.to has actually observed calling this provider. It is the one
+    # thing a vendor's own pricing page cannot print, and it goes above the fold for that reason.
+    obs = await _observed_or_empty(db, [e["id"] for e in eps])
+    o_samples = sum(int(o.get("samples") or 0) for o in obs.values())
+    o_ok = [o for o in obs.values() if o.get("samples") and o.get("ok_rate") is not None]
+    o_ok_rate = (sum(o["ok_rate"] * o["samples"] for o in o_ok) / sum(o["samples"] for o in o_ok)) if o_ok else None
+    o_p50s = sorted(o["p50"] for o in obs.values() if o.get("p50"))
+    o_p50 = o_p50s[len(o_p50s) // 2] if o_p50s else None
+    measured = ""
+    if o_samples:
+        measured = f"{o_samples:,} calls measured"
+        if o_ok_rate is not None:
+            measured += f" · {round(o_ok_rate * 100)}% ok"
+        if o_p50:
+            measured += f" · {(f'{o_p50/1000:.1f}s' if o_p50 >= 1000 else f'{int(o_p50)}ms')} median"
+    used_in = _jobs_by_provider().get(svc, [])
     demo_eps = []
     _seen_caps: set[str] = set()
     for e in sample_eps:
@@ -1822,6 +1911,8 @@ async def tools_provider(service: str):
 
     kicker = (f"{len(eps)} tools · your own account · never metered" if is_oauth
               else f"{len(eps)} tools · from {_esc_html(cheapest)} · $0.000 markup")
+    if measured:
+        kicker += f" · {_esc_html(measured)}"
     lede = (f"{_esc_html(blurb)} Connect your own {esc_d} account once and your agent uses it "
             "from then on, through one treg.to token. Calls on your own connection are never metered."
             if is_oauth else
@@ -2017,16 +2108,35 @@ async def tools_provider(service: str):
                "b.dataset.copy);b.textContent='copied';setTimeout(function(){b.textContent='copy'},1400)"
                "}catch(e){}})});</script>")
 
-    body = _TOOLS_CSS + hero + flow + setup + tryit + why + tools_sec + alt_sec + faq + copy_js
+    # "Used in": the job pages this provider answers. Contextual, intent-matched links from a page
+    # Google already indexes into the ones it had never fetched (see `_jobs_by_provider`).
+    used_sec = ""
+    if used_in:
+        used_sec = ('<section id="used-in"><div class="wrap"><div class="seclab">Used in</div>'
+                    f"<h2>Jobs {esc_d} does, compared with the other providers</h2>"
+                    '<div class="cards">'
+                    + "".join(f'<a class="card" href="/use-cases/{_esc_html(js)}"><h3>{_esc_html(jsent)}</h3>'
+                              f"<p>Every provider that does this job, side by side: price per call, "
+                              f"measured success rate and speed.</p></a>" for js, jsent in used_in)
+                    + "</div></div></section>")
+
+    body = _TOOLS_CSS + hero + flow + setup + tryit + why + tools_sec + used_sec + alt_sec + faq + copy_js
 
     if is_oauth:
         title = f"{display} MCP for AI Agents — connect your own account | treg.to"
         desc = (f"Use {display} from Claude Code, ChatGPT or any MCP agent: {len(eps)} tools "
                 "through one treg.to token. Calls on your own connection are never metered.")
     else:
-        title = f"{display} MCP for AI Agents — {len(eps)} tools, pay per call | treg.to"
-        desc = (f"Use {display} from Claude Code, ChatGPT or any MCP agent: {len(eps)} tools, "
-                f"priced per call{' from ' + cheapest if cheapest else ''}, no {display} signup.")
+        # The title leads with the pricing intent: Search Console shows "{provider} api pricing" is
+        # what reaches these pages ("linkedin api pricing", "1688 api pricing" — the site's one
+        # non-brand click), and the number is the part no vendor page prints.
+        title = (f"{display} API pricing per call: from {cheapest} | treg.to" if cheapest
+                 else f"{display} API pricing per call, no signup | treg.to")
+        if len(title) > _TITLE_MAX:
+            title = f"{display} API pricing per call | treg.to"
+        desc = (f"{display} API pricing, per call, with no {display} signup: {len(eps)} tools "
+                f"{'from ' + cheapest + ' ' if cheapest else ''}through one treg.to key or MCP server"
+                f"{' — ' + measured if measured else ''}. Use it from Claude Code, ChatGPT or any agent.")
 
     ld = [
         {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
@@ -2522,6 +2632,19 @@ async def sitemap_xml():
     out.append("</urlset>")
     return Response("\n".join(out), media_type="application/xml; charset=utf-8",
                     headers={"Cache-Control": "max-age=3600"})
+
+
+# IndexNow (Bing, Yandex, Seznam, Naver share the feed): the key file the protocol needs on this
+# host. Not a secret — the protocol only checks that the key named in a submission is served from
+# the same host, so a submission cannot claim someone else's URLs. `scripts/indexnow_submit.py`
+# pushes every sitemap URL through it after a deploy.
+INDEXNOW_KEY = "7c2e4a91b5d3f8e6treg2026"
+
+
+@app.get(f"/{INDEXNOW_KEY}.txt", include_in_schema=False)
+async def indexnow_key():
+    return Response(INDEXNOW_KEY, media_type="text/plain; charset=utf-8",
+                    headers={"Cache-Control": "public, max-age=86400"})
 
 
 @app.get("/install.sh", include_in_schema=False)

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -178,9 +178,7 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
   <a class="brand" href="/"><span class="glyph">▚</span> treg</a>
   <div class="links">
     {navlink("/catalog", "Catalog")}
-    {navlink("/use-cases", "Use cases")}
-    {navlink("/workflows", "Workflows")}
-    {navlink("/tutorial", "Tutorial", ' class="hidem"')}
+    {navlink("/tutorial", "Tutorial")}
     {navlink("/docs", "API")}
     <a class="hidem" href="{_GH}" target="_blank" rel="noopener">GitHub ↗</a>
     <a class="candy" href="/app?ref={ref}">Start free</a>
@@ -189,13 +187,21 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
 {body}
 <footer>
   <div class="foot-in">
-    <div class="brand"><span class="glyph">▚</span> treg</div>
-    <span style="font-family:var(--mono);font-size:12px">· 100% open source</span>
-    <span class="sp"></span>
-    <a href="/catalog">catalog</a><a href="/use-cases">use cases</a><a href="/workflows">workflows</a
-    ><a href="/agents/claude-code">agents</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a
-    ><a href="{_GH}" target="_blank" rel="noopener">github ↗</a><a href="/docs">api</a
-    ><a href="/terms">terms</a><a href="/privacy">privacy</a>
+    <div class="foot-brand">
+      <div class="brand"><span class="glyph">▚</span> treg</div>
+      <div class="note">100% open source</div>
+    </div>
+    <nav class="foot-cols" aria-label="Site">
+      <div class="foot-col"><div class="lab">Explore</div>
+        <a href="/catalog">Catalog</a><a href="/use-cases">Use cases</a
+        ><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a></div>
+      <div class="foot-col"><div class="lab">Build</div>
+        <a href="/tutorial">Docs</a><a href="/docs">API</a><a href="/llms.txt">llms.txt</a
+        ><a href="{_GH}" target="_blank" rel="noopener">GitHub ↗</a></div>
+      <div class="foot-col"><div class="lab">Company</div>
+        <a href="/resources">Resources</a><a href="/support">Support</a
+        ><a href="/terms">Terms</a><a href="/privacy">Privacy</a></div>
+    </nav>
   </div>
 </footer>
 </body>

--- a/src/treg/web/catalog.css
+++ b/src/treg/web/catalog.css
@@ -141,14 +141,19 @@ pre.call{margin:9px 0 0;background:var(--panel);border-radius:var(--rb);padding:
   padding:1px 6px;color:var(--ink)}
 
 /* ---------- footer ---------- */
-footer{border-top:1px solid var(--line);margin-top:46px;padding:26px 0 40px}
-.foot-in{max-width:1160px;margin:0 auto;padding:0 28px;display:flex;align-items:center;gap:18px;
-  flex-wrap:wrap;font-size:13px}
+footer{border-top:1px solid var(--line);margin-top:46px;padding:34px 0 44px}
+.foot-in{max-width:1160px;margin:0 auto;padding:0 28px;display:flex;align-items:flex-start;
+  justify-content:space-between;gap:32px 56px;flex-wrap:wrap;font-size:13px}
 .foot-in .brand{display:flex;align-items:center;gap:8px;font-family:var(--mono);font-weight:500}
 .foot-in .brand .glyph{width:20px;height:20px;border-radius:6px;background:var(--inverse);
   color:var(--inverse-ink);display:grid;place-items:center;font-size:12px}
-.foot-in .sp{margin-left:auto}
+.foot-brand{display:flex;flex-direction:column;gap:8px}
+.foot-brand .note{font-family:var(--mono);font-size:12px;color:var(--muted)}
+.foot-cols{display:flex;gap:56px;flex-wrap:wrap}
+.foot-col{display:flex;flex-direction:column;gap:8px;min-width:104px}
+.foot-col .lab{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:2px}
 .foot-in a{color:var(--muted)}
+.foot-in a:hover{color:var(--ink)}
 
 @media (max-width:640px){
   .wrap,.foot-in{padding:0 18px}

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1299,7 +1299,9 @@ a:hover{text-decoration-color:var(--muted)}
       <a class="brand" href="/">▚ treg</a>
       <nav class="pubnav-links">
         <a href="/catalog" aria-current="page">Catalog</a>
-        <a href="/tutorial">Tutorial</a>
+        <a href="/use-cases">Use cases</a>
+        <a href="/workflows" class="hidem">Workflows</a>
+        <a href="/tutorial" class="hidem">Tutorial</a>
         <a href="/docs">API</a>
         <a class="hidem" href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">GitHub ↗</a>
         <a @click="openSignin()">Sign in</a>

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1299,9 +1299,7 @@ a:hover{text-decoration-color:var(--muted)}
       <a class="brand" href="/">▚ treg</a>
       <nav class="pubnav-links">
         <a href="/catalog" aria-current="page">Catalog</a>
-        <a href="/use-cases">Use cases</a>
-        <a href="/workflows" class="hidem">Workflows</a>
-        <a href="/tutorial" class="hidem">Tutorial</a>
+        <a href="/tutorial">Tutorial</a>
         <a href="/docs">API</a>
         <a class="hidem" href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">GitHub ↗</a>
         <a @click="openSignin()">Sign in</a>

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -881,7 +881,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
     </div>
     <nav class="foot-cols" aria-label="Site">
       <div class="foot-col"><div class="lab">Explore</div>
-        <a href="/catalog">Catalog</a><a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a></div>
+        <a href="/catalog">Catalog</a><!--hosted--><a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a><!--/hosted--></div>
       <div class="foot-col"><div class="lab">Build</div>
         <a href="/tutorial">Docs</a><a href="/docs">API</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">GitHub ↗</a></div>
       <div class="foot-col"><div class="lab">Company</div>

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -562,6 +562,8 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
       <a href="https://github.com/superdesigndev/treg" class="hidem navico" target="_blank" rel="noopener"><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>Repo</a>
       <a href="https://discord.gg/6mQYYfFMAn" class="hidem navico" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.3 18.3 0 0 0-5.49 0 12.6 12.6 0 0 0-.61-1.25.08.08 0 0 0-.08-.04 19.7 19.7 0 0 0-4.88 1.52.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06c0 .02.01.04.03.05a19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.22-2a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.89.08.08 0 0 1-.01-.13c.13-.09.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.24.2.37.29a.08.08 0 0 1-.01.13c-.6.35-1.22.64-1.87.89a.08.08 0 0 0-.04.11c.36.7.77 1.36 1.22 2a.08.08 0 0 0 .08.03 19.8 19.8 0 0 0 6.02-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.95 2.42-2.16 2.42z"/></svg>Community</a>
       <a href="/catalog">Catalog</a>
+      <a href="/use-cases">Use cases</a>
+      <a href="/workflows" class="hidem">Workflows</a>
       <a onclick="openSignin()">Sign in</a>
       <button class="candy sm" onclick="openSignin()">Start free</button>
     </div>
@@ -873,7 +875,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
     <div class="brand"><span class="glyph">▚</span> treg</div>
     <span style="font-family:var(--mono);font-size:12px">— 100% open source</span>
     <span class="sp"></span>
-    <a href="/catalog">catalog</a><a href="/resources">resources</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">github ↗</a><a href="/docs">api</a><a href="/terms">terms</a><a href="/privacy">privacy</a>
+    <a href="/catalog">catalog</a><a href="/use-cases">use cases</a><a href="/workflows">workflows</a><a href="/agents/claude-code">agents</a><a href="/resources">resources</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">github ↗</a><a href="/docs">api</a><a href="/terms">terms</a><a href="/privacy">privacy</a>
   </div>
   <div class="watermark">treg</div>
 </footer>

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -447,10 +447,15 @@ p.sub b{color:var(--ink);font-weight:600}
 .trustline b{color:var(--muted);font-weight:500}
 
 footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overflow:hidden;background:var(--panel)}
-.foot-in{display:flex;align-items:center;gap:26px;flex-wrap:wrap;padding:44px 28px 150px;position:relative;z-index:1;
-  max-width:1160px;margin:0 auto}
+.foot-in{display:flex;align-items:flex-start;justify-content:space-between;gap:40px 64px;flex-wrap:wrap;
+  padding:44px 28px 150px;position:relative;z-index:1;max-width:1160px;margin:0 auto}
+.foot-brand{display:flex;flex-direction:column;gap:10px}
+.foot-brand .note{font-family:var(--mono);font-size:12px;color:var(--muted)}
+.foot-cols{display:flex;gap:64px;flex-wrap:wrap}
+.foot-col{display:flex;flex-direction:column;gap:9px;min-width:112px}
+.foot-col .lab{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-bottom:2px}
 .foot-in a{color:var(--muted);font-size:14px} .foot-in a:hover{color:var(--ink)}
-.foot-in .sp{flex:1}
+@media (max-width:640px){ .foot-cols{gap:36px} .foot-col{min-width:40%} }
 .watermark{position:absolute;bottom:-.28em;left:50%;transform:translateX(-50%);
   font-family:var(--display);font-size:clamp(120px,22vw,300px);line-height:1;color:#26262309;
   white-space:nowrap;pointer-events:none;user-select:none;letter-spacing:-.02em}
@@ -562,8 +567,6 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
       <a href="https://github.com/superdesigndev/treg" class="hidem navico" target="_blank" rel="noopener"><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>Repo</a>
       <a href="https://discord.gg/6mQYYfFMAn" class="hidem navico" target="_blank" rel="noopener"><svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.3 18.3 0 0 0-5.49 0 12.6 12.6 0 0 0-.61-1.25.08.08 0 0 0-.08-.04 19.7 19.7 0 0 0-4.88 1.52.07.07 0 0 0-.03.03C.53 9.05-.32 13.58.1 18.06c0 .02.01.04.03.05a19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.22-2a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.89.08.08 0 0 1-.01-.13c.13-.09.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08.01c.12.1.24.2.37.29a.08.08 0 0 1-.01.13c-.6.35-1.22.64-1.87.89a.08.08 0 0 0-.04.11c.36.7.77 1.36 1.22 2a.08.08 0 0 0 .08.03 19.8 19.8 0 0 0 6.02-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.16-1.08-2.16-2.42s.96-2.42 2.16-2.42c1.21 0 2.18 1.1 2.16 2.42 0 1.34-.95 2.42-2.16 2.42z"/></svg>Community</a>
       <a href="/catalog">Catalog</a>
-      <a href="/use-cases">Use cases</a>
-      <a href="/workflows" class="hidem">Workflows</a>
       <a onclick="openSignin()">Sign in</a>
       <button class="candy sm" onclick="openSignin()">Start free</button>
     </div>
@@ -872,10 +875,18 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
 
 <footer>
   <div class="foot-in">
-    <div class="brand"><span class="glyph">▚</span> treg</div>
-    <span style="font-family:var(--mono);font-size:12px">— 100% open source</span>
-    <span class="sp"></span>
-    <a href="/catalog">catalog</a><a href="/use-cases">use cases</a><a href="/workflows">workflows</a><a href="/agents/claude-code">agents</a><a href="/resources">resources</a><a href="/tutorial">docs</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">github ↗</a><a href="/docs">api</a><a href="/terms">terms</a><a href="/privacy">privacy</a>
+    <div class="foot-brand">
+      <div class="brand"><span class="glyph">▚</span> treg</div>
+      <div class="note">100% open source</div>
+    </div>
+    <nav class="foot-cols" aria-label="Site">
+      <div class="foot-col"><div class="lab">Explore</div>
+        <a href="/catalog">Catalog</a><a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a></div>
+      <div class="foot-col"><div class="lab">Build</div>
+        <a href="/tutorial">Docs</a><a href="/docs">API</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">GitHub ↗</a></div>
+      <div class="foot-col"><div class="lab">Company</div>
+        <a href="/resources">Resources</a><a href="/support">Support</a><a href="/terms">Terms</a><a href="/privacy">Privacy</a></div>
+    </nav>
   </div>
   <div class="watermark">treg</div>
 </footer>

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -11,6 +11,12 @@ social and trends, enrichment, ads, scraping. Ask for the task, not the tool: yo
 know which vendor sells backlink data, or to hold an account with them. Search the catalog for what
 you want to do, read the price, call it.
 
+Three readable indexes, each also served as Markdown by appending `.md`: `{BASE}/use-cases`
+(one page per job, every provider that does it compared on price, measured success rate and
+speed), `{BASE}/workflows` (several jobs chained into one prompt, each step priced, with the
+receipt from a real run) and `{BASE}/tools/<provider>` (one provider's endpoints and per-call
+prices). Start there when you want the comparison rather than one endpoint.
+
 Why this exists: the tools an agent needs for real work are behind subscriptions nobody buys for a
 single run (Semrush $139/mo, Moz $99/mo, Crunchbase $99/mo, Apollo $59/seat), behind signup walls,
 or behind no public API at all — invite-only, partner-only, app-review-only. treg carries those

--- a/src/treg/web/usecase.css
+++ b/src/treg/web/usecase.css
@@ -207,15 +207,20 @@ details .body em{color:var(--muted2)}
 .final .trust a{color:#d9d9d6}
 
 /* ---------- footer ---------- */
-footer{padding:34px 0;background:var(--inverse)}
-.foot-in{max-width:1160px;margin:0 auto;padding:0 28px;display:flex;align-items:center;
-  gap:18px;flex-wrap:wrap;font-family:var(--mono);font-size:12px}
+footer{padding:40px 0 48px;background:var(--inverse)}
+.foot-in{max-width:1160px;margin:0 auto;padding:0 28px;display:flex;align-items:flex-start;
+  justify-content:space-between;gap:32px 56px;flex-wrap:wrap;font-size:13px}
 .foot-in .brand{color:var(--inverse-ink);font-size:14px}
 .foot-in .brand .glyph{background:#ffffff1f}
-.foot-in .sp{flex:1}
+.foot-brand{display:flex;flex-direction:column;gap:8px}
+.foot-brand .note{font-family:var(--mono);font-size:12px;color:#6e6e6a}
+.foot-cols{display:flex;gap:56px;flex-wrap:wrap}
+.foot-col{display:flex;flex-direction:column;gap:8px;min-width:104px}
+.foot-col .lab{font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;color:#6e6e6a;margin-bottom:2px}
 .foot-in a{color:#8a8a86}
 .foot-in a:hover{color:var(--inverse-ink);text-decoration:none}
 .foot-in .note{color:#6e6e6a}
+@media (max-width:640px){ .foot-cols{gap:32px} .foot-col{min-width:40%} }
 
 /* ---------- the two steps ----------
    Both are the same shape — numbered label, optional hint, dark block. An earlier version put a

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -457,6 +457,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "indexnow_key",
+    "path": "/7c2e4a91b5d3f8e6treg2026.txt"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "install_sh",
     "path": "/install.sh"
   },

--- a/tests/test_endpoint_stats.py
+++ b/tests/test_endpoint_stats.py
@@ -138,7 +138,7 @@ async def test_aggregates_pool_across_orgs_but_carry_nothing_identifying(clients
         await _record(EP, 200, org_id=2)
     got = (await _observed([EP]))[EP]
     assert got["samples"] == 6                                   # pooled across tenants
-    assert set(got) == {"samples", "ok_rate", "p50_ms", "p95_ms", "last_ok_days", "hit_rate", "hit_samples"}
+    assert set(got) == {"samples", "decided", "ok_rate", "p50_ms", "p95_ms", "last_ok_days", "hit_rate", "hit_samples"}
     assert not any(k in got for k in ("org_id", "user_email", "params_hash", "client"))
 
 

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -433,7 +433,7 @@ async def test_compare_titles_carry_the_cheapest_price(clients: AsyncClient):
 async def test_provider_title_leads_with_pricing(clients: AsyncClient):
     html = (await clients.get("/tools/hunter")).text
     title = re.search(r"<title>(.*?)</title>", html, re.S).group(1)
-    assert title.startswith("Hunter API pricing per call"), title
+    assert title.startswith("Hunter API pricing") and "$" in title, title
     assert len(title) <= 65, title
 
 

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -394,3 +394,50 @@ async def test_brand_files_are_hot_linkable(clients: AsyncClient, path: str, cty
 async def test_favicon_is_the_mono_mark(clients: AsyncClient):
     body = (await clients.get("/favicon.svg")).text
     assert 'fill="#000000"' in body and 'fill="#ffffff"' in body
+
+
+# ---- discovery: the hubs are linked from pages Google already crawls -----------------------
+#
+# Before these links existed the 38 job pages and both workflow pages answered "URL is unknown
+# to Google" (Search Console URL inspection, 2026-08-27): they were listed in the sitemap and
+# linked from nothing. Every server-rendered page, the landing and the public catalog now carry
+# the three hubs, /catalog names them in its crawlable prerender, a provider page names the jobs
+# it serves, and a job page names the workflows that chain it.
+
+async def test_every_surface_links_the_three_hubs(clients: AsyncClient):
+    for path in ("/", "/catalog", "/tools/hunter", "/use-cases/verify-an-email"):
+        html = (await clients.get(path)).text
+        for hub in ('href="/use-cases"', 'href="/workflows"'):
+            assert hub in html, f"{path} does not link {hub}"
+    assert 'href="/agents/claude-code"' in (await clients.get("/tools/hunter")).text
+
+
+async def test_provider_page_names_the_jobs_it_serves(clients: AsyncClient):
+    html = (await clients.get("/tools/hunter")).text
+    assert 'id="used-in"' in html
+    assert 'href="/use-cases/verify-an-email"' in html
+    assert 'href="/use-cases/find-professional-emails"' in html
+
+
+async def test_job_page_names_the_workflows_that_chain_it(clients: AsyncClient):
+    html = (await clients.get("/use-cases/verify-an-email")).text
+    assert 'href="/workflows/find-and-verify-a-lead-list"' in html
+
+
+async def test_compare_titles_carry_the_cheapest_price(clients: AsyncClient):
+    html = (await clients.get("/use-cases/verify-an-email")).text
+    title = re.search(r"<title>(.*?)</title>", html, re.S).group(1)
+    assert "$" in title and len(title) <= 65, title
+
+
+async def test_provider_title_leads_with_pricing(clients: AsyncClient):
+    html = (await clients.get("/tools/hunter")).text
+    title = re.search(r"<title>(.*?)</title>", html, re.S).group(1)
+    assert title.startswith("Hunter API pricing per call"), title
+    assert len(title) <= 65, title
+
+
+async def test_indexnow_key_is_served_from_the_root(clients: AsyncClient):
+    from treg.routers.web import INDEXNOW_KEY
+    r = await clients.get(f"/{INDEXNOW_KEY}.txt")
+    assert r.status_code == 200 and r.text == INDEXNOW_KEY

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -441,3 +441,11 @@ async def test_indexnow_key_is_served_from_the_root(clients: AsyncClient):
     from treg.routers.web import INDEXNOW_KEY
     r = await clients.get(f"/{INDEXNOW_KEY}.txt")
     assert r.status_code == 200 and r.text == INDEXNOW_KEY
+
+
+async def test_agent_pages_name_the_workflows(clients: AsyncClient):
+    html = (await clients.get("/agents/grok-bot")).text
+    assert 'id="workflows"' in html
+    assert 'href="/workflows/find-and-verify-a-lead-list"' in html
+    md = (await clients.get("/agents/grok-bot.md")).text
+    assert "/workflows/find-and-verify-a-lead-list" in md

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -404,12 +404,35 @@ async def test_favicon_is_the_mono_mark(clients: AsyncClient):
 # the three hubs, /catalog names them in its crawlable prerender, a provider page names the jobs
 # it serves, and a job page names the workflows that chain it.
 
+HUBS = ('href="/use-cases"', 'href="/workflows"', 'href="/agents/claude-code"')
+
+
 async def test_every_surface_links_the_three_hubs(clients: AsyncClient):
-    for path in ("/", "/catalog", "/tools/hunter", "/use-cases/verify-an-email"):
+    for path in ("/", "/catalog", "/tools/hunter", "/use-cases/verify-an-email",
+                 "/workflows/find-and-verify-a-lead-list", "/agents/grok-bot"):
         html = (await clients.get(path)).text
-        for hub in ('href="/use-cases"', 'href="/workflows"'):
+        for hub in HUBS:
             assert hub in html, f"{path} does not link {hub}"
-    assert 'href="/agents/claude-code"' in (await clients.get("/tools/hunter")).text
+
+
+async def test_hub_links_stay_off_a_self_hosted_registry(monkeypatch):
+    """The job, workflow and agent pages exist on treg.to only (`_hosted`), so a self-hosted
+    registry's footer and catalog must not point at three 404s. The IndexNow key file is generic
+    and stays available everywhere."""
+    from httpx import ASGITransport
+    from treg.api import app
+    from treg.routers.web import INDEXNOW_KEY
+    monkeypatch.setenv("TREG_PUBLIC_URL", "https://registry.example.internal")
+    get_settings.cache_clear()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+            for path in ("/", "/catalog", "/tools/hunter"):
+                html = (await c.get(path)).text
+                for hub in HUBS:
+                    assert hub not in html, f"{path} links {hub} off-host"
+            assert (await c.get(f"/{INDEXNOW_KEY}.txt")).status_code == 200
+    finally:
+        get_settings.cache_clear()
 
 
 async def test_provider_page_names_the_jobs_it_serves(clients: AsyncClient):


### PR DESCRIPTION
## Why

Search Console (28 days to 2026-08-26): 197 clicks / 1,509 impressions, ~61 brand, **1 non-brand click**. The 38 `/use-cases/<job>` pages, `/workflows` and `/agents` had **zero impressions**, and URL inspection said "URL is unknown to Google" for `/use-cases/find-professional-emails` and `/workflows/find-and-verify-a-lead-list`. They were in the sitemap and linked from nothing: the landing linked `/catalog` and `/resources` only, `/catalog` linked `/tools/*` only, `/resources` linked the five outcome pages only, and those five were the only non-homepage URLs with impressions. `/tools/hunter`, linked from `/catalog`, was indexed.

## What

- **Nav + footer on every surface** (landing, public catalog, every server-rendered page): `/use-cases`, `/workflows`, `/agents/claude-code`.
- **`/catalog` prerender** names both hubs in a sentence.
- **Reverse links, generated from the same tables the pages render from** (cached per process): `/tools/<provider>` lists the jobs it serves ("Used in"); `/use-cases/<job>` lists the workflows that chain it ("Run the full sequence"); every `/agents/<agent>` page lists the workflows.
- **Pricing-led titles**: `/tools/<provider>` → `Hunter API pricing: from $0.00245/result, no signup | treg.to` with a measured line in the kicker (calls, ok rate, median latency, via `_observed_or_empty`). Compare-form job titles get `, from $X` when it fits in 65 chars (" compared" dropped to make room). GSC shows "{provider} api pricing" is what reaches the site.
- **IndexNow**: key file served from the root (registered in the ownership table + route snapshot) and `scripts/indexnow_submit.py` to push every sitemap URL to Bing/Yandex/Seznam/Naver and ping Google after deploy.
- **Grok Bot**: three FAQ entries (lead generation, research, what it cannot do yet).
- `llms.txt` points agents at the three indexes.
- Docs: `docs/context/interface/seo.md` (Discovery, titles, IndexNow, agent workflows), `architecture/composition.md` (route). Marketing research + drafts + build plan in `marketing/`.

## Tests

`tests/test_seo.py`: hubs on every surface, provider→jobs, job→workflows, agent→workflows, price in compare titles, provider title leads with pricing, IndexNow key served. Route snapshot updated. Full suite: 1,919 passed, 1 skipped; page/SEO/role tests re-run green after the last commit (199 passed).

## After merge

1. `uv run --frozen python scripts/indexnow_submit.py` (needs the key file live).
2. Resubmit the sitemap in Search Console (`google-search-console.x.webmasters-sitemaps-submit`) and request indexing on `/use-cases`, `/workflows`, `/agents/claude-code`, `/workflows/find-and-verify-a-lead-list`.
3. Day 7: URL-inspect the same four; day 21: exact-head position on the retitled pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmqpzAY3wgcKyfPGDuwsje