### PR TITLE
feat(call): overflow child cycle — same endpoint via a treg-owned aggregator account (plan step E, off by default)

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -20,6 +20,7 @@ Regenerate via `scripts/build-map.py`.
 | `alembic/versions/0001_baseline_current_schema.py` | architecture/data-model.md |
 | `alembic/versions/0002_capacity_policy_snapshot.py` | architecture/data-model.md, ops/capacity.md |
 | `alembic/versions/0003_overflow_route.py` | architecture/data-model.md, ops/capacity.md |
+| `alembic/versions/0004_overflow_spend.py` | architecture/data-model.md, ops/capacity.md |
 | `assets/brand/og-card.html` | interface/seo.md |
 | `docs/CLAUDE-CONNECTOR-SUBMISSION.md` | architecture/mcp-oauth.md |
 | `dsh/cordis.patch.yml` | interface/skill.md |
@@ -54,6 +55,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/call/evidence.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/idempotency.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/intake.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
+| `src/treg/application/call/overflow.py` | architecture/import-boundaries.md, ops/capacity.md |
 | `src/treg/application/call/reserve.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/resolve.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/service.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
@@ -126,8 +128,10 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/domain/capacity/collectors.py` | ops/capacity.md |
 | `src/treg/domain/capacity/marks.py` | ops/capacity.md |
 | `src/treg/domain/capacity/overflow_seed.json` | ops/capacity.md |
+| `src/treg/domain/capacity/overflow_spend.py` | ops/capacity.md |
 | `src/treg/domain/capacity/policy.py` | ops/capacity.md |
 | `src/treg/domain/capacity/routes.py` | ops/capacity.md |
+| `src/treg/domain/capacity/routes_view.py` | ops/capacity.md |
 | `src/treg/domain/capacity/signatures.py` | ops/capacity.md |
 | `src/treg/domain/capacity/sweep.py` | ops/capacity.md |
 | `src/treg/domain/capacity/verify.py` | ops/capacity.md |
@@ -231,6 +235,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_call_architecture.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md |
 | `tests/test_call_cancellation.py` | architecture/proxy-model.md |
 | `tests/test_capacity_know.py` | ops/capacity.md |
+| `tests/test_capacity_overflow.py` | ops/capacity.md |
 | `tests/test_capacity_overflow_routes.py` | ops/capacity.md |
 | `tests/test_capacity_protect.py` | ops/capacity.md |
 | `tests/test_capacity_smoothing.py` | ops/capacity.md |
@@ -255,8 +260,8 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/auth-secrets.md` | `injectors.py`, `injectors.py`, `ssrf.py`, `crypto.py`, `oauth.py`, `__init__.py`, `refresh.py`, `oauth_refresh.py`, `oauth_providers.py`, `health.py`, `connect.py`, `connections.py`, `resources.py`, `__init__.py`, `bindings.py`, `bundles.py`, `test_oauth_refresh.py` |
 | `architecture/catalog.md` | `catalog-drift.yml`, `catalog_drift.py`, `catalog_ingest.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `google-tag-manager.yaml`, `google-tag-manager.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `__init__.py`, `store.py`, `stats.py`, `catalog_store.py`, `endpoint_stats.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `connect.py`, `mcp_oauth.py`, `session.py`, `admin.py`, `auth.py`, `billing.py`, `call.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `web.py`, `dump_surface.py` |
-| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_capacity_policy_snapshot.py`, `0003_overflow_route.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py` |
-| `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
+| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_capacity_policy_snapshot.py`, `0003_overflow_route.py`, `0004_overflow_spend.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py` |
+| `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
 | `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_oauth.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
@@ -276,6 +281,6 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `index.html`, `landing.html`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
+| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0004_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0003_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0002_capacity_policy_snapshot.py`, `test_capacity_know.py` |
 | `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/alembic/versions/0004_overflow_spend.py
