### PR TITLE
fix(routing): a provider that cannot express a supplied filter never wins on price

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1195,6 +1195,24 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   goes to a title-aware search, not a free domain-only one that would answer the whole company.
   Only caller-supplied keys count (`rank(given=…)`), never keys reached through `derive`. Price
   decides among equals.
+- **Ranking, dropped filters (2026-08-29)**: a candidate whose adapter cannot express a filter the
+  caller SENT ranks below every candidate that can — `len(candidate.ignored)` sits in `rank()`'s key
+  between specificity and price. It answers a LOOSER question, and a non-empty answer to the looser
+  question still passes `adapter.miss`, so cheapness alone must never buy it. Found live: a
+  `people.search` for `{q, title, location: "London, United Kingdom", country: GB}` went to the
+  cheapest child, which mapped neither geo filter, and returned people in Bengaluru and San
+  Francisco — reported as a hit, $0.0025, no signal to the caller. `ignored_filters()` is pure and
+  computed at PLANNING time (`routing/plan.py`), so the ranking and the per-attempt report read the
+  same set. The provider stays reachable: it still wins when nothing better is callable, and price
+  still decides among candidates that ignore equally much.
+  **Coverage caveat**: of 16 `people.search` children, only icypeas maps geo today, so the rule
+  currently floats one provider. lusha, crustdata, companyenrich and leadmagic all filter on
+  location upstream — their adapters just do not map it. Until they do, the rule is doing more work
+  than it should have to.
+- **The answer says what it ignored (2026-08-29)**: `ignored_filters` was on `_treg.tried[]` only,
+  which no caller reads. It is now also on `_treg` itself for the child that served and on an
+  `X-Treg-Ignored-Filters` response header, so an agent can post-filter, or say why the rows are
+  wrong, without walking the attempt list.
 - **people.\* sweep (2026-08-29)**: people.search 6 → 16 children (aviato dsl/simple, companyenrich
   scroll, crustdata, fiber-ai, leadsforge, leadmagic search + role-finder, findymail employees +
   domain — the last retagged from email.find, it returns a list), people.enrich 9 → 14 (aviato bulk,
@@ -1217,6 +1235,11 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   them under ALSO with the rest of the same-job endpoints that have no adapter; the search page's
   "+N more" points there. The routed row's example body and `/access` dry-run use the identity
   variant MOST children accept, and the dry-run tries every variant before saying "unservable".
+  That dry-run is ONE identity shape, so its drops are mostly "this adapter takes another identity",
+  not "your team cannot reach this provider" — `/access` used to label them "not available here",
+  which read as a missing key and sent a reader hunting for one (2026-08-29: aviato, callable on
+  treg's platform key and serving live calls, was listed as unavailable). It now names the shape and
+  gives each drop its own `why`.
 - **Coverage (2026-08-28)**: 74 routed capabilities = 80.9% of 30-day platform calls (88% was the
   routable ceiling). The per-capability ledger — what shipped with which children, what is 🚫 and
   why (one usable vendor, async task-post engines, identity-less feeds), and the 49 zero-traffic

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -17,7 +17,6 @@ the endpoint's job is to find the thing — bounded by `X-Treg-Route-Max-Cost` (
 
 from __future__ import annotations
 
-import re
 
 import json
 import logging
@@ -34,7 +33,7 @@ from ...domain.catalog import stats as endpoint_stats
 from ...domain.catalog import store as catalog_store
 from ...domain.catalog.routing.contracts import canonical_identity
 from ...domain.catalog.routing.plan import (
-    MAX_ERROR_FALLBACKS, Candidate, Plan, candidates_for, cost_at, rank,
+    MAX_ERROR_FALLBACKS, Candidate, Plan, candidates_for, cost_at, ignored_filters, rank,
 )
 from .resolve import _host_of, _marketplace_secret
 from .types import CallContext, CallFailure, GatewayFailed, ResolutionFailed, UpstreamResponse
@@ -196,7 +195,8 @@ async def build_plan(ep: dict, identity_given: dict, caller, options: RouteOptio
         price = 0 if tier != "platform" else cost_at(cv, identity)
         c = Candidate(endpoint=e, adapter=ad, variant=v, tier=tier, price_micro=price, hit_rate=st.get("hit_rate"),
                       ok_rate=st.get("ok_rate"), p50_ms=st.get("p50_ms"), last_ok_days=st.get("last_ok_days"),
-                      exhausted=(tier == "platform" and capacity_view.is_exhausted(e["provider"])))
+                      exhausted=(tier == "platform" and capacity_view.is_exhausted(e["provider"])),
+                      ignored=ignored_filters(ad, contract, identity))
         if tier == "platform" and not cat.platform_eligible(e):
             dropped.append({"endpoint_id": e["id"], "why": "not platform-eligible and no own key"})
             continue
@@ -284,9 +284,9 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
         query, body = cand.adapter.to_upstream(plan.identity, cand.variant)
         # A filter the caller sent that this adapter never mentions is silently NOT applied — say so
         # on the attempt (live 2026-08-29: `country: fr` reached icypeas as nothing, rows came from
-        # anywhere; the bench had post-filtered in the agent).
-        used = set(cand.adapter.in_map) | {n for e in (cand.adapter.in_expr or {}).values() for n in re.findall(r"[A-Za-z_]\w*", e)}
-        ignored = tuple(k for k in plan.contract.filters if plan.identity.get(k) not in (None, "") and k not in used)
+        # anywhere; the bench had post-filtered in the agent). Computed at planning time, where it
+        # also ranks the candidate down.
+        ignored = cand.ignored
         child = CallContext(input=_child_input(parent, cand.endpoint, query, body), call_ref=f"{parent.call_ref}:r{n}", meta=parent.meta)
         try:
             response = await execute_child(child, upstream_client)
@@ -366,12 +366,17 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
                        f"every candidate for {ep['id']} failed"})
     cand, doc, output, raw = winner
     served = cand.endpoint["id"]
