### PR TITLE
fix(web): read observed stats through the shared observation reader

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -939,7 +939,8 @@ acceptable entry exists.
 Refresh is process-level singleflight. Concurrent misses join one shared Task, duplicate endpoint ids
 already in flight are not queued again, and the Task batches the requested ids. Its
 `PostgresEndpointObservationReader` opens an independent session only around `stats.observed()` and
-closes it as soon as the two queries finish. HTTP `/catalog/search` and both MCP catalog-search tools
+closes it as soon as the two queries finish. HTTP `/catalog/search`, both MCP catalog-search tools,
+and the prose pages that print observed stats (`/use-cases/*`, `/workflows` and `/workflows/*`)
 receive the same reader instance from bootstrap, so their request paths have no observation DB
 dependency, check out zero connections, and join the same refresh Task. A refresh failure keeps stale
 entries, backs off before retry, and never changes the Catalog response status; a failure with no

--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -42,7 +42,8 @@ byte-identical for `role="all"` unless that composition intentionally changes.
 For every role, the factory wires the Catalog observation port to one process-local
 `CachedEndpointObservationReader` backed by short `session_maker` reads. `all` and `dataplane`
 lifespans inject that exact instance into both mounted MCP catalog surfaces; the HTTP catalog routes
-on `all` and `control` read the instance from app state. This keeps one cache and one refresh Task per
+and the observed-stats prose pages (use-case and workflow) on `all` and `control` read the instance
+from app state. This keeps one cache and one refresh Task per
 process even when HTTP and MCP search concurrently. The refresh Task starts lazily on a miss rather
 than appearing in the role's always-running background-task manifest. The lifespan still owns it:
 shutdown first unbinds it from MCP, then calls `aclose()`, which refuses new refreshes and cancels the

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -22,8 +22,9 @@ from ..domain.identity import session as sess
 from ..config import PUBLIC_HOST_ALIASES, get_settings
 from ..db import get_session
 from ..models import User
-from .catalog import (_observed_or_empty, _platform_rows, _provider_display,
-                      catalog_platform)
+from ..domain.catalog import stats as endpoint_stats
+from .catalog import (_endpoint_observation_reader, _observed_or_empty, _platform_rows,
+                      _provider_display, catalog_platform)
 from ..domain.identity.access import _user_from_session
 from .auth_helpers import OAUTH_RETURN_COOKIE, _is_https, _take_oauth_return
 from .signup_cookies import _remember_referral
@@ -849,7 +850,8 @@ async def use_case_job_page_nested(category: str, job: str):
 @app.get("/use-cases/{job}.md", include_in_schema=False)
 @app.get("/use-cases/{job}", include_in_schema=False)
 async def use_case_job_page(request: Request, job: str,
-                            db: AsyncSession = Depends(get_session)):
+                            observations: endpoint_stats.EndpointObservationReader = Depends(
+                                _endpoint_observation_reader)):
     """One job. The reader does one thing, the prompt; everything else is what the agent sees
     before it calls. The page takes one of three FORMS, chosen from the data rather than by hand:
 
@@ -890,7 +892,7 @@ async def use_case_job_page(request: Request, job: str,
     eps = [e for cid in caps for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
     if not eps:
         raise HTTPException(status_code=404, detail="no endpoints for this job")
-    obs = await _observed_or_empty(db, [e["id"] for e in eps])
+    obs = await _observed_or_empty(observations, [e["id"] for e in eps])
     provs = _uc_providers(cat, eps, obs)
 
     def usd_of(e):
@@ -1365,7 +1367,8 @@ def _wf_use_case_link(cap: str, agent_slug: str) -> str:
     return f"/agents/{agent_slug}"
 
 
-async def _wf_steps(cat, db, spec: dict, agent_slug: str) -> list[dict]:
+async def _wf_steps(cat, observations: endpoint_stats.EndpointObservationReader,
+                    spec: dict, agent_slug: str) -> list[dict]:
     """One dict per step, priced live from the catalog: the endpoint the worked run used, its
     price per billing unit, how many providers do the step, and the observed stats when any."""
     out = []
@@ -1375,7 +1378,7 @@ async def _wf_steps(cat, db, spec: dict, agent_slug: str) -> list[dict]:
         cv = cat.cost_view(used.get("cost"), used.get("provider")) if used else None
         usd = cv["usd"] if cv and cv["usd"] else None
         unit = _UNIT_WORDS.get(((used or {}).get("cost") or {}).get("type"), "call")
-        st = (await _observed_or_empty(db, [ep_id])).get(ep_id) or {} if used else {}
+        st = (await _observed_or_empty(observations, [ep_id])).get(ep_id) or {} if used else {}
         prov = used["provider"] if used else ep_id.split(".")[0]
         out.append({
             "name": name, "cap": cap, "asks": asks, "why": why, "ep": used, "ep_id": ep_id,
@@ -1419,7 +1422,9 @@ async def workflow_csv(slug: str):
 
 @app.get("/workflows/{slug}.md", include_in_schema=False)
 @app.get("/workflows/{slug}", include_in_schema=False)
-async def workflow_page(request: Request, slug: str, db: AsyncSession = Depends(get_session)):
+async def workflow_page(request: Request, slug: str,
+                        observations: endpoint_stats.EndpointObservationReader = Depends(
+                            _endpoint_observation_reader)):
     """One workflow: the sequence a person runs, as ONE prompt. A use-case page answers one job;
     this chains several, with a per-step price pulled live from the catalog, a receipt and CSV from
     a real run (hand-recorded in `agent_pages.WORKFLOWS`, dated), and the failure modes. `.md`
