### PR TITLE
feat(routing): the contract can say what the brief says, and a thin answer is not the end

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1275,6 +1275,17 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   work, not from routing — which is also why a `git revert` of #242 would be the wrong instrument). It exists because "does the router answer well" and "should every agent be led to it by
   default" are separate questions: the bench answered the first (55.4 → 69.2 on recruiting, parity
   with a hand-written policy), and only traffic can answer the second.
+- **creators.search routed (2026-08-29)**: the capability that most needed it and never had it. Two
+  providers answer "find creators" and they are not comparable: influencersclub takes `location`,
+  `keywords_in_bio` and `number_of_followers {min,max}` as REAL filters and returns followers,
+  engagement and location inline; `exa.creators.search` takes a sentence and returns a URL and a
+  title. Unrouted, an agent picks one blind. On the bench it picked exa, then made **115
+  `instagram.user.profile` calls** checking follower counts by hand, discarded everyone it could not
+  confirm, and returned 1 row where the hand-written pipeline returned 15 qualified — influencer was
+  the ONLY category the agent lost (54.4 vs the pipeline's 60.2). With the contract, exa reports
+  `ignored_filters: [platform, followers_min, followers_max]` and ranks below a provider that can
+  express them. `followers_min`/`followers_max` are contract filters because an audience band is the
+  constraint a creator brief almost always carries, and the one a URL-only result cannot answer.
 - **What is not routed on purpose**: `*.bulk` endpoints (a routed call is one subject, one answer),
   and providers whose rows are teasers — hunter multi-domain (masked, no names, ignores limit),
   apollo people.search (free, but last names obfuscated: a search→reveal CHAIN, which mode C of the

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1209,6 +1209,35 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   currently floats one provider. lusha, crustdata, companyenrich and leadmagic all filter on
   location upstream — their adapters just do not map it. Until they do, the rule is doing more work
   than it should have to.
+- **A contract that cannot say what the brief says (2026-08-29)**: `people.search` exposed only
+  `{q, company_domain, title, full_name}` + `{country, location, limit}`, while icypeas natively
+  filters on `keyword`, `skills`, `pastJobTitle`, `school`, `languages` and
+  `totalYearsOfExperience`. And `q` is IDENTITY, so when icypeas matched the `{title}` variant the
+  free text was never sent — a routed search for "backend developers in London with microservices"
+  reached the provider as `title + location`, with the requirement dropped. Every failing bench
+  query had this shape ("football scouting analysts" → `title="Football Analyst"`, 15 rows, 0
+  qualified). `keywords` is now a FILTER (filters always travel; identity does not) mapped to
+  icypeas `query.keyword.include`, leadsforge's keyword field, and folded into exa's semantic query.
+  Measured on the bench's 30 recruiting briefs: **55.4 → 69.2 overall** (nDCG@10 51.2 → 64.3,
+  coverage 49.7 → 68.1), failing queries 8 → 2.
+  A `titles` list filter was tried at the same time and **REVERTED**: paired over the same 30
+  queries it cost −0.068 ± 0.022 (95% CI [−0.112, −0.024]). Broader title variants ("Software
+  Engineer" for a backend brief) buy recall the metric does not want and lose precision.
+- **min_results, and why it is bounded (2026-08-29)**: `X-Treg-Route-Min-Results: N` records a hit
+  with fewer than N rows as `weak` and keeps going, returning the fullest answer seen. It is what
+  the hand-written bench policy did (`if len(rows) < 3 -> semantic fallback`) and the routed path
+  could not express. Unbounded it is ruinous on LOOKUP briefs, whose honest answer IS one person:
+  nothing ever clears the bar, so every call pays the whole ladder — the bench's deterministic set
+  went **$1.76 → $22.35 over 28 queries, 12.7x**, for answers that were already right. Bounded at
+  `MAX_WEAK_FALLBACKS = 2`, mirroring the error fallback, the same set costs ~$0.39 — cheaper than
+  the baseline — and recruiting keeps its gain (it never needed more than one fall-through).
+  Pair it with `X-Treg-Route-Max-Cost` on any capability where thin answers are normal.
+- **Routed parity with a hand-written policy (2026-08-29)**: after the two changes above, paired
+  over the same 30 recruiting briefs against the 08-27 hand-written icypeas policy, the routed path
+  is indistinguishable — nDCG@10 −2.40 (95% CI [−7.12, +2.33]), utility −0.80 ([−3.10, +1.51]),
+  qualified/query −0.53 ([−1.84, +0.77]) — and ahead of the published Lessie 68.2, Exa 64.7 and
+  Claude Code 50.5. The remaining differences are agent-side, not routing: the hand-written policy
+  post-filtered rows on location and over-fetched (`size: 20`, trimmed to 15).
 - **The answer says what it ignored (2026-08-29)**: `ignored_filters` was on `_treg.tried[]` only,
   which no caller reads. It is now also on `_treg` itself for the child that served and on an
   `X-Treg-Ignored-Filters` response header, so an agent can post-filter, or say why the rows are

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -647,7 +647,9 @@ the entire point of giving them a scoped token.
 
 ### The per-org daily cap has two owners
 
-`Org.daily_cap_micro` is the team's own ceiling; `platform_daily_cap_usd` is ours. The effective cap is
+`Org.daily_cap_micro` is the team's own ceiling; `platform_daily_cap_usd` is ours (**$500/day**
+since 2026-08-29 — at $100 a normal agent workload tripped it while the team still held balance).
+The effective cap is
 `min(the two)` (`api._effective_daily_cap`). A team may lower theirs freely and see it at
 `GET /orgs/{id}/settings` — a limit nobody can see becomes a support ticket the first time an agent
 trips it. Raising past our ceiling is **refused, not clamped**: a builder who thinks they set $500/day

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -809,3 +809,25 @@ The overflow child (`application.call.overflow`) is an ordinary metered cycle on
 and `cost_source: "aggregator"` + `served_via` in the ledger `meta`, so `reconcile` needs no join.
 `OverflowSpend` (per aggregator per UTC day) is updated inside that same settle transaction; it is
 accounting for the $20/day budget, not a balance. Shadow mode places no hold and charges nothing.
+
+## A per_success miss the adapter cannot see (2026-08-29)
+
+`per_success` settles at the estimate unless something can say "this body is a miss". The routing
+adapter's predicate covers routed children — but **1330 of 1517** per_success endpoints have no
+adapter, and they are the scrapers, whose failure mode IS an HTTP 200 carrying an error code.
+
+Those providers publish a success rule and the catalog already records it as `expect`
+(`{json_path, equals}`), read until now only by `scripts/catalog_verify.py`. `settle.py` consults it
+when no adapter applies, and `store.py` carries it onto the endpoint — including inherited from the
+provider FILE, the way `cache` already is, because a vendor's "HTTP 200 always, read `code`"
+convention is one fact about the whole provider and an ingest that adds routes must not ship them
+ruleless (33 of justoneapi's 260 were).
+
+Found live: `justoneapi.x.linkedin-search-user-v1` answered `{"code": 301, "message": "COLLECT
+FAILED, SEND REQUEST AGAIN"}` — free on the vendor's own published terms ("only a code-0 response is
+billed") — and treg settled $0.0295 against the caller. Adapter first, `expect` second, estimate
+last; an undecidable rule still settles at the estimate rather than guessing in the caller's favour.
+
+STILL OPEN: tikhub's 919 per_success endpoints have neither an adapter nor an `expect` anywhere.
+That is the larger half of the exposure and needs its success convention verified against the
+vendor's docs before a file-level rule is written.

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -70,15 +70,17 @@ WATERFALL_HEADER = "x-treg-route-waterfall"
 MAX_COST_HEADER = "x-treg-route-max-cost"
 PREFER_HEADER = "x-treg-route-prefer"
 EXCLUDE_HEADER = "x-treg-route-exclude"
+MIN_RESULTS_HEADER = "x-treg-route-min-results"
 _DROP_FROM_CHILD = frozenset({b"content-length", b"content-type", b"transfer-encoding", b"idempotency-key",
                               b"x-treg-route-waterfall", b"x-treg-route-max-cost", b"x-treg-route-prefer",
-                              b"x-treg-route-exclude", b"host"})
+                              b"x-treg-route-exclude", b"x-treg-route-min-results", b"host"})
 _CALLER_FAULT = frozenset({400, 401, 403, 404, 405, 409, 422})
 _CANDIDATE_LOCAL_FAILURES = frozenset({"tool_access_denied", "policy_denied", "capability_pinned"})
 _GLOBAL_REFUSALS = frozenset({"insufficient_balance", "tag_spend_cap_reached",
                               "platform_daily_cap_reached", "daily_cap_reached"})
 
 