+    # The rows answer a LOOSER question than the caller asked when the winner could not express a
+    # filter. It is on the attempt, but no caller reads `tried[]` — say it where the answer is, and
+    # on a header, or the agent post-filters nothing and never knows why the geography is wrong.
     body_out = {"output": output or {k: None for k in plan.contract.output}, "raw": doc,
                 "_treg": {"served_by": served, "provider": cand.endpoint["provider"], "tier": cand.tier,
                           "outcome": tried[-1].outcome, "tried": [t.view() for t in tried], "charged_micro": spent,
+                          **({"ignored_filters": list(cand.ignored)} if cand.ignored else {}),
                           **({"dropped": plan.dropped} if plan.dropped else {})}}
     _audit_parent(parent, ep, 200, spent, audit_client)
     return _json(body_out, 200, {"X-Treg-Served-By": served, "X-Treg-Providers-Tried": ",".join(t.provider for t in tried),
+                                 **({"X-Treg-Ignored-Filters": ",".join(cand.ignored)} if cand.ignored else {}),
                                  "X-Treg-Route-Outcome": tried[-1].outcome}), spent
 
 

--- a/src/treg/domain/catalog/routing/plan.py
+++ b/src/treg/domain/catalog/routing/plan.py
@@ -13,6 +13,13 @@ MAX_ERROR_FALLBACKS = 2
 MIN_HIT_SAMPLES = 50
 
 