+++ b/alembic/versions/0004_overflow_spend.py
@@ -1,0 +1,33 @@
+"""overflow spend accounting (docs/PROVIDER-CAPACITY-PLAN.md §4.3 step 5)
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-08-28
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision: str = '0004'
+down_revision: str | Sequence[str] | None = '0003'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table('overflowspend',
+    sa.Column('aggregator', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('day', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('calls', sa.Integer(), nullable=False),
+    sa.Column('cost_micro', sa.Integer(), nullable=False),
+    sa.Column('delta_micro', sa.Integer(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.PrimaryKeyConstraint('aggregator', 'day')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('overflowspend')

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -49,7 +49,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 
 | Fragment | Status | Covers |
 |---|---|---|
-| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B, B′, D, D′) | __init__.py, collectors.py, policy.py, sweep.py, … |
+| [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B, B′, D, D′, E — overflow off by default, shadow week pending) | __init__.py, collectors.py, policy.py, sweep.py, … |
 | [Running & deploying the server](ops/deploy.md) | shipped | pyproject.toml, __main__.py, worker.py, selfhost.sh, … |
 
 ## Reference

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -7,6 +7,7 @@ sources:
   - alembic/versions/0001_baseline_current_schema.py
   - alembic/versions/0002_capacity_policy_snapshot.py
   - alembic/versions/0003_overflow_route.py
+  - alembic/versions/0004_overflow_spend.py
   - src/treg/web/sitetrack.js
   - src/treg/models.py
   - src/treg/timeutil.py
@@ -209,6 +210,9 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   treg-owned aggregator account, with the aggregator's price, the price ratio, verification stamp and a
   DERIVED `enabled`. Filled by `treg-worker overflow sync` only (alembic `0003`); read-only for the call
   path. See `ops/capacity.md`.
+- **`OverflowSpend`** — per aggregator per UTC day: calls, the aggregator's charge, the delta against
+  treg's direct price. Written inside the overflow child's settle transaction (and by the shadow probe);
+  the $20/day budget reads it. Alembic `0004`. Not a balance.
 
 ## Bindings (the multi-credential shape)
 `Tool.bindings` is a JSON list; each entry is
@@ -242,7 +246,7 @@ parameters compared with timestamp columns follow the same constraint as inserte
 
 ## Alembic baseline
 
-Revisions after the baseline (`0002` capacity tables, `0003` overflow routes) must be paired with the legacy startup path
+Revisions after the baseline (`0002` capacity tables, `0003` overflow routes, `0004` overflow spend) must be paired with the legacy startup path
 until stage 5; the parity test compares a fresh `init_db` schema with `alembic upgrade head`.
 
 

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -8,6 +8,7 @@ sources:
   - src/treg/application/call/__init__.py
   - src/treg/application/call/authorize.py
   - src/treg/application/call/idempotency.py
+  - src/treg/application/call/overflow.py
   - src/treg/application/call/intake.py
   - src/treg/application/call/resolve.py
   - src/treg/application/call/reserve.py
@@ -100,7 +101,8 @@ The capacity domain (`treg.domain.capacity`, plan step B) is a leaf like identit
 It reads config and writes only its own tables and ratestore keys, from worker-profile commands
 (`treg-worker`, a separate console script so the light `treg` CLI never gains a DB import). The call
 application imports the capacity domain inward (`resolve` → `view`, `settle` → `signatures`/`marks`);
-the domain never imports back. The
+the domain never imports back; `application.call.overflow` composes the capacity domain, the
+aggregator envelopes and the money primitives, and the aggregator adapters stay pure envelope code. The
 aggregator envelopes live under `treg.infra.upstream.aggregators` and inherit the upstream contract
 (no HTTP adapters, no routers); the capacity domain's `verify` module may import them because they are
 pure envelope code, not a web framework.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -776,3 +776,12 @@ obligations) is what gets bought rather than built.
 after a tier-4 balance/quota signature. It touches no balance, hold or ledger row — it is a hint for the
 NEXT caller's resolution — and is listed in the dataplane write allowlist on its own
 (`capacity_exhausted_mark`), not under the money entries. See `ops/capacity.md`.
+
+## Overflow money
+
+The overflow child (`application.call.overflow`) is an ordinary metered cycle on its own hold
+(`{call_ref}:overflow`): `_platform_reserve` at the route's aggregator price, `_platform_settle` with
+`observed_override` = the aggregator's in-band charge — the caller pays exactly that, 0% markup —
+and `cost_source: "aggregator"` + `served_via` in the ledger `meta`, so `reconcile` needs no join.
+`OverflowSpend` (per aggregator per UTC day) is updated inside that same settle transaction; it is
+accounting for the $20/day budget, not a balance. Shadow mode places no hold and charges nothing.

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -344,6 +344,46 @@ Both are visible: `X-Treg-Smoothed: wait=<ms>` and/or `retry=1` on the response 
 No audit column yet — `smoothed_ms` would be an ALTER on the hot `callrecord` table, a migration-class
 change kept out of this behaviour PR.
 
+## Overflow — the child cycle (plan step E; off by default)
+
+**Overflow = the same vendor endpoint, another account of ours.** When a tier-4 call fails on treg's
+own key for a treg-side reason — a balance/quota signature, a burst-429 smoothing could not absorb —
+and the worker has an enabled `OverflowRoute` for the endpoint, `application.call.overflow.
+maybe_overflow` runs a **child cycle** after the primary's settle released its hold:
+
+1. Route from the in-process route view (`domain.capacity.routes_view`, Orthogonal first), skipping
+   an aggregator marked unhealthy (`overflow:<name>` in the capacity view) or without a key; budget
+   check against `OverflowSpend` (`overflow_daily_budget_usd`, $20/aggregator/day) on a short session.
+2. **Child hold**, own id `{call_ref}:overflow`, through the ordinary `_platform_reserve` (tag
+   budgets, daily cap, trial allowance apply; an empty balance is the normal 402). Never the parent's
+   id: release-by-id is a conditional claim and `_finish_cancelled_call` releases both ids exactly once.
+3. One aggregator run with **no DB open**: `infra.upstream.aggregators.<name>.build` wraps the
+   caller's original query + buffered body; the key comes from `Settings.overflow_key_<name>` and is
+   never logged. Monid's async runs are polled (bounded).
+4. `parse` → vendor status + body + the real in-band cost. `_platform_settle(child,
+   observed_override=cost, overflow_spend=(aggregator, cost − treg's direct price))` charges **exactly
+   the aggregator's price, 0% markup**, and folds the day's spend delta into the same transaction —
+   the one allowlisted overflow write (`overflow_spend_in_settle`).
+5. The vendor's body goes back as the answer, `X-Treg-Served-Via: overflow:<name>`, `X-Treg-Cost-Micro`
+   the child's charge, `X-Treg-Call-Id` the parent's. Two audit rows share the `call_ref`: the primary
+   attempt with its real status and the child with `credential_tier="platform-overflow"`.
+
+When the resolver already knows the account is out (the exhausted view) **and** a route is on, the
+ladder skips the direct attempt entirely (`MarketplaceCall.skip_direct`): no parent hold, no vendor
+402, straight to the child — the plan's tier 4b.
+
+**An aggregator failure is data.** Its own 401/402/403 (or a vendor 402 relayed through it — seen live)
+releases the child hold, marks `overflow:<name>` unhealthy for 15 minutes, and answers the typed
+`provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call. Its
+stricter-schema refusal (`contract`) releases the child and lets the vendor's own answer stand.
+
+**Shadow mode** (`TREG_OVERFLOW_MODE=shadow`): the aggregator is called, status / shape / cost logged
+and the probe's cost recorded in `OverflowSpend` (treg pays, budget-bounded) — the caller still gets
+the vendor's own error and is charged nothing. This is the week the plan requires before routes serve.
+
+Never on tiers 1/2, a caller-caused 4xx, a 401, a timeout, PUT/PATCH/DELETE, or a route the worker
+has not enabled. Org opt-out (`allow_platform_overflow`) lands with step F.
+
 ## treg's own headers never reach the upstream — by PREFIX, not by name
 
 `proxy._DROP_REQUEST` used to enumerate our control headers, and the enumeration had already failed:

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -95,6 +95,14 @@ on the audit row. The caller's own key for the provider is never affected (tiers
 treg does not call an alternative on the caller's behalf — it names them. Not the pool-saturation 503
 (`treg_saturated`), which is a different exit. See `architecture/proxy-model.md` § Platform capacity.
 
+## `X-Treg-Served-Via` — this answer came through an overflow relay
+
+`overflow:<aggregator>` on a metered call that treg served through a treg-owned aggregator account
+because its own account for the provider was out. Same request, same vendor body shape (routes are
+verified for that), the caller paid the aggregator's real price (`X-Treg-Cost-Micro`), and
+`X-Treg-Call-Id` is the parent call's. Absent on every direct call. Off by default
+(`TREG_OVERFLOW_MODE`). See `architecture/proxy-model.md` § Overflow.
+
 ## `X-Treg-Smoothed` — the call waited for treg's own rate limit
 
 On a metered (tier-4) call only: `wait=<ms>` when the call was spaced behind other callers on the

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -1,6 +1,6 @@
 ---
 title: Provider capacity — knowing what treg's own vendor accounts have left
-status: shipped (steps B, B′, D, D′)
+status: shipped (steps B, B′, D, D′, E — overflow off by default, shadow week pending)
 sources:
   - src/treg/domain/capacity/__init__.py
   - src/treg/domain/capacity/collectors.py
@@ -13,6 +13,11 @@ sources:
   - src/treg/domain/capacity/marks.py
   - tests/test_capacity_protect.py
   - src/treg/infra/upstream/limiter.py
+  - src/treg/domain/capacity/overflow_spend.py
+  - src/treg/domain/capacity/routes_view.py
+  - src/treg/application/call/overflow.py
+  - alembic/versions/0004_overflow_spend.py
+  - tests/test_capacity_overflow.py
   - tests/test_capacity_smoothing.py
   - src/treg/domain/capacity/overflow_seed.json
   - src/treg/infra/upstream/aggregators/__init__.py
@@ -157,8 +162,20 @@ smoothing. The provider's rate limit travels in the published latest state (`Lat
 from `CapacityPolicy.rate_limit`; a call-path mark carries it forward), so the request path never reads
 the policy table. `rate_pressure` alerting is step C.
 
+## Overflow, the child cycle (step E) — off by default
+
+`application/call/overflow.py` is documented in `architecture/proxy-model.md` § Overflow. Operating
+it: `TREG_OVERFLOW_MODE` = `off` (default) | `shadow` | `on`; `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
+per aggregator per UTC day, read from `OverflowSpend`; the aggregator keys `TREG_OVERFLOW_KEY_*` in
+the web service env (the cron pulls them). The route view (`routes_view.py`) is the call path's
+60 s copy of the enabled `OverflowRoute` rows; `overflow sync` / `overflow verify` are the only
+writers. **Rollout (plan §5):** run `shadow` for a week with routes enabled — every probe logs
+`overflow SHADOW <endpoint> via <aggregator>: … shape …` and lands a child audit row
+(`credential_tier=platform-overflow`, `error_response="treg overflow: shadow"`) — then switch to
+`on` (step F, which also adds the org opt-out and amends the charter).
+
 ## Not built yet (plan steps C–F)
 
-Forecasts and alerts (C, gated on the `money-funding-transactions` debt); the
-overflow child cycle through Orthogonal/Monid (E); enabling routes (F). Until F ships, the charter
-row "not built yet: routing/failover" stands and treg still relays a vendor's 402 unchanged.
+Forecasts and alerts (C, gated on the `money-funding-transactions` debt); enabling overflow in
+production with the org opt-out (F). Until F ships, `TREG_OVERFLOW_MODE` stays `off`, the charter row
+"not built yet: routing/failover" stands and treg still relays a vendor's 402 unchanged.

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -323,7 +323,8 @@ base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 
 `treg-capacity-sweep` every hour, with the DB URL, Fernet key and every `TREG_PLATFORM_KEY_*` pulled
 from the web service via `fromService` — so a new platform key is added in ONE place. Aggregator keys
 (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same
-way; they are declared in `config.py` but nothing serves through them yet.
+way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
+govern the overflow child cycle (`ops/capacity.md`); the keys serve nothing while the mode is `off`.
 
 ## A db.py change needs a Postgres-shaped deploy plan
 

--- a/render.yaml
+++ b/render.yaml
@@ -146,7 +146,12 @@ services:
         sync: false
       - key: TREG_PLATFORM_PROVIDERS           # e.g. "tikhub,dataforseo,scrapecreators"; "" = tier 4 off
         value: ""
-      # Overflow aggregator keys (plan §4.3) — declared, unused until overflow ships.
+      # Overflow (docs/context/ops/capacity.md): treg-owned aggregator accounts serving the SAME vendor
+      # endpoint when our own account is out. MODE is the switch: off (default) | shadow | on.
+      - key: TREG_OVERFLOW_MODE
+        value: "off"
+      - key: TREG_OVERFLOW_DAILY_BUDGET_USD
+        value: "20"
       - key: TREG_OVERFLOW_KEY_ORTHOGONAL
         sync: false
       - key: TREG_OVERFLOW_KEY_MONID

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -1,0 +1,236 @@
+"""Overflow — the child cycle (docs/PROVIDER-CAPACITY-PLAN.md §4.3).
+
+When treg's OWN account for a provider fails a tier-4 call (a balance/quota signature, a burst-429
+that smoothing could not absorb, a connect error), serve the SAME vendor endpoint through a
+treg-owned aggregator account: reserve a child hold (own id `{call_ref}:overflow`) → one aggregator
+run, no DB open → settle the child at the aggregator's real price (0% markup) and fold the daily
+spend delta into that settle → return the vendor's body from the aggregator's envelope, disclosed via
+`X-Treg-Served-Via`. One hop: an aggregator that fails is data (child released, aggregator marked
+unhealthy 15 min, typed 503 with alternatives), never a second aggregator.
+
+Shadow mode (`overflow_mode=shadow`): everything except the child hold and the answer — the
+aggregator is called, status/shape/cost logged and the spend recorded (treg pays the probe, bounded
+by the daily budget), and the caller still gets the vendor's own error, charged nothing.
+
+Never on: tiers 1/2, a caller-caused 4xx, a timeout, a non-idempotent method (PUT/PATCH/DELETE), an
+org that opted out (step F), or a route the worker has not enabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, replace
+
+import httpx
+
+from ... import audit
+from ...config import get_settings
+from ...db import session_maker
+from ...domain.capacity import marks as capacity_marks
+from ...domain.capacity import overflow_spend as overflow_spend_ledger
+from ...domain.capacity import signatures as capacity_signatures
+from ...domain.capacity.routes_view import view as routes_view
+from ...domain.capacity.verify import shape
+from ...domain.capacity.view import view as capacity_view
+from ...infra.upstream.aggregators import AggregatorRequest, AggregatorResult, by_name
+from ...timeutil import utcnow_naive
+from .resolve import MarketplaceCall
+from .reserve import _platform_reserve
+from .settle import _platform_settle
+from .types import CallFailure, UpstreamResponse
+
+log = logging.getLogger("treg.overflow")
+
+AGGREGATOR_UNHEALTHY_S = 15 * 60
+OVERFLOW_METHODS = frozenset({"GET", "HEAD", "POST"})  # a POST lookup with a buffered body is re-sendable
+POLL_MAX = 10
+POLL_WAIT_S = 1.5
+
+
+@dataclass
+class OverflowOutcome:
+    served: bool                       # the caller gets the child's answer
+    response: UpstreamResponse | None  # when served
+    body: bytes = b""
+    charged_micro: int = 0
+    observed_micro: int | None = None
+    aggregator: str = ""
+    failure: CallFailure | None = None  # on-mode: the typed 503 to raise instead of the vendor error
+    note: str = ""
+
+
+def _trigger(mk: MarketplaceCall, status: int, headers, body: bytes) -> str | None:
+    """Why this call may overflow, or None. Only treg-side failures qualify (plan §4.1)."""
+    if status == 401:
+        return None
+    signal = capacity_signatures.classify(mk.provider, status, headers, body[:4096])
+    if signal is None:
+        return None
+    if signal.kind in ("balance", "quota"):
+        return signal.kind
+    if signal.kind == "burst":
+        return "burst"
+    return None
+
+
+async def _send(client: httpx.AsyncClient, req: AggregatorRequest) -> httpx.Response:
+    """One HTTP exchange with the aggregator. A seam: tests replace it; production uses the shared
+    upstream client (same timeouts as a direct relay)."""
+    return await client.request(req.method, req.url, headers=req.headers, json=req.json)
+
+
+async def _run(client: httpx.AsyncClient, aggregator: str, route, key: str, query, body: bytes | None,
+               path_params: dict | None) -> AggregatorResult:
+    adapter = by_name(aggregator)
+    req = adapter.build(route, key, query, body, path_params)
+    r = await _send(client, req)
+    res = adapter.parse(r.status_code, r.content)
+    polls = 0
+    while res.failure == "pending" and res.poll_url and polls < POLL_MAX:
+        await asyncio.sleep(POLL_WAIT_S)
+        polls += 1
+        pr = await _send(client, AggregatorRequest("GET", res.poll_url, {"Authorization": f"Bearer {key}"}, {}))
+        res = adapter.parse(pr.status_code, pr.content)
+    return res
+
+
+def _child(mk: MarketplaceCall, route) -> MarketplaceCall:
+    return replace(mk, tier="platform-overflow", call_id=None,
+                   estimate_micro=int(route.agg_price_micro or 0),
+                   cost_type="per_call" if route.agg_unit == "call" else "per_result",
+                   unit_micro=int(route.agg_price_micro or 0))
+
+
+def _response(res: AggregatorResult) -> UpstreamResponse:
+    async def _one():
+        yield res.upstream_body
+
+    async def _closed():
+        return None
+
+    raw = [(b"content-length", str(len(res.upstream_body)).encode()),
+           (b"content-type", b"application/json")]
+    return UpstreamResponse(int(res.upstream_status or 200), tuple(raw), _one(), _closed)
+
+
+def _capacity_503(mk: MarketplaceCall, aggregator: str, why: str) -> CallFailure:
+    from .resolve import _capability_alternatives, _catalog_endpoint_for
+    ep = _catalog_endpoint_for(mk.endpoint_id) or {"id": mk.endpoint_id}
+    alts = _capability_alternatives(ep)
+    return CallFailure("provider_capacity", status_code=503, detail={
+        "error": "provider_capacity_unavailable", "provider": mk.provider, "endpoint_id": mk.endpoint_id,
+        "resets_at": None, "alternatives": [ln.strip() for ln in alts[1:]],
+        "message": (f"treg's own {mk.provider} account is out and the overflow relay ({aggregator}) "
+                    f"could not serve {mk.endpoint_id} ({why}); nothing was charged.\n"
+                    f"  use your own key: treg secret add {mk.provider} --env-var "
+                    f"{mk.provider.upper().replace('-', '_')}_API_KEY\n" + "\n".join(alts)),
+    })
+
+
+async def _record_shadow(aggregator: str, cost_micro: int, delta_micro: int) -> None:
+    """Shadow mode's spend row — the same `overflow_spend` write as the child settle, on its own
+    short session because there is no child hold to settle in."""
+    async with session_maker() as db:
+        await overflow_spend_ledger.add_in_transaction(db, aggregator, cost_micro, delta_micro)
+        await db.commit()
+
+
+async def maybe_overflow(
+    *, mk: MarketplaceCall, caller, meta, call_ref: str, status: int, headers, body: bytes,
+    method: str, query_items: list[tuple[str, str]], caller_body: bytes, client: httpx.AsyncClient,
+    audit_client: str = "", force_trigger: str | None = None,
+) -> OverflowOutcome | None:
+    """After the primary's settle released — or, with `force_trigger`, INSTEAD of a direct attempt
+    the resolver already knows would 402 (`mk.skip_direct`). None = nothing to do (the vendor's
+    answer stands)."""
+    settings = get_settings()
+    mode = settings.overflow_mode
+    if mode == "off" or mk.tier != "platform" or method.upper() not in OVERFLOW_METHODS:
+        return None
+    why = force_trigger or _trigger(mk, status, headers, body)
+    if why is None:
+        return None
+    routes = routes_view.for_endpoint(mk.endpoint_id)
+    routes = [r for r in routes if settings.overflow_key_for(r.aggregator)
+              and not capacity_view.is_exhausted(f"overflow:{r.aggregator}")]
+    if not routes:
+        return None
+    route = routes[0]
+    aggregator = route.aggregator
+    key = settings.overflow_key_for(aggregator) or ""
+    price = int(route.agg_price_micro or 0)
+    # Budget: the aggregator's day so far + this call, before any hold (plan §4.3 step 5).
+    async with session_maker() as db:
+        spent = await overflow_spend_ledger.spent_today(db, aggregator)
+    if spent + price > settings.overflow_daily_budget_micro:
+        log.warning("overflow budget reached for %s (%d + %d > %d)", aggregator, spent, price,
+                    settings.overflow_daily_budget_micro)
+        return None
+    child = _child(mk, route)
+    query = [(k, v) for k, v in query_items if k not in mk.consumed]
+    if mode == "on":
+        # Child hold: own id, same call_ref family. Insufficient balance here is the normal 402.
+        await _platform_reserve(child, caller, meta=meta, call_ref=f"{call_ref}:overflow")
+    res: AggregatorResult | None = None
+    try:
+        res = await _run(client, aggregator, route, key, query, caller_body or None, None)
+    except httpx.RequestError as exc:
+        res = AggregatorResult(None, b"", 0, "malformed", f"{type(exc).__name__}: {exc}")
+    delta = (res.cost_micro or 0) - int(mk.estimate_micro or 0)
+    # --- decide ---
+    if res.failure in ("aggregator_auth", "aggregator_balance", "malformed") or res.upstream_status == 402:
+        why_agg = res.failure or "upstream 402 through the aggregator"
+        await capacity_marks.mark_exhausted(f"overflow:{aggregator}", until=utcnow_naive().replace(microsecond=0)
+                                            + __import__("datetime").timedelta(seconds=AGGREGATOR_UNHEALTHY_S),
+                                            note=f"{why_agg}: {res.detail[:80]}")
+        if mode == "on":
+            await _platform_settle(child, None, reason=f"overflow_{why_agg[:24]}")
+        log.warning("overflow via %s failed for %s: %s %s", aggregator, mk.endpoint_id, why_agg, res.detail)
+        _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note=why_agg)
+        return OverflowOutcome(False, None, aggregator=aggregator, note=why_agg,
+                               failure=_capacity_503(mk, aggregator, why_agg) if mode == "on" else None)
+    if res.failure == "contract" or res.failure == "pending":
+        # The aggregator's stricter schema refused (no vendor call, no charge): this route is wrong for
+        # this call; the vendor's own answer stands. Worth a log line — verify should have caught it.
+        if mode == "on":
+            await _platform_settle(child, None, reason="overflow_contract")
+        log.warning("overflow via %s refused %s: %s", aggregator, mk.endpoint_id, res.detail)
+        _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note=res.failure)
+        return OverflowOutcome(False, None, aggregator=aggregator, note=res.failure)
+    # The vendor answered through the aggregator.
+    if mode == "shadow":
+        try:
+            body_shape = json.dumps(shape(json.loads(res.upstream_body)), sort_keys=True)[:400]
+        except ValueError:
+            body_shape = "non-json"
+        log.info("overflow SHADOW %s via %s: vendor %s direct→%s relay, cost %s, delta %s, shape %s",
+                 mk.endpoint_id, aggregator, status, res.upstream_status, res.cost_micro, delta, body_shape)
+        try:
+            await _record_shadow(aggregator, res.cost_micro or 0, delta)
+        except Exception:  # noqa: BLE001 — accounting for a probe must not touch the caller's answer
+            log.warning("shadow spend row not written", exc_info=True)
+        _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note="shadow")
+        return OverflowOutcome(False, None, aggregator=aggregator, note="shadow")
+    charged, observed = await _platform_settle(
+        child, int(res.upstream_status or 200), res.upstream_body,
+        observed_override=res.cost_micro, overflow_spend=(aggregator, delta))
+    response = _response(res)
+    _audit_child(mk, child, call_ref, aggregator, res, charged=charged, client=audit_client)
+    return OverflowOutcome(True, response, res.upstream_body, charged, observed, aggregator)
+
+
+def _audit_child(mk: MarketplaceCall, child: MarketplaceCall, call_ref: str, aggregator: str,
+                 res: AggregatorResult, *, charged: int, client: str, note: str = "") -> None:
+    """The child's own audit row: same call_ref as the primary, credential_tier platform-overflow,
+    provider = the vendor. Fire-and-forget like every audit row."""
+    audit.record_call(
+        org_id=child.tool.org_id, user_email=child.tool.owner, tool_name=mk.endpoint_id,
+        method="OVERFLOW", path=f"overflow:{aggregator}/{child.tool.name}",
+        status_code=int(res.upstream_status or 0), client=client,
+        telemetry={"call_ref": call_ref, "endpoint_id": mk.endpoint_id, "provider": mk.provider,
+                   "credential_tier": "platform-overflow", "cost_estimated_micro": child.estimate_micro,
+                   "cost_observed_micro": res.cost_micro, "cost_charged_micro": charged,
+                   "response_bytes": len(res.upstream_body), "params_hash": mk.params_hash,
+                   **({"error_response": f"treg overflow: {note}"} if note else {})})