+MAX_WEAK_FALLBACKS = 2   # extra providers asked after a thin-but-real answer (see min_results)
 CHEAP_RETRY_MICRO = 10_000  # ≤ 1¢: a per_call provider cheap enough to be asked after another's 4xx
 
 
@@ -102,6 +104,7 @@ class RouteOptions:
     max_cost_micro: int | None = DEFAULT_MAX_COST_MICRO
     prefer: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
+    min_results: int = 1     # a hit with fewer rows than this is WEAK: keep looking, keep the best
 
     @classmethod
     def from_headers(cls, get, default_max_cost_micro: int | None = None) -> "RouteOptions":
@@ -115,8 +118,14 @@ class RouteOptions:
             raise ResolutionFailed("catalog_parameter_invalid", status_code=400,
                                    detail=f"{MAX_COST_HEADER} must be a USD number, got {mc!r}")
         wf = str(get(WATERFALL_HEADER) or "").strip().lower()
+        try:
+            mr = max(1, int(get(MIN_RESULTS_HEADER) or 1))
+        except ValueError:
+            raise ResolutionFailed("catalog_parameter_invalid", status_code=400,
+                                   detail=f"{MIN_RESULTS_HEADER} must be a whole number, got {get(MIN_RESULTS_HEADER)!r}")
         return cls(waterfall=wf not in ("0", "false", "no", "off"),
-                   max_cost_micro=max_cost, prefer=_list(get(PREFER_HEADER)), exclude=_list(get(EXCLUDE_HEADER)))
+                   max_cost_micro=max_cost, prefer=_list(get(PREFER_HEADER)), exclude=_list(get(EXCLUDE_HEADER)),
+                   min_results=mr)
 
 
 class _Bytes:
@@ -272,6 +281,8 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
     errors = 0
     rejected_by: set[str] = set()  # providers that answered a vendor 4xx
     winner: tuple[Candidate, dict, dict, bytes] | None = None
+    weak_hits = 0
+    best: tuple[int, tuple[Candidate, dict, dict, bytes]] | None = None   # best WEAK answer seen
     for n, cand in enumerate(plan.candidates):
         if options.max_cost_micro is not None and spent + (cand.price_micro or 0) > options.max_cost_micro:
             tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "skipped", None, 0, "would exceed max cost"))
@@ -346,11 +357,34 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
                 continue
             winner = (cand, doc if doc is not None else {}, {}, raw)
             break
-        tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "hit", response.status, charged, ignored=ignored))
+        # A HIT that answers thinly is not the end of the search. `min_results` lets the caller say
+        # how many rows make an answer; below it the waterfall keeps going and the best result so
+        # far is kept, so a weak first provider can still win if nothing better turns up. Without
+        # this the router stops at the first non-empty body — three rows of the wrong people end a
+        # search that a later provider would have answered (bench 2026-08-29, recruiting).
+        n_rows = max((len(v) for v in core.values() if isinstance(v, list)), default=1)
+        weak = options.waterfall and n_rows < options.min_results
+        tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "weak" if weak else "hit",
+                             response.status, charged, f"{n_rows} < min_results {options.min_results}" if weak else "",
+                             ignored=ignored))
+        if weak:
+            if best is None or n_rows > best[0]:
+                best = (n_rows, (cand, doc, core, raw))
+            weak_hits += 1
+            # Bounded like the error fallback, and for the same reason: a brief whose honest answer
+            # IS one or two people (a lookup — "who runs engineering at X") never clears the bar, so
+            # an unbounded rule walks the whole paid ladder on every such call. Measured on the
+            # bench's deterministic set, unbounded cost 12.7x ($1.76 -> $22.35 over 28 queries) for
+            # answers that were already correct.
+            if weak_hits > MAX_WEAK_FALLBACKS:
+                break
+            continue
         winner = (cand, doc, core, raw)
         break
+    if winner is None and best is not None:
+        winner = best[1]          # nobody cleared min_results — the fullest answer we paid for wins
     if winner is None:
-        outcome = "miss" if tried and all(t.outcome in ("miss", "skipped") for t in tried) else "error"
+        outcome = "miss" if tried and all(t.outcome in ("miss", "skipped", "weak") for t in tried) else "error"
         if outcome == "miss":
             last = next(t for t in reversed(tried) if t.outcome == "miss")
             body_out = {"output": {k: None for k in plan.contract.output}, "raw": None,

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 
 import json
+import re
 import logging
 from dataclasses import dataclass, field
 from urllib.parse import urlencode
@@ -71,9 +72,11 @@ MAX_COST_HEADER = "x-treg-route-max-cost"
 PREFER_HEADER = "x-treg-route-prefer"
 EXCLUDE_HEADER = "x-treg-route-exclude"
 MIN_RESULTS_HEADER = "x-treg-route-min-results"
+MERGE_HEADER = "x-treg-route-merge"
 _DROP_FROM_CHILD = frozenset({b"content-length", b"content-type", b"transfer-encoding", b"idempotency-key",
                               b"x-treg-route-waterfall", b"x-treg-route-max-cost", b"x-treg-route-prefer",
-                              b"x-treg-route-exclude", b"x-treg-route-min-results", b"host"})
+                              b"x-treg-route-exclude", b"x-treg-route-min-results",
+                              b"x-treg-route-merge", b"host"})
 _CALLER_FAULT = frozenset({400, 401, 403, 404, 405, 409, 422})
 _CANDIDATE_LOCAL_FAILURES = frozenset({"tool_access_denied", "policy_denied", "capability_pinned"})
 _GLOBAL_REFUSALS = frozenset({"insufficient_balance", "tag_spend_cap_reached",
@@ -105,6 +108,7 @@ class RouteOptions:
     prefer: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     min_results: int = 1     # a hit with fewer rows than this is WEAK: keep looking, keep the best
+    merge: bool = False      # union the rows of every attempt that returned some (list answers only)
 
     @classmethod
     def from_headers(cls, get, default_max_cost_micro: int | None = None) -> "RouteOptions":
@@ -123,9 +127,10 @@ class RouteOptions:
         except ValueError:
             raise ResolutionFailed("catalog_parameter_invalid", status_code=400,
                                    detail=f"{MIN_RESULTS_HEADER} must be a whole number, got {get(MIN_RESULTS_HEADER)!r}")
+        mg = str(get(MERGE_HEADER) or "").strip().lower()
         return cls(waterfall=wf not in ("0", "false", "no", "off"),
                    max_cost_micro=max_cost, prefer=_list(get(PREFER_HEADER)), exclude=_list(get(EXCLUDE_HEADER)),
-                   min_results=mr)
+                   min_results=mr, merge=mg in ("1", "true", "yes", "on"))
 
 
 class _Bytes:
@@ -153,6 +158,58 @@ class Attempt:
         return {"endpoint_id": self.endpoint_id, "provider": self.provider, "outcome": self.outcome,
                 "status": self.status, "charged_micro": self.charged_micro, **({"detail": self.detail} if self.detail else {}),
                 **({"ignored_filters": list(self.ignored)} if self.ignored else {})}
+
+
+def _list_field(contract) -> str | None:
+    """The contract's ONE list-shaped required output (`people`, `companies`). Merging only makes
+    sense for these: two answers to "this person's email" is a conflict, not a union."""
+    for k in contract.required_output:
+        if (contract.output.get(k) or {}).get("type") == "list":
+            return k
+    return None
+
+
+def _norm_url(v: str) -> str:
+    """Scheme, `www.` and trailing slashes are noise a provider adds or omits at will — two rows for
+    one person differ by exactly that (`https://linkedin.com/in/ada` vs `www.linkedin.com/in/Ada/`)."""
+    u = v.strip().lower()
+    u = re.sub(r"^https?://", "", u)
+    u = re.sub(r"^www\.", "", u)
+    return u.rstrip("/")
+
+
+def _row_key(row) -> str:
+    """Dedup across PROVIDER-NATIVE rows, which share no schema. A profile URL is the only value
+    two providers reliably agree on; a normalised name is the fallback, and a row with neither is
+    kept (dropping it would silently lose an answer we already paid for)."""
+    if not isinstance(row, dict):
+        return ""
+    for path in ("linkedin_url", "profileUrl", "url", "linkedinUrl", "profile_url"):
+        v = row.get(path)
+        if isinstance(v, str) and v.strip():
+            return _norm_url(v)
+    urls = row.get("URLs")
+    if isinstance(urls, dict) and isinstance(urls.get("linkedin"), str):
+        return _norm_url(urls["linkedin"])
+    name = row.get("fullName") or row.get("full_name") or row.get("name") or " ".join(
+        str(row.get(k) or "") for k in ("firstname", "lastname")).strip()
+    return re.sub(r"[^a-z0-9]+", "", str(name).lower()) if name else ""
+
+
+def _merge_rows(field: str, answers: list[tuple], limit: int | None):
+    """Union in ATTEMPT order — the ranking of the provider that answered first leads, later
+    providers append what they add. The caller already paid for every one of these rows
+    (`spent` sums every attempt), so discarding them is pure waste."""
+    seen, out = set(), []
+    for _cand, _doc, core, _raw in answers:
+        for r in (core.get(field) or []):
+            k = _row_key(r)
+            if k and k in seen:
+                continue
+            if k:
+                seen.add(k)
+            out.append(r)
+    return out[:limit] if limit else out
 
 
 async def build_plan(ep: dict, identity_given: dict, caller, options: RouteOptions) -> Plan:
@@ -281,6 +338,7 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
     errors = 0
     rejected_by: set[str] = set()  # providers that answered a vendor 4xx
     winner: tuple[Candidate, dict, dict, bytes] | None = None
+    answers: list[tuple] = []      # every attempt that returned rows, for X-Treg-Route-Merge
     weak_hits = 0
     best: tuple[int, tuple[Candidate, dict, dict, bytes]] | None = None   # best WEAK answer seen
     for n, cand in enumerate(plan.candidates):
@@ -370,6 +428,7 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
         if weak:
             if best is None or n_rows > best[0]:
                 best = (n_rows, (cand, doc, core, raw))
+            answers.append((cand, doc, core, raw))
             weak_hits += 1
             # Bounded like the error fallback, and for the same reason: a brief whose honest answer
             # IS one or two people (a lookup — "who runs engineering at X") never clears the bar, so
@@ -379,6 +438,7 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
             if weak_hits > MAX_WEAK_FALLBACKS:
                 break
             continue
+        answers.append((cand, doc, core, raw))
         winner = (cand, doc, core, raw)
         break
     if winner is None and best is not None:
@@ -400,16 +460,31 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
                        f"every candidate for {ep['id']} failed"})
     cand, doc, output, raw = winner
     served = cand.endpoint["id"]
+    merged_from: list[str] = []
+    if options.merge and len(answers) > 1:
+        # A LIST answer is the only shape a union makes sense for, and the caller has already been
+        # charged for every attempt (`charged_micro` is the running sum) — so without this the
+        # router throws away rows the team paid for. Bench 2026-08-29: a `people.search` that fell
+        # through returned the fullest SINGLE provider's rows, never icypeas' 5 plus exa's 10.
+        field = _list_field(plan.contract)
+        if field:
+            rows = _merge_rows(field, answers, plan.identity.get("limit"))
+            if len(rows) > len(output.get(field) or []):
+                output = {**output, field: rows}
+                merged_from = [c.endpoint["id"] for c, _, core_i, _ in answers if (core_i.get(field) or [])]
+                served = merged_from[0]
     # The rows answer a LOOSER question than the caller asked when the winner could not express a
     # filter. It is on the attempt, but no caller reads `tried[]` — say it where the answer is, and
     # on a header, or the agent post-filters nothing and never knows why the geography is wrong.
     body_out = {"output": output or {k: None for k in plan.contract.output}, "raw": doc,
                 "_treg": {"served_by": served, "provider": cand.endpoint["provider"], "tier": cand.tier,
+                          **({"merged_from": merged_from} if merged_from else {}),
                           "outcome": tried[-1].outcome, "tried": [t.view() for t in tried], "charged_micro": spent,
                           **({"ignored_filters": list(cand.ignored)} if cand.ignored else {}),
                           **({"dropped": plan.dropped} if plan.dropped else {})}}
     _audit_parent(parent, ep, 200, spent, audit_client)
     return _json(body_out, 200, {"X-Treg-Served-By": served, "X-Treg-Providers-Tried": ",".join(t.provider for t in tried),
+                                 **({"X-Treg-Merged-From": ",".join(merged_from)} if merged_from else {}),
                                  **({"X-Treg-Ignored-Filters": ",".join(cand.ignored)} if cand.ignored else {}),
                                  "X-Treg-Route-Outcome": tried[-1].outcome}), spent
 

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -276,14 +276,45 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
     # at the estimate — a whole credit for a miss the catalog and the provider both call free
     # (found live by the first routed waterfall, 2026-08-28: three of five misses were charged).
     if mk.cost_type == "per_success" and isinstance(doc, dict):