+def ignored_filters(adapter: Adapter, contract: Contract, identity: dict[str, Any]) -> tuple[str, ...]:
+    """Filters the caller supplied that this adapter has no place for — the provider will answer a
+    LOOSER question than the one asked. Pure, and knowable before the call, so ranking can use it."""
+    used = set(adapter.in_map) | {n for e in (adapter.in_expr or {}).values() for n in re.findall(r"[A-Za-z_]\w*", e)}
+    return tuple(k for k in (contract.filters or ()) if identity.get(k) not in (None, "") and k not in used)
+
+
 def cost_at(cost_view: dict | None, request: dict | None = None) -> int | None:
     """Micro-USD this request will cost at its requested size (plan §3, bench 08-27): per-result
     prices × the requested `limit` (default 1 for a lookup); flat per-call/per-success as listed;
@@ -49,6 +56,7 @@ class Candidate:
     last_ok_days: int | None
     exhausted: bool = False
     note: str = ""
+    ignored: tuple[str, ...] = ()     # caller filters this adapter cannot express (ranks it down)
 
     @property
     def expected_cost_per_hit(self) -> float:
@@ -72,7 +80,8 @@ class Candidate:
                 "identity": list(self.variant), "price_micro": self.price_micro,
                 "expected_cost_per_hit_micro": (None if self.expected_cost_per_hit == float("inf") else int(self.expected_cost_per_hit)),
                 "hit_rate": self.hit_rate, "ok_rate": self.ok_rate, "p50_ms": self.p50_ms,
-                "confidence": self.confidence, "exhausted": self.exhausted, **({"note": self.note} if self.note else {})}
+                "confidence": self.confidence, "exhausted": self.exhausted, **({"note": self.note} if self.note else {}),
+                **({"ignored_filters": list(self.ignored)} if self.ignored else {})}
 
 
 @dataclass
@@ -118,7 +127,13 @@ def rank(candidates: list[Candidate], *, prefer: list[str] | None = None, exclud
         # would return the whole company (live 2026-08-29: a free domain-only provider won and
         # answered 100 unnamed rows). Price decides among candidates of equal specificity.
         specificity = -covers(c.variant) if given else 0
-        return (own, pref, specificity, c.expected_cost_per_hit, c.p50_ms if c.p50_ms is not None else 10**9,
+        # A provider that cannot express a filter the caller SENT answers a looser question, and a
+        # non-empty answer to the looser question still counts as a hit — so it must never win on
+        # price alone (live 2026-08-29: `{q, title, location: London, country: GB}` went to the
+        # cheapest candidate, which dropped both geo filters and returned people in Bengaluru and
+        # San Francisco). It stays reachable, just last among equals.
+        return (own, pref, specificity, len(c.ignored), c.expected_cost_per_hit,
+                c.p50_ms if c.p50_ms is not None else 10**9,
                 c.last_ok_days if c.last_ok_days is not None else 10**6, c.endpoint["id"])
     return sorted(keep, key=key)
 

--- a/src/treg/routers/call.py
+++ b/src/treg/routers/call.py
@@ -198,9 +198,17 @@ async def catalog_endpoint_access(
         first = plan.candidates[0]
         how = ("your registered tool" if first.tier == "tool" else "your own credential" if first.tier == "credential"
                else f"treg's {first.endpoint['provider']} key, ~${(first.price_micro or 0) / 1e6:g}")
+        # The plan above is for ONE identity shape — the endpoint's example body. Most drops are
+        # "this adapter takes a different identity", not "your team cannot reach this provider";
+        # labelling them "not available here" read as no-key and sent a reader hunting for a
+        # missing credential (2026-08-29). Name the shape, and give each drop its reason.
+        dropped_note = ""
+        if plan.dropped:
+            dropped_note = ("; for this {" + ", ".join(plan.variant) + "} example, not usable: "
+                            + ", ".join(f"{d['endpoint_id']} ({d['why']})" for d in plan.dropped))
         return {"tier": "routed", "detail": f"routed — {len(plan.candidates)} providers callable now; first: "
                                             f"{first.endpoint['id']} on {how} (send {{{', '.join(first.variant)}}})"
-                                            + (f"; not available here: {', '.join(d['endpoint_id'] for d in plan.dropped)}" if plan.dropped else ""),
+                                            + dropped_note,
                 "plan": [c.view() for c in plan.candidates], "dropped": plan.dropped}
     provider = oauth_providers.get(service)
     if provider is None or not provider.base_url:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -721,3 +721,46 @@ def test_a_provider_that_cannot_express_a_supplied_filter_ranks_last_among_equal
     assert "country" in ignored_filters(cat.adapters["aviato.people.search"], contract, ident)
     assert ignored_filters(cat.adapters["icypeas.people.search"], contract, ident) == (), \
         "icypeas is the only people.search adapter that maps geo — the rule must float it to the top"
+
+
+async def test_the_geo_aware_child_wins_a_filtered_search_and_the_answer_says_what_was_dropped(
+    clients: AsyncClient, enrichment_on, monkeypatch
+):
+    """End to end on the real people.search ladder: the caller sends geo, so the child that maps it
+    is called even though a CHEAPER one is callable — and when the winner drops a filter, the
+    envelope and a header say so, where a caller will see it (not buried in `tried[]`).
+
+    Live 2026-08-29 this went to aviato ($0.0025, maps neither `country` nor `location`) and came
+    back with people in Bengaluru and San Francisco for a London brief, reported as a hit."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_ICYPEAS", "PLATFORM-ICYPEAS-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "hunter,tomba,leadmagic,leadsforge,findymail,aviato,fiber-ai,icypeas")
+    get_settings.cache_clear()
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, {"leads": [{"firstname": "Aleksei", "lastname": "Strizhak", "lastJobTitle": "Senior Backend Engineer",
+                                       "address": "London Area, United Kingdom", "profileUrl": "https://linkedin.com/in/as"}]})],
+         "*": [(200, {"persons": []})] * 12}, seen))
+    r = await clients.post("/call/treg.people.search",
+                           json={"q": "backend engineer", "title": "Backend Engineer",
+                                 "location": "London, United Kingdom", "country": "GB", "limit": 15})
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["_treg"]["served_by"] == "icypeas.people.search", \
+        "the child that maps country/location leads, though the cheaper geo-blind aviato is callable"
+    assert seen == [("icypeas", "POST", {}, {"query": {"currentJobTitle": {"include": ["Backend Engineer"]},
+                                                      "location": {"include": ["London, United Kingdom"]}},
+                                             "pagination": {"size": 15}})], \
+        "one call, and the geography actually reached the provider"
+    assert "ignored_filters" not in d["_treg"] and "X-Treg-Ignored-Filters" not in r.headers
+
+    # …and when the winner cannot express a filter, the answer says which — envelope, header, attempt
+    seen2 = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"*": [(200, {"items": [{"fullName": "Ada L", "URLs": {"linkedin": "linkedin.com/in/al"}}], "count": {"value": 1}})] * 12}, seen2))
+    r2 = await clients.post("/call/treg.people.search", json={"q": "backend engineer", "country": "GB", "limit": 15})
+    assert r2.status_code == 200, r2.text
+    d2 = r2.json()
+    assert d2["_treg"]["served_by"] == "aviato.people.search", "no geo-aware child answers a {q}-only brief here"
+    assert d2["_treg"]["ignored_filters"] == ["country"], "the caller sent it; aviato has no place for it"
+    assert r2.headers["X-Treg-Ignored-Filters"] == "country"
+    assert d2["_treg"]["tried"][-1]["ignored_filters"] == ["country"], "same set in all three places"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -695,3 +695,29 @@ def test_rank_prefers_the_candidate_that_uses_more_of_the_identity():
     hunter = cand("hunter.people.email.find", ("first_name", "last_name", "domain"), 4_900)
     apollo = cand("apollo.people.enrich", ("full_name", "domain"), 26_000)
     assert rank([apollo, hunter], given={"full_name", "domain"}, derive=derive)[0] is hunter
