### PR TITLE
fix(capacity): three blocking fixes from the #242 review

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -250,6 +250,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_capacity_know.py` | ops/capacity.md |
 | `tests/test_capacity_overflow.py` | ops/capacity.md |
 | `tests/test_capacity_overflow_routes.py` | ops/capacity.md |
+| `tests/test_capacity_overflow_spend.py` | ops/capacity.md |
 | `tests/test_capacity_protect.py` | ops/capacity.md |
 | `tests/test_capacity_smoothing.py` | ops/capacity.md |
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
@@ -296,6 +297,6 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `index.html`, `landing.html`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py` |
+| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py` |
 | `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           tests/test_call_pool_discipline.py
           tests/test_postgres_reset.py
           tests/test_marketplace_call.py
+          tests/test_capacity_overflow_spend.py
           tests/test_billing.py
           tests/test_agent_capture.py
           tests/test_adsconv.py

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1149,7 +1149,8 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   that would breach it is `skipped`). Response: `{output, raw, _treg: {served_by, provider, tier,
   outcome, tried[], charged_micro}}`, `X-Treg-Served-By`, `X-Treg-Providers-Tried`,
   `X-Treg-Route-Outcome`, `X-Treg-Cost-Micro` = the sum, one `X-Treg-Call-Id`. The parent owns
-  the idempotency label (a replay never touches a provider) and writes one audit row
+  the idempotency label (a success, or a terminal failure after a paid child, replays without
+  touching a provider) and writes one audit row
   (`credential_tier: routed`) beside the children's.
 - **Hit rate** — `CallRecord.hit` (nullable, alembic `0009`, last column) is the adapter's verdict
   written at settle; `stats.observed` publishes `hit_rate`/`hit_samples` (floor 20) and, for

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -950,9 +950,10 @@ Refresh is process-level singleflight. Concurrent misses join one shared Task, d
 already in flight are not queued again, and the Task batches the requested ids. Its
 `PostgresEndpointObservationReader` opens an independent session only around `stats.observed()` and
 closes it as soon as the two queries finish. HTTP `/catalog/search`, both MCP catalog-search tools,
-and the prose pages that print observed stats (`/use-cases/*`, `/workflows` and `/workflows/*`)
-receive the same reader instance from bootstrap, so their request paths have no observation DB
-dependency, check out zero connections, and join the same refresh Task. A refresh failure keeps stale
+routed planning in `application.call.route.build_plan`, and the prose pages that print observed stats
+(`/use-cases/*`, `/workflows` and `/workflows/*`) receive the same reader instance from bootstrap, so
+their request paths have no observation DB dependency, check out zero connections, and join the same
+refresh Task. A refresh failure keeps stale
 entries, backs off before retry, and never changes the Catalog response status; a failure with no
 cached entry is honest emptiness. The adapter exposes entry-level `fresh`, `stale`, and `miss`
 counters plus `refresh` and `refresh_failure` counts. Its invalidation story is the two TTLs: deploys
@@ -1128,7 +1129,9 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   `expected_cost_per_hit = cost_at(request) × P(billed) / P(hit)` where `cost_at` prices *this*
   request at its requested size (per-result × limit, credit-with-minimum rounded up) and `P(hit)`
   is the measured hit rate when ≥ 20 decided samples exist, else `ok_rate`, else 1.0 (flagged
-  `unmeasured`). `X-Treg-Route-Prefer` / `-Exclude` override; exhausted providers (capacity view)
+  `unmeasured`). `build_plan` reads that evidence through bootstrap's shared process cache; cold or
+  unavailable observations degrade to unmeasured ranking while the cache refreshes off the request
+  path. `X-Treg-Route-Prefer` / `-Exclude` override; exhausted providers (capacity view)
   and providers with no key on the deployment are dropped and named in `dropped` (`needs {…}`
   says which identity variant a dropped child wanted).
 - **Execution** — `application/call/route.py`, entered from `service._execute_call` when the

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1143,8 +1143,13 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   rejected request — per_success, free, the org's own key, or per_call ≤ 1¢ (`CHEAP_RETRY_MICRO`)
   — never the same provider again, within the error bound; if every one rejects it, the caller
   gets `route_caller_fault` naming each attempt. Our 5xx/503/429 or a vendor 5xx/429/402 = error →