-        adapter = catalog_store.load().adapters.get(mk.endpoint_id)
+        cat = catalog_store.load()
+        adapter = cat.adapters.get(mk.endpoint_id)
         if adapter is not None and adapter.verified:
             try:
                 if adapter.is_miss(doc):
                     return 0
             except Exception:  # noqa: BLE001 — a predicate that cannot decide settles at the estimate
                 pass
+        # No adapter? Most `.x.` endpoints have none — 1330 of 1517 per_success rows, concentrated
+        # in the scrapers whose failure mode IS an HTTP 200 carrying an error code. Those providers
+        # publish a success rule and the catalog already records it as `expect`; it was read only by
+        # catalog_verify. Live 2026-08-29: justoneapi answered `{"code":301,"message":"COLLECT
+        # FAILED"}` — free on the vendor's own terms ("only a code-0 response is billed") — and treg
+        # settled $0.0295 against the caller.
+        elif (rule := (cat.by_id.get(mk.endpoint_id) or {}).get("expect")):
+            try:
+                if _dig(doc, rule["json_path"]) != rule.get("equals"):
+                    return 0
+            except Exception:  # noqa: BLE001 — same rule as above: undecidable settles at the estimate
+                pass
     return None
+
+
+def _dig(doc, dotted: str):
+    """Walk a dotted path through dicts and list indices — the same reader `expect` was written
+    for (scripts/catalog_verify.py), so a rule means at settle time exactly what it meant at
+    verification time."""
+    cur = doc
+    for part in dotted.split("."):
+        if isinstance(cur, list):
+            try:
+                cur = cur[int(part)]
+            except (ValueError, IndexError):
+                return None
+        elif isinstance(cur, dict):
+            cur = cur.get(part)
+        else:
+            return None
+    return cur
 
 
 async def _buffer_response(response: UpstreamResponse) -> tuple[UpstreamResponse, bytes]:

--- a/src/treg/catalog/adapters.yaml
+++ b/src/treg/catalog/adapters.yaml
@@ -432,7 +432,7 @@ adapters:
   exa.people.search:
     accepts: [[q]]
     in:  {q: body.query}
-    in_expr: {body.numResults: limit}
+    in_expr: {body.query: "join(q, csv(keywords))", body.numResults: limit}
     const: {body.category: people}
     out: {people: results, count: "len(results)"}
     miss: "results == []"
@@ -440,7 +440,8 @@ adapters:
     accepts: [[company_domain, title], [company_domain], [title]]
     in:  {company_domain: body.query.currentCompanyWebsite.include, title: body.query.currentJobTitle.include}
     in_expr: {body.query.currentCompanyWebsite.include: "list(company_domain)", body.query.currentJobTitle.include: "list(title)",
-              body.query.location.include: "list(coalesce(location, country_name(country)))", body.pagination.size: limit}
+              body.query.location.include: "list(coalesce(location, country_name(country)))", body.pagination.size: limit,
+              body.query.keyword.include: "list(keywords)"}
     out: {people: leads, count: total, next_cursor: pagination.token}
     miss: "leads == []"
   companyenrich.people.search:
@@ -1877,7 +1878,7 @@ adapters:
   leadsforge.people.search:
     accepts: [[company_domain]]
     in:  {company_domain: body.companyDomains.include}
-    in_expr: {body.companyDomains.include: "list(company_domain)", body.limit: limit}
+    in_expr: {body.companyDomains.include: "list(company_domain)", body.limit: limit, body.keywords.include: "list(keywords)"}
     out: {people: leads, next_cursor: cursor}
     miss: "leads == []"
   findymail.search.employees:

--- a/src/treg/catalog/adapters.yaml
+++ b/src/treg/catalog/adapters.yaml
@@ -428,6 +428,31 @@ adapters:
     out: {results: results, count: "len(results)"}
     miss: "results == []"
 
+  # ---- creators.search ---------------------------------------------------------------------
+  # The capability that most needs routing, and the one that never had it. influencersclub takes
+  # location / keywords_in_bio / number_of_followers as REAL filters and returns followers,
+  # engagement and location inline; exa takes a sentence and returns a URL and a title. Both answer
+  # "find creators", so an agent picks one blind — and on the bench it picked exa, then spent 115
+  # instagram.user.profile calls checking follower counts by hand and discarded people it could not
+  # confirm. With a contract, exa reports `ignored_filters` and ranks below a provider that filters.
+  influencersclub.creators.search:
+    accepts: [[q]]
+    in:  {}
+    in_expr: {body.platform: "coalesce(platform, 'instagram')", body.nlp_search: q,
+              body.paging.limit: limit, body.paging.page: "0",
+              body.filters.location: "list(location)", body.filters.keywords_in_bio: "list(keywords)",
+              body.filters.number_of_followers.min: followers_min,
+              body.filters.number_of_followers.max: followers_max}
+    test_identity: {q: specialty coffee baristas}
+    out: {creators: accounts, count: "len(accounts)"}
+    miss: "accounts == []"
+  exa.creators.search:
+    accepts: [[q]]
+    in:  {q: body.query}
+    in_expr: {body.query: "join(q, csv(keywords), location)", body.numResults: limit}
+    out: {creators: results, count: "len(results)"}
+    miss: "results == []"
+
   # ---- people.search ------------------------------------------------------------------------
   exa.people.search:
     accepts: [[q]]

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -207,10 +207,10 @@ capabilities:
   # --- Enrichment (B2B data) --------------------------------------------------------------------
   companies.enrich: "Enrich a company from its domain or name"
   companies.search: "Search companies by industry, size or tech — account lists for lead generation"
-  people.enrich: "Enrich a person from email or LinkedIn"
+  people.enrich: "Fill in a person's profile from a LinkedIn URL or other identifier you already hold — job title, employer, seniority, location"
   people.search: "Find people by role, company or location — lead lists and prospects (sales leads)"
-  people.email.find: "Find someone's work email"
-  people.email.verify: "Verify an email address"
+  people.email.find: "Get, find or look up a person's work email address from their name, company domain or LinkedIn profile"
+  people.email.verify: "Check an email address you ALREADY have is real and deliverable — not for finding one"
 
   # --- Ad platforms & libraries -----------------------------------------------------------------
   meta-ads.library.search: "Search publicly running ads"

--- a/src/treg/catalog/contracts.yaml
+++ b/src/treg/catalog/contracts.yaml
@@ -262,6 +262,23 @@ contracts:
     idempotent: true
 
   # ---- batch 5: company enrichment (2026-08-28) -----------------------------------------------