--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -15,6 +15,7 @@ from sqlmodel import select
 from ... import catalog_store, oauth_providers
 from ... import sandbox as demo_sandbox
 from ...config import get_settings, platform_setting_name
+from ...domain.capacity.routes_view import view as overflow_routes_view
 from ...domain.capacity.view import view as capacity_view
 from ...db import session_maker
 from ...domain.governance import access as access_policy
@@ -263,7 +264,7 @@ class MarketplaceCall:
     consumed: set[str]              # query params eaten by `{placeholder}` path substitution
     endpoint_id: str
     provider: str
-    tier: str                       # tool | credential | platform
+    tier: str                       # tool | credential | platform | platform-overflow (child cycle only)
     cost_type: str = ""             # cost.type — decides whether a 4xx is billable (per_call is)
     estimate_micro: int = 0         # RAW provider estimate; the ledger applies the margin
     params_hash: str = ""
@@ -274,13 +275,16 @@ class MarketplaceCall:
     # is metered anyway. Set by `_billed_marketplace` after the bound secrets are known.
     billed_oauth: bool = False
     unit_micro: int = 0             # RAW per-resource price for a per_result settle-by-count
+    # treg's own account is marked exhausted AND an overflow route is enabled: skip the direct
+    # attempt (no hold, no vendor 402) and go straight to the child cycle (plan §4 ladder).
+    skip_direct: bool = False
 
     @property
     def metered(self) -> bool:
         """True when OUR money is at stake: treg's platform key (tier 4), or an org credential that
         rides treg's pay-per-use OAuth app (`billed_oauth`). Tiers 1/2 on a provider that bills the
         account owner stay unmetered — there the org's own account pays."""
