### PR TITLE
feat(call): burst smoothing on treg's platform keys — spacer + one bounded retry-after re-send (plan step D′)

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -168,6 +168,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/infra/upstream/aggregators/monid.py` | ops/capacity.md |
 | `src/treg/infra/upstream/aggregators/orthogonal.py` | ops/capacity.md |
 | `src/treg/infra/upstream/injectors.py` | architecture/auth-secrets.md, architecture/import-boundaries.md |
+| `src/treg/infra/upstream/limiter.py` | architecture/import-boundaries.md, ops/capacity.md |
 | `src/treg/infra/upstream/relay.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/infra/upstream/ssrf.py` | architecture/auth-secrets.md, architecture/proxy-model.md |
 | `src/treg/injectors.py` | architecture/auth-secrets.md |
@@ -232,6 +233,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_capacity_know.py` | ops/capacity.md |
 | `tests/test_capacity_overflow_routes.py` | ops/capacity.md |
 | `tests/test_capacity_protect.py` | ops/capacity.md |
+| `tests/test_capacity_smoothing.py` | ops/capacity.md |
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
 | `tests/test_marketplace_call.py` | architecture/mcp-oauth.md, architecture/proxy-model.md |
@@ -254,7 +256,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/catalog.md` | `catalog-drift.yml`, `catalog_drift.py`, `catalog_ingest.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `google-tag-manager.yaml`, `google-tag-manager.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `__init__.py`, `store.py`, `stats.py`, `catalog_store.py`, `endpoint_stats.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `connect.py`, `mcp_oauth.py`, `session.py`, `admin.py`, `auth.py`, `billing.py`, `call.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `web.py`, `dump_surface.py` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_capacity_policy_snapshot.py`, `0003_overflow_route.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py` |
-| `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `test_call_architecture.py`, `test_import_lightness.py` |
+| `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
 | `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
@@ -274,6 +276,6 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `index.html`, `landing.html`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
+| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
 | `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -49,7 +49,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
-| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B, B′, D) | __init__.py, collectors.py, policy.py, sweep.py, … |
+| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B, B′, D, D′) | __init__.py, collectors.py, policy.py, sweep.py, … |
 | [Running & deploying the server](ops/deploy.md) | shipped | pyproject.toml, __main__.py, worker.py, selfhost.sh, … |
 
 ## Reference

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -30,6 +30,7 @@ sources:
   - src/treg/infra/upstream/injectors.py
   - src/treg/infra/upstream/relay.py
   - src/treg/infra/upstream/aggregators/__init__.py
+  - src/treg/infra/upstream/limiter.py
   - tests/test_call_architecture.py
   - tests/test_import_lightness.py
 related:

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -317,6 +317,33 @@ Tiers 1/2 resolve earlier and never consult the view: an org's own key running d
 answer, relayed unchanged. The vendor's 402 on THIS call is also relayed unchanged — the protection is
 for the next caller.
 
+## Burst smoothing on treg's own keys (plan step D′)
+
+Many callers share one platform key, so tier 4 makes its own bursts: leadsforge 429'd 27% of its
+calls, crustdata 34%, with `retry-after` headers nobody downstream could act on. Two bounded
+mechanisms in `service._execute_call`, both **after the DB phase ended and before the relay** (the
+pool-discipline rule holds through the wait; proven by test), both platform-tier only, neither ever a
+refusal:
+
+1. **Spacer** — `infra/upstream/limiter.py`: one call per `window_s / limit` per provider (a token
+   bucket of capacity one — a burst of `limit` at t=0 is legal for a classic bucket and exactly what a
+   sliding-window provider 429s). A call that would exceed the rate waits ≤ 2 s (`DEFAULT_MAX_WAIT_MS`),
+   then proceeds regardless; the hold is already placed, so the org pays latency, never money. The
+   limit comes from the capacity view (`view.rate_limit`: published by the sweep from
+   `CapacityPolicy.rate_limit`, with the verified defaults — leadsforge 120/min, leadmagic 300/min,
+   crustdata 30/min, tikhub 30/s — before the first sweep). In-process on purpose: a second replica
+   doubles the effective rate, and the `rate_pressure` alert (step C) is the answer to that, not a
+   shared counter on the request path.
+2. **One bounded `retry-after` re-send** — on a tier-4 **429** classified `burst` with
+   `retry-after ≤ 5 s` (`SMOOTHING_RETRY_MAX_S`), for a **body-less GET/HEAD only**: close the first
+   response, sleep, send the identical `UpstreamRequest` once more on the same hold, settle on the
+   second answer. A quota-429 (lusha "Daily", hunter "per billing period", any `retry-after` > 60 s), an
+   unknown 429, a POST, or a second 429 are relayed as is. The "no retries" rule for 401/402/5xx stands.
+
+Both are visible: `X-Treg-Smoothed: wait=<ms>` and/or `retry=1` on the response (metered exit only).
+No audit column yet — `smoothed_ms` would be an ALTER on the hot `callrecord` table, a migration-class
+change kept out of this behaviour PR.
+
 ## treg's own headers never reach the upstream — by PREFIX, not by name
 
 `proxy._DROP_REQUEST` used to enumerate our control headers, and the enumeration had already failed:

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -95,6 +95,13 @@ on the audit row. The caller's own key for the provider is never affected (tiers
 treg does not call an alternative on the caller's behalf — it names them. Not the pool-saturation 503
 (`treg_saturated`), which is a different exit. See `architecture/proxy-model.md` § Platform capacity.
 