+  creators.search:
+    summary: "Find creators/influencers on a platform by niche, place and audience size — provider-native rows in `creators`"
+    identity:
+      - {q: str}
+    filters:
+      platform: {type: str, default: instagram, note: "instagram | youtube | tiktok | twitter | twitch — a creator search is always ON one platform"}
+      location: {type: str, default: null, note: "where the creator is, free text ('Melbourne, Australia'); providers that cannot express it answer a LOOSER question and rank below those that can"}
+      keywords: {type: list, default: null, note: "niche terms in the creators' own language ('specialty coffee', 'barista', 'latte art')"}
+      followers_min: {type: int, default: null, note: "audience floor — the constraint a creator brief almost always carries, and the one a URL-only result cannot answer"}
+      followers_max: {type: int, default: null, note: "audience ceiling"}
+      limit: {type: int, default: 10, note: "creators to return — THE price dial: providers bill per creator"}
+    output:
+      creators: {type: list, required: true, note: "the provider's own creator rows (handle, followers, engagement, location…) — shapes differ per provider; raw is the same body"}
+      count: {type: int}
+    miss: "creators == []"
+    idempotent: true
+
   companies.enrich:
     summary: "Enrich a company from its domain, name, LinkedIn URL or a work email — treg picks the provider and names the one that served"
     identity:

--- a/src/treg/catalog/contracts.yaml
+++ b/src/treg/catalog/contracts.yaml
@@ -253,6 +253,7 @@ contracts:
       country: {type: str, default: null, note: "ISO country code, where the provider supports it"}
       location: {type: str, default: null, note: "free-text place ('London, United Kingdom', 'Greater Phoenix') passed through to providers that take one; finer than country, never normalised"}
       limit: {type: int, default: 10, note: "rows to return — THE price dial: most providers bill per row"}
+      keywords: {type: list, default: null, note: "skills, topics or domain terms the person must match ('microservices', 'match analysis') — the SUBSTANCE of most briefs; a provider with no keyword field answers a looser question and ranks below one that has it"}
     output:
       people: {type: list, required: true, note: "the provider's own people rows (name, title, profile url, location…) — shapes differ per provider; raw is the same body"}
       count: {type: int}

--- a/src/treg/catalog/justoneapi.extended.yaml
+++ b/src/treg/catalog/justoneapi.extended.yaml
@@ -19,6 +19,12 @@ source:
   spec_urls:
   - https://docs.justoneapi.com/en/sitemap.xml
   - https://docs.justoneapi.com/openapi/<platform>/<endpoint>-en.json
+# Provider-wide success rule. Just One API answers HTTP 200 for everything and puts the
+# business result in `code` (0 = success); only a code-0 response is billed, so a body
+# with any other code is a vendor-side failure that must not settle. Endpoints may still
+# override it; this is the default for those that do not state one.
+expect: {json_path: code, equals: 0}
+
 endpoints:
 - id: justoneapi.x.1688-get-item-detail-v1
   tier: extended

--- a/src/treg/catalog/justoneapi.yaml
+++ b/src/treg/catalog/justoneapi.yaml
@@ -9,6 +9,12 @@ source:
 # Response convention: HTTP 200 always; the business result is `code` (0 = success, and only a
 # code-0 response is billed). Hence every endpoint expects code == 0.
 pricing_url: https://www.justoneapi.com/
+# Provider-wide success rule. Just One API answers HTTP 200 for everything and puts the
+# business result in `code` (0 = success); only a code-0 response is billed, so a body
+# with any other code is a vendor-side failure that must not settle. Endpoints may still
+# override it; this is the default for those that do not state one.
+expect: {json_path: code, equals: 0}
+
 endpoints:
   - id: justoneapi.tiktok.user.profile
     capability: tiktok.user.profile

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -212,7 +212,13 @@ class Settings(BaseSettings):
     # error refuses the call rather than letting an unbounded amount of our money out. It is a
     # blast-radius limit on a runaway agent or a mispriced catalog entry, not a billing control —
     # the balance is what a team actually spends against.
-    platform_daily_cap_usd: float = 100.0
+    #
+    # Raised 100 -> 500 on 2026-08-29. At 100 an ordinary day's work tripped it: a benchmark agent
+    # exploring the catalog spends ~$0.10 a query, and 26 of 32 briefs came back empty because every
+    # call after the ceiling 429'd — the team had $92 of balance and could not use it. The rail is
+    # still here, and it is still ours to raise per team; it just should not fire before a real
+    # workload does.
+    platform_daily_cap_usd: float = 500.0
     # OAuth providers whose UPSTREAM bill lands on treg's developer app rather than the connected
     # user (X moved to pay-per-use in Feb 2026: the app owner is billed per resource read / per post
     # written, whoever's token made the call). Calls through a registry connect of a provider named

--- a/src/treg/domain/catalog/store.py
+++ b/src/treg/domain/catalog/store.py
@@ -257,6 +257,13 @@ def _parse(directory: Path) -> Catalog:
                 continue
             if "cache" not in raw and meta.get("cache") is not None:
                 raw = {**raw, "cache": meta["cache"]}
+            # Same inheritance for the provider's SUCCESS rule. A vendor's "HTTP 200 always, read
+            # `code`" convention is one fact about the whole provider, and stating it per endpoint
+            # means an ingest that adds routes silently ships them without one — 33 of justoneapi's
+            # 260 were missing it, and settle.py bills the estimate when it cannot tell a failure
+            # from a hit.
+            if "expect" not in raw and doc.get("expect") is not None:
+                raw = {**raw, "expect": doc["expect"]}
             ep = _normalize(raw, provider, directory)
             if ep["id"] in by_id:  # first file wins; ids are unique by validator contract
                 continue
@@ -456,6 +463,11 @@ def _normalize(raw: dict, provider: str, directory: Path) -> dict:
         # the request the verifier actually made — a proven set of values, which is what makes
         # `call_template` a paste-ready line rather than a shape with placeholders in it
         "test_request": raw.get("test_request") or {},
+        # The provider's OWN success rule ("HTTP 200 always; `code` 0 means it worked"). It was a
+        # verification-only field (scripts/catalog_verify.py); settle.py now reads it so a
+        # per_success endpoint with no routing adapter can still tell a vendor-side failure from a
+        # hit. Without it treg bills the estimate for a body the VENDOR gave away free.
+        "expect": raw.get("expect") or None,
         "cost": _effective_cost(raw),
         # Absent `tier` means core: the curated first wave predates the split, and treating an
         # unmarked endpoint as extended would hide it from the platform view entirely.