+
+
+def test_a_provider_that_cannot_express_a_supplied_filter_ranks_last_among_equals():
+    """Live 2026-08-29: `{q, title, location: London, country: GB}` went to the cheapest candidate,
+    which had no place for either geo filter, and returned people in Bengaluru and San Francisco —
+    reported as a hit. Cheapness must not buy an answer to a looser question."""
+    from treg.domain.catalog.routing.plan import Candidate, ignored_filters, rank
+    def cand(eid, price, ignored=()):
+        return Candidate(endpoint={"id": eid, "provider": eid.split(".")[0], "cost": {"type": "per_result"}},
+                         adapter=None, variant=("q",), tier="platform", price_micro=price, hit_rate=None,
+                         ok_rate=None, p50_ms=None, last_ok_days=None, ignored=ignored)
+    geo_blind = cand("aviato.people.search", 2_500, ignored=("country", "location"))
+    geo_aware = cand("icypeas.people.search", 5_700)
+    assert [c.endpoint["id"] for c in rank([geo_blind, geo_aware], given={"q"})] == [
+        "icypeas.people.search", "aviato.people.search"], "the dearer provider that honours the filters leads"
+    # still reachable when it is the only candidate, and price still decides among equals
+    assert rank([geo_blind], given={"q"})[0] is geo_blind
+    assert rank([geo_blind, cand("z.people.search", 9_000, ignored=("country", "location"))], given={"q"})[0] is geo_blind
+
+    # and the set itself is read off the adapter's input map, not guessed
+    cat = catalog_store.load()
+    contract = cat.contracts["people.search"]
+    ident = {"q": "backend engineers", "country": "GB", "location": "London, United Kingdom", "limit": 15}
+    assert "country" in ignored_filters(cat.adapters["aviato.people.search"], contract, ident)
+    assert ignored_filters(cat.adapters["icypeas.people.search"], contract, ident) == (), \
+        "icypeas is the only people.search adapter that maps geo — the rule must float it to the top"