-        return self.tier == "platform" or self.billed_oauth
+        return self.tier in ("platform", "platform-overflow") or self.billed_oauth
 
 
 # A `per_result` price is per ROW, so an estimate needs a row count. The caller's own limit param is
@@ -823,18 +827,23 @@ async def _resolve_marketplace_call(
     # an org that brought its own credential is billed by the provider, not by us, and must never be
     # silently switched onto our key (their quota, their rate limits, their data agreements).
     cost = _platform_offer(ep, provider, caller.org)
+    skip_direct = False
     if cost is not None and capacity_view.is_exhausted(service):
-        # Refuse BEFORE reserve (plan §4.2): treg's own account for this provider is known to be
-        # out (a confirmed balance/quota signature, or the sweep). No hold is ever placed for a
-        # call we know will 402; the caller gets a typed 503 naming when and what else.
-        raise _provider_capacity_unavailable(ep, service, capacity_view.get(service))
+        # treg's own account for this provider is known to be out (a confirmed balance/quota
+        # signature, or the sweep). Never relay a call we know will 402: with an enabled overflow
+        # route the ladder skips straight to the child cycle (plan §4); otherwise refuse BEFORE
+        # reserve with a typed 503 naming when and what else (§4.2).
+        if get_settings().overflow_mode == "on" and overflow_routes_view.for_endpoint(ep["id"]):
+            skip_direct = True
+        else:
+            raise _provider_capacity_unavailable(ep, service, capacity_view.get(service))
     if cost is not None:
         virtual = Tool(
             org_id=caller.org_id, name=ep["id"], owner=caller.email,
             base_url=provider.base_url, host=_host_of(provider.base_url),
             bindings=_platform_bindings(provider),
         )
-        return MarketplaceCall(tool=virtual, tier="platform", **{
+        return MarketplaceCall(tool=virtual, tier="platform", skip_direct=skip_direct, **{
             **common, "cost_type": str(cost.get("type") or "per_call"),
             "estimate_micro": info_est, "unit_micro": info_unit})
     raise _marketplace_no_credential(service, ep["id"], provider, ep)
@@ -871,6 +880,8 @@ async def resolve_marketplace_target(
     # connection is held at a time, and before any hold exists. Cached 60 s; a stale or empty view
     # never refuses (plan §4.1: blocking fires on confirmed signals only).
     await capacity_view.load()
+    if get_settings().overflow_mode != "off":
+        await overflow_routes_view.load()  # same discipline: before the session, cached 60 s
     async with session_maker() as db:
         return await _resolve_marketplace_call(
             ep,

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -46,6 +46,7 @@ from .resolve import (
     resolve_call_target,
     resolve_marketplace_target,
 )
+from . import overflow as overflow_cycle
 from .settle import (
     _buffer_response,
     _finish_cancelled_call as finish_cancelled_call,
@@ -521,6 +522,44 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             read_body=request.body,
         ), request, call_ref)
 
+    if mk is not None and mk.skip_direct:
+        # The resolver knows treg's own account is out and an overflow route is on: no direct
+        # attempt, no parent hold — straight to the child cycle (plan §4 ladder, tier 4b). The DB
+        # phase ends here; the child places its own hold and the aggregator answers with none open.
+        await db.commit()
+        _audit(503, charged_micro=0, refused_by="capacity",
+               error_response="treg: own account exhausted — served via overflow" )
+        try:
+            outcome = await overflow_cycle.maybe_overflow(
+                mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=402,
+                headers=httpx.Headers(()), body=b"", method=request.method,
+                query_items=request.query_params.multi_items(), caller_body=caller_body,
+                client=upstream_client, audit_client=_client_name(request), force_trigger="exhausted")
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, mk, call_ref)
+            raise
+        if outcome is None or not outcome.served or outcome.response is None:
+            request.state.call_cost_micro = 0
+            from .resolve import _provider_capacity_unavailable
+            raise (outcome.failure if outcome is not None and outcome.failure is not None
+                   else _provider_capacity_unavailable(
+                       _catalog_endpoint_for(mk.endpoint_id) or {"id": mk.endpoint_id},
+                       mk.provider, capacity_view.get(mk.provider)))
+        response, body, charged = outcome.response, outcome.body, outcome.charged_micro
+        if idem_key:
+            try:
+                await _store_idempotent(idem_key, caller, status_code=response.status, body=body,
+                                        media_type=_response_header(response, "content-type"),
+                                        charged_micro=charged, metered=True, call_ref=call_ref)
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
+            request.state.idem_claim = None
+        _set_response_header(response, "X-Treg-Cost-Micro", str(charged))
+        _set_response_header(response, "X-Treg-Call-Id", call_ref)
+        _set_response_header(response, "X-Treg-Served-Via", f"overflow:{outcome.aggregator}")
+        return response
+
     # Metered — treg's own money is about to be spent (tier 4's platform key, or a registry OAuth
     # connect on a pay-per-use app), so take the money FIRST. Deliberately the last gate before the
     # network: everything above (ACL, deny rules, caps) can still refuse the call, and a refused
@@ -743,6 +782,30 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         _audit(response.status, observed_micro=observed, charged_micro=charged,
                duration_ms=duration_ms, response_bytes=len(body),
                error_request=err_request, error_response=err_response)
+        served_via = ""
+        if response.status >= 400 and mk.tier == "platform":
+            # Overflow (plan §4.3): the primary attempt is settled ($0) and audited above; a child
+            # cycle may now serve the SAME endpoint through an aggregator. Off by default; shadow
+            # mode returns the vendor's answer regardless.
+            try:
+                outcome = await overflow_cycle.maybe_overflow(
+                    mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=response.status,
+                    headers=httpx.Headers(response.raw_headers), body=body, method=request.method,
+                    query_items=request.query_params.multi_items(), caller_body=caller_body,
+                    client=upstream_client, audit_client=_client_name(request))
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, mk, call_ref, response)
+                raise
+            except CallFailure as exc:  # the child's own 402 (insufficient balance for the child hold)
+                request.state.call_cost_micro = 0
+                raise
+            if outcome is not None and outcome.failure is not None:
+                request.state.call_cost_micro = 0
+                raise outcome.failure
+            if outcome is not None and outcome.served and outcome.response is not None:
+                await response.close()
+                response, body, charged = outcome.response, outcome.body, outcome.charged_micro
+                served_via = f"overflow:{outcome.aggregator}"
         if idem_key:
             # Here, and not earlier: this is the first point where BOTH the response and what it
             # actually cost are known, and a replay has to hand back the real charge rather than the
@@ -762,6 +825,8 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         # `0` there would read as "free" rather than "not applicable".
         _set_response_header(response, "X-Treg-Cost-Micro", str(charged))
         _set_response_header(response, "X-Treg-Call-Id", call_ref)
+        if served_via:
+            _set_response_header(response, "X-Treg-Served-Via", served_via)
         if smoothed:
             _set_response_header(response, "X-Treg-Smoothed", " ".join(smoothed))
         return response

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 
 from ... import adsconv, catalog_store, ledger
 from ...domain.capacity import marks as capacity_marks
+from ...domain.capacity import overflow_spend as overflow_spend_ledger
 from ...domain.capacity import signatures as capacity_signatures
 from ...db import session_maker
 from ...models import Org
@@ -335,6 +336,7 @@ async def _peek_stream_head(response: UpstreamResponse, limit: int) -> tuple[Ups
 async def _platform_settle(
     mk: MarketplaceCall, status_code: int | None, body: bytes = b"", *, headers=None,
     reason: str = "", finalized: Callable[[], None] | None = None,
+    observed_override: int | None = None, overflow_spend: tuple[str, int] | None = None,
 ) -> tuple[int, int | None]:
     """Close the hold for a metered call → (charged_micro, observed_micro). `charged_micro` is what
     actually hit the org's balance (0 on a release) — the number the Activity feed must show, because
@@ -350,7 +352,12 @@ async def _platform_settle(
     if not mk.metered or not mk.call_id:
         return 0, None
     billable = status_code is not None and _platform_billable(status_code, mk.cost_type)
-    observed = _observed_cost_micro(mk, body, headers) if billable else None
+    # `observed_override`: the overflow child cycle knows its cost from the aggregator's envelope, not
+    # from the vendor body — the caller pays exactly that (plan §4.3 step 5), whatever the vendor's
+    # own billing shape. `overflow_spend` = (aggregator, delta vs treg's direct price): folded into
+    # the SAME settle transaction, the one allowlisted overflow write (`overflow_spend_in_settle`).
+    observed = ((observed_override if observed_override is not None
+                 else _observed_cost_micro(mk, body, headers)) if billable else None)
     call_id, mk.call_id = mk.call_id, None  # closing is once-only, even if two paths try
     charged = 0
 
@@ -359,7 +366,12 @@ async def _platform_settle(
             if billable:
                 charged = await ledger.settle_in_transaction(db, call_id, observed, meta={
                     "provider": mk.provider, "status_code": status_code, "cost_type": mk.cost_type,
-                    "cost_source": "provider" if observed is not None else "estimate"})
+                    "cost_source": ("aggregator" if overflow_spend is not None
+                                    else "provider" if observed is not None else "estimate"),
+                    **({"served_via": f"overflow:{overflow_spend[0]}"} if overflow_spend else {})})
+                if overflow_spend is not None:
+                    await overflow_spend_ledger.add_in_transaction(
+                        db, overflow_spend[0], observed or 0, overflow_spend[1])
             else:
                 await ledger.release_in_transaction(
                     db, call_id, reason=reason or f"not_billable_{status_code}",
@@ -412,13 +424,17 @@ async def _finish_cancelled_call(
             mk.call_id = None
             try:
                 async with session_maker() as cleanup_db:
-                    await ledger.release_in_transaction(
-                        cleanup_db,
-                        call_ref,
-                        reason="call_cancelled",
-                        meta={"provider": mk.provider, "cost_type": mk.cost_type,
-                              "status_code": None},
-                    )
+                    # The parent hold AND the overflow child's (`{call_ref}:overflow`, plan §4.3
+                    # step 2): each release is a conditional claim, so a hold that never existed or
+                    # was already closed is a safe no-op, and both are released exactly once.
+                    for hold_id in (call_ref, f"{call_ref}:overflow"):
+                        await ledger.release_in_transaction(
+                            cleanup_db,
+                            hold_id,
+                            reason="call_cancelled",
+                            meta={"provider": mk.provider, "cost_type": mk.cost_type,
+                                  "status_code": None},
+                        )
                     await cleanup_db.commit()
             except (Exception, asyncio.CancelledError):  # noqa: BLE001
                 logging.getLogger("treg.ledger").error(

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -189,6 +189,11 @@ class Settings(BaseSettings):
     # Not platform_key_* on purpose: they are a credential RUNG (platform-overflow), not a provider.
     overflow_key_orthogonal: str = ""
     overflow_key_monid: str = ""
+    # off (default) | shadow | on. Shadow: on a tier-4 capacity failure, call the aggregator anyway,
+    # log status/shape/cost, still return the vendor's own error and charge the caller nothing —
+    # treg pays the probe, bounded by the daily budget. On: the child cycle serves the caller.
+    overflow_mode: str = "off"
+    overflow_daily_budget_usd: float = 20.0  # per aggregator, per UTC day; crossing it skips overflow
     # The KILL SWITCH, and the reason a key alone isn't enough: a provider serves tier 4 only if it is
     # named here AND its key is set. Empty (the default) = tier 4 is entirely off, so a deploy that
     # happens to hold a key can't start spending it by accident. `TREG_PLATFORM_PROVIDERS=""` in the
@@ -406,6 +411,13 @@ class Settings(BaseSettings):
     @property
     def platform_daily_cap_micro(self) -> int:
         return int(round(self.platform_daily_cap_usd * 1_000_000))
+
+    @property
+    def overflow_daily_budget_micro(self) -> int:
+        return int(round(self.overflow_daily_budget_usd * 1_000_000))
+
+    def overflow_key_for(self, aggregator: str) -> str | None:
+        return getattr(self, f"overflow_key_{aggregator}", "") or None
 
     @property
     def oauth_billed_set(self) -> frozenset[str]:

--- a/src/treg/domain/capacity/overflow_spend.py
+++ b/src/treg/domain/capacity/overflow_spend.py
@@ -1,0 +1,36 @@
+"""Per-aggregator daily overflow accounting (`OverflowSpend`) — the budget the child cycle checks
+before it places a hold, and the row its settle updates in the same transaction."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ...models import OverflowSpend
+from ...timeutil import utcnow_naive
+
+
+def utc_day(now: datetime | None = None) -> str:
+    return (now or utcnow_naive()).strftime("%Y-%m-%d")
+
+
+async def add_in_transaction(db: AsyncSession, aggregator: str, cost_micro: int, delta_micro: int,
+                             *, day: str | None = None) -> OverflowSpend:
+    """Add one call to the day's row. Does NOT commit: the caller owns the transaction (the child
+    settle, or the shadow probe's own short session)."""
+    day = day or utc_day()
+    row = await db.get(OverflowSpend, (aggregator, day))
+    if row is None:
+        row = OverflowSpend(aggregator=aggregator, day=day)
+        db.add(row)
+    row.calls += 1
+    row.cost_micro += int(cost_micro)
+    row.delta_micro += int(delta_micro)
+    row.updated_at = utcnow_naive()
+    return row
+
+
+async def spent_today(db: AsyncSession, aggregator: str, *, day: str | None = None) -> int:
+    row = await db.get(OverflowSpend, (aggregator, day or utc_day()))
+    return int(row.cost_micro) if row is not None else 0

--- a/src/treg/domain/capacity/routes_view.py
+++ b/src/treg/domain/capacity/routes_view.py
@@ -1,0 +1,42 @@
+"""The in-process overflow route view: the enabled `OverflowRoute` rows, reloaded on a 60 s TTL by
+an explicit `await load()` (before the resolution session opens), read sync and I/O-free by the
+child cycle. Same invalidation story as the capacity view (time-based; every replica sees a sync
+within one TTL). Read-only: the worker's `overflow sync` is the only writer."""
+
+from __future__ import annotations
+
+import time
+
+from sqlalchemy import select
+
+from ...db import session_maker
+from ...models import OverflowRoute
+from .routes import route_for
+
+TTL_S = 60.0
+
+
+class RouteView:
+    def __init__(self, ttl_s: float = TTL_S) -> None:
+        self._ttl = ttl_s
+        self._loaded_at = -1.0
+        self._routes: list[OverflowRoute] = []
+
+    async def load(self, *, force: bool = False) -> list[OverflowRoute]:
+        if not force and time.monotonic() - self._loaded_at < self._ttl:
+            return self._routes
+        async with session_maker() as db:
+            rows = (await db.execute(select(OverflowRoute).where(OverflowRoute.enabled == True))).scalars().all()  # noqa: E712
+            db.expunge_all()
+        self._routes, self._loaded_at = list(rows), time.monotonic()
+        return self._routes
+
+    def for_endpoint(self, endpoint_id: str) -> list[OverflowRoute]:
+        """Enabled routes, Orthogonal first. Sync."""
+        return route_for(self._routes, endpoint_id)
+
+    def invalidate(self) -> None:
+        self._loaded_at = -1.0
+
+
+view = RouteView()

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1119,3 +1119,20 @@ class OverflowRoute(SQLModel, table=True):
     matched_at: datetime | None = Field(default=None)
     last_verified_at: datetime | None = Field(default=None)
     updated_at: datetime = Field(default_factory=_now)
+
+
+class OverflowSpend(SQLModel, table=True):
+    """Per-aggregator, per-UTC-day overflow accounting: what the aggregator charged treg
+    (`cost_micro`) and the delta against what the caller would have paid direct (`delta_micro`,
+    may be negative). Written INSIDE the child's settle transaction (allowlist entry
+    `overflow_spend_in_settle`) and, in shadow mode, by the shadow probe — never anywhere else. The
+    $20/day/aggregator budget (`Settings.overflow_daily_budget_usd`) is checked against it before a
+    child hold is placed. Not money: balances move only through domain/money.
+    """
+
+    aggregator: str = Field(primary_key=True)
+    day: str = Field(primary_key=True)  # YYYY-MM-DD, UTC
+    calls: int = Field(default=0)
+    cost_micro: int = Field(default=0)
+    delta_micro: int = Field(default=0)
+    updated_at: datetime = Field(default_factory=_now)

--- a/tests/test_call_architecture.py
+++ b/tests/test_call_architecture.py
@@ -11,7 +11,7 @@ import pytest
 
 from treg import bootstrap
 from treg.application import billing
-from treg.application.call import authorize, reserve, settle
+from treg.application.call import authorize, overflow, reserve, settle
 from treg.domain import money
 from treg.domain.capacity import marks as capacity_marks
 
@@ -41,7 +41,14 @@ _DATAPLANE_DERIVED_WRITES = {
     # table) AFTER the settle, so the next call is refused before a hold exists.
     "capacity_exhausted_mark": (
         (settle._note_capacity_signal, "capacity_marks.mark_exhausted"),
+        (overflow.maybe_overflow, "capacity_marks.mark_exhausted"),
         (capacity_marks.mark_exhausted, "ratestore.kv_put"),
+    ),
+    # Plan §4.3 step 5: the overflow child's settle folds the aggregator's daily spend delta into
+    # the SAME transaction; shadow mode records the probe's cost on its own short session.
+    "overflow_spend_in_settle": (
+        (settle._platform_settle, "overflow_spend_ledger.add_in_transaction"),
+        (overflow._record_shadow, "overflow_spend_ledger.add_in_transaction"),
     ),
 }
 _EXPECTED_DATAPLANE_WRITES = frozenset({
@@ -51,6 +58,7 @@ _EXPECTED_DATAPLANE_WRITES = frozenset({
     "first_call_adconversion_outbox",
     "lazy_stale_hold_reap",
     "capacity_exhausted_mark",
+    "overflow_spend_in_settle",
 })
 _DERIVED_WRITE_FILES = {
     _SRC / "application" / "billing.py": {"loop.create_task"},
@@ -58,7 +66,12 @@ _DERIVED_WRITE_FILES = {
         "publicdemo_policy.enforce_public_demo_ip_cap",
     },
     _SRC / "application" / "call" / "reserve.py": {"billing.maybe_schedule_autotopup"},
-    _SRC / "application" / "call" / "settle.py": {"adsconv.queue", "capacity_marks.mark_exhausted"},
+    _SRC / "application" / "call" / "settle.py": {
+        "adsconv.queue", "capacity_marks.mark_exhausted", "overflow_spend_ledger.add_in_transaction",
+    },
+    _SRC / "application" / "call" / "overflow.py": {
+        "capacity_marks.mark_exhausted", "overflow_spend_ledger.add_in_transaction",
+    },
     _SRC / "domain" / "capacity" / "marks.py": {"ratestore.kv_put"},
     _SRC / "domain" / "governance" / "publicdemo.py": {
         "ratestore.sweep", "ratestore.rate_check",
@@ -75,6 +88,10 @@ _EXPECTED_DERIVED_WRITE_SITES = {
      "billing.maybe_schedule_autotopup"),
     ("application/call/settle.py", "_record_first_call", "adsconv.queue"),
     ("application/call/settle.py", "_note_capacity_signal", "capacity_marks.mark_exhausted"),
+    ("application/call/settle.py", "_platform_settle", "overflow_spend_ledger.add_in_transaction"),
+    ("application/call/settle.py", "_close", "overflow_spend_ledger.add_in_transaction"),
+    ("application/call/overflow.py", "maybe_overflow", "capacity_marks.mark_exhausted"),
+    ("application/call/overflow.py", "_record_shadow", "overflow_spend_ledger.add_in_transaction"),
     ("domain/capacity/marks.py", "mark_exhausted", "ratestore.kv_put"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.rate_check"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.sweep"),

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -1,0 +1,265 @@
+"""Step E of docs/PROVIDER-CAPACITY-PLAN.md — the overflow child cycle: the same vendor endpoint
+served through a treg-owned aggregator account when treg's own account fails a tier-4 call.
+Off by default; shadow mode never changes the caller's answer."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from httpx import AsyncClient
+from sqlmodel import select
+
+from treg import audit, ratestore
+from treg.application.call import overflow as O
+from treg.application.call import service as call_service
+from treg.application.call.types import UpstreamResponse
+from treg.config import get_settings
+from treg.db import session_maker
+from treg.domain.capacity.policy import LatestState
+from treg.domain.capacity.routes_view import view as routes_view
+from treg.domain.capacity.sweep import STATE_NS
+from treg.domain.capacity.view import view as capacity_view
+from treg.models import Hold, LedgerEntry, OverflowRoute, OverflowSpend
+from treg.timeutil import utcnow_naive
+
+from test_marketplace_call import EP, EP_MICRO, EP_PATH, _balance, _fake_relay, platform_on  # noqa: F401
+
+VENDOR_BODY = {"data": {"comments": [{"id": "1", "text": "hashed"}], "cursor": 20}}
+
+
+@pytest.fixture
+def overflow_on(monkeypatch, platform_on):
+    monkeypatch.setenv("TREG_OVERFLOW_MODE", "on")
+    monkeypatch.setenv("TREG_OVERFLOW_KEY_ORTHOGONAL", "ORTH-KEY")
+    monkeypatch.setenv("TREG_OVERFLOW_KEY_MONID", "MONID-KEY")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _route(aggregator="orthogonal", price_micro=3_000, enabled=True):
+    async with session_maker() as db:
+        db.add(OverflowRoute(endpoint_id=EP, aggregator=aggregator, provider="tikhub", method="GET", path=EP_PATH,
+                             agg_slug="tikhub", agg_path=EP_PATH, agg_price_micro=price_micro, agg_unit="call",
+                             ratio=3.0, enabled=enabled, last_verified_at=utcnow_naive()))
+        await db.commit()
+    routes_view.invalidate()
+    capacity_view.invalidate()
+
+
+def _orthogonal(answers: list[tuple[int, dict]], seen: list):
+    async def _send(client, req):
+        seen.append(req)
+        status, body = answers.pop(0)
+        return httpx.Response(status, json=body, request=httpx.Request(req.method, req.url))
+    return _send
+
+
+async def _holds():
+    async with session_maker() as db:
+        return (await db.execute(select(Hold))).scalars().all()
+
+
+async def _rows(model):
+    async with session_maker() as db:
+        return (await db.execute(select(model))).scalars().all()
+
+
+async def test_off_by_default_the_vendor_402_is_relayed_unchanged(clients: AsyncClient, platform_on, monkeypatch):
+    await _route()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {})], seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and seen == [] and "X-Treg-Served-Via" not in r.headers
+
+
+async def test_findymail_shaped_402_on_tier4_runs_one_child_cycle(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    seen = []
+    envelope = {"success": True, "data": VENDOR_BODY, "priceCents": 0.3, "requestId": "run_1",
+                "billing": {"chargedPriceCents": 0.3}}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, envelope)], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r.status_code == 200, r.text
+    assert r.json() == VENDOR_BODY, "the vendor's body, byte-for-byte the fixture's data"
+    assert r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    assert r.headers["X-Treg-Cost-Micro"] == "3000", "the aggregator's real price, 0% markup"
+    assert before - await _balance(clients) == 3_000
+    # the aggregator saw the SAME vendor request, wrapped
+    assert len(seen) == 1 and seen[0].json == {"api": "tikhub", "path": EP_PATH, "query": {"aweme_id": "7", "count": "5"}}
+    assert seen[0].headers["Authorization"] == "Bearer ORTH-KEY"
+    assert await _holds() == [], "both holds closed"
+    entries = await _rows(LedgerEntry)
+    kinds = sorted((e.kind, e.call_id or "") for e in entries if e.kind != "grant")
+    parent = r.headers["X-Treg-Call-Id"]
+    assert kinds == sorted([("reserve", parent), ("release", parent), ("reserve", f"{parent}:overflow"), ("settle", f"{parent}:overflow")])
+    settle = next(e for e in entries if e.kind == "settle")
+    assert settle.meta["cost_source"] == "aggregator" and settle.meta["served_via"] == "overflow:orthogonal"
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1 and spend[0].aggregator == "orthogonal" and spend[0].calls == 1 and spend[0].cost_micro == 3_000
+    assert spend[0].delta_micro == 3_000 - EP_MICRO
+    await audit.drain()
+    rows = (await clients.get("/calls")).json()
+    mine = [x for x in rows if x["tool_name"] == EP]
+    assert len(mine) == 2, "primary attempt + child, sharing call_ref"
+    tiers = {x.get("credential_tier") for x in mine}
+    assert tiers == {"platform", "platform-overflow"}
+
+
+async def test_aggregator_402_releases_the_child_marks_it_unhealthy_and_answers_a_typed_503(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route()
+    async with session_maker() as db:  # a second route exists; it must NOT be tried
+        db.add(OverflowRoute(endpoint_id=EP, aggregator="monid", provider="tikhub", method="GET", path=EP_PATH,
+                             agg_slug="tikhub", agg_path=EP_PATH, agg_price_micro=2_000, agg_unit="call",
+                             ratio=2.0, enabled=True, last_verified_at=utcnow_naive()))
+        await db.commit()
+    routes_view.invalidate()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b"out"))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(402, {"success": False, "error": "insufficient balance"})], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503 and r.json()["detail"]["error"] == "provider_capacity_unavailable"
+    assert r.headers["X-Treg-Error"] == "1" and r.headers.get("X-Treg-Cost-Micro") in (None, "0")
+    assert await _balance(clients) == before and await _holds() == []
+    assert len(seen) == 1, "one hop: the second aggregator is never contacted"
+    async with session_maker() as db:
+        state = LatestState.from_json(await ratestore.kv_get(db, STATE_NS, "overflow:orthogonal"))
+    assert state.is_exhausted()
+    # …and the next call skips the unhealthy aggregator and uses Monid
+    capacity_view.invalidate()
+    monid_ok = {"runId": "r", "status": "COMPLETED", "output": VENDOR_BODY, "providerResponse": {"httpStatus": 200},
+                "billing": {"reportedCost": {"value": 2000, "unit": "MICRO_DOLLAR"}}}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, monid_ok)], seen))
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r2.status_code == 200 and r2.headers["X-Treg-Served-Via"] == "overflow:monid"
+    assert seen[-1].json["provider"] == "tikhub" and r2.headers["X-Treg-Cost-Micro"] == "2000"
+
+
+async def test_contract_refusal_falls_back_to_the_vendor_answer(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"nope"}'))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(400, {"success": False, "error": "x",
+                                                        "_orthogonal": {"error": "orthogonal_endpoint_contract", "message": "company required"}})], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and r.text == '{"detail":"nope"}'
+    assert await _balance(clients) == before and await _holds() == []
+
+
+async def test_budget_crossing_skips_overflow(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(price_micro=3_000)
+    monkeypatch.setenv("TREG_OVERFLOW_DAILY_BUDGET_USD", "0.004")
+    get_settings.cache_clear()
+    async with session_maker() as db:
+        from treg.domain.capacity.overflow_spend import add_in_transaction
+        await add_in_transaction(db, "orthogonal", 2_000, 0)
+        await db.commit()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b"out"))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {})], seen))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and seen == [] and await _holds() == []
+
+
+async def test_caller_400_and_own_key_never_overflow(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route()
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {})], seen))
+    monkeypatch.setattr(call_service, "relay", _fake_relay(400, b'{"detail":"bad id"}'))
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 400
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b"out"))
+    await clients.post("/secrets", json={"name": "tikhub", "value": "MKKEY"})  # tier 2
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 402
+    assert seen == []
+
+
+async def test_shadow_mode_probes_records_spend_and_returns_the_vendor_error(clients: AsyncClient, overflow_on, monkeypatch):
+    monkeypatch.setenv("TREG_OVERFLOW_MODE", "shadow")
+    get_settings.cache_clear()
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and "X-Treg-Served-Via" not in r.headers and r.headers["X-Treg-Cost-Micro"] == "0"
+    assert len(seen) == 1 and await _balance(clients) == before and await _holds() == []
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1 and spend[0].cost_micro == 3_000 and spend[0].calls == 1
+    kinds = {e.kind for e in await _rows(LedgerEntry)}
+    assert "settle" not in kinds, "shadow never charges"
+
+
+async def test_cancellation_cleanup_releases_both_holds_exactly_once(clients: AsyncClient, overflow_on):
+    from treg import ledger
+    from treg.application.call.settle import _finish_cancelled_call
+    from treg.application.call.resolve import MarketplaceCall
+    from treg.models import Tool
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        await ledger.reserve_in_transaction(db, org_id, EP, 1_000, call_id="REF")
+        await ledger.reserve_in_transaction(db, org_id, EP, 3_000, call_id="REF:overflow")
+        await db.commit()
+    assert len(await _holds()) == 2
+    mk = MarketplaceCall(tool=Tool(org_id=org_id, name=EP, owner="x", base_url="https://x", host="x"),
+                         upstream="https://x", consumed=set(), endpoint_id=EP, provider="tikhub",
+                         tier="platform", estimate_micro=1_000, call_id="REF")
+    await _finish_cancelled_call(None, mk, "REF")
+    assert await _holds() == []
+    releases = [e for e in await _rows(LedgerEntry) if e.kind == "release"]
+    assert sorted(e.call_id for e in releases) == ["REF", "REF:overflow"]
+    await _finish_cancelled_call(None, mk, "REF")  # again: nothing to release, nothing breaks
+    assert len([e for e in await _rows(LedgerEntry) if e.kind == "release"]) == 2
+
+
+async def test_an_exhausted_account_with_a_route_skips_the_direct_attempt(clients: AsyncClient, overflow_on, monkeypatch):
+    """The ladder (plan §4): view says exhausted → no direct attempt, no parent hold → child cycle."""
+    await _route(price_micro=3_000)
+    now = utcnow_naive()
+    from datetime import timedelta
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "tikhub", LatestState(
+            "tikhub", 0.0, "USD", now, "exact", exhausted_until=now + timedelta(hours=1), health="exhausted").to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+    direct = []
+    async def never(*a, **k):
+        direct.append(1)
+        raise AssertionError("the direct relay must not run")
+    monkeypatch.setattr(call_service, "relay", never)
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "k1"})
+    assert r.status_code == 200 and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal", r.text
+    assert direct == [] and len(seen) == 1
+    assert before - await _balance(clients) == 3_000 and await _holds() == []
+    parent = r.headers["X-Treg-Call-Id"]
+    kinds = sorted((e.kind, e.call_id or "") for e in await _rows(LedgerEntry) if e.kind != "grant")
+    assert kinds == [("reserve", f"{parent}:overflow"), ("settle", f"{parent}:overflow")], "no parent hold at all"
+    replay = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "k1"})
+    assert replay.status_code == 200 and replay.headers.get("X-Treg-Idempotent-Replay") == "true"
+    assert len(seen) == 1, "the replay never touched the aggregator"
+
+
+async def test_an_exhausted_account_without_a_route_is_still_the_typed_503(clients: AsyncClient, overflow_on):
+    from datetime import timedelta
+    now = utcnow_naive()
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "tikhub", LatestState(
+            "tikhub", 0.0, "USD", now, "exact", exhausted_until=now + timedelta(hours=1), health="exhausted").to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+    routes_view.invalidate()
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503 and r.json()["detail"]["error"] == "provider_capacity_unavailable"
+    assert await _holds() == []


### PR DESCRIPTION
Step **E** of the provider-capacity plan. Stacked on #238. **Off by default** (`TREG_OVERFLOW_MODE=off`); nothing changes for any caller until the mode is set. Shadow week per plan §5 comes before `on` (step F).

## What this builds
- `application/call/overflow.py` — the child cycle, exactly plan §4.3: route from the in-process route view (Orthogonal first; unhealthy/keyless aggregators skipped) → $20/day/aggregator budget check (`OverflowSpend`, alembic `0004`) → **child hold `{call_ref}:overflow`** via the ordinary `_platform_reserve` → one aggregator run, **no DB open** (Monid async runs polled, bounded) → `_platform_settle(child, observed_override=<aggregator cost>, overflow_spend=(agg, delta))` — the caller pays the aggregator's real price, 0% markup; the spend delta is folded into the **same** settle transaction → vendor body back, `X-Treg-Served-Via: overflow:<name>`, `X-Treg-Cost-Micro` = the child's charge, `X-Treg-Call-Id` = the parent's; two audit rows share the `call_ref` (`credential_tier=platform-overflow` on the child).
- **Ladder tier 4b:** when the exhausted view says the account is out **and** a route is on, the resolver marks the call `skip_direct` — no parent hold, no vendor 402, straight to the child. Without a route, the D behaviour (typed 503) stands.
- **Aggregator failure is data:** its 401/402/403 or a vendor 402 through it → child released, `overflow:<name>` marked unhealthy 15 min, typed `provider_capacity` 503 — **never a second aggregator** on the same call. Its stricter-schema refusal → child released, the vendor's own answer stands.
- **Shadow mode:** calls the aggregator, logs status/shape/cost, records the probe's cost in `OverflowSpend` (treg pays, budget-bounded), returns the vendor's own error, charges nothing.
- `_finish_cancelled_call` now releases both `call_ref` and `{call_ref}:overflow` (each a conditional claim → exactly once).
- Allowlist: one new entry `overflow_spend_in_settle` (settle transaction + the shadow probe's own session); `capacity_exhausted_mark` gains the overflow site. Mutation test unchanged.
- Docs in the same commit: `proxy-model.md` § Overflow, `money.md`, `data-model.md`, `interface/api.md`, `import-boundaries.md`, `ops/capacity.md`, `ops/deploy.md`, `render.yaml` (mode/budget env). Charter untouched (F).

## Deviations from the plan, stated
- No `served_via` **column** on `callrecord` (hot-table ALTER = migration risk): the child row uses the existing `credential_tier="platform-overflow"`; `served_via` lives in the ledger `meta` (reconcile needs no join) and the header.
- `Org.allow_platform_overflow` (opt-out) deferred to F with its own migration — not needed while the mode is off/shadow.
- POST lookups with a buffered body are overflow-eligible (enrichment is mostly POST); PUT/PATCH/DELETE never.
- Monid "one hop" = one run, bounded polling.

## Intentional behavior changes
None while `TREG_OVERFLOW_MODE=off` (the default; render.yaml sets it explicitly). New table `overflowspend`. In `shadow`/`on` the behaviours above apply and are covered by tests.

## Verification
- `tests/test_capacity_overflow.py` (10): off relays the vendor 402 · findymail-shaped 402 → one child cycle, vendor body verbatim, charged the aggregator price, 4 ledger entries on 2 hold ids, 2 audit rows, spend row · aggregator 402 → child released, unhealthy, 503, second aggregator untouched, next call uses Monid · contract → vendor answer stands · budget crossing skips · caller 400 / own key never overflow · shadow probes + records + charges nothing · cancellation releases both holds exactly once · exhausted + route → direct skipped, no parent hold, idempotent replay never re-touches the aggregator · exhausted without route → 503.
- callmatrix (31 unchanged) + pool discipline + cancellation + marketplace + contract + architecture + capacity suites: 214 passed. `lint-imports`: 11 kept. Full clean-worktree suite: **2199 passed, 1 failed** = `test_postgres_reset` (env-only, identical on main).
- `drift.sh`:
```
Changed sources in feat/capacity-smoothing..HEAD → fragments to review:
  src/treg/application/call/overflow.py            → architecture/import-boundaries.md, ops/capacity.md
  src/treg/application/call/resolve.py             → architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md
  src/treg/application/call/service.py             → architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md
  src/treg/application/call/settle.py              → architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md
  src/treg/config.py                               → architecture/super-admin.md, guides/expanding-a-category.md, ops/deploy.md
  src/treg/domain/capacity/overflow_spend.py       → ops/capacity.md
  src/treg/domain/capacity/routes_view.py          → ops/capacity.md
  src/treg/models.py                               → architecture/data-model.md, architecture/money.md, architecture/multi-tenancy.md
```
- **Not run:** anything live against Orthogonal/Monid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LeYKFQQpvESoBUX4WuUkZy