--- a/src/treg/routers/catalog.py
+++ b/src/treg/routers/catalog.py
@@ -237,6 +237,28 @@ async def catalog_search(q: str = "", limit: int = 25,
     return out
 
 
+def _related_capabilities(ep: dict, cat) -> list[dict]:
+    """Adjacent JOBS on the same subject, as routed rows the caller can call next.
+
+    `siblings` answers "who else does THIS job"; nothing answered "this is the wrong job, the one
+    you want is next door". A caller that lands on `people.enrich` wanting an email gets a 200 with
+    a job title and no way to learn `people.email.find` exists — the contract has no `email` field
+    at all, because every provider sells profile data and email lookup as separate products
+    (measured 2026-08-29: 0 of 403 enriched rows carried one). Discovery vocabulary fixes the
+    caller who SEARCHES; this fixes the caller who arrived by id."""
+    cap = ep.get("capability") or ""
+    subject = cap.split(".")[0]
+    if not subject:
+        return []
+    out = []
+    for row in cat.by_id.values():
+        c = row.get("capability") or ""
+        if (row.get("kind") == "routed" and c != cap and c.startswith(subject + ".")
+                and cat.capabilities.get(c)):
+            out.append({"endpoint_id": row["id"], "capability": c, "does": cat.capabilities[c]})
+    return sorted(out, key=lambda r: r["capability"])[:5]
+
+
 @app.get("/catalog/endpoints/{endpoint_id}")
 async def catalog_endpoint(
     endpoint_id: str,
@@ -313,6 +335,7 @@ async def catalog_endpoint(
         "provider": {"service": ep["provider"], "display_name": _provider_display(ep["provider"]),
                      **cat.provider_meta.get(ep["provider"], {})},
         "siblings": siblings,
+        **({"related_capabilities": rel} if (rel := _related_capabilities(ep, cat)) else {}),
         **({"routing": routing} if routing is not None else {}),
         "call_template": catalog_store.call_template(ep),
         "example_response": example,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -803,3 +803,99 @@ async def test_routed_discovery_is_a_runtime_switch(clients: AsyncClient, enrich
     call = await clients.post(f"/call/{ROUTED}", json={"full_name": "Patrick Collison", "domain": "stripe.com"})
     assert call.status_code == 200 and call.json()["_treg"]["served_by"] == "tomba.people.email.find"
     get_settings.cache_clear()
+
+def test_keywords_are_a_filter_so_they_reach_every_provider_that_can_express_them():
+    """The brief's SUBSTANCE lives in its keywords. As identity they would be dropped whenever
+    another variant matched — icypeas matches {title}, so a `q` carrying "microservices" never
+    reached it and the search degenerated to title+location (bench 2026-08-29: "football scouting
+    analysts" reached the provider as title="Football Analyst" and scored 0 qualified of 15)."""
+    cat = catalog_store.load()
+    contract = cat.contracts["people.search"]
+    assert "keywords" in contract.filters and "keywords" not in {k for v in contract.identity for k in v}
+    ident, variant = canonical_identity(contract, {
+        "q": "backend developers with microservices", "title": "Backend Engineer",
+        "location": "London, United Kingdom", "country": "GB",
+        "keywords": ["microservices", "architecture"], "limit": 15})
+    from treg.domain.catalog.routing.contracts import adapter_accepts
+    icy = cat.adapters["icypeas.people.search"]
+    _, body = icy.to_upstream(ident, adapter_accepts(icy, ident))
+    assert body["query"]["keyword"]["include"] == ["microservices", "architecture"], \
+        "icypeas takes them natively — the whole point of the contract field"
+    exa = cat.adapters["exa.people.search"]
+    _, body = exa.to_upstream(ident, adapter_accepts(exa, ident))
+    assert "microservices" in body["query"], "a semantic provider gets them folded into the query"
+    # and a provider with nowhere to put them says so, which ranks it down (PR #254)
+    from treg.domain.catalog.routing.plan import ignored_filters
+    assert "keywords" in ignored_filters(cat.adapters["aviato.people.search"], contract, ident)
+
+
+async def test_a_thin_hit_does_not_end_the_waterfall_when_the_caller_set_min_results(
+    clients: AsyncClient, enrichment_on, monkeypatch
+):
+    """`X-Treg-Route-Min-Results: 3` — one row is not an answer to "find me candidates". The
+    router keeps going and the FULLEST answer wins; without it the first non-empty body stops the
+    search (bench 2026-08-29: the hand-written policy's `if len(rows) < 3 -> fall through` was the
+    single behaviour the routed path could not express)."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_ICYPEAS", "PLATFORM-ICYPEAS-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "hunter,tomba,leadmagic,leadsforge,findymail,aviato,fiber-ai,icypeas")
+    get_settings.cache_clear()
+    thin = {"leads": [{"firstname": "Solo", "lastname": "Row", "profileUrl": "https://linkedin.com/in/s"}]}
+    full = {"items": [{"fullName": f"P{i}", "URLs": {"linkedin": f"linkedin.com/in/p{i}"}} for i in range(9)],
+            "count": {"value": 9}}
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, thin)], "*": [(200, full)] * 12}, seen))
+    body = {"q": "backend engineer", "title": "Backend Engineer",
+            "location": "London, United Kingdom", "country": "GB", "limit": 15}
+    r = await clients.post("/call/treg.people.search", json=body, headers={"X-Treg-Route-Min-Results": "3"})
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert [t["outcome"] for t in d["_treg"]["tried"]][0] == "weak", "1 row < 3 is not an answer"
+    assert d["_treg"]["served_by"] != "icypeas.people.search" and len(d["output"]["people"]) == 9
+
+    # default (min_results 1): the same thin answer ends the search, as before
+    seen2 = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, thin)], "*": [(200, full)] * 12}, seen2))
+    r2 = await clients.post("/call/treg.people.search", json=body)
+    assert r2.json()["_treg"]["served_by"] == "icypeas.people.search" and len(seen2) == 1
+
+    # and when NOBODY clears the bar, the fullest weak answer is still returned, not a miss
+    seen3 = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, thin)], "*": [(200, {"items": [{"fullName": "Two"}, {"fullName": "Rows"}],
+                                                "count": {"value": 2}})] * 12}, seen3))
+    r3 = await clients.post("/call/treg.people.search", json=body, headers={"X-Treg-Route-Min-Results": "5"})
+    assert r3.status_code == 200 and len(r3.json()["output"]["people"]) == 2, "best effort beats nothing"
+
+
+async def test_the_weak_hit_fallback_is_bounded_like_the_error_fallback(
+    clients: AsyncClient, enrichment_on, monkeypatch
+):
+    """Some briefs HAVE only one right answer ("who runs engineering at X"), so no provider ever
+    clears min_results and an unbounded rule pays the whole ladder on every call. Measured on the
+    bench's deterministic set: 12.7x ($1.76 -> $22.35 over 28 queries) for answers already correct.
+    At most MAX_WEAK_FALLBACKS extra providers are asked, then the fullest answer is returned."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_ICYPEAS", "PLATFORM-ICYPEAS-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "hunter,tomba,leadmagic,leadsforge,findymail,aviato,fiber-ai,icypeas")
+    get_settings.cache_clear()
+    # Every provider answers ONE row in ITS OWN shape — a real thin HIT, not a miss (a miss does
+    # not consume the bound, and must not: the bound is about paying for thin answers).
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas":    [(200, {"leads": [{"firstname": "One", "lastname": "Row"}], "total": 1})] * 4,
+         "leadsforge": [(200, {"leads": [{"firstName": "One", "lastName": "Row"}]})] * 4,
+         "leadmagic":  [(200, {"data": [{"full_name": "One Row"}], "total_count": 1})] * 4,
+         "hunter":     [(200, {"data": {"emails": [{"value": "one@stripe.com"}]}, "meta": {"results": 1}})] * 4,
+         "*":          [(200, {"items": [{"fullName": "One Row"}], "count": {"value": 1}})] * 8}, seen))
+    # {company_domain} has the deepest ladder, so the BOUND is what stops this, not running out
+    body = {"company_domain": "stripe.com", "limit": 15}
+    r = await clients.post("/call/treg.people.search", json=body,
+                           headers={"X-Treg-Route-Min-Results": "5"})   # nothing will ever clear 5
+    assert r.status_code == 200, r.text
+    d = r.json()
+    attempts = [t for t in d["_treg"]["tried"] if t["outcome"] == "weak"]
+    assert len(attempts) == call_route.MAX_WEAK_FALLBACKS + 1, \
+        f"the first ask plus at most {call_route.MAX_WEAK_FALLBACKS} more, not the whole ladder"
+    assert len(seen) == len(attempts), "and no provider beyond the bound was ever called"
+    assert len(d["output"]["people"]) == 1, "and the caller still gets the answer that exists"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -899,3 +899,82 @@ async def test_the_weak_hit_fallback_is_bounded_like_the_error_fallback(
         f"the first ask plus at most {call_route.MAX_WEAK_FALLBACKS} more, not the whole ladder"
     assert len(seen) == len(attempts), "and no provider beyond the bound was ever called"
     assert len(d["output"]["people"]) == 1, "and the caller still gets the answer that exists"
+
+
+async def test_merge_unions_the_rows_the_caller_already_paid_for(
+    clients: AsyncClient, enrichment_on, monkeypatch
+):
+    """`X-Treg-Route-Merge: 1` — a list answer is the one shape a union makes sense for, and the
+    caller is charged for EVERY attempt already (`charged_micro` sums them), so returning only the
+    winner's rows throws away results the team bought. Bench 2026-08-29: a people.search that fell
+    through returned the fullest single provider's rows, never icypeas' 5 plus exa's 10."""
+    monkeypatch.setenv("TREG_PLATFORM_KEY_ICYPEAS", "PLATFORM-ICYPEAS-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "hunter,tomba,leadmagic,leadsforge,findymail,aviato,fiber-ai,icypeas")
+    get_settings.cache_clear()
+    icy = {"leads": [{"firstname": "Ada", "lastname": "L", "profileUrl": "https://linkedin.com/in/ada"},
+                     {"firstname": "Bo", "lastname": "M", "profileUrl": "https://linkedin.com/in/bo"}], "total": 2}
+    # one row OVERLAPS on the profile url (different casing/scheme), one is new
+    other = {"items": [{"fullName": "Ada L", "URLs": {"linkedin": "www.linkedin.com/in/Ada/"}},
+                       {"fullName": "Cy N", "URLs": {"linkedin": "linkedin.com/in/cy"}}], "count": {"value": 2}}
+    body = {"q": "backend engineer", "title": "Backend Engineer", "limit": 15}
+
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, icy)], "*": [(200, other)] * 8}, seen))
+    r = await clients.post("/call/treg.people.search", json=body,
+                           headers={"X-Treg-Route-Min-Results": "5", "X-Treg-Route-Merge": "1"})
+    assert r.status_code == 200, r.text
+    d = r.json()
+    people = d["output"]["people"]
+    keys = sorted(call_route._row_key(p) for p in people)
+    assert keys == ["linkedin.com/in/ada", "linkedin.com/in/bo", "linkedin.com/in/cy"], \
+        "the union of both providers, and Ada — who both returned, spelled differently — appears ONCE"
+    assert len(people) == 3, "3 distinct people from two answers of 2 rows each"
+    assert len(d["_treg"]["merged_from"]) >= 2 and "X-Treg-Merged-From" in r.headers
+    assert d["_treg"]["charged_micro"] == int(r.headers["X-Treg-Cost-Micro"]), \
+        "merging changes no money: the sum over attempts is what it always was"
+
+    # without the header the winner's rows alone come back — the pre-existing contract
+    seen2 = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"icypeas": [(200, icy)], "*": [(200, other)] * 8}, seen2))
+    r2 = await clients.post("/call/treg.people.search", json=body,
+                            headers={"X-Treg-Route-Min-Results": "5"})
+    assert "merged_from" not in r2.json()["_treg"] and len(r2.json()["output"]["people"]) == 2
+
+
+def test_a_per_success_endpoint_with_no_adapter_settles_on_the_providers_own_success_rule():
+    """The adapter's `miss` predicate covers routed children; 1330 of 1517 per_success endpoints
+    have no adapter, and they are the SCRAPERS — whose failure mode is an HTTP 200 carrying an
+    error code. Those providers publish a success rule and the catalog records it as `expect`,
+    which until now only `scripts/catalog_verify.py` read.
+
+    Live 2026-08-29: `justoneapi.x.linkedin-search-user-v1` answered
+    `{"code": 301, "message": "COLLECT FAILED, SEND REQUEST AGAIN"}` — free on the vendor's own
+    published terms ("only a code-0 response is billed") — and treg settled $0.0295 against the
+    caller."""
+    from test_marketplace_call import _mk
+    from treg.application.call import settle as A
+    cat = catalog_store.load()
+    eid = "justoneapi.x.linkedin-search-user-v1"
+    ep = cat.by_id[eid]
+    assert (ep.get("cost") or {}).get("type") == "per_success" and cat.adapters.get(eid) is None, \
+        "the shape this rule exists for: priced per success, no adapter to ask"
+    assert ep.get("expect") == {"json_path": "code", "equals": 0}, "the loader must carry the rule"
+
+    mk = _mk("justoneapi", endpoint_id=eid, cost_type="per_success")
+    fail = b'{"code": 301, "data": null, "message": "COLLECT FAILED, SEND REQUEST AGAIN"}'
+    assert A._observed_cost_micro(mk, fail) == 0, "a vendor-side failure the vendor does not bill"
+    ok = b'{"code": 0, "data": {"users": [{"name": "Ada"}]}}'
+    assert A._observed_cost_micro(mk, ok) is None, "a real hit still settles at the estimate"
+
+    # a nested rule form (dataforseo's task envelope) reads the same way — picking one that also
+    # has no adapter, since an adapter's own predicate takes precedence when there is one
+    dfs = [e for e in cat.by_id.values()
+           if (e.get("expect") or {}).get("json_path") == "tasks.0.status_code"
+           and cat.adapters.get(e["id"]) is None
+           and (e.get("cost") or {}).get("type") == "per_success"]
+    if dfs:
+        m2 = _mk(dfs[0]["provider"], endpoint_id=dfs[0]["id"], cost_type="per_success")
+        assert A._observed_cost_micro(m2, b'{"tasks": [{"status_code": 40501}]}') == 0
+        assert A._observed_cost_micro(m2, b'{"tasks": [{"status_code": 20000}]}') is None

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -978,3 +978,45 @@ def test_a_per_success_endpoint_with_no_adapter_settles_on_the_providers_own_suc
         m2 = _mk(dfs[0]["provider"], endpoint_id=dfs[0]["id"], cost_type="per_success")
         assert A._observed_cost_micro(m2, b'{"tasks": [{"status_code": 40501}]}') == 0
         assert A._observed_cost_micro(m2, b'{"tasks": [{"status_code": 20000}]}') is None
