### PR TITLE
feat(call): refuse before reserve on an exhausted platform account + typed provider_capacity 503 (plan step D)

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -124,6 +124,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/domain/__init__.py` | architecture/import-boundaries.md |
 | `src/treg/domain/capacity/__init__.py` | architecture/import-boundaries.md, ops/capacity.md |
 | `src/treg/domain/capacity/collectors.py` | ops/capacity.md |
+| `src/treg/domain/capacity/marks.py` | ops/capacity.md |
 | `src/treg/domain/capacity/overflow_seed.json` | ops/capacity.md |
 | `src/treg/domain/capacity/policy.py` | ops/capacity.md |
 | `src/treg/domain/capacity/routes.py` | ops/capacity.md |
@@ -230,6 +231,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_call_cancellation.py` | architecture/proxy-model.md |
 | `tests/test_capacity_know.py` | ops/capacity.md |
 | `tests/test_capacity_overflow_routes.py` | ops/capacity.md |
+| `tests/test_capacity_protect.py` | ops/capacity.md |
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
 | `tests/test_marketplace_call.py` | architecture/mcp-oauth.md, architecture/proxy-model.md |
@@ -272,6 +274,6 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `index.html`, `landing.html`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
+| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
 | `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/USAGE.md
+++ b/USAGE.md
@@ -174,6 +174,11 @@ Out of balance is an HTTP **402** carrying `balance_micro`, `estimated_cost_micr
 so an agent can act on it without reading prose. There is also a per-day ceiling on spend against
 treg's keys, so a runaway agent has a bounded blast radius.
 
+If treg's **own** account for a provider is out, a metered call is refused with HTTP **503**
+`provider_capacity_unavailable` before anything is reserved — nothing is charged, the body names
+`resets_at` when known and `alternatives` (other providers for the same capability). Your own key
+for the provider is never affected, and treg does not switch providers on your behalf.
+
 ## Calling
 
 | Command | Options | What it does |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -49,7 +49,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
-| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B + B′; observe-only, nothing on the call path) | __init__.py, collectors.py, policy.py, sweep.py, … |
+| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B, B′, D) | __init__.py, collectors.py, policy.py, sweep.py, … |
 | [Running & deploying the server](ops/deploy.md) | shipped | pyproject.toml, __main__.py, worker.py, selfhost.sh, … |
 
 ## Reference

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -97,7 +97,9 @@ Base dependencies such as httpx and questionary remain allowed.
 The capacity domain (`treg.domain.capacity`, plan step B) is a leaf like identity: it cannot import
 `treg.api`, `treg.routers`, `treg.application`, `treg.bootstrap`, `treg.audit`, FastAPI or Starlette.
 It reads config and writes only its own tables and ratestore keys, from worker-profile commands
-(`treg-worker`, a separate console script so the light `treg` CLI never gains a DB import). The
+(`treg-worker`, a separate console script so the light `treg` CLI never gains a DB import). The call
+application imports the capacity domain inward (`resolve` → `view`, `settle` → `signatures`/`marks`);
+the domain never imports back. The
 aggregator envelopes live under `treg.infra.upstream.aggregators` and inherit the upstream contract
 (no HTTP adapters, no routers); the capacity domain's `verify` module may import them because they are
 pure envelope code, not a web framework.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -769,3 +769,10 @@ that this protects the person who opted into the program and exposes the person 
 the commercial conversation that replaces an uncapped percentage. When an influencer tier lands, it
 reads `/admin/referrals` — the same table, filtered — and the payout rail (and its W-9/1099
 obligations) is what gets bought rather than built.