-  next candidate, at most two extra, only for idempotent contracts. A 2xx whose body lacks a
-  REQUIRED core field is a MISS, not a hit (dataforseo's `result: null` under a 20000 envelope). A
+  next candidate, at most two extra, only for idempotent contracts. A treg-side
+  `tool_access_denied`, `policy_denied`, or `capability_pinned` refusal is local to that child and
+  follows the same error fallback. A platform child's vendor 401/403 also falls back because it
+  indicates treg's provider credential, not the routed caller's request. Balance and spend-cap
+  refusals remain terminal because another provider cannot change the org-wide decision. A 2xx
+  response whose body lacks a REQUIRED core field is a MISS, not a hit (dataforseo's `result: null`
+  under a 20000 envelope). A
   MISS tries the next candidate — the waterfall is ON by default (decided
   2026-08-28: the endpoint's job is to find the thing, and misses on the per-success children are
   free); `X-Treg-Route-Waterfall: 0` stops at the first miss. Every attempt is settled at its real

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -524,10 +524,11 @@ correctness feature into a 24-hour cache that quietly serves stale data.
 
 ### What is stored, and for how long
 
-Metered successes only, for 24 hours. A team calling on its **own** key is billed by the provider, so
-there is nothing to protect and no reason to hold their response. A failure is never billed, and
-replaying one would freeze an error the caller should be free to retry out of — so a failed call
-frees its label immediately.
+Metered successes, plus a routed waterfall's terminal failure after one or more paid children, for
+24 hours. A team calling on its **own** key is billed by the provider, so there is nothing to protect
+and no reason to hold their response. An uncharged failure frees its label immediately so the caller
+can retry; a partially charged routed failure stores the same status, `{"detail": ...}` body,
+`charged_micro` and call id, because rerunning its children would pay the providers twice.
 
 That is also what bounds storage: bodies are kept only for calls that actually cost money, for a day.
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -168,8 +168,17 @@ the policy table. `rate_pressure` alerting is step C.
 
 `application/call/overflow.py` is documented in `architecture/proxy-model.md` § Overflow. Operating
 it: `TREG_OVERFLOW_MODE` = `off` (default) | `shadow` | `on`; `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
-per aggregator per UTC day, read from `OverflowSpend`; the aggregator keys `TREG_OVERFLOW_KEY_*` in
-the web service env (the cron pulls them). The route view (`routes_view.py`) is the call path's
+per aggregator per UTC day is a hard admission cap backed by `OverflowSpend`. Before either an
+`on` call or a `shadow` probe goes to the network, a conditional atomic upsert reserves the route's
+estimated micro-USD only if the resulting daily total fits under the cap. Completion reconciles the
+estimate to actual aggregator cost and increments `calls` once, including a vendor 5xx that the
+aggregator charged but treg cannot charge to the caller. Known no-charge failures return the whole
+estimate. Once network I/O has started, a timeout, disconnect, parser crash, cancellation, or any
+other outcome without a known actual fee keeps the estimate reserved. A process crash after the
+reservation commit can do the same; that bias is deliberately conservative because it reduces later
+service instead of allowing excess prepaid spend.
+The aggregator keys `TREG_OVERFLOW_KEY_*` live in the web service env (the cron pulls them). The
+route view (`routes_view.py`) is the call path's
 60 s copy of the enabled `OverflowRoute` rows; `overflow sync` / `overflow verify` are the only
 writers. **Rollout (plan §5):** run `shadow` for a week with routes enabled — every probe logs
 `overflow SHADOW <endpoint> via <aggregator>: … shape …` and lands a child audit row

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -175,6 +175,11 @@ writers. **Rollout (plan §5):** run `shadow` for a week with routes enabled —
 `overflow SHADOW <endpoint> via <aggregator>: … shape …` and lands a child audit row
 (`credential_tier=platform-overflow`, `error_response="treg overflow: shadow"`) — then switch to
 `on` (step F, which also adds the org opt-out and amends the charter).
+Overflow remains advisory across its full attempt: an unexpected budget, adapter, capacity-mark,
+or settlement-path failure is logged, any reserved child hold is released, and the caller falls
+back to the direct vendor response. A skip-direct call has no direct response, so the same fallback
+returns the original typed `provider_capacity` 503. Cancellation and typed call failures still
+propagate to the call service for their dedicated cleanup and response handling.
 
 ## Enabling overflow (step F) — the opt-out and the rollout
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -18,6 +18,7 @@ sources:
   - src/treg/application/call/overflow.py
   - alembic/versions/0007_overflow_spend.py
   - tests/test_capacity_overflow.py
+  - tests/test_capacity_overflow_spend.py
   - alembic/versions/0008_org_platform_overflow_disabled.py
   - tests/test_capacity_smoothing.py
   - src/treg/domain/capacity/overflow_seed.json

--- a/src/treg/application/call/idempotency.py
+++ b/src/treg/application/call/idempotency.py
@@ -188,13 +188,14 @@ async def _claim_idempotent(key: str, fingerprint: str, rest: str, caller: Calle
 
 async def _store_idempotent(key: str, caller: Caller, *, status_code: int, body: bytes,
                             media_type: str, charged_micro: int, metered: bool,
-                            call_ref: str = "") -> None:
-    """Remember a METERED success so a retry can be answered without paying twice.
+                            call_ref: str = "", terminal: bool = False) -> None:
+    """Remember a metered success or an explicitly terminal, partially charged routed failure.
 
     Metered only. A team calling on its OWN key is billed by the provider, not by us, so there is
-    nothing to protect and no reason for treg to hold their response. Successes only, because a
-    failure was never billed — replaying one would freeze an error the caller should be free to
-    retry out of.
+    nothing to protect and no reason for treg to hold their response. Ordinary failures are not
+    retained, because no charge landed and the caller should be free to retry. A routed waterfall
+    may already have settled paid children before its terminal failure; `terminal=True` retains that
+    exact failure so a retry cannot repeat those charges.
 
     Anything else drops the claim, which frees the label immediately rather than making the caller
     wait out the window before they can try again.
@@ -202,7 +203,7 @@ async def _store_idempotent(key: str, caller: Caller, *, status_code: int, body:
     Never raises: the caller already has their answer, and a bookkeeping failure must not turn a
     served call into a 500. Its own session, because the request's may be mid-rollback.
     """
-    keep = metered and 200 <= status_code < 300
+    keep = metered and (200 <= status_code < 300 or terminal)
     try:
         async with session_maker() as db:
             row = (await db.execute(select(IdempotentCall).where(

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -61,6 +61,16 @@ class OverflowOutcome:
     note: str = ""
 
 
+@dataclass
+class _BudgetReservation:
+    aggregator: str
+    estimate_micro: int
+    direct_micro: int
+    outbound: bool = False
+    actual_micro: int | None = None
+    finalized: bool = False
+
+
 def _trigger(mk: MarketplaceCall, status: int, headers, body: bytes) -> str | None:
     """Why this call may overflow, or None. Only treg-side failures qualify (plan §4.1)."""
     if status == 401:
@@ -82,9 +92,11 @@ async def _send(client: httpx.AsyncClient, req: AggregatorRequest) -> httpx.Resp
 
 
 async def _run(client: httpx.AsyncClient, aggregator: str, route, key: str, query, body: bytes | None,
-               path_params: dict | None) -> AggregatorResult:
+               path_params: dict | None, budget: _BudgetReservation | None = None) -> AggregatorResult:
     adapter = by_name(aggregator)
     req = adapter.build(route, key, query, body, path_params)
+    if budget is not None:
+        budget.outbound = True
     r = await _send(client, req)
     res = adapter.parse(r.status_code, r.content)
     polls = 0
@@ -129,12 +141,78 @@ def _capacity_503(mk: MarketplaceCall, aggregator: str, why: str) -> CallFailure
     })
 
 
-async def _record_shadow(aggregator: str, cost_micro: int, delta_micro: int) -> None:
+async def _record_shadow(
+    aggregator: str, actual_micro: int, estimate_micro: int, delta_micro: int,
+) -> None:
     """Shadow mode's spend row — the same `overflow_spend` write as the child settle, on its own
     short session because there is no child hold to settle in."""
     async with session_maker() as db:
-        await overflow_spend_ledger.add_in_transaction(db, aggregator, cost_micro, delta_micro)
+        await overflow_spend_ledger.add_in_transaction(
+            db, aggregator, actual_micro - estimate_micro, delta_micro,
+        )
         await db.commit()
+
+
+async def _release_budget(reservation: _BudgetReservation) -> None:
+    """Return an estimate for an attempt that never reached the aggregator."""
+    if reservation.finalized:
+        return
+    async with session_maker() as db:
+        await overflow_spend_ledger.release_reservation_in_transaction(
+            db, reservation.aggregator, reservation.estimate_micro,
+        )
+        await db.commit()
+    reservation.finalized = True
+
+
+async def _finish_budget(reservation: _BudgetReservation, actual_micro: int) -> None:
+    """Reconcile a completed attempt to actual spend and count it once."""
+    if reservation.finalized:
+        return
+    async with session_maker() as db:
+        await overflow_spend_ledger.add_in_transaction(
+            db, reservation.aggregator, actual_micro - reservation.estimate_micro,
+            actual_micro - reservation.direct_micro,
+        )
+        await db.commit()
+    reservation.finalized = True
+
+
+async def _preserve_unknown_budget(reservation: _BudgetReservation) -> None:
+    """Count a cancelled outbound attempt while conservatively retaining its estimate."""
+    if reservation.finalized:
+        return
+    async with session_maker() as db:
+        await overflow_spend_ledger.add_in_transaction(
+            db, reservation.aggregator, 0,
+            reservation.estimate_micro - reservation.direct_micro,
+        )
+        await db.commit()
+    reservation.finalized = True
+
+
+def _overflow_spend_adjustment(
+    reservation: _BudgetReservation,
+) -> tuple[str, int, int] | None:
+    """Return the known actual adjustment, or None when the estimate must stay reserved."""
+    if reservation.actual_micro is None:
+        return None
+    return (
+        reservation.aggregator,
+        reservation.actual_micro - reservation.estimate_micro,
+        reservation.actual_micro - reservation.direct_micro,
+    )
+
+
+async def _record_shadow_budget(reservation: _BudgetReservation) -> None:
+    if reservation.actual_micro is None:
+        await _preserve_unknown_budget(reservation)
+        return
+    await _record_shadow(
+        reservation.aggregator, reservation.actual_micro,
+        reservation.estimate_micro, reservation.actual_micro - reservation.direct_micro,
+    )
+    reservation.finalized = True
 
 
 async def _maybe_overflow_attempt(
@@ -142,6 +220,7 @@ async def _maybe_overflow_attempt(
     method: str, query_items: list[tuple[str, str]], caller_body: bytes, client: httpx.AsyncClient,
     audit_client: str = "", force_trigger: str | None = None,
     reserved: list[MarketplaceCall],
+    budget_reservations: list[_BudgetReservation],
 ) -> OverflowOutcome | None:
     """After the primary's settle released — or, with `force_trigger`, INSTEAD of a direct attempt
     the resolver already knows would 402 (`mk.skip_direct`). None = nothing to do (the vendor's
@@ -164,13 +243,19 @@ async def _maybe_overflow_attempt(
     aggregator = route.aggregator
     key = settings.overflow_key_for(aggregator) or ""
     price = int(route.agg_price_micro or 0)
-    # Budget: the aggregator's day so far + this call, before any hold (plan §4.3 step 5).
+    # Atomically reserve the estimate before any network call. A rejected upsert means another
+    # concurrent attempt already claimed the remaining daily budget.
     async with session_maker() as db:
-        spent = await overflow_spend_ledger.spent_today(db, aggregator)
-    if spent + price > settings.overflow_daily_budget_micro:
-        log.warning("overflow budget reached for %s (%d + %d > %d)", aggregator, spent, price,
+        budget_row = await overflow_spend_ledger.reserve_in_transaction(
+            db, aggregator, price, settings.overflow_daily_budget_micro,
+        )
+        await db.commit()
+    if budget_row is None:
+        log.warning("overflow budget reached for %s (estimate %d, cap %d)", aggregator, price,
                     settings.overflow_daily_budget_micro)
         return None
+    budget = _BudgetReservation(aggregator, price, int(mk.estimate_micro or 0))
+    budget_reservations.append(budget)
     child = _child(mk, route)
     query = [(k, v) for k, v in query_items if k not in mk.consumed]
     path_params = {k: v for k, v in query_items if k in mk.consumed}
@@ -180,10 +265,14 @@ async def _maybe_overflow_attempt(
         reserved.append(child)
     res: AggregatorResult | None = None
     try:
-        res = await _run(client, aggregator, route, key, query, caller_body or None, path_params)
+        res = await _run(
+            client, aggregator, route, key, query, caller_body or None, path_params, budget,
+        )
     except httpx.RequestError as exc:
-        res = AggregatorResult(None, b"", 0, "malformed", f"{type(exc).__name__}: {exc}")
-    delta = (res.cost_micro or 0) - int(mk.estimate_micro or 0)
+        res = AggregatorResult(None, b"", None, "malformed", f"{type(exc).__name__}: {exc}")
+    budget.actual_micro = int(res.cost_micro) if res.cost_micro is not None else None
+    delta = (budget.actual_micro - budget.direct_micro
+             if budget.actual_micro is not None else None)
     # --- decide ---
     if res.failure in ("aggregator_auth", "aggregator_balance", "malformed") or res.upstream_status == 402:
         why_agg = res.failure or "upstream 402 through the aggregator"
@@ -191,7 +280,17 @@ async def _maybe_overflow_attempt(
                                             + __import__("datetime").timedelta(seconds=AGGREGATOR_UNHEALTHY_S),
                                             note=f"{why_agg}: {res.detail[:80]}")
         if mode == "on":
-            await _platform_settle(child, None, reason=f"overflow_{why_agg[:24]}")
+            spend_adjustment = _overflow_spend_adjustment(budget)
+            await _platform_settle(
+                child, None, reason=f"overflow_{why_agg[:24]}",
+                overflow_spend=spend_adjustment,
+            )
+            if spend_adjustment is None:
+                await _preserve_unknown_budget(budget)
+            else:
+                budget.finalized = True
+        else:
+            await _record_shadow_budget(budget)
         log.warning("overflow via %s failed for %s: %s %s", aggregator, mk.endpoint_id, why_agg, res.detail)
         _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note=why_agg)
         return OverflowOutcome(False, None, aggregator=aggregator, note=why_agg,
@@ -200,7 +299,17 @@ async def _maybe_overflow_attempt(
         # The aggregator's stricter schema refused (no vendor call, no charge): this route is wrong for
         # this call; the vendor's own answer stands. Worth a log line — verify should have caught it.
         if mode == "on":
-            await _platform_settle(child, None, reason="overflow_contract")
+            spend_adjustment = _overflow_spend_adjustment(budget)
+            await _platform_settle(
+                child, None, reason="overflow_contract",
+                overflow_spend=spend_adjustment,
+            )
+            if spend_adjustment is None:
+                await _preserve_unknown_budget(budget)
+            else:
+                budget.finalized = True
+        else:
+            await _record_shadow_budget(budget)
         log.warning("overflow via %s refused %s: %s", aggregator, mk.endpoint_id, res.detail)
         _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note=res.failure)
         return OverflowOutcome(False, None, aggregator=aggregator, note=res.failure)
@@ -212,15 +321,18 @@ async def _maybe_overflow_attempt(
             body_shape = "non-json"
         log.info("overflow SHADOW %s via %s: vendor %s direct→%s relay, cost %s, delta %s, shape %s",
                  mk.endpoint_id, aggregator, status, res.upstream_status, res.cost_micro, delta, body_shape)
-        try:
-            await _record_shadow(aggregator, res.cost_micro or 0, delta)
-        except Exception:  # noqa: BLE001 — accounting for a probe must not touch the caller's answer
-            log.warning("shadow spend row not written", exc_info=True)
+        await _record_shadow_budget(budget)
         _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note="shadow")
         return OverflowOutcome(False, None, aggregator=aggregator, note="shadow")
+    spend_adjustment = _overflow_spend_adjustment(budget)
     charged, observed = await _platform_settle(
         child, int(res.upstream_status or 200), res.upstream_body,
-        observed_override=res.cost_micro, overflow_spend=(aggregator, delta))
+        observed_override=res.cost_micro,
+        overflow_spend=spend_adjustment)
+    if spend_adjustment is None:
+        await _preserve_unknown_budget(budget)
+    else:
+        budget.finalized = True
     response = _response(res)
     _audit_child(mk, child, call_ref, aggregator, res, charged=charged, client=audit_client)
     return OverflowOutcome(True, response, res.upstream_body, charged, observed, aggregator)
@@ -234,21 +346,51 @@ async def maybe_overflow(
     """Run one optional overflow attempt without letting its infrastructure replace the caller's
     existing vendor answer. A skip-direct caller interprets None as its original capacity 503."""
     reserved: list[MarketplaceCall] = []
+    budget_reservations: list[_BudgetReservation] = []
     try:
         return await _maybe_overflow_attempt(
             mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=status, headers=headers,
             body=body, method=method, query_items=query_items, caller_body=caller_body,
             client=client, audit_client=audit_client, force_trigger=force_trigger,
-            reserved=reserved,
+            reserved=reserved, budget_reservations=budget_reservations,
         )
     except asyncio.CancelledError:
+        if budget_reservations:
+            try:
+                if budget_reservations[0].actual_micro is not None:
+                    await _finish_budget(
+                        budget_reservations[0], budget_reservations[0].actual_micro,
+                    )
+                elif budget_reservations[0].outbound:
+                    await _preserve_unknown_budget(budget_reservations[0])
+                else:
+                    await _release_budget(budget_reservations[0])
+            except Exception:  # noqa: BLE001 - cancellation must remain the result
+                log.exception("overflow budget cleanup failed for cancelled %s", mk.endpoint_id)
         raise
     except CallFailure:
+        if budget_reservations:
+            try:
+                await _release_budget(budget_reservations[0])
+            except Exception:  # noqa: BLE001 - preserve the typed call failure
+                log.exception("overflow budget release failed for %s", mk.endpoint_id)
         raise
     except Exception:  # noqa: BLE001 - overflow is advisory and must not replace the primary result
         log.exception("overflow attempt crashed for %s", mk.endpoint_id)
         if reserved:
             await _platform_settle(reserved[0], None, reason="overflow_crashed")
+        if budget_reservations:
+            try:
+                if budget_reservations[0].actual_micro is not None:
+                    await _finish_budget(
+                        budget_reservations[0], budget_reservations[0].actual_micro,
+                    )
+                elif budget_reservations[0].outbound:
+                    await _preserve_unknown_budget(budget_reservations[0])
+                else:
+                    await _release_budget(budget_reservations[0])
+            except Exception:  # noqa: BLE001 - the primary vendor answer still wins
+                log.exception("overflow budget release failed for crashed %s", mk.endpoint_id)
         return None
 
 

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -172,12 +172,13 @@ async def maybe_overflow(
         return None
     child = _child(mk, route)
     query = [(k, v) for k, v in query_items if k not in mk.consumed]
+    path_params = {k: v for k, v in query_items if k in mk.consumed}
     if mode == "on":
         # Child hold: own id, same call_ref family. Insufficient balance here is the normal 402.
         await _platform_reserve(child, caller, meta=meta, call_ref=f"{call_ref}:overflow")
     res: AggregatorResult | None = None
     try:
-        res = await _run(client, aggregator, route, key, query, caller_body or None, None)
+        res = await _run(client, aggregator, route, key, query, caller_body or None, path_params)
     except httpx.RequestError as exc:
         res = AggregatorResult(None, b"", 0, "malformed", f"{type(exc).__name__}: {exc}")
     delta = (res.cost_micro or 0) - int(mk.estimate_micro or 0)

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -137,10 +137,11 @@ async def _record_shadow(aggregator: str, cost_micro: int, delta_micro: int) -> 
         await db.commit()
 
 
-async def maybe_overflow(
+async def _maybe_overflow_attempt(
     *, mk: MarketplaceCall, caller, meta, call_ref: str, status: int, headers, body: bytes,
     method: str, query_items: list[tuple[str, str]], caller_body: bytes, client: httpx.AsyncClient,
     audit_client: str = "", force_trigger: str | None = None,
+    reserved: list[MarketplaceCall],
 ) -> OverflowOutcome | None:
     """After the primary's settle released — or, with `force_trigger`, INSTEAD of a direct attempt
     the resolver already knows would 402 (`mk.skip_direct`). None = nothing to do (the vendor's
@@ -176,6 +177,7 @@ async def maybe_overflow(
     if mode == "on":
         # Child hold: own id, same call_ref family. Insufficient balance here is the normal 402.
         await _platform_reserve(child, caller, meta=meta, call_ref=f"{call_ref}:overflow")
+        reserved.append(child)
     res: AggregatorResult | None = None
     try:
         res = await _run(client, aggregator, route, key, query, caller_body or None, path_params)
@@ -222,6 +224,32 @@ async def maybe_overflow(
     response = _response(res)
     _audit_child(mk, child, call_ref, aggregator, res, charged=charged, client=audit_client)
     return OverflowOutcome(True, response, res.upstream_body, charged, observed, aggregator)
+
+
+async def maybe_overflow(
+    *, mk: MarketplaceCall, caller, meta, call_ref: str, status: int, headers, body: bytes,
+    method: str, query_items: list[tuple[str, str]], caller_body: bytes, client: httpx.AsyncClient,
+    audit_client: str = "", force_trigger: str | None = None,
+) -> OverflowOutcome | None:
+    """Run one optional overflow attempt without letting its infrastructure replace the caller's
+    existing vendor answer. A skip-direct caller interprets None as its original capacity 503."""
+    reserved: list[MarketplaceCall] = []
+    try:
+        return await _maybe_overflow_attempt(
+            mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=status, headers=headers,
+            body=body, method=method, query_items=query_items, caller_body=caller_body,
+            client=client, audit_client=audit_client, force_trigger=force_trigger,
+            reserved=reserved,
+        )
+    except asyncio.CancelledError:
+        raise
+    except CallFailure:
+        raise
+    except Exception:  # noqa: BLE001 - overflow is advisory and must not replace the primary result
+        log.exception("overflow attempt crashed for %s", mk.endpoint_id)
+        if reserved:
+            await _platform_settle(reserved[0], None, reason="overflow_crashed")
+        return None
 
 
 def _audit_child(mk: MarketplaceCall, child: MarketplaceCall, call_ref: str, aggregator: str,

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -8,7 +8,9 @@ core `output` (via the child's adapter), the child's `raw` body, and `_treg: {se
 
 Fallback follows the overflow rules: on an ERROR (our 5xx/503, a vendor 5xx/429/402) the next
 candidate is tried, at most two extra, idempotent contracts only; a caller-caused refusal (4xx)
-stops at once — it would be the same 4xx everywhere. A MISS (2xx, `adapter.miss`) stops unless the
+stops at once — it would be the same 4xx everywhere. Child-local treg authorization failures and
+platform vendor 401/403 responses are errors because another child may work. A MISS (2xx,
+`adapter.miss`) stops unless the
 caller turned the waterfall off (`X-Treg-Route-Waterfall: 0`). The waterfall is ON by default —
 the endpoint's job is to find the thing — bounded by `X-Treg-Route-Max-Cost` (default $1.00).
 """
@@ -71,6 +73,9 @@ _DROP_FROM_CHILD = frozenset({b"content-length", b"content-type", b"transfer-enc
                               b"x-treg-route-waterfall", b"x-treg-route-max-cost", b"x-treg-route-prefer",
                               b"x-treg-route-exclude", b"host"})
 _CALLER_FAULT = frozenset({400, 401, 403, 404, 405, 409, 422})
+_CANDIDATE_LOCAL_FAILURES = frozenset({"tool_access_denied", "policy_denied", "capability_pinned"})
+_GLOBAL_REFUSALS = frozenset({"insufficient_balance", "tag_spend_cap_reached",
+                              "platform_daily_cap_reached", "daily_cap_reached"})
 
 
 CHEAP_RETRY_MICRO = 10_000  # ≤ 1¢: a per_call provider cheap enough to be asked after another's 4xx
@@ -275,8 +280,9 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
         try:
             response = await execute_child(child, upstream_client)
         except CallFailure as exc:
-            if exc.status_code in _CALLER_FAULT or exc.kind in ("insufficient_balance", "tag_spend_cap_reached",
-                                                                  "platform_daily_cap_reached", "daily_cap_reached"):
+            if exc.kind in _GLOBAL_REFUSALS or (
+                exc.status_code in _CALLER_FAULT and exc.kind not in _CANDIDATE_LOCAL_FAILURES
+            ):
                 raise  # the same refusal everywhere; nothing to fall back to
             errors += 1
             tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "error", exc.status_code, 0, str(exc.detail)[:120]))
@@ -286,7 +292,9 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
         raw = await _read(response)
         charged = int(_header(response, "X-Treg-Cost-Micro") or 0)
         spent += charged
-        if 400 <= response.status < 500 and response.status not in (402, 408, 429):
+        platform_auth_failure = cand.tier == "platform" and response.status in (401, 403)
+        if (400 <= response.status < 500 and response.status not in (402, 408, 429)
+                and not platform_auth_failure):
             # The vendor rejected the REQUEST. Usually the caller's mistake and the same answer
             # everywhere — but a scraper's "Request failed. Please retry" is also a 400 (tikhub,
             # live 2026-08-28), so the waterfall goes on to providers that are FREE ON FAILURE

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -36,6 +36,32 @@ from .resolve import _host_of, _marketplace_secret
 from .types import CallContext, CallFailure, GatewayFailed, ResolutionFailed, UpstreamResponse
 
 log = logging.getLogger("treg.route")
+_endpoint_observation_reader: endpoint_stats.EndpointObservationReader | None = None
+
+
+def configure_endpoint_observation_reader(reader: endpoint_stats.EndpointObservationReader) -> None:
+    """Bind bootstrap's shared process cache to routed planning."""
+    global _endpoint_observation_reader
+    _endpoint_observation_reader = reader
+
+
+def clear_endpoint_observation_reader(reader: endpoint_stats.EndpointObservationReader) -> None:
+    """Unbind only the reader owned by the lifespan that is stopping."""
+    global _endpoint_observation_reader
+    if _endpoint_observation_reader is reader:
+        _endpoint_observation_reader = None
+
+
+async def _observed_stats(endpoint_ids: list[str]) -> endpoint_stats.ObservationSnapshot:
+    """Read advisory routing evidence without making the request wait for its DB aggregate."""
+    reader = _endpoint_observation_reader
+    if reader is None:
+        return {}
+    try:
+        return await reader.get_many(endpoint_ids)
+    except Exception:  # noqa: BLE001 - routing evidence always degrades to deterministic ranking
+        log.warning("endpoint stats unavailable for routed plan", exc_info=True)
+        return {}
 
 WATERFALL_HEADER = "x-treg-route-waterfall"
 MAX_COST_HEADER = "x-treg-route-max-cost"
@@ -128,7 +154,7 @@ async def build_plan(ep: dict, identity_given: dict, caller, options: RouteOptio
             "variants": [list(v) for v in contract.identity]})
     raw, dropped = candidates_for(contract, cat.for_capability(ep["capability"]), cat.adapters, identity)
     ids = [e["id"] for e, _, _ in raw]
-    stats: dict[str, dict] = {}
+    stats = await _observed_stats(ids)
     own: set[str] = set()
     own_tools: set[str] = set()
     if ids:
@@ -136,11 +162,6 @@ async def build_plan(ep: dict, identity_given: dict, caller, options: RouteOptio
         from ... import oauth_providers
         from ...models import Tool
         async with session_maker() as db:
-            try:
-                stats = await endpoint_stats.observed(
-                    db, ids, per_success={e["id"] for e, _, _ in raw if (e.get("cost") or {}).get("type") == "per_success"})
-            except Exception:  # noqa: BLE001 — stats are advisory
-                stats = {}
             services = {e["provider"] for e, _, _ in raw}
             if caller.org_id is not None:
                 # tier 1: a tool the team REGISTERED for the provider's host (their credential,

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -341,6 +341,7 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             media_type=replayed.media_type,
             headers={"X-Treg-Idempotent-Replay": "true",
                      "X-Treg-Cost-Micro": str(replayed.charged_micro),
+                     **({"X-Treg-Error": "1"} if replayed.status_code >= 400 else {}),
                      **({"X-Treg-Call-Id": replayed.call_ref} if replayed.call_ref else {})},
         )
     # Park it so a failure anywhere below can give the label back. Set AFTER the claim succeeds,
@@ -387,6 +388,25 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             raise
         except CallFailure as exc:
             request.state.call_audited = True
+            charged = (int(exc.detail.get("charged_micro") or 0)
+                       if isinstance(exc.detail, dict) else 0)
+            if exc.kind in ("route_caller_fault", "route_failed"):
+                request.state.call_cost_micro = charged
+            if idem_key and charged > 0 and exc.kind in ("route_caller_fault", "route_failed"):
+                error_body = json.dumps(
+                    {"detail": exc.detail}, ensure_ascii=False, allow_nan=False,
+                    separators=(",", ":"),
+                ).encode()
+                try:
+                    await _store_idempotent(
+                        idem_key, caller, status_code=exc.status_code, body=error_body,
+                        media_type="application/json", charged_micro=charged, metered=True,
+                        call_ref=call_ref, terminal=True,
+                    )
+                except asyncio.CancelledError:
+                    await _finish_cancelled_call(request, None, call_ref)
+                    raise
+                request.state.idem_claim = None
             audit.record_call(
                 org_id=caller.org_id, user_email=caller.email, tool_name=ep["id"],
                 method=request.method, path=rest, status_code=exc.status_code,

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -349,7 +349,7 @@ async def _peek_stream_head(response: UpstreamResponse, limit: int) -> tuple[Ups
 async def _platform_settle(
     mk: MarketplaceCall, status_code: int | None, body: bytes = b"", *, headers=None,
     reason: str = "", finalized: Callable[[], None] | None = None,
-    observed_override: int | None = None, overflow_spend: tuple[str, int] | None = None,
+    observed_override: int | None = None, overflow_spend: tuple[str, int, int] | None = None,
 ) -> tuple[int, int | None]:
     """Close the hold for a metered call → (charged_micro, observed_micro). `charged_micro` is what
     actually hit the org's balance (0 on a release) — the number the Activity feed must show, because
@@ -367,8 +367,10 @@ async def _platform_settle(
     billable = status_code is not None and _platform_billable(status_code, mk.cost_type)
     # `observed_override`: the overflow child cycle knows its cost from the aggregator's envelope, not
     # from the vendor body — the caller pays exactly that (plan §4.3 step 5), whatever the vendor's
-    # own billing shape. `overflow_spend` = (aggregator, delta vs treg's direct price): folded into
-    # the SAME settle transaction, the one allowlisted overflow write (`overflow_spend_in_settle`).
+    # own billing shape. `overflow_spend` = (aggregator, adjustment from the budget reservation,
+    # delta vs treg's direct price): folded into the SAME settle transaction, the one allowlisted
+    # overflow write (`overflow_spend_in_settle`). It is recorded even when the vendor response is
+    # not billable to the caller because the aggregator's prepaid account still incurred the cost.
     observed = ((observed_override if observed_override is not None
                  else _observed_cost_micro(mk, body, headers)) if billable else None)
     call_id, mk.call_id = mk.call_id, None  # closing is once-only, even if two paths try
@@ -382,15 +384,15 @@ async def _platform_settle(
                     "cost_source": ("aggregator" if overflow_spend is not None
                                     else "provider" if observed is not None else "estimate"),
                     **({"served_via": f"overflow:{overflow_spend[0]}"} if overflow_spend else {})})
-                if overflow_spend is not None:
-                    await overflow_spend_ledger.add_in_transaction(
-                        db, overflow_spend[0], observed or 0, overflow_spend[1])
             else:
                 await ledger.release_in_transaction(
                     db, call_id, reason=reason or f"not_billable_{status_code}",
                     meta={"provider": mk.provider, "cost_type": mk.cost_type,
                           "status_code": status_code})
                 charged = 0
+            if overflow_spend is not None:
+                await overflow_spend_ledger.add_in_transaction(
+                    db, overflow_spend[0], overflow_spend[1], overflow_spend[2])
             await db.commit()
             if finalized is not None:
                 finalized()

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -17,6 +17,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.routing import BaseRoute, Mount
 
 from . import adsconv, analytics, archive, audit
+from .application.call import route as routed_call
 from . import bootstrap_handlers
 from .bootstrap_http import (
     _BodyDecodeMiddleware,
@@ -435,6 +436,7 @@ def _lifespan(api_module, role: AppRole):
             else None
         )
         endpoint_observations = app.state.endpoint_observation_reader
+        routed_call.configure_endpoint_observation_reader(endpoint_observations)
         mcp_reader_bound = role != "control" and _mcp is not None
         if mcp_reader_bound:
             _mcp.configure_endpoint_observation_reader(endpoint_observations)
@@ -454,6 +456,7 @@ def _lifespan(api_module, role: AppRole):
                 archive_task.cancel()
             if mcp_reader_bound:
                 _mcp.clear_endpoint_observation_reader(endpoint_observations)
+            routed_call.clear_endpoint_observation_reader(endpoint_observations)
             await endpoint_observations.aclose()
             await audit.drain()
             await analytics.drain()

--- a/src/treg/domain/capacity/overflow_spend.py
+++ b/src/treg/domain/capacity/overflow_spend.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...models import OverflowSpend
@@ -20,15 +22,31 @@ async def add_in_transaction(db: AsyncSession, aggregator: str, cost_micro: int,
     """Add one call to the day's row. Does NOT commit: the caller owns the transaction (the child
     settle, or the shadow probe's own short session)."""
     day = day or utc_day()
-    row = await db.get(OverflowSpend, (aggregator, day))
-    if row is None:
-        row = OverflowSpend(aggregator=aggregator, day=day)
-        db.add(row)
-    row.calls += 1
-    row.cost_micro += int(cost_micro)
-    row.delta_micro += int(delta_micro)
-    row.updated_at = utcnow_naive()
-    return row
+    now = utcnow_naive()
+    dialect = db.get_bind().dialect.name
+    if dialect == "postgresql":
+        insert = postgresql_insert
+    elif dialect == "sqlite":
+        insert = sqlite_insert
+    else:
+        raise RuntimeError(f"unsupported database dialect: {dialect}")
+    statement = insert(OverflowSpend).values(
+        aggregator=aggregator,
+        day=day,
+        calls=1,
+        cost_micro=int(cost_micro),
+        delta_micro=int(delta_micro),
+        updated_at=now,
+    ).on_conflict_do_update(
+        index_elements=[OverflowSpend.aggregator, OverflowSpend.day],
+        set_={
+            "calls": OverflowSpend.calls + 1,
+            "cost_micro": OverflowSpend.cost_micro + int(cost_micro),
+            "delta_micro": OverflowSpend.delta_micro + int(delta_micro),
+            "updated_at": now,
+        },
+    ).returning(OverflowSpend).execution_options(populate_existing=True)
+    return (await db.execute(statement)).scalar_one()
 
 
 async def spent_today(db: AsyncSession, aggregator: str, *, day: str | None = None) -> int:

--- a/src/treg/domain/capacity/overflow_spend.py
+++ b/src/treg/domain/capacity/overflow_spend.py
@@ -1,10 +1,15 @@
-"""Per-aggregator daily overflow accounting (`OverflowSpend`) — the budget the child cycle checks
-before it places a hold, and the row its settle updates in the same transaction."""
+"""Per-aggregator daily overflow accounting (`OverflowSpend`).
+
+The child cycle atomically reserves estimated spend before network I/O, then reconciles the row to
+actual aggregator cost after the attempt. This makes the configured daily budget a concurrency-safe
+admission cap rather than a read-before-write hint.
+"""
 
 from __future__ import annotations
 
 from datetime import datetime
 
+from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,20 +22,73 @@ def utc_day(now: datetime | None = None) -> str:
     return (now or utcnow_naive()).strftime("%Y-%m-%d")
 
 
+def _insert_for(db: AsyncSession):
+    dialect = db.get_bind().dialect.name
+    if dialect == "postgresql":
+        return postgresql_insert
+    if dialect == "sqlite":
+        return sqlite_insert
+    raise RuntimeError(f"unsupported database dialect: {dialect}")
+
+
+async def reserve_in_transaction(
+    db: AsyncSession, aggregator: str, estimate_micro: int, cap_micro: int,
+    *, day: str | None = None,
+) -> OverflowSpend | None:
+    """Atomically reserve estimated aggregator spend if it fits under the daily cap.
+
+    The reservation does not count a call. The completed attempt reconciles estimate to actual and
+    increments calls through `add_in_transaction`. Does NOT commit: the caller owns the short
+    transaction. A process crash after its caller commits leaves the estimate in place, which is a
+    conservative bias toward serving less rather than exceeding the prepaid-account guardrail.
+    """
+    estimate_micro = int(estimate_micro)
+    cap_micro = int(cap_micro)
+    if estimate_micro < 0 or cap_micro < 0:
+        raise ValueError("overflow budget values must be non-negative micro-USD")
+    if estimate_micro > cap_micro:
+        return None
+    day = day or utc_day()
+    now = utcnow_naive()
+    statement = _insert_for(db)(OverflowSpend).values(
+        aggregator=aggregator,
+        day=day,
+        calls=0,
+        cost_micro=estimate_micro,
+        delta_micro=0,
+        updated_at=now,
+    ).on_conflict_do_update(
+        index_elements=[OverflowSpend.aggregator, OverflowSpend.day],
+        set_={
+            "cost_micro": OverflowSpend.cost_micro + estimate_micro,
+            "updated_at": now,
+        },
+        where=OverflowSpend.cost_micro + estimate_micro <= cap_micro,
+    ).returning(OverflowSpend).execution_options(populate_existing=True)
+    return (await db.execute(statement)).scalar_one_or_none()
+
+
+async def release_reservation_in_transaction(
+    db: AsyncSession, aggregator: str, estimate_micro: int, *, day: str | None = None,
+) -> OverflowSpend | None:
+    """Return an unconsumed estimate without counting a call. Does NOT commit."""
+    statement = update(OverflowSpend).where(
+        OverflowSpend.aggregator == aggregator,
+        OverflowSpend.day == (day or utc_day()),
+    ).values(
+        cost_micro=OverflowSpend.cost_micro - int(estimate_micro),
+        updated_at=utcnow_naive(),
+    ).returning(OverflowSpend).execution_options(populate_existing=True)
+    return (await db.execute(statement)).scalar_one_or_none()
+
+
 async def add_in_transaction(db: AsyncSession, aggregator: str, cost_micro: int, delta_micro: int,
                              *, day: str | None = None) -> OverflowSpend:
     """Add one call to the day's row. Does NOT commit: the caller owns the transaction (the child
     settle, or the shadow probe's own short session)."""
     day = day or utc_day()
     now = utcnow_naive()
-    dialect = db.get_bind().dialect.name
-    if dialect == "postgresql":
-        insert = postgresql_insert
-    elif dialect == "sqlite":
-        insert = sqlite_insert
-    else:
-        raise RuntimeError(f"unsupported database dialect: {dialect}")
-    statement = insert(OverflowSpend).values(
+    statement = _insert_for(db)(OverflowSpend).values(
         aggregator=aggregator,
         day=day,
         calls=1,

--- a/tests/test_call_architecture.py
+++ b/tests/test_call_architecture.py
@@ -41,7 +41,7 @@ _DATAPLANE_DERIVED_WRITES = {
     # table) AFTER the settle, so the next call is refused before a hold exists.
     "capacity_exhausted_mark": (
         (settle._note_capacity_signal, "capacity_marks.mark_exhausted"),
-        (overflow.maybe_overflow, "capacity_marks.mark_exhausted"),
+        (overflow._maybe_overflow_attempt, "capacity_marks.mark_exhausted"),
         (capacity_marks.mark_exhausted, "ratestore.kv_put"),
     ),
     # Plan §4.3 step 5: the overflow child's settle folds the aggregator's daily spend delta into
@@ -90,7 +90,7 @@ _EXPECTED_DERIVED_WRITE_SITES = {
     ("application/call/settle.py", "_note_capacity_signal", "capacity_marks.mark_exhausted"),
     ("application/call/settle.py", "_platform_settle", "overflow_spend_ledger.add_in_transaction"),
     ("application/call/settle.py", "_close", "overflow_spend_ledger.add_in_transaction"),
-    ("application/call/overflow.py", "maybe_overflow", "capacity_marks.mark_exhausted"),
+    ("application/call/overflow.py", "_maybe_overflow_attempt", "capacity_marks.mark_exhausted"),
     ("application/call/overflow.py", "_record_shadow", "overflow_spend_ledger.add_in_transaction"),
     ("domain/capacity/marks.py", "mark_exhausted", "ratestore.kv_put"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.rate_check"),

--- a/tests/test_call_architecture.py
+++ b/tests/test_call_architecture.py
@@ -49,6 +49,12 @@ _DATAPLANE_DERIVED_WRITES = {
     "overflow_spend_in_settle": (
         (settle._platform_settle, "overflow_spend_ledger.add_in_transaction"),
         (overflow._record_shadow, "overflow_spend_ledger.add_in_transaction"),
+        (overflow._finish_budget, "overflow_spend_ledger.add_in_transaction"),
+        (overflow._preserve_unknown_budget, "overflow_spend_ledger.add_in_transaction"),
+    ),
+    "overflow_budget_reservation": (
+        (overflow._maybe_overflow_attempt, "overflow_spend_ledger.reserve_in_transaction"),
+        (overflow._release_budget, "overflow_spend_ledger.release_reservation_in_transaction"),
     ),
 }
 _EXPECTED_DATAPLANE_WRITES = frozenset({
@@ -59,6 +65,7 @@ _EXPECTED_DATAPLANE_WRITES = frozenset({
     "lazy_stale_hold_reap",
     "capacity_exhausted_mark",
     "overflow_spend_in_settle",
+    "overflow_budget_reservation",
 })
 _DERIVED_WRITE_FILES = {
     _SRC / "application" / "billing.py": {"loop.create_task"},
@@ -71,6 +78,8 @@ _DERIVED_WRITE_FILES = {
     },
     _SRC / "application" / "call" / "overflow.py": {
         "capacity_marks.mark_exhausted", "overflow_spend_ledger.add_in_transaction",
+        "overflow_spend_ledger.reserve_in_transaction",
+        "overflow_spend_ledger.release_reservation_in_transaction",
     },
     _SRC / "domain" / "capacity" / "marks.py": {"ratestore.kv_put"},
     _SRC / "domain" / "governance" / "publicdemo.py": {
@@ -92,6 +101,12 @@ _EXPECTED_DERIVED_WRITE_SITES = {
     ("application/call/settle.py", "_close", "overflow_spend_ledger.add_in_transaction"),
     ("application/call/overflow.py", "_maybe_overflow_attempt", "capacity_marks.mark_exhausted"),
     ("application/call/overflow.py", "_record_shadow", "overflow_spend_ledger.add_in_transaction"),
+    ("application/call/overflow.py", "_finish_budget", "overflow_spend_ledger.add_in_transaction"),
+    ("application/call/overflow.py", "_preserve_unknown_budget", "overflow_spend_ledger.add_in_transaction"),
+    ("application/call/overflow.py", "_maybe_overflow_attempt",
+     "overflow_spend_ledger.reserve_in_transaction"),
+    ("application/call/overflow.py", "_release_budget",
+     "overflow_spend_ledger.release_reservation_in_transaction"),
     ("domain/capacity/marks.py", "mark_exhausted", "ratestore.kv_put"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.rate_check"),
     ("domain/governance/publicdemo.py", "enforce_public_demo_ip_cap", "ratestore.sweep"),

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -111,6 +111,39 @@ async def test_findymail_shaped_402_on_tier4_runs_one_child_cycle(clients: Async
     assert tiers == {"platform", "platform-overflow"}
 
 
+async def test_overflow_substitutes_consumed_path_params_before_calling_aggregator(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    endpoint = "predictleads.companies.enrich"
+    monkeypatch.setenv("TREG_PLATFORM_KEY_PREDICTLEADS", "TEST-PREDICTLEADS-KEY")
+    monkeypatch.setenv(
+        "TREG_PLATFORM_PROVIDERS", "tikhub,scrapecreators,dataforseo,brightdata,predictleads",
+    )
+    get_settings.cache_clear()
+    async with session_maker() as db:
+        db.add(OverflowRoute(
+            endpoint_id=endpoint, aggregator="orthogonal", provider="predictleads", method="GET",
+            path="/companies/{id_or_domain}", agg_slug="predictleads",
+            agg_path="/v3/companies/{id_or_domain}", agg_price_micro=40_000, agg_unit="call",
+            ratio=1.0, enabled=True, last_verified_at=utcnow_naive(),
+        ))
+        await db.commit()
+    routes_view.invalidate()
+    capacity_view.invalidate()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    seen = []
+    envelope = {"success": True, "data": VENDOR_BODY, "priceCents": 4.0}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, envelope)], seen))
+
+    r = await clients.get(f"/call/{endpoint}?id_or_domain=stripe.com")
+
+    assert r.status_code == 200, r.text
+    assert len(seen) == 1
+    assert seen[0].json["path"] == "/v3/companies/stripe.com"
+    assert "{" not in seen[0].json["path"] and "}" not in seen[0].json["path"]
+    assert "query" not in seen[0].json
+
+
 async def test_aggregator_402_releases_the_child_marks_it_unhealthy_and_answers_a_typed_503(
     clients: AsyncClient, overflow_on, monkeypatch,
 ):

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -188,6 +188,30 @@ async def test_contract_refusal_falls_back_to_the_vendor_answer(clients: AsyncCl
     assert await _balance(clients) == before and await _holds() == []
 
 
+async def test_adapter_parse_crash_falls_back_to_vendor_answer_and_releases_child_hold(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"vendor out"}'))
+    seen = []
+    monkeypatch.setattr(
+        O, "_send",
+        _orthogonal([(200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], seen),
+    )
+
+    def crash_parse(status, body):
+        raise RuntimeError("adapter parse crashed")
+
+    monkeypatch.setattr(O.by_name("orthogonal"), "parse", crash_parse)
+
+    response = await clients.get(f"/call/{EP}?aweme_id=7")
+
+    assert response.status_code == 402
+    assert response.content == b'{"detail":"vendor out"}'
+    assert len(seen) == 1
+    assert not any(hold.call_id.endswith(":overflow") for hold in await _holds())
+
+
 async def test_budget_crossing_skips_overflow(clients: AsyncClient, overflow_on, monkeypatch):
     await _route(price_micro=3_000)
     monkeypatch.setenv("TREG_OVERFLOW_DAILY_BUDGET_USD", "0.004")
@@ -282,6 +306,33 @@ async def test_an_exhausted_account_with_a_route_skips_the_direct_attempt(client
     replay = await clients.get(f"/call/{EP}?aweme_id=7", headers={"Idempotency-Key": "k1"})
     assert replay.status_code == 200 and replay.headers.get("X-Treg-Idempotent-Replay") == "true"
     assert len(seen) == 1, "the replay never touched the aggregator"
+
+
+async def test_skip_direct_spend_lookup_crash_falls_back_to_typed_capacity_503(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    from datetime import timedelta
+
+    await _route(price_micro=3_000)
+    now = utcnow_naive()
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "tikhub", LatestState(
+            "tikhub", 0.0, "USD", now, "exact", exhausted_until=now + timedelta(hours=1),
+            health="exhausted",
+        ).to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+
+    async def crash_spent_today(db, aggregator, *, day=None):
+        raise RuntimeError("spend lookup crashed")
+
+    monkeypatch.setattr(O.overflow_spend_ledger, "spent_today", crash_spent_today)
+
+    response = await clients.get(f"/call/{EP}?aweme_id=7")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "provider_capacity_unavailable"
+    assert await _holds() == []
 
 
 async def test_an_exhausted_account_without_a_route_is_still_the_typed_503(clients: AsyncClient, overflow_on):

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -111,6 +111,24 @@ async def test_findymail_shaped_402_on_tier4_runs_one_child_cycle(clients: Async
     assert tiers == {"platform", "platform-overflow"}
 
 
+async def test_overflow_budget_reconciles_the_estimate_to_the_actual_cost(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"out"}'))
+    seen = []
+    envelope = {"success": True, "data": VENDOR_BODY, "priceCents": 0.25}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, envelope)], seen))
+
+    response = await clients.get(f"/call/{EP}?aweme_id=7")
+
+    assert response.status_code == 200
+    assert response.headers["X-Treg-Cost-Micro"] == "2500"
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1
+    assert (spend[0].calls, spend[0].cost_micro) == (1, 2_500)
+
+
 async def test_overflow_substitutes_consumed_path_params_before_calling_aggregator(
     clients: AsyncClient, overflow_on, monkeypatch,
 ):
@@ -210,6 +228,57 @@ async def test_adapter_parse_crash_falls_back_to_vendor_answer_and_releases_chil
     assert response.content == b'{"detail":"vendor out"}'
     assert len(seen) == 1
     assert not any(hold.call_id.endswith(":overflow") for hold in await _holds())
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1
+    assert (spend[0].calls, spend[0].cost_micro) == (1, 3_000)
+
+
+async def test_request_error_after_send_preserves_unknown_budget_estimate(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"vendor out"}'))
+    seen = []
+
+    async def timeout_after_send(client, request):
+        seen.append(request)
+        raise httpx.ReadTimeout(
+            "aggregator response timed out",
+            request=httpx.Request(request.method, request.url),
+        )
+
+    monkeypatch.setattr(O, "_send", timeout_after_send)
+
+    response = await clients.get(f"/call/{EP}?aweme_id=7")
+
+    assert response.status_code == 503
+    assert len(seen) == 1
+    assert await _holds() == []
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1
+    assert (spend[0].calls, spend[0].cost_micro) == (1, 3_000)
+
+
+async def test_vendor_500_cost_reported_by_aggregator_is_counted_in_daily_spend(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"out"}'))
+    seen = []
+    envelope = {
+        "success": False,
+        "error": "upstream returned status 500",
+        "data": {"error": "vendor failed"},
+        "priceCents": 0.3,
+    }
+    monkeypatch.setattr(O, "_send", _orthogonal([(500, envelope)], seen))
+
+    response = await clients.get(f"/call/{EP}?aweme_id=7")
+
+    assert response.status_code == 500
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1
+    assert (spend[0].calls, spend[0].cost_micro) == (1, 3_000)
 
 
 async def test_budget_crossing_skips_overflow(clients: AsyncClient, overflow_on, monkeypatch):
@@ -308,7 +377,7 @@ async def test_an_exhausted_account_with_a_route_skips_the_direct_attempt(client
     assert len(seen) == 1, "the replay never touched the aggregator"
 
 
-async def test_skip_direct_spend_lookup_crash_falls_back_to_typed_capacity_503(
+async def test_skip_direct_budget_reservation_crash_falls_back_to_typed_capacity_503(
     clients: AsyncClient, overflow_on, monkeypatch,
 ):
     from datetime import timedelta
@@ -323,10 +392,10 @@ async def test_skip_direct_spend_lookup_crash_falls_back_to_typed_capacity_503(
         await db.commit()
     capacity_view.invalidate()
 
-    async def crash_spent_today(db, aggregator, *, day=None):
-        raise RuntimeError("spend lookup crashed")
+    async def crash_reservation(db, aggregator, estimate_micro, cap_micro, *, day=None):
+        raise RuntimeError("budget reservation crashed")
 
-    monkeypatch.setattr(O.overflow_spend_ledger, "spent_today", crash_spent_today)
+    monkeypatch.setattr(O.overflow_spend_ledger, "reserve_in_transaction", crash_reservation)
 
     response = await clients.get(f"/call/{EP}?aweme_id=7")
 

--- a/tests/test_capacity_overflow_spend.py
+++ b/tests/test_capacity_overflow_spend.py
@@ -7,6 +7,7 @@ import asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from treg.db import session_maker
+from treg.domain.capacity import overflow_spend as spend_ledger
 from treg.domain.capacity.overflow_spend import add_in_transaction
 from treg.models import OverflowSpend
 
@@ -58,3 +59,45 @@ async def test_concurrent_first_adds_are_atomic(clients, monkeypatch):
         row = await db.get(OverflowSpend, ("orthogonal", "2026-08-28"))
     assert row is not None
     assert (row.calls, row.cost_micro, row.delta_micro) == (2, 5_000, 50)
+
+
+async def test_concurrent_budget_reservations_allow_at_most_one_call_at_the_cap(clients):
+    async def reserve() -> bool:
+        async with session_maker() as db:
+            row = await spend_ledger.reserve_in_transaction(
+                db, "orthogonal", 3_000, 4_000, day="2026-08-28",
+            )
+            await db.commit()
+            return row is not None
+
+    admitted = await asyncio.gather(reserve(), reserve())
+
+    assert sum(admitted) == 1
+    async with session_maker() as db:
+        row = await db.get(OverflowSpend, ("orthogonal", "2026-08-28"))
+    assert row is not None
+    assert (row.calls, row.cost_micro) == (0, 3_000)
+
+
+async def test_first_budget_reservation_larger_than_the_cap_is_rejected(clients):
+    async with session_maker() as db:
+        row = await spend_ledger.reserve_in_transaction(
+            db, "orthogonal", 5_000, 4_000, day="2026-08-28",
+        )
+        await db.commit()
+
+    assert row is None
+    async with session_maker() as db:
+        assert await db.get(OverflowSpend, ("orthogonal", "2026-08-28")) is None
+
+
+async def test_budget_reservation_does_not_commit_for_its_caller(clients):
+    async with session_maker() as db:
+        row = await spend_ledger.reserve_in_transaction(
+            db, "orthogonal", 3_000, 4_000, day="2026-08-28",
+        )
+        assert row is not None
+        await db.rollback()
+
+    async with session_maker() as db:
+        assert await db.get(OverflowSpend, ("orthogonal", "2026-08-28")) is None

--- a/tests/test_capacity_overflow_spend.py
+++ b/tests/test_capacity_overflow_spend.py
@@ -1,0 +1,60 @@
+"""Atomic daily accounting for overflow aggregator spend."""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from treg.db import session_maker
+from treg.domain.capacity.overflow_spend import add_in_transaction
+from treg.models import OverflowSpend
+
+
+async def test_add_in_transaction_does_not_commit_for_its_caller(clients):
+    async with session_maker() as db:
+        row = await add_in_transaction(db, "orthogonal", 2_000, 100, day="2026-08-28")
+        row = await add_in_transaction(db, "orthogonal", 3_000, -50, day="2026-08-28")
+        assert (row.calls, row.cost_micro, row.delta_micro) == (2, 5_000, 50)
+        await db.rollback()
+
+    async with session_maker() as db:
+        assert await db.get(OverflowSpend, ("orthogonal", "2026-08-28")) is None
+
+
+async def test_concurrent_first_adds_are_atomic(clients, monkeypatch):
+    original_get = AsyncSession.get
+    both_read_missing = asyncio.Event()
+    reads = 0
+    gate_reads = True
+
+    async def get_after_both_read(self, entity, ident, *args, **kwargs):
+        nonlocal reads
+        row = await original_get(self, entity, ident, *args, **kwargs)
+        if (
+            gate_reads and entity is OverflowSpend
+            and ident == ("orthogonal", "2026-08-28")
+        ):
+            reads += 1
+            if reads == 2:
+                both_read_missing.set()
+            await asyncio.wait_for(both_read_missing.wait(), timeout=2)
+        return row
+
+    monkeypatch.setattr(AsyncSession, "get", get_after_both_read)
+
+    async def add(cost_micro: int, delta_micro: int) -> None:
+        async with session_maker() as db:
+            await add_in_transaction(
+                db, "orthogonal", cost_micro, delta_micro, day="2026-08-28",
+            )
+            await db.commit()
+
+    results = await asyncio.gather(add(2_000, 100), add(3_000, -50), return_exceptions=True)
+    gate_reads = False
+
+    assert results == [None, None]
+    async with session_maker() as db:
+        row = await db.get(OverflowSpend, ("orthogonal", "2026-08-28"))
+    assert row is not None
+    assert (row.calls, row.cost_micro, row.delta_micro) == (2, 5_000, 50)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -10,6 +11,7 @@ from httpx import AsyncClient
 from sqlmodel import select
 
 from treg import audit
+from treg.application.call import route as call_route
 from treg.application.call import service as call_service
 from treg.application.call.types import UpstreamResponse
 from treg.config import get_settings
@@ -18,7 +20,8 @@ from treg.domain.catalog import store as catalog_store
 from treg.domain.catalog.routing import paths as P
 from treg.domain.catalog.routing.contracts import canonical_identity
 from treg.domain.catalog.routing.plan import Candidate, cost_at, rank
-from treg.models import Hold, LedgerEntry
+from treg.infra.catalog_observations import CachedEndpointObservationReader
+from treg.models import CallRecord, Hold, LedgerEntry
 
 from test_marketplace_call import _balance, platform_on  # noqa: F401
 
@@ -115,6 +118,99 @@ def test_cost_at_and_ranking_math():
     assert [c.endpoint["id"] for c in rank([a, b], exclude=["a"])] == ["b.x"]
     a.exhausted = True
     assert [c.endpoint["id"] for c in rank([a, b])] == ["b.x"]
+
+
+async def test_concurrent_routed_plans_share_one_cached_observation_refresh(
+    clients: AsyncClient, enrichment_on, monkeypatch,
+):
+    from treg.domain.catalog import stats
+
+    class Source:
+        calls = 0
+
+        async def get_many(self, endpoint_ids):
+            self.calls += 1
+            return {
+                endpoint_id: {
+                    "samples": 20, "ok_rate": 1.0, "p50_ms": 20, "p95_ms": 40,
+                    "last_ok_days": 0, "hit_rate": 0.5, "hit_samples": 20,
+                }
+                for endpoint_id in endpoint_ids
+            }
+
+    async def request_time_aggregate(*args, **kwargs):
+        raise AssertionError("routed planning must not aggregate CallRecord on the request path")
+
+    source = Source()
+    reader = CachedEndpointObservationReader(source)
+    monkeypatch.setattr(call_route, "_endpoint_observation_reader", reader, raising=False)
+    monkeypatch.setattr(stats, "observed", request_time_aggregate)
+    ep = catalog_store.load().by_id[ROUTED]
+
+    class _Org:
+        id = 1
+
+    class _Caller:
+        org_id = 1
+        org = _Org()
+
+    try:
+        plans = await asyncio.gather(*(
+            call_route.build_plan(
+                ep, {"full_name": "Patrick Collison", "domain": "stripe.com"},
+                _Caller(), call_route.RouteOptions.from_headers(lambda key: None),
+            )
+            for _ in range(20)
+        ))
+        await reader.wait_for_idle()
+    finally:
+        await reader.aclose()
+
+    assert all(plan.candidates for plan in plans)
+    assert source.calls == 1
+
+
+async def test_routed_plan_keeps_per_success_hit_fallback_from_the_cache(
+    clients: AsyncClient, enrichment_on, monkeypatch,
+):
+    from treg import api as A
+    from treg.domain.catalog import stats
+
+    endpoint_id = "tomba.people.email.find"
+    async with session_maker() as db:
+        for cost_micro in (8_900, 8_900, 0):
+            db.add(CallRecord(
+                org_id=1, user_email="a@b.c", tool_name=endpoint_id, method="GET", path="/x",
+                status_code=200, endpoint_id=endpoint_id, cost_observed_micro=cost_micro, hit=None,
+            ))
+        await db.commit()
+    monkeypatch.setattr(stats, "MIN_HIT_SAMPLES", 3)
+    reader = A.app.state.endpoint_observation_reader
+    assert await reader.get_many([endpoint_id]) == {}
+    await reader.wait_for_idle()
+    warm = await reader.get_many([endpoint_id])
+    assert warm[endpoint_id]["hit_rate"] == pytest.approx(2 / 3, abs=1e-3)
+
+    async def request_time_aggregate(*args, **kwargs):
+        raise AssertionError("the routed plan must use the warm observation cache")
+
+    monkeypatch.setattr(stats, "observed", request_time_aggregate)
+    monkeypatch.setattr(call_route, "_endpoint_observation_reader", reader, raising=False)
+    ep = catalog_store.load().by_id[ROUTED]
+
+    class _Org:
+        id = 1
+
+    class _Caller:
+        org_id = 1
+        org = _Org()
+
+    plan = await call_route.build_plan(
+        ep, {"full_name": "Patrick Collison", "domain": "stripe.com"},
+        _Caller(), call_route.RouteOptions.from_headers(lambda key: None),
+    )
+    tomba = next(candidate for candidate in plan.candidates if candidate.endpoint["id"] == endpoint_id)
+    assert tomba.hit_rate == pytest.approx(2 / 3, abs=1e-3)
 
 
 # ---- the call path ---------------------------------------------------------------------------
@@ -376,6 +472,7 @@ async def test_hit_verdict_is_recorded_and_becomes_a_hit_rate(clients: AsyncClie
     # the catalog reads observations through the process cache: a cold entry answers nothing and
     # refreshes in the background, so warm it the way test_endpoint_stats does
     from treg import api as A
+    monkeypatch.setattr(call_route, "_endpoint_observation_reader", A.app.state.endpoint_observation_reader)
     await clients.get(f"/catalog/endpoints/{ROUTED}")
     await A.app.state.endpoint_observation_reader.wait_for_idle()
     r = await clients.get(f"/catalog/endpoints/{ROUTED}")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -10,7 +10,7 @@ import pytest
 from httpx import AsyncClient
 from sqlmodel import select
 
-from treg import audit
+from treg import audit, ledger
 from treg.application.call import route as call_route
 from treg.application.call import service as call_service
 from treg.application.call.types import UpstreamResponse
@@ -256,6 +256,88 @@ async def test_error_on_the_first_child_falls_back_to_the_second(clients: AsyncC
     assert r.headers["X-Treg-Providers-Tried"] == "tomba,findymail"
     assert before - await _balance(clients) == 19_800, "the failed child released its hold; only findymail charged"
     assert seen[1] == ("findymail", "POST", {}, {"name": "Patrick Collison", "domain": "stripe.com"})
+
+
+async def test_child_capability_pin_refusal_falls_back_to_the_pinned_provider(
+    clients: AsyncClient, enrichment_on, monkeypatch,
+):
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    pinned = await clients.post(
+        f"/orgs/{org_id}/pins",
+        json={"capability": "people.email.find", "provider": "hunter"},
+    )
+    assert pinned.status_code == 200, pinned.text
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({
+        "hunter": [(200, {"data": {
+            "email": "patrick@stripe.com", "score": 90,
+            "verification": {"status": "valid"},
+        }})],
+    }, seen))
+
+    response = await clients.post(
+        f"/call/{ROUTED}",
+        json={"full_name": "Patrick Collison", "domain": "stripe.com"},
+        headers={"X-Treg-Route-Prefer": "tomba,hunter"},
+    )
+
+    assert response.status_code == 200, response.text
+    doc = response.json()
+    assert doc["_treg"]["served_by"] == "hunter.people.email.find"
+    assert [attempt["outcome"] for attempt in doc["_treg"]["tried"]] == ["error", "hit"]
+    assert doc["_treg"]["tried"][0]["endpoint_id"] == "tomba.people.email.find"
+    assert [provider for provider, *_ in seen] == ["hunter"]
+
+
+async def test_platform_vendor_401_falls_back_to_the_next_provider(
+    clients: AsyncClient, enrichment_on, monkeypatch,
+):
+    findymail = catalog_store.load().by_id["findymail.search.name"]
+    monkeypatch.setitem(findymail, "cost", {**findymail["cost"], "type": "per_call"})
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({
+        "tomba": [(401, {"error": "invalid platform key"})],
+        "findymail": [(200, {"contact": {
+            "name": "Patrick Collison", "email": "patrick@stripe.com",
+        }})],
+    }, seen))
+
+    response = await clients.post(
+        f"/call/{ROUTED}",
+        json={"full_name": "Patrick Collison", "domain": "stripe.com"},
+        headers={
+            "X-Treg-Route-Prefer": "tomba,findymail",
+            "X-Treg-Route-Exclude": "hunter,leadmagic,leadsforge,aviato,fiber-ai",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    doc = response.json()
+    assert doc["_treg"]["served_by"] == "findymail.search.name"
+    assert [attempt["outcome"] for attempt in doc["_treg"]["tried"]] == ["error", "hit"]
+    assert [provider for provider, *_ in seen] == ["tomba", "findymail"]
+
+
+async def test_routed_insufficient_balance_still_stops_before_fallback(
+    clients: AsyncClient, enrichment_on, monkeypatch,
+):
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+    async with session_maker() as db:
+        await ledger.reserve(db, org_id, "drain routed balance", 1_000_000)
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({
+        "tomba": [(200, {"data": {"email": "should-not-run@example.com"}})],
+    }, seen))
+
+    response = await clients.post(
+        f"/call/{ROUTED}",
+        json={"full_name": "Patrick Collison", "domain": "stripe.com"},
+        headers={"X-Treg-Route-Prefer": "tomba,findymail"},
+    )
+
+    assert response.status_code == 402
+    assert response.json()["detail"]["error"] == "insufficient_balance"
+    assert seen == []
 
 
 async def test_waterfall_is_on_by_default_can_be_turned_off_and_respects_max_cost(clients: AsyncClient, enrichment_on, monkeypatch):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -276,6 +276,41 @@ async def test_idempotent_replay_of_a_routed_call_never_calls_a_provider_twice(c
     assert r2.json() == r1.json() and len(seen) == 1
 
 
+@pytest.mark.parametrize(
+    ("terminal", "expected_status", "expected_error"),
+    [
+        ((400, {"message": "invalid email"}), 400, "route_caller_fault"),
+        ((503, {"message": "provider down"}), 502, "route_failed"),
+    ],
+)
+async def test_idempotent_replay_preserves_a_routed_failure_after_partial_charge(
+    clients: AsyncClient, enrichment_on, monkeypatch, terminal, expected_status, expected_error,
+):
+    routed = "treg.people.email.verify"
+    tomba_miss = (200, {"data": {"email": {"status": None, "score": None}}})
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"tomba": [tomba_miss, tomba_miss], "leadmagic": [terminal, terminal]},
+        seen,
+    ))
+    headers = {
+        "Idempotency-Key": "route-partially-charged-failure",
+        "X-Treg-Route-Prefer": "tomba,leadmagic",
+        "X-Treg-Route-Exclude": "hunter",
+    }
+    before = await _balance(clients)
+
+    r1 = await clients.post(f"/call/{routed}", json={"email": "bad@example.com"}, headers=headers)
+    r2 = await clients.post(f"/call/{routed}", json={"email": "bad@example.com"}, headers=headers)
+
+    assert r1.status_code == expected_status and r1.json()["detail"]["error"] == expected_error
+    assert r2.status_code == r1.status_code and r2.json() == r1.json()
+    assert r2.headers.get("X-Treg-Idempotent-Replay") == "true"
+    assert r1.headers["X-Treg-Cost-Micro"] == r2.headers["X-Treg-Cost-Micro"] == "8900"
+    assert before - await _balance(clients) == 8_900
+    assert [provider for provider, *_ in seen] == ["tomba", "leadmagic"]
+
+
 def test_a_per_success_miss_settles_at_zero_when_the_adapter_can_tell():
     """Live 2026-08-28: the first waterfall charged tomba, findymail and leadsforge for misses the
     catalog calls free. The adapter's `miss` predicate is the missing knowledge."""


### PR DESCRIPTION
## Summary

This PR fixes seven capacity and routed-call blockers. B1 and B2 were independently identified by all three review passes on PR #242; B3 was also found during the PR #242 review. B4, B5, and B6 came from the subsequent confirmed review, and B2b closes the remaining daily-budget race exposed after B2's atomic upsert work.

### B1: overflow dropped path parameters

Problem: `maybe_overflow` removed parameters consumed by vendor path placeholders from the query, then called the aggregator without `path_params`.

Failure chain: routes such as PredictLeads `/companies/{id_or_domain}` reached the aggregator with literal braces, the vendor returned 404, and the child could still settle as though the vendor had answered.

Fix: forward consumed query items as named path parameters while keeping them out of the aggregator query.

Regression: `test_overflow_substitutes_consumed_path_params_before_calling_aggregator`.

### B2: concurrent OverflowSpend updates could break settle

Problem: `add_in_transaction` used an unlocked read-modify-write sequence.

Failure chain: concurrent first writes could race on the aggregator/day primary key and roll back child settle after real upstream spend; existing rows could also lose updates under READ COMMITTED.

Fix: use dialect-aware SQLite/Postgres `INSERT ... ON CONFLICT DO UPDATE` increments. The helper remains transaction-owned by its caller and never commits.

Regressions: `test_concurrent_first_adds_are_atomic` and `test_add_in_transaction_does_not_commit_for_its_caller`.

### B3: idempotency was lost after a partially charged routed failure

Problem: terminal routed failures were re-raised without storing an idempotency result.

Failure chain: earlier waterfall children could settle real per-call charges, a later child could end in `route_caller_fault` or `route_failed`, and retrying the same key reran providers and charged again.

Fix: persist the exact terminal error body, status, original call id, and total `charged_micro`; replay returns the same failure and bill without contacting providers. Uncharged failures remain retryable.

Regression: parametrized `test_idempotent_replay_preserves_a_routed_failure_after_partial_charge`.

### B4: routed planning performed a 30-day aggregate on every request

Problem: `build_plan` opened a request-time session and called `endpoint_stats.observed` directly.

Failure chain: routed traffic repeated the same 30-day `CallRecord` aggregate that exhausted the DB pool, bypassing the shared fresh/stale cache and singleflight introduced by #241.

Fix: bootstrap injects the shared endpoint-observation reader into routed planning. Own-tool and own-key PK lookups remain in their short session, and cached per-success hit fallback is preserved.

Regressions: `test_concurrent_routed_plans_share_one_cached_observation_refresh` and `test_routed_plan_keeps_per_success_hit_fallback_from_the_cache`.

### B5: overflow infrastructure exceptions leaked child holds and replaced vendor answers

Problem: only `httpx.RequestError` around `_run` was contained; budget, adapter, capacity-mark, and accounting exceptions escaped.

Failure chain: a child hold could remain open and a caller with an existing vendor response could receive a 500. Skip-direct calls also lost their typed capacity 503.

Fix: contain the complete overflow attempt, preserve cancellation and typed call-failure semantics, release reserved child holds, and fall back to the original vendor response or skip-direct `provider_capacity` 503.

Regressions: `test_adapter_parse_crash_falls_back_to_vendor_answer_and_releases_child_hold` and `test_skip_direct_budget_reservation_crash_falls_back_to_typed_capacity_503`.

### B6: child-local 403 and platform vendor auth failures stopped the waterfall

Problem: routed handling classified every 401/403 CallFailure or vendor response as a caller fault.

Failure chain: a pin or ACL rejection for one child, or a bad treg-owned platform key, terminated the entire routed call even when the next provider could answer.

Fix: treat `tool_access_denied`, `policy_denied`, and `capability_pinned` as candidate-local error fallback, and treat platform-tier vendor 401/403 as treg-side provider errors. Balance and spend-cap refusals remain terminal.

Regressions: `test_child_capability_pin_refusal_falls_back_to_the_pinned_provider`, `test_platform_vendor_401_falls_back_to_the_next_provider`, and `test_routed_insufficient_balance_still_stops_before_fallback`.

### B2b: overflow daily budget was still check-then-spend

Problem: overflow read daily spend, performed network I/O, and only recorded cost during settle.

Failure chain: concurrent calls could all observe room under the cap and overspend the aggregator's prepaid account; charged vendor 5xx responses were also omitted from daily spend.

Fix: atomically reserve estimated micro-USD before network I/O with a conditional upsert, then reconcile estimate to actual cost. Known no-charge failures release the reservation, while an outbound attempt with an unknown fee conservatively keeps its estimate. Shadow probes share the same cap, and charged vendor 5xx responses count even when the caller is not billed. Crash-window estimates remain conservatively reserved.

Regressions: `test_concurrent_budget_reservations_allow_at_most_one_call_at_the_cap`, `test_first_budget_reservation_larger_than_the_cap_is_rejected`, `test_budget_reservation_does_not_commit_for_its_caller`, `test_overflow_budget_reconciles_the_estimate_to_the_actual_cost`, `test_shadow_mode_probes_records_spend_and_returns_the_vendor_error`, and `test_vendor_500_cost_reported_by_aggregator_is_counted_in_daily_spend`, `test_request_error_after_send_preserves_unknown_budget_estimate`, and `test_adapter_parse_crash_falls_back_to_vendor_answer_and_releases_child_hold`.

## Verification

- Full suite: `uv run --frozen python -m pytest -q` - 2312 passed, 4 skipped, 24 warnings.
- B1 targeted: `tests/test_capacity_overflow.py tests/test_capacity_overflow_routes.py` - 26 passed.
- B2 targeted: `tests/test_capacity_overflow_spend.py tests/test_capacity_overflow.py tests/test_call_architecture.py` - 30 passed at that commit.
- B3 targeted: `tests/test_routing.py tests/test_marketplace_call.py tests/callmatrix/test_matrix.py tests/test_call_architecture.py` - 172 passed.
- B4 targeted: `tests/test_routing.py tests/test_endpoint_stats.py tests/test_call_pool_discipline.py tests/test_app_roles.py tests/test_call_architecture.py` - 74 passed, 3 skipped.
- B5/B2b targeted: `tests/test_capacity_overflow.py tests/test_capacity_overflow_spend.py tests/test_call_cancellation.py tests/test_call_architecture.py` - 45 passed.
- B6 targeted: `tests/test_routing.py tests/test_capability_pins.py tests/test_marketplace_call.py` - 142 passed.