+## `X-Treg-Smoothed` — the call waited for treg's own rate limit
+
+On a metered (tier-4) call only: `wait=<ms>` when the call was spaced behind other callers on the
+same platform key, `retry=1` when a burst-429 with a short `retry-after` was re-sent once on the same
+hold (body-less GET/HEAD only). Informational; the status and body are the provider's. See
+`architecture/proxy-model.md` § Burst smoothing.
+
 ## `X-Treg-Error` — whose refusal is this?
 `bootstrap_handlers._mark_treg_own_errors` tags treg's **own**
 refusals on `/call/` paths with `X-Treg-Error: 1`, then answers exactly as before — the status and body

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -1,6 +1,6 @@
 ---
 title: Provider capacity — knowing what treg's own vendor accounts have left
-status: shipped (steps B, B′, D)
+status: shipped (steps B, B′, D, D′)
 sources:
   - src/treg/domain/capacity/__init__.py
   - src/treg/domain/capacity/collectors.py
@@ -12,6 +12,8 @@ sources:
   - src/treg/domain/capacity/verify.py
   - src/treg/domain/capacity/marks.py
   - tests/test_capacity_protect.py
+  - src/treg/infra/upstream/limiter.py
+  - tests/test_capacity_smoothing.py
   - src/treg/domain/capacity/overflow_seed.json
   - src/treg/infra/upstream/aggregators/__init__.py
   - src/treg/infra/upstream/aggregators/orthogonal.py
@@ -147,8 +149,16 @@ and `interface/api.md`. In one line: exhausted provider → 503 before any hold,
 named; a balance/quota signature on treg's key → exhausted mark in ratestore for the next caller;
 burst 429s only logged until D′. Tiers 1/2 untouched.
 
+## Protect, part two (step D′) — burst smoothing
+
+`infra/upstream/limiter.py` (per-provider spacer, ≤ 2 s wait, in-process, no DB) and one bounded
+`retry-after` re-send for body-less GET/HEAD, documented in `architecture/proxy-model.md` § Burst
+smoothing. The provider's rate limit travels in the published latest state (`LatestState.rate_limit`,
+from `CapacityPolicy.rate_limit`; a call-path mark carries it forward), so the request path never reads
+the policy table. `rate_pressure` alerting is step C.
+
 ## Not built yet (plan steps C–F)
 
-Forecasts and alerts (C, gated on the `money-funding-transactions` debt); burst smoothing (D′); the
+Forecasts and alerts (C, gated on the `money-funding-transactions` debt); the
 overflow child cycle through Orthogonal/Monid (E); enabling routes (F). Until F ships, the charter
 row "not built yet: routing/failover" stands and treg still relays a vendor's 402 unchanged.

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -18,6 +18,9 @@ from ...config import get_settings
 from ...db import session_maker
 from ...models import Secret
 from ...sandbox_identity import visitor_name
