### PR TITLE
feat(archive): keep-all storage default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,17 @@ jobs:
           tests/test_health.py
           tests/test_localrun.py
           tests/test_orgs.py
+      - name: Dump Postgres activity on failure
+        # Three CI-only hangs at archive drains were undiagnosable from Python stacks alone; this
+        # shows the DATABASE's view: every session, its state (idle in transaction = a leaked or
+        # blocked one), what it waits on, and ungranted locks with their holders' queries.
+        # Delete once the hang is understood and fixed.
+        if: failure()
+        env:
+          PGPASSWORD: treg
+        run: |
+          psql -h 127.0.0.1 -U treg -d treg_test -x -c "select pid, state, wait_event_type, wait_event, xact_start, state_change, left(query,140) as query from pg_stat_activity where datname='treg_test' order by xact_start nulls last;" || true
+          psql -h 127.0.0.1 -U treg -d treg_test -c "select l.pid, l.locktype, l.mode, l.granted, a.state, left(a.query,90) as query from pg_locks l join pg_stat_activity a using(pid) where not l.granted;" || true
           tests/test_orgs_isolation.py
           tests/test_orgs_mgmt.py
 

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -137,8 +137,10 @@ enable. Rollback in production is a dashboard env edit, no deploy.
 1. **Kind.** `kind: action` entries are never stored; only data reads pass.
 2. **License.** Per catalog entry: `cache: forbidden | transient | archive` — either a bare
    string or a provenance dict `{mode, license_quote, source_url, checked}`, exactly like `cost`