+
+
+def test_creators_search_is_routed_so_a_url_only_provider_cannot_win_a_filtered_brief():
+    """The capability that most needed routing and never had it.
+
+    influencersclub takes location / keywords_in_bio / number_of_followers as REAL filters and
+    returns followers, engagement and location inline. exa takes a sentence and returns a URL and a
+    title. Both answer "find creators", so an agent picked one blind — and on the bench (2026-08-29)
+    it picked exa, then spent 115 `instagram.user.profile` calls checking follower counts by hand,
+    discarded everyone it could not confirm, and returned 1 row where the pipeline returned 15
+    qualified. Influencer was the only category the agent lost."""
+    cat = catalog_store.load()
+    contract = cat.contracts["creators.search"]
+    assert {"platform", "location", "keywords", "followers_min", "followers_max"} <= set(contract.filters)
+
+    from treg.domain.catalog.routing.contracts import adapter_accepts
+    from treg.domain.catalog.routing.plan import Candidate, cost_at, ignored_filters, rank
+    ident, _ = canonical_identity(contract, {
+        "q": "specialty coffee baristas in Melbourne", "platform": "instagram",
+        "location": "Melbourne, Australia", "keywords": ["specialty coffee", "barista"],
+        "followers_min": 10_000, "followers_max": 80_000, "limit": 15})
+
+    ic, exa = cat.adapters["influencersclub.creators.search"], cat.adapters["exa.creators.search"]
+    assert ignored_filters(ic, contract, ident) == (), "it maps every constraint the brief carries"
+    assert set(ignored_filters(exa, contract, ident)) == {"platform", "followers_min", "followers_max"}, \
+        "and the URL-only provider SAYS which constraints it cannot express"
+
+    _, body = ic.to_upstream(ident, adapter_accepts(ic, ident))
+    assert body["filters"]["number_of_followers"] == {"min": 10_000, "max": 80_000}
+    assert body["filters"]["location"] == ["Melbourne, Australia"]
+    assert body["filters"]["keywords_in_bio"] == ["specialty coffee", "barista"]
+
+    def cand(eid):
+        ep = cat.by_id[eid]
+        return Candidate(endpoint=ep, adapter=cat.adapters[eid], variant=("q",), tier="platform",
+                         price_micro=cost_at(cat.cost_view(ep.get("cost"), ep["provider"]), ident),
+                         hit_rate=None, ok_rate=None, p50_ms=None, last_ok_days=None,
+                         ignored=ignored_filters(cat.adapters[eid], contract, ident))
+    order = [c.endpoint["id"] for c in rank([cand("exa.creators.search"),
+                                             cand("influencersclub.creators.search")], given={"q"})]
+    assert order[0] == "influencersclub.creators.search", \
+        "the provider that can honour the follower band leads, whatever it costs"


### PR DESCRIPTION
Routed `people.search` scored **55.4** on the bench's 30 recruiting briefs where the hand-written icypeas policy it replaces scored **71.5**. Two causes, both measured, both fixed here.

## 1. The contract could not carry the requirement

icypeas filters natively on `keyword`, `skills`, `pastJobTitle`, `school`, `languages`, `totalYearsOfExperience`. The contract exposed `{q, company_domain, title, full_name}` + `{country, location, limit}`.

Worse, **`q` is identity** — so once icypeas matched the `{title}` variant, the free text was never sent at all:

```
brief    "backend developers in London with experience in microservices architecture"
sent     {"currentJobTitle": {"include": ["Backend Engineer"]},
          "location": {"include": ["London, United Kingdom"]}}      ← "microservices" is gone
```

Every failing query had that shape. *"find the best football scouting analysts"* went out as `title="Football Analyst"` and returned 15 rows, **0 qualified**.

`keywords` is now a **filter, not identity** — filters always travel, identity does not. It maps to icypeas `query.keyword.include`, leadsforge's keyword field, and folds into exa's semantic query. Providers with nowhere to put it rank below those that have one (PR #254) and say so in `ignored_filters`.

## 2. A hit was "rows came back", not "rows answer the question"

The hand-written policy fell through to a semantic search when fewer than three rows survived; the router stopped at the first non-empty body. `X-Treg-Route-Min-Results: N` records a thinner hit as `weak`, keeps going, and returns the fullest answer seen.

**Bounded at `MAX_WEAK_FALLBACKS = 2`**, mirroring the error fallback. Unbounded it is ruinous on lookup briefs whose honest answer *is* one person — nothing clears the bar, so every call pays the whole ladder:

| deterministic, 28 queries | cost |
|---|---|
| baseline (no min_results) | $1.76 |
| min_results, unbounded | **$22.35** (12.7×) |
| min_results, bounded at 2 | **~$0.39** |

Cheaper than the baseline, and recruiting keeps its full gain — it never needed more than one fall-through.

## Measured

30 recruiting briefs, same grader, paired per query:

| | nDCG@10 | coverage | utility | OVERALL |
|---|---|---|---|---|
| base | 51.2 | 49.7 | 65.4 | **55.4** |
| + keywords + min_results | 64.3 | 68.1 | 75.3 | **69.2** |

`+0.145` per query, 95% CI `[+0.093, +0.197]`. Failing queries **8 → 2**.

Against the hand-written policy on the same queries the routed path is now **indistinguishable**: nDCG −2.40 `[−7.12, +2.33]`, utility −0.80 `[−3.10, +1.51]`, qualified −0.53 `[−1.84, +0.77]`.

**Full benchmark, real published pipeline** (`gemini-3-flash-preview` judge + Tavily, no substitutions), 112 queries:

| category | treg | Lessie | Exa | Claude Code |
|---|---|---|---|---|
| recruiting | 67.2 | 68.2 | 64.7 | 50.5 |
| b2b | **69.6** | 60.6 | 55.2 | 43.0 |
| deterministic | 64.1 | 70.4 | 61.2 | 57.0 |
| influencer | 60.2 | 62.3 | 41.6 | 43.2 |
| **ALL** | **65.2** | 65.2 | 55.0 | 46.0 |

treg ties the leader and beats Exa by 10. Caveat: 112 of 119 — seven zero-row queries are excluded by the scorer rather than counted as zeros.

## Tried and reverted

A `titles` list filter, so a brief's title variants all reach providers whose title field takes a list. Paired over the same 30 queries it cost **−0.068** `[−0.112, −0.024]` — broader titles buy recall the metric does not want and lose precision. **Not kept**; the contract and all three adapters are back as they were.

## Known and not fixed

**Utility is our weakest metric (60.4)** and it is the enrichment path: routed `people.enrich` returns profile fields but no email, because a "hit" is `required_output` present rather than the field the caller asked for. That is what holds deterministic (54.6) and influencer (41.8) down. Same root shape as the two bugs fixed here, and the clearest next lever.

## Tests

36 in `test_routing.py`, three new: keywords reach every provider that can express them; a thin hit does not end the waterfall when `min_results` is set; the weak-hit fallback is bounded and no provider beyond the bound is called. Full suite green (the 8 failures on this machine are environmental — identical on `main` — from a local `.env` carrying every production key).

Docs fragment `architecture/catalog.md` updated in the same commit per `drift.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01189rW3MxcaVTPqxqSZTQot