### PR DESCRIPTION
Found by running [LessieAI/people-search-bench](https://github.com/LessieAI/people-search-bench) through the shipped router — 8 calibration queries, \$0.64 of real spend.

## The bug

A `people.search` for `{q, title, location: "London, United Kingdom", country: GB}` routed to the cheapest child, which maps neither geo filter:

```
Kiran Bandreddi   |  |  | Cary, North Carolina, United States
Gretchen Tuscher  |  |  | San Francisco, California
Mandeep Cheema    |  |  | Gurugram, Haryana, India
```

Zero in London. Reported `outcome: hit`, charged \$0.0025, told the caller nothing. All 3 recruiting calibration queries did this.

`rank()`'s specificity tiebreak counts **identity** keys only, so `country` and `location` never entered the decision — aviato covers `{q}` exactly as well as a geo-aware provider and is cheaper, so it won. `ignored_filters` was already reported honestly on the attempt; nothing acted on it.

## Three fixes

1. **`rank()` puts `len(candidate.ignored)` between specificity and price.** A candidate that answers a *looser* question than the one asked ranks below every candidate that answers the asked one. It stays reachable when nothing better is callable, and price still decides among candidates that ignore equally much. `ignored_filters()` moves into `routing/plan.py` — pure, computed at planning time, so ranking and the per-attempt report read one set (`route.py` now reuses it instead of recomputing).

2. **The answer says what it ignored.** `ignored_filters` was on `_treg.tried[]`, which no caller reads. It is now also on `_treg` for the child that served, and on an `X-Treg-Ignored-Filters` response header — so an agent can post-filter, or explain why the rows are wrong, instead of trusting them.

3. **`/access` stops calling a drop "not available here".** That dry-run is ONE identity shape, so most drops mean *"this adapter takes another identity"*, not *"your team cannot reach this provider"*. aviato — callable on treg's platform key, serving live calls — was listed as unavailable, which reads as a missing credential and sends a reader hunting for one. It now names the shape and gives each drop its own `why`.

## Effect

For the bench query, against the live catalog:

| | before | after |
|---|---|---|
| 1st | aviato.people.search \$0.0025, drops `country`+`location` | **icypeas.people.search \$0.0057, drops nothing** |
| 2nd | icypeas … | aviato … |

The dearer provider that honours the filters now leads.

## Coverage caveat — documented, not fixed

Of the 16 `people.search` children, **only icypeas maps geo at all**, so this rule currently floats exactly one provider. lusha, crustdata, companyenrich and leadmagic all filter on location upstream — their adapters just do not map it. Worth a follow-up; the rule is doing more work than it should have to.

## Tests

- New regression test in `tests/test_routing.py`: the geo-blind cheap provider ranks second, is still reachable alone, price still decides among equals, and `ignored_filters()` is read off the adapter's input map rather than guessed.
- `tests/test_routing.py` + `tests/test_agent_pages.py`: 159 passed. Full suite: 2246 passed, 1 pre-existing unrelated deselect.
- Docs fragment `architecture/catalog.md` updated in the same commit per `drift.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01189rW3MxcaVTPqxqSZTQot