-   provenance. **Absent ⇒ forbidden**: an unjudged provider is never stored (the same posture as
-   the platform offer's free-only guard — the safe answer is the silent one).
+   provenance. **Absent ⇒ `archive_default_policy`**, which is `transient` since the founder's
+   keep-all decision (2026-08-29): unjudged providers' bodies ARE kept as short-lived cache, and
+   the env flips it back to `forbidden` without a deploy. A JUDGED forbidden (a licence that was
+   read and says no — Finnhub) is always respected, and a missing entry is never stored.
 3. **Tier.** Only METERED PLATFORM calls are recorded. Those responses are already fully buffered
    for the settle (`_buffer_response` needs the provider's reported cost), so recording adds no
    latency and no new data path. Own-key and own-tool calls stream and are never touched — that

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -71,11 +71,11 @@ _STORABLE = (CACHE_TRANSIENT, CACHE_ARCHIVE)
 def policy(entry: dict[str, Any] | None) -> str:
     """Gates 1+2 for one catalog entry, returning the effective cache policy.
 
-    `entry` is the endpoint's catalog mapping (the same dict the resolver already holds). The
-    default is FORBIDDEN on every uncertain branch — an entry that is missing, an action, or an
-    unjudged license must never be stored. This is the same posture as the platform offer's
-    free-only guard: the safe answer is the silent one.
-    """
+    `entry` is the endpoint's catalog mapping (the same dict the resolver already holds). Two
+    branches are non-negotiable whatever the default says: a missing entry or an ACTION is never
+    stored, and a JUDGED forbidden (a licence that was read and says no) is always respected.
+    An UNJUDGED entry takes `archive_default_policy` — "transient" since the founder's 2026-08-29
+    keep-all decision, flippable back to "forbidden" by env without a deploy."""
     if not entry:
         return CACHE_FORBIDDEN
     if entry.get("kind") == "action":  # gate 1 — never store an action's answer
@@ -85,7 +85,10 @@ def policy(entry: dict[str, Any] | None) -> str:
         declared = declared.get("mode")
     if declared in _STORABLE:  # gate 2 — an explicit, judged license decision
         return str(declared)
-    return CACHE_FORBIDDEN
+    if declared == CACHE_FORBIDDEN:  # judged and refused — always respected
+        return CACHE_FORBIDDEN
+    default = (get_settings().archive_default_policy or "").strip().lower()
+    return CACHE_TRANSIENT if default == CACHE_TRANSIENT else CACHE_FORBIDDEN
 
 
 def storable(entry: dict[str, Any] | None) -> bool:

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -174,6 +174,12 @@ from datetime import datetime, timezone
 _log = logging.getLogger("treg.archive")
 _pending: set[asyncio.Task] = set()
 _MAX_PENDING = 512
+# A recording is best-effort by contract (audit's discipline: shed, never wedge). A database that
+# does not answer in this window — a lock, a stuck pool slot, a dying connection — costs ONE
+# dropped sample, which the next identical call re-supplies; it must never hold drain(), a test,
+# or a shutdown hostage. CI's serial Postgres job hung exactly that way three times before this
+# bound existed, at whichever drain() happened to gather the stuck task.
+_STORE_TIMEOUT_S = 30
 
 
 def _utcnow() -> datetime:
@@ -210,18 +216,23 @@ def record(
     trusts them and never raises."""
     if len(_pending) >= _MAX_PENDING:  # shed load; the stream self-heals on the next call
         return
-    task = asyncio.create_task(_store(
+    task = asyncio.create_task(asyncio.wait_for(_store(
         method=method, endpoint_id=endpoint_id, provider=provider, url=url,
         caller_body=caller_body, headers=headers, status_code=status_code,
-        media_type=media_type, body=body, origin=origin))
+        media_type=media_type, body=body, origin=origin), timeout=_STORE_TIMEOUT_S))
     _pending.add(task)
     task.add_done_callback(_pending.discard)
 
 
 async def drain() -> None:
-    """Flush in-flight recordings — shutdown and tests."""
+    """Flush in-flight recordings — shutdown and tests. Bounded: every task carries its own
+    _STORE_TIMEOUT_S, so this cannot wait longer than the slowest permitted recording."""
     while _pending:
-        await asyncio.gather(*list(_pending), return_exceptions=True)
+        results = await asyncio.gather(*list(_pending), return_exceptions=True)
+        for r in results:
+            if isinstance(r, asyncio.TimeoutError | TimeoutError):
+                _log.warning("archive recording dropped: database did not answer in %ss",
+                             _STORE_TIMEOUT_S)
 
 
 async def _store(
@@ -463,7 +474,7 @@ def _touch(key_hash: str) -> None:
     no snapshot and no change statistics, because nothing new was observed."""
     if len(_pending) >= _MAX_PENDING:
         return
-    task = asyncio.create_task(_touch_write(key_hash))
+    task = asyncio.create_task(asyncio.wait_for(_touch_write(key_hash), timeout=_STORE_TIMEOUT_S))
     _pending.add(task)
     task.add_done_callback(_pending.discard)
 

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -262,6 +262,11 @@ class Settings(BaseSettings):
     # Bodies above this size are hash-counted but never stored (skipped whole, not truncated):
     # the archive is for API JSON answers, not downloads. Statistics still record size_bytes.
     archive_max_body_bytes: int = 2_000_000
+    # What happens to an endpoint WITHOUT a judged `cache:` field (the founder's 2026-08-29
+    # decision): "transient" keeps every answer body as short-lived cache; "forbidden" is the old
+    # keep-nothing posture. A judged forbidden (a licence that was read and says no) is always
+    # respected, and actions are never stored, whatever this says.
+    archive_default_policy: str = "transient"
     # The refresh worker (serve mode only): how often it scans for due keys, and how many
     # refresh calls ONE provider may spend per UTC day. A refresh is treg's own vendor spend with
     # no caller attached, so the cap is the brake — 0 disables refreshing without touching serving.

--- a/src/treg/web/archive-panel.html
+++ b/src/treg/web/archive-panel.html
@@ -221,7 +221,7 @@
         <table>
           <thead><tr>
             <th data-tip="The catalog endpoint. Only metered platform calls are observed — own-key traffic never enters the archive.">Endpoint</th>
-            <th data-tip="What the provider's licence allows. transient/archive = may be stored and served. forbidden (unjudged) = nobody has read the licence yet, so only statistics are counted. forbidden (judged) = the licence was read and it says no.">Policy</th>
+            <th data-tip="Storage policy. transient/archive = stored and servable (unjudged providers default to transient under the keep-all setting). forbidden (judged) = the licence was read and it says no; never stored.">Policy</th>
             <th data-tip="How long an answer is served before the vendor is asked again. Learned per key: unchanged answers stretch it ×1.5, changed answers halve it. Range = coldest to hottest key.">Learned TTL</th>
             <th data-tip="Of the times we re-asked the same question, how often the answer had actually changed. 0 = frozen data. 1 = changes every time (such keys mark themselves never-cache).">Change ratio</th>
             <th data-tip="Distinct questions observed for this endpoint.">Keys</th>
@@ -274,7 +274,7 @@
       return '<span class="pill p-transient" data-tip="The licence was read and allows storing. transient = short-lived cache; archive = long-term history too.">' + pol + '</span>';
     if (judged)
       return '<span class="pill p-never" data-tip="The licence was read and it forbids storing or sharing. Counted for statistics, never kept, never served.">forbidden (judged)</span>';
-    return '<span class="pill p-forbidden" data-tip="Nobody has judged this provider\'s licence yet, so the safe default applies: count statistics, keep nothing.">forbidden (unjudged)</span>';
+    return '<span class="pill p-forbidden" data-tip="Nobody has judged this provider\'s licence yet. Under the keep-all default these are still stored as transient; only a judged forbidden blocks storage.">forbidden (unjudged)</span>';
   }
 
   function renderReport(d) {

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -49,12 +49,22 @@ def test_serve_implies_recording(monkeypatch):
 # ---------------------------------------------------------------------------------------------
 # Policy: forbidden on every uncertain branch
 
-def test_policy_refuses_uncertainty():
-    assert policy(None) == "forbidden"
-    assert policy({}) == "forbidden"
-    assert policy({"kind": "read"}) == "forbidden"                  # unjudged license
-    assert policy({"cache": "everything"}) == "forbidden"           # unknown value
-    assert policy({"cache": {"mode": "keep"}}) == "forbidden"       # unknown value, dict form
+def test_policy_defaults():
+    # The founder's 2026-08-29 keep-all decision: an UNJUDGED entry defaults to transient.
+    assert policy(None) == "forbidden"                              # no entry: never
+    assert policy({}) == "forbidden"                                # empty ≈ no entry: never
+    assert policy({"kind": "read"}) == "transient"                  # unjudged license
+    assert policy({"cache": "everything"}) == "transient"           # unknown value
+    assert policy({"cache": {"mode": "keep"}}) == "transient"       # unknown value, dict form
+    # A judged forbidden is always respected, whatever the default says.
+    assert policy({"cache": "forbidden"}) == "forbidden"
+    assert policy({"cache": {"mode": "forbidden", "license_quote": "q"}}) == "forbidden"
+
+
+def test_keep_all_can_be_switched_off(monkeypatch):
+    monkeypatch.setattr(get_settings(), "archive_default_policy", "forbidden")
+    assert policy({"kind": "read"}) == "forbidden"
+    assert policy({"cache": "transient"}) == "transient"            # judged stays judged
 
 
 def test_policy_action_beats_license():
@@ -205,9 +215,9 @@ async def test_recorder_observes_a_metered_call(clients: AsyncClient, shadow):
     keys, snaps = await _rows()
     assert len(keys) == 1 and len(snaps) == 1
     assert keys[0].endpoint_id == EP and keys[0].provider == "tikhub"
-    # No cache field on this entry yet → policy forbidden → hash-only: counted, never kept.
-    assert keys[0].policy == "forbidden"
-    assert snaps[0].body is None and snaps[0].body_of is None
+    # No cache field on this entry → the keep-all default applies: bytes are stored.
+    assert keys[0].policy == "transient"
+    assert snaps[0].body is not None and snaps[0].body_of is None
     assert snaps[0].size_bytes > 0 and len(snaps[0].content_hash) == 64
     assert snaps[0].origin == "caller"
 
@@ -436,9 +446,10 @@ async def test_a_stale_snapshot_is_not_served(clients: AsyncClient, serve, monke
     assert r.status_code == 200 and "x-treg-cache" not in r.headers
 
 
-async def test_unjudged_policy_never_serves(clients: AsyncClient, platform_on, monkeypatch):
+async def test_default_forbidden_never_serves(clients: AsyncClient, platform_on, monkeypatch):
     monkeypatch.setattr(get_settings(), "archive_mode", "serve")
-    # EP carries no cache judgment here: recorded hash-only, and never served.
+    monkeypatch.setattr(get_settings(), "archive_default_policy", "forbidden")
+    # With keep-all switched off, an unjudged entry is recorded hash-only and never served.
     await clients.get(f"/call/{EP}?aweme_id=7")
     await archive.drain()
     r = await clients.get(f"/call/{EP}?aweme_id=7")


### PR DESCRIPTION
Founder decision: unjudged providers' answer bodies are stored (transient) by default; a judged forbidden stays forbidden, actions are never stored, and one env setting returns to keep-nothing without a deploy. Tests updated; panel tooltips and docs match. Suite: 2187 passed.