@@ -1436,7 +1441,7 @@ async def workflow_page(request: Request, slug: str, db: AsyncSession = Depends(
     cat = catalog_store.load()
     base = get_settings().public_url.rstrip("/")
     agent_slug, agent_name = _uc_agent()
-    steps = await _wf_steps(cat, db, spec, agent_slug)
+    steps = await _wf_steps(cat, observations, spec, agent_slug)
     run = spec["run"]
     n_steps = len(steps)
     n_prov = len({s["provider"] for s in steps})
@@ -1627,7 +1632,8 @@ async def workflow_page(request: Request, slug: str, db: AsyncSession = Depends(
 
 
 @app.get("/workflows", include_in_schema=False)
-async def workflows_hub(db: AsyncSession = Depends(get_session)):
+async def workflows_hub(observations: endpoint_stats.EndpointObservationReader = Depends(
+        _endpoint_observation_reader)):
     """The hub the workflow pages hang from: one card per workflow, priced per row from the catalog."""
     if not _hosted():
         raise HTTPException(status_code=404, detail="not found")
@@ -1636,7 +1642,7 @@ async def workflows_hub(db: AsyncSession = Depends(get_session)):
     agent_slug, _agent_name = _uc_agent()
     cards = []
     for slug, spec in agent_pages.WORKFLOWS.items():
-        steps = await _wf_steps(cat, db, spec, agent_slug)
+        steps = await _wf_steps(cat, observations, spec, agent_slug)
         # Per row: a once-per-run step (the list page) is spread over the run's rows.
         rows_in = int(spec["run"].get("rows_in") or 0) or 1
         once = set(spec.get("once") or ())

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -496,6 +496,37 @@ def test_every_category_has_a_blurb_and_a_prompt():
 WORKFLOW = "/workflows/find-and-verify-a-lead-list"
 
 
+async def test_the_prose_pages_consult_the_shared_observation_reader(clients: AsyncClient, monkeypatch):
+    """The use-case and workflow pages read observed stats through the process-wide reader, like
+    the catalog routes. Wiring a raw DB session in instead fails silently — the session has no
+    `get_many`, the degrade-to-empty guard eats the AttributeError, and every page quietly loses
+    its reliability numbers while the logs fill with tracebacks."""
+    calls: list[list[str]] = []
+
+    class Reader:
+        async def get_many(self, endpoint_ids):
+            ids = list(endpoint_ids)
+            calls.append(ids)
+            return {i: {"samples": 4321, "ok_rate": 1.0, "p50_ms": 40, "p95_ms": 90,
+                        "last_ok_days": 0} for i in ids}
+
+    monkeypatch.setattr(app.state, "endpoint_observation_reader", Reader())
+
+    html = (await clients.get(USECASE)).text
+    assert calls and calls[0], "the use-case page never consulted the observation reader"
+    assert "4321 calls" in html
+
+    calls.clear()
+    r = await clients.get(WORKFLOW)
+    assert r.status_code == 200, r.text[:300]
+    assert calls, "the workflow page never consulted the observation reader"
+    assert "4321 calls" in r.text
+
+    calls.clear()
+    assert (await clients.get("/workflows")).status_code == 200
+    assert calls, "the workflows hub never consulted the observation reader"
+
+
 async def test_workflow_page_is_served_with_the_crawler_essentials(clients: AsyncClient):
     r = await clients.get(WORKFLOW)
     assert r.status_code == 200, r.text[:300]


### PR DESCRIPTION
## What changed

- the three prose-page handlers that print observed stats — `/use-cases/{job}`, `/workflows/{slug}` and the `/workflows` hub — now depend on the bootstrap-owned `EndpointObservationReader` instead of a request DB session
- `_wf_steps` takes the reader instead of a session
- regression test stubs the reader on app state and asserts each of the three pages both consults it and renders its numbers

## Why

PR #241 changed `_observed_or_empty` to take the observation reader but missed its three `routers/web.py` callers, which still passed their `AsyncSession`. In production since the 08:57 UTC deploy: every hit on those pages raises `AttributeError: 'AsyncSession' object has no attribute 'get_many'`, the degrade-to-empty guard swallows it, the page answers 200 with all reliability numbers silently gone, and one traceback is logged per request (first seen 09:02:05 UTC by the release watcher).

## Intentional behavior changes

- The three prose pages read observed stats from the shared process cache: eventually consistent (up to 5 minutes normally, 30 during refresh failures), empty on cold start until the background refresh lands. Same semantics the catalog routes adopted in #241 — and strictly better than current production, where the numbers are always missing.
- These handlers no longer check out a DB connection at all (the session was only feeding the stats query).

## Validation

- `uv run --frozen pytest -q`: 2158 passed, 4 skipped
- the new regression test reproduces the exact production traceback on main before the fix
- `uv run --frozen lint-imports`: 10 contracts kept
- drift.sh: web.py mapped fragments reviewed; `architecture/catalog.md` and `architecture/composition.md` updated in the same commit