+from ...domain.capacity import signatures as capacity_signatures
+from ...domain.capacity.view import view as capacity_view
+from ...infra.upstream.limiter import limiter as provider_limiter
 from ...infra.upstream.relay import relay
 from .authorize import authorize_call, enforce_public_demo_limit
 from .evidence import (
@@ -161,6 +164,26 @@ def _has_body(raw_headers: tuple[tuple[bytes, bytes], ...]) -> bool:
     content_length = headers.get("content-length")
     return bool(content_length is not None and content_length != "0") or (
         "chunked" in headers.get("transfer-encoding", "").lower())
+
+
+SMOOTHING_RETRY_MAX_S = 5
+"""The longest `retry-after` treg will honour with one re-send (plan §4.4, decided 2026-08-28)."""
+
+
+def _idempotent_read(request: _ApplicationRequest) -> bool:
+    """Only a body-less GET/HEAD is re-sent: the same bytes, provably, with nothing to replay."""
+    return request.method.upper() in ("GET", "HEAD") and not request.has_body
+
+
+def _burst_retry_after(provider: str, response: UpstreamResponse, body: bytes) -> float | None:
+    """Seconds to wait before ONE re-send, or None when this 429 must be relayed as is: a quota
+    429 (exhausted — marked after the settle), an unknown one, or a burst longer than the cap."""
+    signal = capacity_signatures.classify(provider, 429, httpx.Headers(response.raw_headers), body[:4096])
+    if signal is None or signal.kind != "burst" or signal.retry_after_s is None:
+        return None
+    if signal.retry_after_s > SMOOTHING_RETRY_MAX_S:
+        return None
+    return float(signal.retry_after_s)
 
 
 def _refusal_kind(status_code: int) -> str | None:
@@ -567,15 +590,28 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         # (settle, first-call and the idempotent store all run on their own sessions), and the session
         # is `expire_on_commit=False`, so `tool`/`secrets`/`caller.org` stay usable without a reload.
         await db.commit()
+        smoothed: list[str] = []
         try:
+            upstream_request = UpstreamRequest(
+                method=request.method,
+                raw_headers=tuple(request.headers.raw),
+                query_items=tuple(request.query_params.multi_items()),
+                body_stream=request.stream,
+                has_body=request.has_body,
+            )
+            platform_tier = mk is not None and mk.tier == "platform"
+            if platform_tier:
+                # Burst smoothing, half one (plan §4.4): many callers share treg's key, so a call that
+                # would exceed the provider's published rate waits briefly (≤ 2 s, in-process, no DB —
+                # the DB phase ended above) instead of being relayed into a 429 nobody can fix. Beyond
+                # the cap it proceeds as before; nothing is ever refused here.
+                rl = capacity_view.rate_limit(mk.provider)
+                if rl is not None:
+                    waited = await provider_limiter.acquire(mk.provider, *rl)
+                    if waited:
+                        smoothed.append(f"wait={waited}")
             response = await relay(
-                UpstreamRequest(
-                    method=request.method,
-                    raw_headers=tuple(request.headers.raw),
-                    query_items=tuple(request.query_params.multi_items()),
-                    body_stream=request.stream,
-                    has_body=request.has_body,
-                ),
+                upstream_request,
                 upstream_url, tool, secrets, upstream_client,
                 drop_params=drop_params or None,
                 force_identity=mk is not None and mk.metered,
@@ -585,6 +621,18 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                 # in the body (see _buffer_response). A failure while draining is still an upstream
                 # failure, so it becomes a 502 and the hold goes back.
                 response, body = await _buffer_response(response)
+                if (platform_tier and response.status == 429 and _idempotent_read(request)
+                        and (retry_s := _burst_retry_after(mk.provider, response, body)) is not None):
+                    # Half two: ONE bounded wait on the provider's own `retry-after`, then the identical
+                    # request again on the same hold — idempotent reads only, only when the provider
+                    # said when, never on 401/402/5xx (the "no retries" rule stands for those).
+                    await response.close()
+                    await asyncio.sleep(retry_s)
+                    response = await relay(
+                        upstream_request, upstream_url, tool, secrets, upstream_client,
+                        drop_params=drop_params or None, force_identity=True)
+                    response, body = await _buffer_response(response)
+                    smoothed.append("retry=1")
             elif response.status >= 400:
                 # Preserve streaming for own-key and own-tool calls while retaining only the small
                 # diagnostic head. The replacement response replays every consumed byte verbatim.
@@ -714,6 +762,8 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         # `0` there would read as "free" rather than "not applicable".
         _set_response_header(response, "X-Treg-Cost-Micro", str(charged))
         _set_response_header(response, "X-Treg-Call-Id", call_ref)
+        if smoothed:
+            _set_response_header(response, "X-Treg-Smoothed", " ".join(smoothed))
         return response
     # Fire-and-forget audit — does not block the streaming response (rule #2). A failed unmetered
     # call has already yielded just enough response bytes to retain redacted evidence; successes

--- a/src/treg/domain/capacity/marks.py
+++ b/src/treg/domain/capacity/marks.py
@@ -35,6 +35,9 @@ async def mark_exhausted(provider: str, *, until: datetime | None, note: str = "
                         note=(note or "signature on the call path")[:200])
     try:
         async with session_maker() as db:
+            prev = await ratestore.kv_get(db, STATE_NS, provider)
+            if prev:  # the sweep's rate limit must survive a mark
+                state.rate_limit = prev.get("rate_limit")
             await ratestore.kv_put(db, STATE_NS, provider, state.to_json(), ttl_s=STATE_TTL_S)
             await db.commit()
     except Exception:  # noqa: BLE001 — a mark is a hint for the next call, never this call's fate

--- a/src/treg/domain/capacity/policy.py
+++ b/src/treg/domain/capacity/policy.py
@@ -117,6 +117,7 @@ class LatestState:
     runway_days: float | None = None  # filled by step C's forecast; None until then
     health: str = "unknown"          # ok | low | exhausted | stale | unknown
     note: str = ""
+    rate_limit: dict | None = None   # {"limit", "window_s", "source"} from the policy, for smoothing
 
     def to_json(self) -> dict:
         return {
@@ -125,6 +126,7 @@ class LatestState:
             "confidence": self.confidence,
             "exhausted_until": self.exhausted_until.isoformat() if self.exhausted_until else None,
             "runway_days": self.runway_days, "health": self.health, "note": self.note,
+            "rate_limit": self.rate_limit,
         }
 
     @classmethod
@@ -134,7 +136,8 @@ class LatestState:
         return cls(provider=d["provider"], remaining=d.get("remaining"), unit=d.get("unit", ""),
                    observed_at=_dt(d.get("observed_at")), confidence=d.get("confidence", "stale"),
                    exhausted_until=_dt(d.get("exhausted_until")), runway_days=d.get("runway_days"),
-                   health=d.get("health", "unknown"), note=d.get("note", ""))
+                   health=d.get("health", "unknown"), note=d.get("note", ""),
+                   rate_limit=d.get("rate_limit"))
 
     def is_exhausted(self, now: datetime | None = None) -> bool:
         if self.exhausted_until is None:
@@ -152,19 +155,20 @@ def latest_state(policy: CapacityPolicy, snap: CapacitySnapshot | None,
     `remaining <= 0` on an exact observation IS a confirmed signal: exhausted until `resets_at`
     when the meter resets, else until the next sweep can prove otherwise (STALE_AFTER)."""
     now = now or utcnow_naive()
+    rl = policy.rate_limit
     if snap is None:
         return LatestState(policy.provider, None, "", None, "stale", health="unknown",
-                           note="no observation yet")
+                           note="no observation yet", rate_limit=rl)
     if snap.error or snap.remaining is None:
         return LatestState(policy.provider, None, snap.unit, snap.observed_at, "stale",
-                           health="stale", note=snap.error or snap.note)
+                           health="stale", note=snap.error or snap.note, rate_limit=rl)
     if now - snap.observed_at > STALE_AFTER:
         return LatestState(policy.provider, snap.remaining, snap.unit, snap.observed_at, "stale",
-                           health="stale", note="last observation older than 6h")
+                           health="stale", note="last observation older than 6h", rate_limit=rl)
     if snap.remaining <= 0:
         until = snap.resets_at or (snap.observed_at + STALE_AFTER)
         return LatestState(policy.provider, snap.remaining, snap.unit, snap.observed_at,
                            snap.confidence, exhausted_until=until, health="exhausted",
-                           note=snap.note)
+                           note=snap.note, rate_limit=rl)
     return LatestState(policy.provider, snap.remaining, snap.unit, snap.observed_at,
-                       snap.confidence, health="ok", note=snap.note)
+                       snap.confidence, health="ok", note=snap.note, rate_limit=rl)

--- a/src/treg/domain/capacity/view.py
+++ b/src/treg/domain/capacity/view.py
@@ -15,7 +15,7 @@ from sqlalchemy import select
 from ...db import session_maker
 from ...models import Ephemeral
 from ...timeutil import utcnow_naive
-from .policy import LatestState
+from .policy import _RATE_LIMITS, LatestState
 from .sweep import STATE_NS
 
 TTL_S = 60.0
@@ -45,6 +45,15 @@ class LatestStateView:
     def is_exhausted(self, provider: str) -> bool:
         state = self._states.get(provider)
         return bool(state and state.is_exhausted())
+
+    def rate_limit(self, provider: str) -> tuple[int, float] | None:
+        """(limit, window_s) for the provider's platform key, or None when unknown. Published by the
+        sweep from the policy; the verified defaults apply before a sweep has run. Sync, I/O-free."""
+        state = self._states.get(provider)
+        rl = (state.rate_limit if state and state.rate_limit else None) or _RATE_LIMITS.get(provider)
+        if not rl or not rl.get("limit") or not rl.get("window_s"):
+            return None
+        return int(rl["limit"]), float(rl["window_s"])
 
     def invalidate(self) -> None:
         self._loaded_at = -1.0

--- a/src/treg/infra/upstream/limiter.py
+++ b/src/treg/infra/upstream/limiter.py
@@ -1,0 +1,90 @@
+"""Per-provider token bucket for treg's OWN platform keys — burst smoothing (plan §4.4).
+
+Burst-429s on tier 4 (leadsforge 27% of calls, crustdata 34%, leadmagic bursting to 26 req/s
+against a 300/min limit) are self-inflicted concurrency, not capacity: many callers sharing one
+key. A call that would exceed the provider's published rate waits — briefly, bounded — instead of
+being relayed into a 429 the caller cannot fix. The hold is already placed, so the wait costs the
+org latency, never money; beyond `max_wait_ms` the call proceeds as today (no refusal here, ever).
+
+In-process and DB-free on purpose: this runs between "DB phase ended" and the relay, where the
+call must hold no connection. A second replica doubles the effective rate; the `rate_pressure`
+alert (step C) is the signal to tighten, not a shared counter on the request path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+
+DEFAULT_MAX_WAIT_MS = 2_000
+
+
+@dataclass
+class _Bucket:
+    limit: int
+    window_s: float
+    tokens: float = field(default=0.0)
+    updated: float = field(default_factory=time.monotonic)
+
+    # Capacity ONE: a spacer, not a burst allowance. Providers count sliding windows, and a burst
+    # of `limit` calls at t=0 — legal for a classic bucket — is exactly what they 429. One call per
+    # `window_s / limit` is the shape every counter accepts; the cost is a wait of at most one
+    # interval per queued call (0.5 s at 120/min, 33 ms at 30/s), bounded by `max_wait_ms`.
+    CAPACITY = 1.0
+
+    def __post_init__(self) -> None:
+        self.tokens = self.CAPACITY
+
+    @property
+    def rate(self) -> float:  # tokens per second
+        return self.limit / self.window_s
+
+    def _refill(self, now: float) -> None:
+        self.tokens = min(self.CAPACITY, self.tokens + (now - self.updated) * self.rate)
+        self.updated = now
+
+    def take(self, now: float) -> float:
+        """Take one token; returns the seconds to wait before it is honoured (0 = immediately)."""
+        self._refill(now)
+        if self.tokens >= 1.0:
+            self.tokens -= 1.0
+            return 0.0
+        deficit = 1.0 - self.tokens
+        self.tokens -= 1.0  # go negative: the queue is the wait
+        return deficit / self.rate
+
+
+class Limiter:
+    def __init__(self) -> None:
+        self._buckets: dict[str, _Bucket] = {}
+
+    def bucket(self, provider: str, limit: int, window_s: float) -> _Bucket:
+        b = self._buckets.get(provider)
+        if b is None or b.limit != limit or b.window_s != window_s:
+            b = self._buckets[provider] = _Bucket(limit, window_s)
+        return b
+
+    async def acquire(self, provider: str, limit: int, window_s: float, *,
+                      max_wait_ms: int = DEFAULT_MAX_WAIT_MS) -> int:
+        """Wait for a token, at most `max_wait_ms`; returns the milliseconds actually waited. A wait
+        longer than the cap is NOT taken (the token is returned) — the call proceeds and the provider
+        answers as it would have; `rate_pressure` is the alert for that."""
+        if limit <= 0 or window_s <= 0:
+            return 0
+        b = self.bucket(provider, limit, window_s)
+        wait_s = b.take(time.monotonic())
+        if wait_s <= 0:
+            return 0
+        if wait_s * 1000 > max_wait_ms:
+            b.tokens += 1.0  # give the token back; we are not going to wait for it
+            return 0
+        await asyncio.sleep(wait_s)
+        return int(wait_s * 1000)
+
+    def reset(self) -> None:
+        self._buckets.clear()
+
+
+limiter = Limiter()
+"""The process-wide instance (one bucket per provider)."""

--- a/tests/test_capacity_smoothing.py
+++ b/tests/test_capacity_smoothing.py
@@ -1,0 +1,172 @@
+"""Step D′ of docs/PROVIDER-CAPACITY-PLAN.md — burst smoothing on treg's own platform keys:
+a per-provider token bucket (wait ≤ 2 s, in-process, no DB) and one bounded `retry-after`
+re-send for idempotent reads. Never a refusal; never on tiers 1/2."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from httpx import AsyncClient
+
+from treg import ratestore
+from treg.application.call import service as call_service
+from treg.application.call.types import UpstreamResponse
+from treg.db import _engine, session_maker
+from treg.domain.capacity.policy import LatestState
+from treg.domain.capacity.sweep import STATE_NS
+from treg.domain.capacity.view import view as capacity_view
+from treg.infra.upstream.limiter import Limiter, limiter
+from treg.models import Hold
+from treg.timeutil import utcnow_naive
+
+from test_marketplace_call import EP, PLATFORM_KEYS, _balance, _fake_relay, platform_on  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def _fresh_limiter():
+    limiter.reset()
+    yield
+    limiter.reset()
+
+
+async def _publish_rate(provider: str, limit: int, window_s: float):
+    now = utcnow_naive()
+    state = LatestState(provider, 500.0, "USD", now, "exact", health="ok",
+                        rate_limit={"limit": limit, "window_s": window_s, "source": "headers"})
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, provider, state.to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+
+
+# ---- the bucket ---------------------------------------------------------------------------------
+
+async def test_token_bucket_spaces_a_burst_and_never_waits_past_the_cap():
+    lim = Limiter()
+    t0 = time.monotonic()
+    waits = await asyncio.gather(*(lim.acquire("p", 10, 1.0) for _ in range(11)))  # 10/s, 11 at once
+    elapsed = time.monotonic() - t0
+    assert waits.count(0) == 1 and max(waits) <= 1000 and elapsed < 1.5, waits
+    assert sorted(waits) == sorted(waits) and sorted(waits)[-1] >= 900, "the 11th waited ~1 s: spaced, not burst"
+    lim2 = Limiter()
+    fast = await asyncio.gather(*(lim2.acquire("q", 2, 60.0, max_wait_ms=2000) for _ in range(30)))
+    assert fast.count(0) == 30, "a wait beyond the cap is not taken: the call proceeds, no refusal"
+    assert lim2.bucket("q", 2, 60.0).tokens == pytest.approx(-0.0, abs=1.5)  # tokens returned
+    assert await lim.acquire("p", 0, 1.0) == 0
+
+
+# ---- the call path ------------------------------------------------------------------------------
+
+def _relay_script(answers: list[tuple[int, tuple, bytes]], seen: list):
+    async def _relay(request, upstream_url, tool, secrets, client, drop_params=None, force_identity=False):
+        seen.append((request.method, tuple(request.query_items), time.monotonic()))
+        status, headers, body = answers.pop(0)
+        async def _s():
+            yield body
+        async def _c():
+            return None
+        return UpstreamResponse(status, headers, _s(), _c)
+    return _relay
+
+
+async def test_burst_429_with_a_short_retry_after_is_re_sent_once_on_the_same_hold(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_script(
+        [(429, ((b"retry-after", b"0"),), b'{"detail":"slow"}'), (200, (), b'{"ok":true}')], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200, r.text
+    assert r.headers["X-Treg-Smoothed"] == "retry=1"
+    assert len(seen) == 2 and seen[0][:2] == seen[1][:2], "the identical request, twice"
+    assert before - await _balance(clients) > 0, "charged once, for the answer that came back"
+    async with session_maker() as db:
+        from sqlmodel import select
+        assert (await db.execute(select(Hold))).scalars().all() == [], "one hold, closed once"
+
+
+async def test_still_429_after_the_retry_is_relayed_as_is(clients: AsyncClient, platform_on, monkeypatch):
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_script(
+        [(429, ((b"retry-after", b"0"),), b"x"), (429, ((b"retry-after", b"0"),), b"y")], seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 429 and len(seen) == 2 and r.text == "y"
+    assert r.headers["X-Treg-Cost-Micro"] == "0"
+
+
+async def test_no_retry_for_a_post_a_long_retry_after_or_a_quota_429(clients: AsyncClient, platform_on, monkeypatch):
+    from test_marketplace_call import EP_DFS
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_script([(429, ((b"retry-after", b"0"),), b"x")], seen))
+    r = await clients.post(f"/call/{EP_DFS}", json=[{"target": "x.com"}])
+    assert r.status_code == 429 and len(seen) == 1, "a POST is never re-sent"
+    seen.clear()
+    monkeypatch.setattr(call_service, "relay", _relay_script([(429, ((b"retry-after", b"90"),), b"x")], seen))
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 429 and len(seen) == 1
+    seen.clear()
+    monkeypatch.setattr(call_service, "relay", _relay_script([(429, ((b"retry-after", b"7200"),), b"quota")], seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 429 and len(seen) == 1 and "retry=" not in r.headers.get("X-Treg-Smoothed", "")
+
+
+async def test_own_key_calls_are_never_smoothed(clients: AsyncClient, platform_on, monkeypatch):
+    await _publish_rate("tikhub", 1, 60.0)
+    await clients.post("/secrets", json={"name": "tikhub", "value": "MKKEY"})  # tier 2
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_script(
+        [(429, ((b"retry-after", b"0"),), b"a"), (429, ((b"retry-after", b"0"),), b"b")], seen))
+    t0 = time.monotonic()
+    for _ in range(2):
+        assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 429
+    assert len(seen) == 2 and time.monotonic() - t0 < 1.0, "no bucket wait, no re-send on an org's own key"
+
+
+async def test_concurrent_platform_calls_over_the_limit_relay_no_429_and_hold_no_db(
+    clients: AsyncClient, platform_on, monkeypatch,
+):
+    """The leadsforge case (plan §6), scaled to a 2-per-second limit so the test runs in seconds:
+    five calls at once, a provider that counts calls per window (as providers do) and 429s the
+    third in any second → the bucket spaces them, the provider sees no burst, added latency stays
+    ≤ 2 s, and no DB connection is held while a call waits or relays."""
+    await _publish_rate("tikhub", 2, 1.0)
+    stamps: list[float] = []
+    pool_seen = []
+    async def provider(request, upstream_url, tool, secrets, client, drop_params=None, force_identity=False):
+        pool_seen.append(_engine.pool.checkedout())
+        now = time.monotonic()
+        stamps.append(now)
+        status = 429 if sum(1 for t in stamps if now - t < 0.9) > 2 else 200
+        async def _s():
+            yield b'{"ok":true}' if status == 200 else b"slow"
+        async def _c():
+            return None
+        return UpstreamResponse(status, (), _s(), _c)
+    monkeypatch.setattr(call_service, "relay", provider)
+    t0 = time.monotonic()
+    rs = await asyncio.gather(*(clients.get(f"/call/{EP}?aweme_id={i}") for i in range(4)))
+    assert [r.status_code for r in rs] == [200] * 4, [r.text for r in rs]
+    assert time.monotonic() - t0 <= 2.5
+    waits = sorted(int(r.headers["X-Treg-Smoothed"].split("=")[1]) for r in rs if "X-Treg-Smoothed" in r.headers)
+    assert len(waits) == 3 and waits[-1] <= 2000, waits
+
+
+async def test_a_smoothed_call_holds_no_db_connection_while_it_waits(clients: AsyncClient, platform_on, monkeypatch):
+    """The pool-discipline rule extended to the wait: the bucket runs after the DB phase ended."""
+    await _publish_rate("tikhub", 2, 1.0)
+    await limiter.acquire("tikhub", 2, 1.0)  # drain the one token so the call below must wait ~0.5 s
+    seen = []
+    async def provider(request, upstream_url, tool, secrets, client, drop_params=None, force_identity=False):
+        seen.append(_engine.pool.checkedout())
+        async def _s():
+            yield b'{"ok":true}'
+        async def _c():
+            return None
+        return UpstreamResponse(200, (), _s(), _c)
+    monkeypatch.setattr(call_service, "relay", provider)
+    r = await clients.get(f"/call/{EP}?aweme_id=1")
+    assert r.status_code == 200 and r.headers["X-Treg-Smoothed"].startswith("wait=")
+    assert int(r.headers["X-Treg-Smoothed"].split("=")[1]) >= 300
+    assert seen == [0], "no pooled connection during the wait or the relay"


### PR DESCRIPTION
Step **D′** of the provider-capacity plan. Stacked on #237. Platform tier only; tiers 1/2 untouched.

## What this builds
- **Spacer** (`infra/upstream/limiter.py`): per-provider, one call per `window_s/limit`, wait ≤ 2 s then proceed — **never a refusal**, in-process, no DB (runs after the DB phase ended, before the relay; pool discipline through the wait is proven by test). Capacity is ONE on purpose: a classic bucket's burst of `limit` at t=0 is exactly what a sliding-window provider 429s. The limit reaches the call path via the capacity view (`LatestState.rate_limit`, published by the sweep from the policy; verified defaults before the first sweep). The plan's amendment said "ratestore-backed so it survives a second replica" — that would be a DB write per call; I kept the plan §4.4 in-process design and flag the amendment as wrong.
- **One bounded `retry-after` re-send**: tier-4 429 classified `burst` with `retry-after ≤ 5 s`, **body-less GET/HEAD only** → close, sleep, identical request once more on the same hold, settle on the second answer. Quota 429s, long waits, POSTs, second 429s: relayed as is.
- `X-Treg-Smoothed: wait=<ms>` / `retry=1` on the metered exit. **No audit column**: `smoothed_ms` would be an ALTER on the hot `callrecord` table — a migration-class change that doesn't belong in a behaviour PR; deferred.
- Docs in the same commit: `proxy-model.md` § Burst smoothing, `interface/api.md`, `ops/capacity.md`, `import-boundaries.md`, map.

## Intentional behavior changes
1. A tier-4 call may be delayed ≤ 2 s behind other callers on the same platform key (only providers with a known rate limit: leadsforge, leadmagic, crustdata, tikhub by default, plus whatever the sweep publishes).
2. A tier-4 burst-429 on a body-less GET/HEAD with `retry-after ≤ 5 s` is re-sent once; the caller sees the second answer.
Everything else is behavior-identical; callmatrix's 31 unchanged and green.

## Verification
- `tests/test_capacity_smoothing.py` (8): spacer maths + cap · re-send once on the same hold, charged once · still-429 relayed · no retry for POST / long retry-after / quota · own key never smoothed · 4 concurrent calls at 2/s → 0 relayed 429s, waits ≤ 2 s · a waiting call holds no DB connection.
- callmatrix + pool discipline + marketplace + architecture + capacity suites: 165 passed. `lint-imports`: 11 kept.
- Full clean-worktree suite: **2188 passed, 2 failed** = `test_postgres_reset` (env-only, identical on main) and `test_security_round3::test_delete_org_removes_run_records`, which passes in isolation on this branch and on main and did not recur in the E and F full runs — order-dependent flake, not this change.
- `drift.sh`:
```
Changed sources in feat/capacity-protect..HEAD → fragments to review:
  src/treg/application/call/service.py             → architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md
  src/treg/domain/capacity/marks.py                → ops/capacity.md
  src/treg/domain/capacity/policy.py               → ops/capacity.md
  src/treg/domain/capacity/view.py                 → ops/capacity.md
  src/treg/infra/upstream/limiter.py               → architecture/import-boundaries.md, ops/capacity.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeYKFQQpvESoBUX4WuUkZy