### PR TITLE
fix(archive): drain busy-spin starved the event loop — the serial Postgres CI hang

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -113,10 +113,9 @@ call, body already in memory" is a fact, which IS eligibility gate 3. Metered 2x
 `X-Treg-Cache`-style serve headers do not exist yet. `archive.record()` is fire-and-forget with
 audit's discipline: bounded pending set (512), failures swallowed with a log line, `drain()` on
 shutdown (bootstrap) and in tests. A recorder crash cannot fail a call (tested). `drain()` removes
-the tasks it gathered itself rather than waiting on their done callbacks: a callback runs one loop
-iteration after its task, while awaiting a gather of finished tasks returns without yielding — a
-loop keyed on the callback busy-spins and starves the event loop, timers included (the 2026-08
-serial-Postgres CI hang; regression-tested).
+the tasks it gathered itself rather than waiting on their done callbacks — audit's exact drain
+discipline; the busy-spin both avoid (the 2026-08 serial-Postgres CI hang) is explained and pinned
+for both modules in `tests/test_audit.py`.
 
 **Counted vs kept.** Statistics and the raw-body `content_hash` are recorded for every observed
 answer (a hash is an identity, not the content); body BYTES are kept only when the entry's cache

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -112,7 +112,11 @@ Hooked in `call_tool` immediately after `_buffer_response` — the one line wher
 call, body already in memory" is a fact, which IS eligibility gate 3. Metered 2xx only; the
 `X-Treg-Cache`-style serve headers do not exist yet. `archive.record()` is fire-and-forget with
 audit's discipline: bounded pending set (512), failures swallowed with a log line, `drain()` on
-shutdown (bootstrap) and in tests. A recorder crash cannot fail a call (tested).
+shutdown (bootstrap) and in tests. A recorder crash cannot fail a call (tested). `drain()` removes
+the tasks it gathered itself rather than waiting on their done callbacks: a callback runs one loop
+iteration after its task, while awaiting a gather of finished tasks returns without yielding — a
+loop keyed on the callback busy-spins and starves the event loop, timers included (the 2026-08
+serial-Postgres CI hang; regression-tested).
 
 **Counted vs kept.** Statistics and the raw-body `content_hash` are recorded for every observed
 answer (a hash is an identity, not the content); body BYTES are kept only when the entry's cache

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -221,6 +221,9 @@ def record(
         caller_body=caller_body, headers=headers, status_code=status_code,
         media_type=media_type, body=body, origin=origin), timeout=_STORE_TIMEOUT_S))
     _pending.add(task)
+    # NOT redundant with drain()'s own removal: on a running server drain() never fires, and this
+    # callback is the only exit from `_pending` — without it the set fills to _MAX_PENDING and
+    # record() sheds every recording from then on.
     task.add_done_callback(_pending.discard)
 
 
@@ -230,13 +233,10 @@ async def drain() -> None:
     while _pending:
         tasks = list(_pending)
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        # Remove what was just gathered HERE, without yielding. The `_pending.discard` done
-        # callback runs a loop iteration after its task finishes — and awaiting a gather of
-        # already-finished tasks returns synchronously, without yielding. Entered in that window
-        # (task done, callback still queued), a loop keyed on the callback re-gathers the same
-        # completed set forever without ever reaching the scheduler, starving the whole event
-        # loop — timers included, so no timeout can break it. That busy-spin is what hung CI's
-        # serial Postgres job at `await archive.drain()` five times (2026-08-28/29).
+        # Remove what was just gathered HERE: a gather of already-finished tasks returns without
+        # yielding, so the queued `_pending.discard` callbacks may not have run yet, and a loop
+        # keyed on them busy-spins forever, starving the loop and every timer on it (the 2026-08
+        # serial-Postgres CI hang). Same discipline as audit.drain(); test_audit.py pins both.
         _pending.difference_update(tasks)
         for r in results:
             if isinstance(r, asyncio.TimeoutError | TimeoutError):

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -228,7 +228,16 @@ async def drain() -> None:
     """Flush in-flight recordings — shutdown and tests. Bounded: every task carries its own
     _STORE_TIMEOUT_S, so this cannot wait longer than the slowest permitted recording."""
     while _pending:
-        results = await asyncio.gather(*list(_pending), return_exceptions=True)
+        tasks = list(_pending)
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        # Remove what was just gathered HERE, without yielding. The `_pending.discard` done
+        # callback runs a loop iteration after its task finishes — and awaiting a gather of
+        # already-finished tasks returns synchronously, without yielding. Entered in that window
+        # (task done, callback still queued), a loop keyed on the callback re-gathers the same
+        # completed set forever without ever reaching the scheduler, starving the whole event
+        # loop — timers included, so no timeout can break it. That busy-spin is what hung CI's
+        # serial Postgres job at `await archive.drain()` five times (2026-08-28/29).
+        _pending.difference_update(tasks)
         for r in results:
             if isinstance(r, asyncio.TimeoutError | TimeoutError):
                 _log.warning("archive recording dropped: database did not answer in %ss",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -293,6 +293,30 @@ async def test_a_recorder_crash_never_fails_the_call(clients: AsyncClient, shado
     await archive.drain()
 
 
+async def test_drain_entered_between_completion_and_its_callbacks_returns():
+    """The busy-spin that hung CI's serial Postgres job five times (2026-08-28/29).
+
+    A finished task leaves `_pending` via its done callback, which runs one loop iteration
+    AFTER completion — while awaiting a gather of already-finished tasks returns synchronously,
+    without yielding. Entered in that window, a drain keyed on the callback re-gathers the same
+    completed set forever and starves the loop (timers included, so no timeout breaks it).
+    The scheduling below opens that exact window deterministically: create_task queues the
+    task's step, sleep(0) queues this coroutine's resume behind it, and the task's discard
+    callback lands behind the resume — so drain() starts with the task done but still pending."""
+    import asyncio
+
+    async def instant():
+        return None
+
+    t = asyncio.create_task(instant())
+    archive._pending.add(t)
+    t.add_done_callback(archive._pending.discard)
+    await asyncio.sleep(0)
+    assert t.done() and t in archive._pending    # the window is open, or this test proves nothing
+    await archive.drain()                        # the old drain never returned from here
+    assert t not in archive._pending
+
+
 # ---------------------------------------------------------------------------------------------
 # The catalog cache field (PR 3): one judgment at the file header covers the provider
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -293,30 +293,6 @@ async def test_a_recorder_crash_never_fails_the_call(clients: AsyncClient, shado
     await archive.drain()
 
 
-async def test_drain_entered_between_completion_and_its_callbacks_returns():
-    """The busy-spin that hung CI's serial Postgres job five times (2026-08-28/29).
-
-    A finished task leaves `_pending` via its done callback, which runs one loop iteration
-    AFTER completion — while awaiting a gather of already-finished tasks returns synchronously,
-    without yielding. Entered in that window, a drain keyed on the callback re-gathers the same
-    completed set forever and starves the loop (timers included, so no timeout breaks it).
-    The scheduling below opens that exact window deterministically: create_task queues the
-    task's step, sleep(0) queues this coroutine's resume behind it, and the task's discard
-    callback lands behind the resume — so drain() starts with the task done but still pending."""
-    import asyncio
-
-    async def instant():
-        return None
-
-    t = asyncio.create_task(instant())
-    archive._pending.add(t)
-    t.add_done_callback(archive._pending.discard)
-    await asyncio.sleep(0)
-    assert t.done() and t in archive._pending    # the window is open, or this test proves nothing
-    await archive.drain()                        # the old drain never returned from here
-    assert t not in archive._pending
-
-
 # ---------------------------------------------------------------------------------------------
 # The catalog cache field (PR 3): one judgment at the file header covers the provider
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,13 +1,22 @@
-"""The audit queue's drain discipline."""
+"""The fire-and-forget drain discipline — audit and archive carry twin copies of it."""
 
 import asyncio
 import subprocess
 import sys
 
-from treg import audit
+import pytest
+
+from treg import archive, audit
+
+# Two hand-copied implementations of the same pending-set/drain pattern (archive documents itself
+# as "audit's discipline"), so both are pinned here: archive copied audit's drain BEFORE the
+# busy-spin fix landed in audit, and the stale copy went on wedging CI for a day after audit was
+# already safe. A shared pin is what keeps the twins from diverging again.
+_MODULES = [audit, archive]
 
 
-async def test_drain_exits_when_a_finished_task_lingers_in_the_pending_set():
+@pytest.mark.parametrize("mod", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+async def test_drain_exits_when_a_finished_task_lingers_in_the_pending_set(mod):
     """The CI livelock shape: a completed task still in `_pending` with no removal callback coming.
 
     Awaiting a gather of already-complete tasks never suspends (Python ≥3.10 gather returns a done
@@ -20,12 +29,13 @@ async def test_drain_exits_when_a_finished_task_lingers_in_the_pending_set():
 
     task = asyncio.create_task(_noop())
     await task
-    audit._pending.add(task)
-    await asyncio.wait_for(audit.drain(), timeout=5)
-    assert task not in audit._pending
+    mod._pending.add(task)
+    await asyncio.wait_for(mod.drain(), timeout=5)
+    assert task not in mod._pending
 
 
-def test_drain_livelock_regression_fails_instead_of_wedging():
+@pytest.mark.parametrize("name", ["audit", "archive"])
+def test_drain_livelock_regression_fails_instead_of_wedging(name):
     """Run the same shape in a subprocess with a parent-side deadline.
 
     A regression here livelocks the event loop at ~100% CPU, starving every in-process watchdog —
@@ -33,16 +43,16 @@ def test_drain_livelock_regression_fails_instead_of_wedging():
     bug presented on CI; a reintroduction must fail in seconds instead.
     """
     program = (
-        "import asyncio\n"
-        "from treg import audit\n"
+        f"import asyncio\n"
+        f"from treg import {name} as mod\n"
         "async def main():\n"
         "    async def _noop():\n"
         "        return None\n"
         "    task = asyncio.create_task(_noop())\n"
         "    await task\n"
-        "    audit._pending.add(task)\n"
-        "    await audit.drain()\n"
-        "    assert not audit._pending\n"
+        "    mod._pending.add(task)\n"
+        "    await mod.drain()\n"
+        "    assert not mod._pending\n"
         "asyncio.run(main())\n"
     )
     result = subprocess.run(


### PR DESCRIPTION
## The bug

CI's serial Postgres job hung five times over 2026-08-28/29, always at some `await archive.drain()`, always dumping the same stack (`gather` ← `archive.py drain`), always silent for the full 15-minute job timeout. Three prior patches (drain around reset_db, session-scoped loop, a 30s per-recording `wait_for`) treated it as a database problem and didn't stop it.

It is not a database problem. `drain()` was a **pure-asyncio busy-spin**:

1. A finished task leaves `_pending` via its `discard` done callback — which the loop runs **one iteration after** the task completes.
2. `await asyncio.gather(...)` over tasks that are **already finished** returns synchronously, **without yielding** (`Future.__await__` short-circuits on a done future).
3. So a drain entered in the window between a recording's completion and its callback re-gathers the same completed set forever, never reaches the scheduler, and **starves the entire event loop — timers included**. That is why the 30-second `wait_for` bound never fired and why the hang produced zero output: no timeout can break a loop that never yields.

The window is deterministic scheduling, not luck: a test that calls `drain()` immediately after the `await clients.get(...)` that produced the recording steps straight into it. Slow 2-core CI runners bunch task completions together, which is why CI hit it and fast local machines almost never did.

## Diagnosis trail (why the DB theories were ruled out)

- The hung runs logged **zero** "recording dropped" warnings in 300s → the 30s timer never ran → the loop wasn't running → busy-spin, not blocked I/O.
- A live-lock experiment showed Postgres's deadlock detector kills a genuine TRUNCATE-vs-open-transaction cycle in ~1s — a real DB deadlock cannot hang for 5 minutes.
- Cancellation experiments (cancel mid-transaction, cancel during a lock wait) showed SQLAlchemy+asyncpg cleans up correctly — no leaked idle-in-transaction connections.
- A 15-line reproduction of the callback window hangs the old `drain()` in seconds with **the exact stack CI dumped**, and passes in 0.05s with the fix.

## The fix

`drain()` removes the tasks it just gathered itself (`_pending.difference_update(tasks)`), on the spot, instead of depending on done callbacks that the spin itself prevents from running. The `discard` callback stays as the no-drain-path cleanup; it is idempotent.

The regression test opens the exact window deterministically (create_task → `sleep(0)` → task done but still pending) and asserts the precondition, so it fails loudly rather than silently testing nothing if scheduling semantics ever change.

## Verification

- New regression test: hangs the old code (faulthandler dumps the CI stack), passes with the fix.
- CI's serial Postgres list, run locally against postgres:16: **503 passed**.
- Default suite: **2317 passed, 4 skipped**.
- `docs/context/architecture/archive.md` updated in the same commit (drift.sh).

## Intentional behavior changes

None beyond the fix itself: `drain()` still waits for every in-flight recording; it just terminates.

## Note for a follow-up

The `pg_stat_activity` diagnostic step added in 4ac7a0f is `if: failure()` — a job killed by `timeout-minutes` is *cancelled*, not failed, so it has never run. `if: failure() || cancelled()` would make it fire on the next hang. Left out of this PR to keep it single-purpose.