+
+## Not money: the capacity mark
+
+`application.call.settle._note_capacity_signal` writes a ratestore row (`capacity:state:<provider>`)
+after a tier-4 balance/quota signature. It touches no balance, hold or ledger row — it is a hint for the
+NEXT caller's resolution — and is listed in the dataplane write allowlist on its own
+(`capacity_exhausted_mark`), not under the money entries. See `ops/capacity.md`.

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -294,6 +294,29 @@ also rejects numeric IP encodings — decimal/hex/octal/short forms like `213070
 
 > Why relay instead of modeling the upstream: [foundation/charter.md](../foundation/charter.md).
 
+## Platform capacity: refuse before reserve (plan step D)
+
+Tier 4 spends treg's own vendor account, and that account can be empty. `_resolve_marketplace_call`
+asks two questions after `_platform_offer` says yes: is the provider marked **exhausted** in the
+in-process capacity view (`domain.capacity.view`, loaded from ratestore `capacity:state:<provider>` on a
+60 s TTL by `resolve_marketplace_target` before its session opens)? If so it raises
+`CallFailure("provider_capacity", 503, blame="treg")` — **before any hold exists** — whose body carries
+`resets_at` when known and the same-capability alternatives from `_capability_alternatives`. treg still
+does not choose for the caller (charter): it names the options. The audit row is `refused_by="capacity"`,
+`X-Treg-Error: 1`, cost 0. A stale, empty or "ok" view never refuses; only a confirmed signal does.
+
+The signal comes from the call path itself as well as from the worker's sweep: after a tier-4 answer
+≥ 400, `settle._note_capacity_signal` runs `domain.capacity.signatures.classify` on the vendor's
+status/headers/body. A `balance` or `quota` signature (findymail "Not enough credits", lusha's "Daily"
+429, hunter's "per billing period" 429, any bare 402, …) writes the exhausted mark through
+`domain.capacity.marks.mark_exhausted` — its own short session, **after** the settle closed the hold,
+never during flight — and the next call is refused without waiting for a sweep. A burst 429
+(`retry-after ≤ 60 s`) or an unknown one only logs; step D′ smooths those. That mark is the single
+dataplane write this feature adds (`capacity_exhausted_mark` in `tests/test_call_architecture.py`).
+Tiers 1/2 resolve earlier and never consult the view: an org's own key running dry is the org's own
+answer, relayed unchanged. The vendor's 402 on THIS call is also relayed unchanged — the protection is
+for the next caller.
+
 ## treg's own headers never reach the upstream — by PREFIX, not by name
 
 `proxy._DROP_REQUEST` used to enumerate our control headers, and the enumeration had already failed:

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -85,6 +85,16 @@ only a real `http.disconnect`. If the client disconnects before the encoded body
 middleware skips decoding and replays each consumed partial-body message followed by that real
 disconnect.
 
+## `503 provider_capacity_unavailable` — treg's own account is out
+
+A metered (tier-4) call whose provider treg's own account cannot serve right now (a confirmed
+balance/quota signal, or the capacity sweep) is refused **before any hold** with a typed 503:
+`{"detail": {"error": "provider_capacity_unavailable", "provider", "endpoint_id", "resets_at" | null,
+"alternatives": [...], "message"}}`, `X-Treg-Error: 1`, no `X-Treg-Cost-Micro`, `refused_by="capacity"`
+on the audit row. The caller's own key for the provider is never affected (tiers 1/2 win first), and
+treg does not call an alternative on the caller's behalf — it names them. Not the pool-saturation 503
+(`treg_saturated`), which is a different exit. See `architecture/proxy-model.md` § Platform capacity.
+
 ## `X-Treg-Error` — whose refusal is this?
 `bootstrap_handlers._mark_treg_own_errors` tags treg's **own**
 refusals on `/call/` paths with `X-Treg-Error: 1`, then answers exactly as before — the status and body

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -1,6 +1,6 @@
 ---
 title: Provider capacity — knowing what treg's own vendor accounts have left
-status: shipped (steps B + B′; observe-only, nothing on the call path)
+status: shipped (steps B, B′, D)
 sources:
   - src/treg/domain/capacity/__init__.py
   - src/treg/domain/capacity/collectors.py
@@ -10,6 +10,8 @@ sources:
   - src/treg/domain/capacity/routes.py
   - src/treg/domain/capacity/signatures.py
   - src/treg/domain/capacity/verify.py
+  - src/treg/domain/capacity/marks.py
+  - tests/test_capacity_protect.py
   - src/treg/domain/capacity/overflow_seed.json
   - src/treg/infra/upstream/aggregators/__init__.py
   - src/treg/infra/upstream/aggregators/orthogonal.py
@@ -137,9 +139,16 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   with the reason. Spends real money (bounded by `--max-usd`, default 2¢); needs the aggregator
   keys in the env — a Render cron, never the dataplane.
 
+## Protect, part one (step D) — refuse before reserve
+
+The call path now reads the view and writes one mark (`marks.py`); the mechanics and the
+typed `provider_capacity` 503 are documented in `architecture/proxy-model.md` § Platform capacity
+and `interface/api.md`. In one line: exhausted provider → 503 before any hold, with alternatives
+named; a balance/quota signature on treg's key → exhausted mark in ratestore for the next caller;
+burst 429s only logged until D′. Tiers 1/2 untouched.
+
 ## Not built yet (plan steps C–F)
 
-Forecasts and alerts (C, gated on the `money-funding-transactions` debt); the exhausted view read
-in `_platform_offer` and the typed `provider_capacity` 503 (D); burst smoothing (D′); the
+Forecasts and alerts (C, gated on the `money-funding-transactions` debt); burst smoothing (D′); the
 overflow child cycle through Orthogonal/Monid (E); enabling routes (F). Until F ships, the charter
 row "not built yet: routing/failover" stands and treg still relays a vendor's 402 unchanged.

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -116,6 +116,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -119,6 +119,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -100,6 +100,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -98,6 +98,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -98,6 +98,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -15,6 +15,7 @@ from sqlmodel import select
 from ... import catalog_store, oauth_providers
 from ... import sandbox as demo_sandbox
 from ...config import get_settings, platform_setting_name
+from ...domain.capacity.view import view as capacity_view
 from ...db import session_maker
 from ...domain.governance import access as access_policy
 from ...domain.identity.access import Caller
@@ -822,6 +823,11 @@ async def _resolve_marketplace_call(
     # an org that brought its own credential is billed by the provider, not by us, and must never be
     # silently switched onto our key (their quota, their rate limits, their data agreements).
     cost = _platform_offer(ep, provider, caller.org)
+    if cost is not None and capacity_view.is_exhausted(service):
+        # Refuse BEFORE reserve (plan §4.2): treg's own account for this provider is known to be
+        # out (a confirmed balance/quota signature, or the sweep). No hold is ever placed for a
+        # call we know will 402; the caller gets a typed 503 naming when and what else.
+        raise _provider_capacity_unavailable(ep, service, capacity_view.get(service))
     if cost is not None:
         virtual = Tool(
             org_id=caller.org_id, name=ep["id"], owner=caller.email,
@@ -834,6 +840,23 @@ async def _resolve_marketplace_call(
     raise _marketplace_no_credential(service, ep["id"], provider, ep)
 
 
+def _provider_capacity_unavailable(ep: dict, service: str, state) -> ResolutionFailed:
+    """The typed floor (plan §4.5): no charge, `resets_at` when known, and the same-capability
+    alternatives — treg names them and leaves the choice to the caller (charter: no failover)."""
+    resets = getattr(state, "exhausted_until", None)
+    lines = [f"treg's own {service} account is out of capacity right now — {ep['id']} can't be "
+             f"served on treg's key" + (f" until about {resets:%Y-%m-%d %H:%M} UTC" if resets else "")]
+    lines.append(f"  use your own key: treg secret add {service} --env-var "
+                 f"{service.upper().replace('-', '_')}_API_KEY  (own keys are never affected)")
+    lines.extend(_capability_alternatives(ep))
+    return ResolutionFailed("provider_capacity", status_code=503, detail={
+        "error": "provider_capacity_unavailable", "provider": service, "endpoint_id": ep["id"],
+        "resets_at": resets.isoformat() + "Z" if resets else None,
+        "alternatives": [ln.strip() for ln in _capability_alternatives(ep)[1:]],
+        "message": "\n".join(lines),
+    })
+
+
 async def resolve_marketplace_target(
     ep: dict,
     *,
@@ -844,6 +867,10 @@ async def resolve_marketplace_target(
     caller: Caller,
     resolve_call: Callable[[str, Caller, AsyncSession], Awaitable[ResolvedTarget]],
 ) -> MarketplaceCall:
+    # The exhausted view is refreshed here — before the resolution session opens, so at most one
+    # connection is held at a time, and before any hold exists. Cached 60 s; a stale or empty view
+    # never refuses (plan §4.1: blocking fires on confirmed signals only).
+    await capacity_view.load()
     async with session_maker() as db:
         return await _resolve_marketplace_call(
             ep,

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -46,6 +46,7 @@ from .resolve import (
 from .settle import (
     _buffer_response,
     _finish_cancelled_call as finish_cancelled_call,
+    _note_capacity_signal,
     _peek_stream_head,
     _platform_settle,
     _record_first_call,
@@ -321,7 +322,9 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             audit.record_call(
                 org_id=caller.org_id, user_email=caller.email, tool_name=ep["id"],
                 method=request.method, path=rest, status_code=mkexc.status_code,
-                client=_client_name(request), refused_by=_refusal_kind(mkexc.status_code),
+                client=_client_name(request),
+                refused_by=("capacity" if mkexc.kind == "provider_capacity"
+                            else _refusal_kind(mkexc.status_code)),
                 telemetry={"call_ref": call_ref,
                            "endpoint_id": ep["id"], "provider": ep.get("provider"),
                            **_tag_telemetry(meta)})
@@ -666,6 +669,14 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         except asyncio.CancelledError:
             await _finish_cancelled_call(request, mk, call_ref, response)
             raise
+        if response.status >= 400:
+            # Did the provider just say OUR account is out? Mark it for the next caller (plan
+            # §4.1). After the settle on purpose: the hold is closed, no connection is held.
+            try:
+                await _note_capacity_signal(mk, response.status, httpx.Headers(response.raw_headers), body)
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
         # A relayed non-2xx arrives HERE, as a Response — the vendor's own status is never raised
         # (see _refusal_kind). So this is where the provider's own explanation is captured, and the
         # only place it exists: nothing downstream keeps the body.

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -11,6 +11,8 @@ from sqlalchemy import update
 from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 
 from ... import adsconv, catalog_store, ledger
+from ...domain.capacity import marks as capacity_marks
+from ...domain.capacity import signatures as capacity_signatures
 from ...db import session_maker
 from ...models import Org
 from ...timeutil import utcnow_naive as _utcnow_naive
@@ -436,6 +438,33 @@ async def _finish_cancelled_call(
             # same cleanup task so compensation completes before the original cancellation escapes.
             continue
     await cleanup
+async def _note_capacity_signal(mk: MarketplaceCall, status_code: int, headers, body: bytes) -> None:
+    """After a tier-4 answer: did the provider just tell us OUR account is out? A confirmed balance/
+    quota signature (domain.capacity.signatures) marks the provider exhausted in ratestore so the next
+    call is refused before a hold exists. Burst/unknown 429s only log (D′ smooths them). Runs after
+    the settle, on its own short session, and never raises. Platform tier only: an org's own key
+    running dry is the org's business, and an oauth-billed connect has no shared account to mark."""
+    if mk.tier != "platform" or status_code < 400:
+        return
+    try:
+        signal = capacity_signatures.classify(mk.provider, status_code, headers, body[:4096])
+        if signal is None:
+            return
+        if capacity_signatures.is_exhausting(signal):
+            await capacity_marks.mark_exhausted(
+                mk.provider, until=signal.resets_at,
+                note=f"{signal.kind} signature on {mk.endpoint_id}: {signal.detail[:80]}")
+            logging.getLogger("treg.capacity").warning(
+                "platform account exhausted: %s (%s on %s)", mk.provider, signal.kind, mk.endpoint_id)
+        else:
+            logging.getLogger("treg.capacity").info(
+                "rate signal on %s: %s retry_after=%s", mk.provider, signal.kind, signal.retry_after_s)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 — the caller already has the provider's answer; a mark is a hint
+        logging.getLogger("treg.capacity").warning("capacity signal handling failed", exc_info=True)
+
+
 async def _record_first_call(org_id: int) -> None:
     """Set Org.first_call_at once — the metric that decides whether a marketing channel is real (see
     marketing/landing/_measurement.md). A CONDITIONAL UPDATE, not read-then-write: concurrent first

--- a/src/treg/application/call/types.py
+++ b/src/treg/application/call/types.py
@@ -37,6 +37,9 @@ _BLAME_BY_KIND: dict[str, Blame] = {
     "tag_call_cap_reached": "caller",
     "tag_spend_cap_reached": "caller",
     "insufficient_balance": "caller",
+    # treg's OWN vendor account for the provider is out (balance/quota) — a 503 the caller cannot
+    # fix, answered before any hold exists, with the same-capability alternatives named.
+    "provider_capacity": "treg",
     "injection_failed": "treg",
     "ssrf_refused": "treg",
     "connect_failed": "upstream",

--- a/src/treg/domain/capacity/marks.py
+++ b/src/treg/domain/capacity/marks.py
@@ -1,0 +1,43 @@
+"""Capacity marks written FROM the call path — the one sanctioned dataplane write of this domain.
+
+A confirmed balance/quota signature on treg's own key (plan §4.1) marks the provider exhausted in
+ratestore (`capacity:state:<provider>`, the same key the sweep publishes) so the NEXT call is refused
+before a hold exists, without waiting for a sweep tick. Ratestore is the shared `Ephemeral` table:
+this is a DB write, listed in `tests/test_call_architecture.py`'s dataplane allowlist as
+`capacity_exhausted_mark`. It runs on its own short session AFTER the settle — never while an
+upstream request is in flight — and never raises: a failed mark costs one more relayed 402, not
+the call. The tables (`capacitypolicy`, `capacitysnapshot`) are worker-only; nothing here touches them.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from ... import ratestore
+from ...db import session_maker
+from ...timeutil import utcnow_naive
+from .policy import LatestState
+from .sweep import STATE_NS, STATE_TTL_S
+
+DEFAULT_EXHAUSTED_FOR = timedelta(hours=1)
+"""A balance signature carries no reset time: hold the mark this long, then let a call probe again
+(the sweep, hourly, refreshes it from the account API in between)."""
+
+log = logging.getLogger("treg.capacity")
+
+
+async def mark_exhausted(provider: str, *, until: datetime | None, note: str = "",
+                         now: datetime | None = None) -> LatestState | None:
+    now = now or utcnow_naive()
+    until = until or (now + DEFAULT_EXHAUSTED_FOR)
+    state = LatestState(provider, 0.0, "", now, "exact", exhausted_until=until, health="exhausted",
+                        note=(note or "signature on the call path")[:200])
+    try:
+        async with session_maker() as db:
+            await ratestore.kv_put(db, STATE_NS, provider, state.to_json(), ttl_s=STATE_TTL_S)
+            await db.commit()
+    except Exception:  # noqa: BLE001 — a mark is a hint for the next call, never this call's fate
+        log.warning("capacity mark for %s not written", provider, exc_info=True)
+        return None
+    return state

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -198,6 +198,10 @@ Money notes for agents:
   `estimated_cost_micro`, `topup_url`. Recovery: `treg balance` (ledger), top up in the
   dashboard (Team → Billing), or connect the org's own key for that provider - own keys
   are never billed to the balance.
+- HTTP **503** with `error: provider_capacity_unavailable` → treg's OWN account for that
+  provider is out right now (not your balance, nothing charged). The body names `resets_at`
+  when known and `alternatives` — other providers for the same capability; pick one, or use
+  your own key for the provider (never affected). treg does not switch providers for you.
 - `treg balance` shows the prepaid balance and recent charges; the dashboard Activity page
   shows the exact settled cost of every call.
 

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -77,6 +77,9 @@ Notes:
   `estimated_cost_micro`, `topup_url`). Recovery: `treg balance` → top up in the dashboard
   (Team → Billing) → or store the org's own key for that provider (own keys are never billed
   to the balance — they take priority automatically).
+- HTTP **503** `provider_capacity_unavailable` = treg's own account for that provider is out
+  (not your balance; nothing charged). Body has `resets_at` and `alternatives` (same capability,
+  other providers) — choose one, or use your own key. treg never switches providers for you.
 - An org tool or secret for the provider always wins over treg's key, automatically — the catalog
   is the fallback, not a replacement for keys the team already has.
 - **Choosing between providers of one capability — the procedure.** `treg catalog get <id>` lists

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,6 +230,24 @@ async def clients():
 
 
 @pytest.fixture(autouse=True)
+def _reset_call_path_caches():
+    """The call path keeps in-process copies of ratestore state (the capacity view: 'provider X is
+    exhausted' for 60 s) and per-provider rate buckets. `reset_db()` wipes the tables, not process
+    memory — so a test that relays a vendor 402 would otherwise leave the NEXT test's tier-4 call
+    refused with a 503 it never asked for (CI, xdist worker gw3, 2026-08-28)."""
+    from treg.domain.capacity.routes_view import view as routes_view
+    from treg.domain.capacity.view import view as capacity_view
+    from treg.infra.upstream.limiter import limiter
+    capacity_view.invalidate(); capacity_view._states = {}
+    routes_view.invalidate(); routes_view._routes = []
+    limiter.reset()
+    yield
+    capacity_view.invalidate(); capacity_view._states = {}
+    routes_view.invalidate(); routes_view._routes = []
+    limiter.reset()
+
+
+@pytest.fixture(autouse=True)
 def _no_ambient_treg_identity(monkeypatch):
     """A dev machine may carry a per-agent identity in its environment (TREG_TOKEN et al — the
     'Scope this agent' setup persists them into the coding agent's global env, and the CLI lets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -232,19 +232,29 @@ async def clients():
 @pytest.fixture(autouse=True)
 def _reset_call_path_caches():
     """The call path keeps in-process copies of ratestore state (the capacity view: 'provider X is
-    exhausted' for 60 s) and per-provider rate buckets. `reset_db()` wipes the tables, not process
-    memory — so a test that relays a vendor 402 would otherwise leave the NEXT test's tier-4 call
-    refused with a 503 it never asked for (CI, xdist worker gw3, 2026-08-28)."""
-    from treg.domain.capacity.routes_view import view as routes_view
-    from treg.domain.capacity.view import view as capacity_view
-    from treg.infra.upstream.limiter import limiter
-    capacity_view.invalidate(); capacity_view._states = {}
-    routes_view.invalidate(); routes_view._routes = []
-    limiter.reset()
+    exhausted' for 60 s), the overflow route view and per-provider rate buckets. `reset_db()` wipes
+    the tables, not process memory — so a test that relays a vendor 402 would otherwise leave the
+    NEXT test's tier-4 call refused with a 503 it never asked for (CI, xdist worker gw3, 2026-08-28).
+    Each cache is optional: the modules land in successive PRs of the capacity stack."""
+    def _clear() -> None:
+        try:
+            from treg.domain.capacity.view import view as capacity_view
+            capacity_view.invalidate(); capacity_view._states = {}
+        except ImportError:
+            pass
+        try:
+            from treg.domain.capacity.routes_view import view as routes_view
+            routes_view.invalidate(); routes_view._routes = []
+        except ImportError:
+            pass
+        try:
+            from treg.infra.upstream.limiter import limiter
+            limiter.reset()
+        except ImportError:
+            pass
+    _clear()
     yield
-    capacity_view.invalidate(); capacity_view._states = {}
-    routes_view.invalidate(); routes_view._routes = []
-    limiter.reset()
+    _clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_call_architecture.py
+++ b/tests/test_call_architecture.py
@@ -13,6 +13,7 @@ from treg import bootstrap
 from treg.application import billing
 from treg.application.call import authorize, reserve, settle
 from treg.domain import money
+from treg.domain.capacity import marks as capacity_marks
 
 
 _SRC = Path(__file__).parents[1] / "src" / "treg"
@@ -35,6 +36,13 @@ _DATAPLANE_DERIVED_WRITES = {
         (money.reserve_in_transaction, "reap_stale_holds"),
         (money.reap_stale_holds, "release"),
     ),
+    # Plan §4.1 / refactor plan §1.6 "platform-account capacity marks": a confirmed balance/quota
+    # signature on treg's own key marks the provider exhausted in ratestore (the shared Ephemeral
+    # table) AFTER the settle, so the next call is refused before a hold exists.
+    "capacity_exhausted_mark": (
+        (settle._note_capacity_signal, "capacity_marks.mark_exhausted"),
+        (capacity_marks.mark_exhausted, "ratestore.kv_put"),
+    ),
 }
 _EXPECTED_DATAPLANE_WRITES = frozenset({
     "auto_topup_task",
@@ -42,6 +50,7 @@ _EXPECTED_DATAPLANE_WRITES = frozenset({
     "sandbox_ratestore_hit",
     "first_call_adconversion_outbox",
     "lazy_stale_hold_reap",
+    "capacity_exhausted_mark",
 })
 _DERIVED_WRITE_FILES = {
     _SRC / "application" / "billing.py": {"loop.create_task"},
@@ -49,7 +58,8 @@ _DERIVED_WRITE_FILES = {
         "publicdemo_policy.enforce_public_demo_ip_cap",
     },
     _SRC / "application" / "call" / "reserve.py": {"billing.maybe_schedule_autotopup"},
-    _SRC / "application" / "call" / "settle.py": {"adsconv.queue"},
+    _SRC / "application" / "call" / "settle.py": {"adsconv.queue", "capacity_marks.mark_exhausted"},
+    _SRC / "domain" / "capacity" / "marks.py": {"ratestore.kv_put"},
     _SRC / "domain" / "governance" / "publicdemo.py": {
         "ratestore.sweep", "ratestore.rate_check",
     },
@@ -64,6 +74,8 @@ _EXPECTED_DERIVED_WRITE_SITES = {
     ("application/call/reserve.py", "_platform_reserve",
      "billing.maybe_schedule_autotopup"),
     ("application/call/settle.py", "_record_first_call", "adsconv.queue"),
+    ("application/call/settle.py", "_note_capacity_signal", "capacity_marks.mark_exhausted"),
+    ("domain/capacity/marks.py", "mark_exhausted", "ratestore.kv_put"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.rate_check"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.sweep"),
     ("domain/money/__init__.py", "reap_stale_holds", "release"),

--- a/tests/test_capacity_protect.py
+++ b/tests/test_capacity_protect.py
@@ -1,0 +1,149 @@
+"""Step D of docs/PROVIDER-CAPACITY-PLAN.md — Protect: refuse-before-reserve on an exhausted
+platform account, the typed `provider_capacity` 503, and the call-path capacity mark.
+
+Tiers 1/2 (an org's own tool or key) never consult any of this."""
+
+from __future__ import annotations
+
+import json
+from datetime import timedelta
+
+from httpx import AsyncClient
+from sqlmodel import select
+
+from treg import audit, ratestore
+from treg.application.call import service as call_service
+from treg.application.call import settle as call_settle
+from treg.application.call.types import CallFailure
+from treg.db import session_maker
+from treg.domain.capacity.policy import LatestState
+from treg.domain.capacity.sweep import STATE_NS
+from treg.domain.capacity.view import view as capacity_view
+from treg.models import Hold, LedgerEntry
+from treg.timeutil import utcnow_naive
+
+from test_marketplace_call import EP, EP_MICRO, PLATFORM_KEYS, _balance, _fake_relay, platform_on  # noqa: F401
+
+
+async def _publish(provider: str, *, exhausted: bool, hours: float = 1.0, health: str | None = None):
+    now = utcnow_naive()
+    state = LatestState(provider, 0.0 if exhausted else 500.0, "USD", now, "exact",
+                        exhausted_until=(now + timedelta(hours=hours)) if exhausted else None,
+                        health=health or ("exhausted" if exhausted else "ok"))
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, provider, state.to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+
+
+async def _rows(model):
+    async with session_maker() as db:
+        return (await db.execute(select(model))).scalars().all()
+
+
+async def test_exhausted_platform_account_is_refused_before_any_hold(clients: AsyncClient, platform_on):
+    await _publish("tikhub", exhausted=True)
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503, r.text
+    assert r.headers["X-Treg-Error"] == "1"
+    assert "X-Treg-Call-Id" in r.headers
+    body = r.json()["detail"]
+    assert body["error"] == "provider_capacity_unavailable" and body["provider"] == "tikhub"
+    assert body["endpoint_id"] == EP and body["resets_at"] and "own key" in body["message"]
+    assert isinstance(body["alternatives"], list)
+    assert await _balance(clients) == before, "no charge"
+    assert await _rows(Hold) == [], "refused BEFORE reserve: no hold row ever existed"
+    assert {e.kind for e in await _rows(LedgerEntry)} <= {"grant"}, "no reserve/release entry either"
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert row["status_code"] == 503 and row["refused_by"] == "capacity" and row["tool_name"] == EP
+
+
+async def test_own_key_is_never_affected_by_an_exhausted_platform_account(clients: AsyncClient, platform_on):
+    await _publish("tikhub", exhausted=True)
+    await clients.post("/secrets", json={"name": "tikhub", "value": "MKKEY"})  # tier 2
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200, r.text
+    assert r.json()["auth"] == "Bearer MKKEY"
+
+
+async def test_a_stale_or_ok_view_never_refuses(clients: AsyncClient, platform_on, monkeypatch):
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"ok":true}'))
+    await _publish("tikhub", exhausted=False)
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 200
+    now = utcnow_naive()
+    stale = LatestState("tikhub", None, "", now - timedelta(hours=9), "stale", health="stale")
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "tikhub", stale.to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 200
+
+
+async def test_a_balance_signature_on_the_platform_key_marks_the_provider_for_the_next_call(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    await _publish("tikhub", exhausted=False)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402, "this call still relays the vendor's answer unchanged"
+    assert "X-Treg-Error" not in r.headers
+    assert r.headers["X-Treg-Cost-Micro"] == "0" and await _balance(clients) == before
+    async with session_maker() as db:  # the mark landed in ratestore, on its own session
+        state = LatestState.from_json(await ratestore.kv_get(db, STATE_NS, "tikhub"))
+    assert state.health == "exhausted" and state.is_exhausted() and "balance signature" in state.note
+    # …and the NEXT platform call is refused before any hold, even though the view is cached
+    capacity_view.invalidate()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"never":"reached"}'))
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r2.status_code == 503 and r2.json()["detail"]["error"] == "provider_capacity_unavailable"
+    assert await _rows(Hold) == []
+
+
+async def test_burst_429_and_caller_400_never_mark(clients: AsyncClient, platform_on, monkeypatch):
+    await _publish("tikhub", exhausted=False)
+    for status, body in ((429, b'{"detail":"slow down"}'), (400, b'{"detail":"bad aweme_id"}')):
+        monkeypatch.setattr(call_service, "relay", _fake_relay(status, body))
+        r = await clients.get(f"/call/{EP}?aweme_id=7")
+        assert r.status_code == status
+        async with session_maker() as db:
+            state = LatestState.from_json(await ratestore.kv_get(db, STATE_NS, "tikhub"))
+        assert state.health == "ok" and not state.is_exhausted()
+
+
+async def test_quota_429_marks_until_the_reset(clients: AsyncClient, platform_on, monkeypatch):
+    await _publish("tikhub", exhausted=False)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(429, b'{"detail":"limit reached"}'))
+
+    async def relay_with_retry_after(request, upstream_url, tool, secrets, client, drop_params=None, force_identity=False):
+        from treg.application.call.types import UpstreamResponse
+        async def _s():
+            yield b'{"detail":"quota"}'
+        async def _c():
+            return None
+        return UpstreamResponse(429, ((b"retry-after", b"7200"),), _s(), _c)
+    monkeypatch.setattr(call_service, "relay", relay_with_retry_after)
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 429
+    async with session_maker() as db:
+        state = LatestState.from_json(await ratestore.kv_get(db, STATE_NS, "tikhub"))
+    assert state.health == "exhausted"
+    assert timedelta(hours=1, minutes=55) < (state.exhausted_until - utcnow_naive()) <= timedelta(hours=2)
+
+
+async def test_a_failed_mark_never_fails_the_call(clients: AsyncClient, platform_on, monkeypatch):
+    await _publish("tikhub", exhausted=False)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b"out"))
+
+    async def boom(*a, **k):
+        raise RuntimeError("db gone")
+    monkeypatch.setattr(call_settle.capacity_marks, "mark_exhausted", boom)
+    # mark_exhausted itself swallows; simulate the seam above it raising to prove the guard
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and r.headers["X-Treg-Cost-Micro"] == "0"
+
+
+def test_provider_capacity_is_a_treg_blamed_typed_failure():
+    exc = CallFailure("provider_capacity", status_code=503, detail={"error": "x"})
+    assert exc.blame == "treg" and exc.status_code == 503

--- a/uv.lock
+++ b/uv.lock
@@ -20,9 +20,9 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/ca/4dc52902cf3491892d464f5265a81e9dff094692c8a049a3ed6a05fe7ee8/alembic-1.16.5.tar.gz", hash = "sha256:a88bb7f6e513bd4301ecf4c7f2206fe93f9913f9b48dac3b78babde2d6fe765e", size = 1969868, upload-time = "2025-08-27T18:02:05.668425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/ca/4dc52902cf3491892d464f5265a81e9dff094692c8a049a3ed6a05fe7ee8/alembic-1.16.5.tar.gz", hash = "sha256:a88bb7f6e513bd4301ecf4c7f2206fe93f9913f9b48dac3b78babde2d6fe765e", size = 1969868, upload-time = "2025-08-27T18:02:05.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/4a/4c61d4c84cfd9befb6fa08a702535b27b21fff08c946bc2f6139decbf7f7/alembic-1.16.5-py3-none-any.whl", hash = "sha256:e845dfe090c5ffa7b92593ae6687c5cb1a101e91fa53868497dbd79847f9dbe3", size = 247355, upload-time = "2025-08-27T18:02:07.370338Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/4c61d4c84cfd9befb6fa08a702535b27b21fff08c946bc2f6139decbf7f7/alembic-1.16.5-py3-none-any.whl", hash = "sha256:e845dfe090c5ffa7b92593ae6687c5cb1a101e91fa53868497dbd79847f9dbe3", size = 247355, upload-time = "2025-08-27T18:02:07.37Z" },
 ]
 
 [[package]]
@@ -271,6 +271,42 @@ wheels = [
 ]
 
 [[package]]
+name = "grimp"
+version = "3.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/73/ce58881177b003def779c87b5e10f396deef068933c97d6d206bd46d4cb7/grimp-3.15.tar.gz", hash = "sha256:91b57d4d801dc107ebfb5a7040d4777a152c579b5dc202426e1185e50931fe1e", size = 831734, upload-time = "2026-07-03T12:09:36.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/66/621abde26d8ece0d34ba611ca94bc62bf8c9c4389760d8909b0d96964878/grimp-3.15-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:915ea140cf55107fd6825c3e9eae2c4fda18aa19b87e8eee05d510b4d44ab928", size = 2143914, upload-time = "2026-07-03T12:08:50.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/76/a27fff8de84dbf46db9d6da937fe772f04a0e21e057a4863fd30e6fcaa55/grimp-3.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ae2d4d958d871792a9686ad51845e9e1e0886e9db13ecc47a9475899f4b27db", size = 2089296, upload-time = "2026-07-03T12:08:42.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/3d/fe38a0881ce7e00ef8590745853bccff5d337a943dc0d1d0735b0eb605f9/grimp-3.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19a1039d50ed6a9b221f44b32c7b07cb43dda70971e892fe8149995c0e9c1840", size = 2254829, upload-time = "2026-07-03T12:07:34.365Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a2/ef18989048e8f0c92171eabb15dffe9cd72de6404b86e3a37553f7d16dd6/grimp-3.15-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b7b649f2a34278897237670b6650073c9ab0fc1abf56821301bda28cb5c4256", size = 2193553, upload-time = "2026-07-03T12:07:45.06Z" },
+    { url = "https://files.pythonhosted.org/packages/85/22/82303539d21068021cc28c526be5e1b1cc0b7a61704c1663909497dd9b8a/grimp-3.15-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:020a8875c0cb67f407eb019b7be65b574d49071653f155c243f801aa87a1fd4d", size = 2345941, upload-time = "2026-07-03T12:08:18.082Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/20/3c66e7c814ba2b6b0cd230ca2445825c605f28242f4f3a658e5bb9adda73/grimp-3.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f0a0705cf9a10648c4aea71edde8fe3dfbf1cf05bd434ef38c813ad7c544886", size = 2604369, upload-time = "2026-07-03T12:07:55.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/2f642969950e096a67a43909ba66f33cb4750974e30c2c771e293aeb787c/grimp-3.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c36373cd0a2d4c9b53fabefbaa9edcc4c511ad2d335fb1296484f6ca550e4f82", size = 2326619, upload-time = "2026-07-03T12:08:05.931Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/99/98d39545e54e239a52a54d8e96752780778b11b5ebc78096dfa090f9d2ac/grimp-3.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:477ac0abcd12c697a0bd01b40875605f7f0db97332df6148e4d4057ee3ad199d", size = 2272955, upload-time = "2026-07-03T12:08:30.488Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/02/fabd5ae2b12276530f4bae038ffcf3a556ac2c9b9fa271f83fbeb4036a08/grimp-3.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:017e493fee9962d50db6f7a8b5d49ad2ae508484a06078d700adbef30f1ff1f0", size = 2431271, upload-time = "2026-07-03T12:08:57.606Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c8/fa3ec84df9c3ccc2b08177be41a48b76178e9e5773f4471f1caff4fc5c46/grimp-3.15-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e77982dd5b0977945034fa328f65cfb62ff589cb0da97a0f6042de78525c5c73", size = 2466937, upload-time = "2026-07-03T12:09:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/52d3acd2bbd6cebdf2ee6546c334f50f6358c25ae58624ae63d2ec3ad30b/grimp-3.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d129a8c57b7a19a44e8da94caf38a02753f1c9953aaba8c1a4633747f097164f", size = 2504734, upload-time = "2026-07-03T12:09:17.998Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/ad27750eb8b4a0c3ecb5ca7d78c7230f0f5e814515ed6f8986be527117ff/grimp-3.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba25002e92b1792f13391295a1f805d2e09781b846d92ec1a791ff9ed89298b6", size = 2514448, upload-time = "2026-07-03T12:09:28.401Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c0/8cc474a24198c1c2936269c5854be92af41787bd76d3190af584a9cebca7/grimp-3.15-cp312-cp312-win32.whl", hash = "sha256:232bf7a4c7536f62a99478eeb01de63c455261add35ee00c6ec9f04f280f853e", size = 1855806, upload-time = "2026-07-03T12:09:48.396Z" },
+    { url = "https://files.pythonhosted.org/packages/91/11/e46139fd43dd5714fae93f09f1c858fb2dc83a575d5f8cb1daf8a15a261b/grimp-3.15-cp312-cp312-win_amd64.whl", hash = "sha256:13be2285e358a7687c0f3b798ac9d4819f275976ad8d651297966e5a75bfafb9", size = 1985556, upload-time = "2026-07-03T12:09:40.786Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/6a/3e0a0760cc509cd09764d128de78a1f329740306c74e42dba82c58a99118/grimp-3.15-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f19b957053d1c736aaa0015eed2d4855bb2511637c5360d32b3c5ea045904e7a", size = 2143197, upload-time = "2026-07-03T12:08:51.685Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2e/127cbce04a5603d382c6a2bbc1a19b6889be49d60b88864bcdb174c8926d/grimp-3.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6480472c2d1f7f6a903906c92e9897d4e3dee5d69ce3881f04368d4ec6d2dde", size = 2088342, upload-time = "2026-07-03T12:08:44.227Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/36/af9df683bf6c8711e0e9136876ca130f9971102d945ff3a36d0c45dae2ec/grimp-3.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c14b64dbf2e4397df2e35fa8aa7028533621ecf1f8ea7ec24bc296a9c695ea4", size = 2254509, upload-time = "2026-07-03T12:07:35.809Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f5/e712633b68ea14d04e7de84ede4f8ddbba763d5f2d29ae8d6af721f84870/grimp-3.15-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26364c2c9f7db88243365299b4d1c4d948b74304ff03c8a6e4f028147fed3b22", size = 2193831, upload-time = "2026-07-03T12:07:46.309Z" },
+    { url = "https://files.pythonhosted.org/packages/13/74/151bdd73d6a60bd77d4b956f36d03dd558dd46a9b5ec8f5ad15921b503d7/grimp-3.15-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69331e1be693415596c6084342059b9ba3ecf1cfe2e3b1c761598dd2fe14d522", size = 2345289, upload-time = "2026-07-03T12:08:19.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/b8/3fc950fa73b757cbc35f77542bd662f431b9a8f360e63196ded640771a33/grimp-3.15-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe397991c269868c2fb08114099b2aa4f1bc803d03fadaaf97e006019f9e5da2", size = 2604407, upload-time = "2026-07-03T12:07:57.217Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/d8/98916b9dc0b89a3e89e0d714ce0872be859fff40ceee3e2cb6886b106eb4/grimp-3.15-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d556bd62664ee044c47cff64d737be132408064d4ba68ca9f756cb29b41cc2d", size = 2326769, upload-time = "2026-07-03T12:08:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/63/51/39595c5857f609e976e0bba1f19c1f45182ee4d8d2ea5cdfab72841eafbc/grimp-3.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9061c5b6f01130ff8639c49c80176d29d921acc36741b2ae0b763a7668106082", size = 2272498, upload-time = "2026-07-03T12:08:32.03Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/a44cc9db500ae80c45425238ee44d9556796aa88b8c0649cfa613fb88d14/grimp-3.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a9d04c195f0c6da4476361560d3d206a6a784b9eb0da7156fc6974511337e2e3", size = 2431075, upload-time = "2026-07-03T12:08:58.935Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/41/544f197ddb44990789683c25740ffa72474a57f0b16bc6b4a544edf9a2a9/grimp-3.15-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:01fd68c74cfd08b110bfd338d77efaa470670530f7179e6977764f44cd74d5cc", size = 2467361, upload-time = "2026-07-03T12:09:09.275Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b1/8261018b9f1ab47fffbb7739d7af3f04c8b529555b7fb2ae8b742d42d3db/grimp-3.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bd1ddd428a124d6730bed49ea60fb2ca6c8e0640c8f5abe1d0f6fc27a92fd8bc", size = 2503500, upload-time = "2026-07-03T12:09:19.585Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d6/99a2421c4c0de9f203a7e246030b13b676766e62e48504883863942646fb/grimp-3.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07e645e9d45ed43bb8ea8da5982c19eacf13ee685d8440e3dc280064c005599c", size = 2513834, upload-time = "2026-07-03T12:09:29.758Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a5/263729e23d64541cd99d36dbb592e29c1ecea803deb3bb5c0c463b43c2ec/grimp-3.15-cp313-cp313-win32.whl", hash = "sha256:473646e0a74a554b4ab071d7fcbf5f442eb8cf87561770dae269818636b8edf2", size = 1855743, upload-time = "2026-07-03T12:09:49.789Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/a072bbea2e2e94da38f90bd8794037c90fb4eba389b49d01cdd2bb85e13c/grimp-3.15-cp313-cp313-win_amd64.whl", hash = "sha256:dbc2c15a1fbca2ff358f86cc90067176096dd73bec27d002515521b3125ba507", size = 1984546, upload-time = "2026-07-03T12:09:42.543Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -378,6 +414,21 @@ wheels = [
 ]
 
 [[package]]
+name = "import-linter"
+version = "2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "grimp" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/c6/42962eb043df4d6984c1540220735b20442572fe37dab5e65ac807c939b9/import_linter-2.13.tar.gz", hash = "sha256:13af4a1d6b06044c58ea784e8732fd7fe48eec821a75feb4d6a1a2de36dd5c27", size = 1279761, upload-time = "2026-07-03T14:00:31.285Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/13/e7725e6eb32607fd4af51ccf3edfe835826e5cdf783b4d7fdc8f459196ae/import_linter-2.13-py3-none-any.whl", hash = "sha256:c0372e7ee5e15657bc06a8e841445e13237afd738a672d26863dc927af9f0bf5", size = 638185, upload-time = "2026-07-03T14:00:29.676Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -411,6 +462,68 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -452,6 +565,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
@@ -461,30 +583,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
-]
-
-[[package]]
-name = "mako"
-version = "1.3.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.160810Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297730Z" },
-]
-
-[[package]]
-name = "markupsafe"
-version = "3.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822387Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133071Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382230Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029161Z" },
 ]
 
 [[package]]
@@ -753,6 +851,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -876,93 +987,8 @@ wheels = [
 ]
 
 [[package]]
-name = "grimp"
-version = "3.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/73/ce58881177b003def779c87b5e10f396deef068933c97d6d206bd46d4cb7/grimp-3.15.tar.gz", hash = "sha256:91b57d4d801dc107ebfb5a7040d4777a152c579b5dc202426e1185e50931fe1e", size = 831734, upload-time = "2026-07-03T12:09:36.244551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/66/621abde26d8ece0d34ba611ca94bc62bf8c9c4389760d8909b0d96964878/grimp-3.15-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:915ea140cf55107fd6825c3e9eae2c4fda18aa19b87e8eee05d510b4d44ab928", size = 2143914, upload-time = "2026-07-03T12:08:50.423702Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/76/a27fff8de84dbf46db9d6da937fe772f04a0e21e057a4863fd30e6fcaa55/grimp-3.15-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ae2d4d958d871792a9686ad51845e9e1e0886e9db13ecc47a9475899f4b27db", size = 2089296, upload-time = "2026-07-03T12:08:42.802020Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/3d/fe38a0881ce7e00ef8590745853bccff5d337a943dc0d1d0735b0eb605f9/grimp-3.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19a1039d50ed6a9b221f44b32c7b07cb43dda70971e892fe8149995c0e9c1840", size = 2254829, upload-time = "2026-07-03T12:07:34.365794Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/a2/ef18989048e8f0c92171eabb15dffe9cd72de6404b86e3a37553f7d16dd6/grimp-3.15-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b7b649f2a34278897237670b6650073c9ab0fc1abf56821301bda28cb5c4256", size = 2193553, upload-time = "2026-07-03T12:07:45.060327Z" },
-    { url = "https://files.pythonhosted.org/packages/85/22/82303539d21068021cc28c526be5e1b1cc0b7a61704c1663909497dd9b8a/grimp-3.15-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:020a8875c0cb67f407eb019b7be65b574d49071653f155c243f801aa87a1fd4d", size = 2345941, upload-time = "2026-07-03T12:08:18.082512Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/20/3c66e7c814ba2b6b0cd230ca2445825c605f28242f4f3a658e5bb9adda73/grimp-3.15-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f0a0705cf9a10648c4aea71edde8fe3dfbf1cf05bd434ef38c813ad7c544886", size = 2604369, upload-time = "2026-07-03T12:07:55.926801Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/2f642969950e096a67a43909ba66f33cb4750974e30c2c771e293aeb787c/grimp-3.15-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c36373cd0a2d4c9b53fabefbaa9edcc4c511ad2d335fb1296484f6ca550e4f82", size = 2326619, upload-time = "2026-07-03T12:08:05.931310Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/99/98d39545e54e239a52a54d8e96752780778b11b5ebc78096dfa090f9d2ac/grimp-3.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:477ac0abcd12c697a0bd01b40875605f7f0db97332df6148e4d4057ee3ad199d", size = 2272955, upload-time = "2026-07-03T12:08:30.488742Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/02/fabd5ae2b12276530f4bae038ffcf3a556ac2c9b9fa271f83fbeb4036a08/grimp-3.15-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:017e493fee9962d50db6f7a8b5d49ad2ae508484a06078d700adbef30f1ff1f0", size = 2431271, upload-time = "2026-07-03T12:08:57.606199Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/c8/fa3ec84df9c3ccc2b08177be41a48b76178e9e5773f4471f1caff4fc5c46/grimp-3.15-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e77982dd5b0977945034fa328f65cfb62ff589cb0da97a0f6042de78525c5c73", size = 2466937, upload-time = "2026-07-03T12:09:07.857971Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7e/52d3acd2bbd6cebdf2ee6546c334f50f6358c25ae58624ae63d2ec3ad30b/grimp-3.15-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d129a8c57b7a19a44e8da94caf38a02753f1c9953aaba8c1a4633747f097164f", size = 2504734, upload-time = "2026-07-03T12:09:17.998479Z" },
-    { url = "https://files.pythonhosted.org/packages/33/53/ad27750eb8b4a0c3ecb5ca7d78c7230f0f5e814515ed6f8986be527117ff/grimp-3.15-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba25002e92b1792f13391295a1f805d2e09781b846d92ec1a791ff9ed89298b6", size = 2514448, upload-time = "2026-07-03T12:09:28.401968Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c0/8cc474a24198c1c2936269c5854be92af41787bd76d3190af584a9cebca7/grimp-3.15-cp312-cp312-win32.whl", hash = "sha256:232bf7a4c7536f62a99478eeb01de63c455261add35ee00c6ec9f04f280f853e", size = 1855806, upload-time = "2026-07-03T12:09:48.396141Z" },
-    { url = "https://files.pythonhosted.org/packages/91/11/e46139fd43dd5714fae93f09f1c858fb2dc83a575d5f8cb1daf8a15a261b/grimp-3.15-cp312-cp312-win_amd64.whl", hash = "sha256:13be2285e358a7687c0f3b798ac9d4819f275976ad8d651297966e5a75bfafb9", size = 1985556, upload-time = "2026-07-03T12:09:40.786458Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/6a/3e0a0760cc509cd09764d128de78a1f329740306c74e42dba82c58a99118/grimp-3.15-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f19b957053d1c736aaa0015eed2d4855bb2511637c5360d32b3c5ea045904e7a", size = 2143197, upload-time = "2026-07-03T12:08:51.685590Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/2e/127cbce04a5603d382c6a2bbc1a19b6889be49d60b88864bcdb174c8926d/grimp-3.15-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a6480472c2d1f7f6a903906c92e9897d4e3dee5d69ce3881f04368d4ec6d2dde", size = 2088342, upload-time = "2026-07-03T12:08:44.227137Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/36/af9df683bf6c8711e0e9136876ca130f9971102d945ff3a36d0c45dae2ec/grimp-3.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c14b64dbf2e4397df2e35fa8aa7028533621ecf1f8ea7ec24bc296a9c695ea4", size = 2254509, upload-time = "2026-07-03T12:07:35.809476Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f5/e712633b68ea14d04e7de84ede4f8ddbba763d5f2d29ae8d6af721f84870/grimp-3.15-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26364c2c9f7db88243365299b4d1c4d948b74304ff03c8a6e4f028147fed3b22", size = 2193831, upload-time = "2026-07-03T12:07:46.309194Z" },
-    { url = "https://files.pythonhosted.org/packages/13/74/151bdd73d6a60bd77d4b956f36d03dd558dd46a9b5ec8f5ad15921b503d7/grimp-3.15-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69331e1be693415596c6084342059b9ba3ecf1cfe2e3b1c761598dd2fe14d522", size = 2345289, upload-time = "2026-07-03T12:08:19.458597Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/b8/3fc950fa73b757cbc35f77542bd662f431b9a8f360e63196ded640771a33/grimp-3.15-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe397991c269868c2fb08114099b2aa4f1bc803d03fadaaf97e006019f9e5da2", size = 2604407, upload-time = "2026-07-03T12:07:57.217773Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/d8/98916b9dc0b89a3e89e0d714ce0872be859fff40ceee3e2cb6886b106eb4/grimp-3.15-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1d556bd62664ee044c47cff64d737be132408064d4ba68ca9f756cb29b41cc2d", size = 2326769, upload-time = "2026-07-03T12:08:08.773755Z" },
-    { url = "https://files.pythonhosted.org/packages/63/51/39595c5857f609e976e0bba1f19c1f45182ee4d8d2ea5cdfab72841eafbc/grimp-3.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9061c5b6f01130ff8639c49c80176d29d921acc36741b2ae0b763a7668106082", size = 2272498, upload-time = "2026-07-03T12:08:32.030878Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d8/a44cc9db500ae80c45425238ee44d9556796aa88b8c0649cfa613fb88d14/grimp-3.15-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a9d04c195f0c6da4476361560d3d206a6a784b9eb0da7156fc6974511337e2e3", size = 2431075, upload-time = "2026-07-03T12:08:58.935893Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/41/544f197ddb44990789683c25740ffa72474a57f0b16bc6b4a544edf9a2a9/grimp-3.15-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:01fd68c74cfd08b110bfd338d77efaa470670530f7179e6977764f44cd74d5cc", size = 2467361, upload-time = "2026-07-03T12:09:09.275618Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/b1/8261018b9f1ab47fffbb7739d7af3f04c8b529555b7fb2ae8b742d42d3db/grimp-3.15-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bd1ddd428a124d6730bed49ea60fb2ca6c8e0640c8f5abe1d0f6fc27a92fd8bc", size = 2503500, upload-time = "2026-07-03T12:09:19.585689Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d6/99a2421c4c0de9f203a7e246030b13b676766e62e48504883863942646fb/grimp-3.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07e645e9d45ed43bb8ea8da5982c19eacf13ee685d8440e3dc280064c005599c", size = 2513834, upload-time = "2026-07-03T12:09:29.758069Z" },
-    { url = "https://files.pythonhosted.org/packages/62/a5/263729e23d64541cd99d36dbb592e29c1ecea803deb3bb5c0c463b43c2ec/grimp-3.15-cp313-cp313-win32.whl", hash = "sha256:473646e0a74a554b4ab071d7fcbf5f442eb8cf87561770dae269818636b8edf2", size = 1855743, upload-time = "2026-07-03T12:09:49.789709Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/8c/a072bbea2e2e94da38f90bd8794037c90fb4eba389b49d01cdd2bb85e13c/grimp-3.15-cp313-cp313-win_amd64.whl", hash = "sha256:dbc2c15a1fbca2ff358f86cc90067176096dd73bec27d002515521b3125ba507", size = 1984546, upload-time = "2026-07-03T12:09:42.543369Z" },
-]
-
-[[package]]
-name = "import-linter"
-version = "2.13"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "grimp" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c6/42962eb043df4d6984c1540220735b20442572fe37dab5e65ac807c939b9/import_linter-2.13.tar.gz", hash = "sha256:13af4a1d6b06044c58ea784e8732fd7fe48eec821a75feb4d6a1a2de36dd5c27", size = 1279761, upload-time = "2026-07-03T14:00:31.285270Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/13/e7725e6eb32607fd4af51ccf3edfe835826e5cdf783b4d7fdc8f459196ae/import_linter-2.13-py3-none-any.whl", hash = "sha256:c0372e7ee5e15657bc06a8e841445e13237afd738a672d26863dc927af9f0bf5", size = 638185, upload-time = "2026-07-03T14:00:29.676445Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.360612Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182789Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846281Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779676Z" },
-]
-
-[[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.750018Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.830783Z" },
-]
-
-[[package]]
 name = "tools-registry"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Step **D** of the provider-capacity plan — the first call-path change, on the merged #214 kernel. Stacked on #236.

## What this builds
- **Refuse before reserve.** In `_resolve_marketplace_call`, after `_platform_offer` says yes, tier 4 consults the in-process capacity view (`domain/capacity/view`, ratestore-backed, 60 s TTL, refreshed by `resolve_marketplace_target` before its session opens). An exhausted provider raises `CallFailure("provider_capacity", 503, blame="treg")` — **no hold is ever placed** — with a body naming `resets_at` and the same-capability `alternatives` (treg still does not choose). `refused_by="capacity"`, `X-Treg-Error: 1`, cost 0. A stale/empty/ok view never refuses.
- **The call-path mark.** After a tier-4 answer ≥ 400 and after the settle, `settle._note_capacity_signal` classifies the vendor's answer (`domain/capacity/signatures`); a confirmed balance/quota signature writes the exhausted mark to ratestore via `domain/capacity/marks.mark_exhausted` on its own short session, so the **next** call is refused without waiting for a sweep. Burst/unknown 429s only log. Never raises (proven).
- **Allowlist:** exactly one new dataplane derived write, `capacity_exhausted_mark` (`tests/test_call_architecture.py`), with its derived-write sites; the mutation test still rejects anything else. Ratestore is the shared `Ephemeral` table, so the plan's "ratestore, never the DB" is worded as "ratestore, listed in the allowlist, never mid-flight" in the docs.
- Docs in the same commit: `proxy-model.md` (new § Platform capacity), `interface/api.md` (503 vocabulary), `money.md` (not money), `import-boundaries.md`, `ops/capacity.md`; agent-facing `llms.txt`, `skill.md` (+ plugin regenerated), `USAGE.md`. Charter row unchanged — still no failover.

## Intentional behavior changes
1. A metered tier-4 call to a provider marked exhausted now answers **503 `provider_capacity_unavailable`** instead of relaying the vendor's 402. Only when a mark exists (a confirmed signature on treg's key, or the sweep); tiers 1/2 never consult it.
2. After a relayed tier-4 balance/quota error, one ratestore row is written (the mark). The relayed response itself is unchanged.
Everything else is behavior-identical: callmatrix's 31 scenarios untouched and green, surface snapshots unchanged.

## Verification
- Clean-worktree full suite: **2181 passed, 2 failed** = `test_postgres_reset` (env, identical on main) and `test_plugin…not_stale` — fixed in this commit by regenerating the plugin (`tests/test_plugin.py` green after).
- `tests/test_capacity_protect.py` (8): refused before any hold row · own key unaffected · stale/ok never refuses · balance 402 marks → next call 503 · burst/caller 4xx never mark · quota 429 marks until reset · failed mark never fails the call · blame pin.
- callmatrix + pool discipline + marketplace + architecture + contract: 183 passed. `lint-imports`: 11 kept.
- `drift.sh`:
```
Changed sources in feat/capacity-overflow-routes..feat/capacity-protect → fragments to review:
  src/treg/application/call/resolve.py             → architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md
  src/treg/application/call/service.py             → architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md
  src/treg/application/call/settle.py              → architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md
  src/treg/application/call/types.py               → architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md
  src/treg/domain/capacity/marks.py                → ops/capacity.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeYKFQQpvESoBUX4WuUkZy