### PR TITLE
feat(catalog): TREG_ROUTED_DISCOVERY — steering is a runtime switch, separate from calling

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1236,7 +1236,14 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   One choke point (`group_routed`) serves both callers (`mcp.py`, `routers/catalog.py`); MCP also
   narrows its rank band back to `limit` when off, since the widening exists only so groups can
   collapse. Same dashboard-flip shape as `platform_providers` and `TREG_OVERFLOW_MODE` — no
-  redeploy. It exists because "does the router answer well" and "should every agent be led to it by
+  redeploy. It covers every surface that steers, not just search: the platform BROWSE view
+  (`/catalog/platforms/{slug}`, which sorts the routed parent to the top of its capability group)
+  drops routed rows too, and `/skill.md` and `/llms.txt` strip their routed section — a deployment
+  that hides the row from search must not keep TEACHING agents to call it, or the docs and the
+  catalog disagree and the agent believes the docs. The section is delimited in those two files by
+  `<!--routed-->…<!--/routed-->`; the markers are stripped either way, and the unrelated overflow /
+  `provider_capacity_unavailable` guidance in the same paragraphs is kept (it came from the capacity
+  work, not from routing — which is also why a `git revert` of #242 would be the wrong instrument). It exists because "does the router answer well" and "should every agent be led to it by
   default" are separate questions: the bench answered the first (55.4 → 69.2 on recruiting, parity
   with a hand-written policy), and only traffic can answer the second.
 - **What is not routed on purpose**: `*.bulk` endpoints (a routed call is one subject, one answer),

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1228,6 +1228,17 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   is listed on the attempt as `ignored_filters` — silently unapplied was the worst outcome (the bench
   had post-filtered in the agent because of it). Bench re-run, recruiting 30: same icypeas rows as the
   hand-written policy, one automatic fall-through, region briefs rescued by the pass-through.
+- **Routed DISCOVERY is a runtime switch (2026-08-29)**: `TREG_ROUTED_DISCOVERY=off` (default `on`)
+  stops search leading with `treg.<capability>` and stops a routed parent riding in when a child
+  matches — the endpoints stay callable, priced and reachable by id, and `catalog get`/`POST /call/`
+  are untouched. Off also HIDES routed rows from search results, not merely ungroups them: a routed
+  row matches a keyword query on its own summary, so leaving it in would steer by the back door.
+  One choke point (`group_routed`) serves both callers (`mcp.py`, `routers/catalog.py`); MCP also
+  narrows its rank band back to `limit` when off, since the widening exists only so groups can
+  collapse. Same dashboard-flip shape as `platform_providers` and `TREG_OVERFLOW_MODE` — no
+  redeploy. It exists because "does the router answer well" and "should every agent be led to it by
+  default" are separate questions: the bench answered the first (55.4 → 69.2 on recruiting, parity
+  with a hand-written policy), and only traffic can answer the second.
 - **What is not routed on purpose**: `*.bulk` endpoints (a routed call is one subject, one answer),
   and providers whose rows are teasers — hunter multi-domain (masked, no names, ignores limit),
   apollo people.search (free, but last names obfuscated: a search→reveal CHAIN, which mode C of the

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -265,6 +265,19 @@ in the ledger. Empty = those calls are free (the pre-2026-08-18 behaviour). Curr
 BYO-app connections are never metered. Ongoing spend is visible in the reconcile reports under
 `tier: oauth`; the burn from the free period is only in console.x.com.
 
+## Routed discovery — the steering switch (2026-08-29)
+
+`TREG_ROUTED_DISCOVERY` (`on` by default, `off` to disable) decides whether DISCOVERY steers to
+`treg.<capability>` rows. Off, search and the platform browse view stop showing them and
+`/skill.md` + `/llms.txt` stop teaching them — while the endpoints stay generated, priced,
+`catalog get`-able and callable by id, so agents that already hold one keep working. A dashboard
+flip, no redeploy, like `TREG_PLATFORM_PROVIDERS` and `TREG_OVERFLOW_MODE`.
+
+It exists because two questions are separate: whether the router ANSWERS well (measured — the
+people-search bench puts the routed path at parity with the hand-written policy it replaces) and
+whether every agent should be LED to it by default (only traffic answers that). Flip it rather than
+reverting the feature.
+
 ## Market data platform keys (2026-08-16)
 
 Five more `TREG_PLATFORM_KEY_*` env vars beside the originals, and the providers must ALSO be in

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -259,6 +259,11 @@ def render(variant: str) -> str:
         # stamping it here is what lets one generated file satisfy both registries.
         fm = f"{fm.rstrip()}\nversion: {package_version()}\n"
     out = f"---{fm}---\n{bootstrap}\n{body.lstrip(chr(10))}"
+    # 4. `<!--routed-->` / `<!--/routed-->` delimit the section the SERVER strips when a deployment
+    #    sets TREG_ROUTED_DISCOVERY=off. A plugin copy is static and cannot know a deployment's
+    #    setting, so it keeps the content — but the markers themselves must never ship, or the
+    #    product's most-read page starts with visible HTML comments.
+    out = out.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
     return out.replace("{BASE}", PUBLIC_BASE)
 
 

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -199,6 +199,14 @@ class Settings(BaseSettings):
     # happens to hold a key can't start spending it by accident. `TREG_PLATFORM_PROVIDERS=""` in the
     # Render dashboard turns the whole feature off without a redeploy.
     platform_providers: str = ""
+    # Whether DISCOVERY steers to routed rows: `treg.<capability>` first in search, and a routed
+    # parent pulled in whenever one of its children matched. `off` leaves every routed endpoint
+    # callable and priced — only the steering stops, and search looks as it did before routing
+    # shipped. Same runtime-switch shape as `platform_providers`: flip it in the dashboard, no
+    # redeploy. It exists because "does the router answer well" and "should every agent be led to
+    # it by default" are separate questions, and the second one is answered by traffic, not by
+    # argument.
+    routed_discovery: str = "on"
     # Per-org, per-UTC-day ceiling on tier-4 spend, and the CEILING a team may raise its own
     # `Org.daily_cap_micro` to. Enforced FAIL-CLOSED (unlike the soft per-user call cap): a query
     # error refuses the call rather than letting an unbounded amount of our money out. It is a

--- a/src/treg/domain/catalog/store.py
+++ b/src/treg/domain/catalog/store.py
@@ -574,7 +574,19 @@ def group_routed(rows: list[dict], key=lambda r: r, max_children: int | None = N
     providers must not eat the whole result budget (`find leads`, 2026-08-28: people.search's
     children pushed people.email.find to one line and people.enrich off the page). The children
     kept are the best-ranked ones; the parent row is stamped `children_hidden` = how many were cut,
-    and the full ranked list is one `catalog get <parent>` away."""
+    and the full ranked list is one `catalog get <parent>` away.
+
+    `TREG_ROUTED_DISCOVERY=off` turns the STEERING off and returns the rows untouched: routed
+    endpoints stay callable, priced and reachable by id — search simply stops leading with them, as
+    it did before routing shipped. Whether the router answers well and whether every agent should
+    be pointed at it by default are different questions; this is the switch for the second one."""
+    from ...config import get_settings
+    if str(get_settings().routed_discovery).strip().lower() in ("off", "0", "false", "no"):
+        # Not merely "do not group": before routing shipped these rows did not exist, and a routed
+        # row still MATCHES a keyword search on its own summary, so leaving it in would keep
+        # steering by the back door. Off means search never surfaces one; `catalog get <id>` and
+        # `POST /call/<id>` are untouched.
+        return [r for r in rows if key(r).get("kind") != "routed"]
     routed_caps = {key(r)["capability"] for r in rows if key(r).get("kind") == "routed"}
     if not routed_caps:
         return rows

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -568,7 +568,11 @@ async def _catalog_search_impl(
     # one of the 24 "ad library" matches scores 6 — so with a default limit of 8 the rows an agent
     # actually sees were decided by file order. That handed back seven tikhub rows (one of them
     # uncallable) and hid the cheapest endpoint with a perfect measured record.
-    ranked, total, tie_truncated = catalog_store.rank_band(query, cat, min(100, limit * 4))  # wider: groups collapse below
+    # The band is widened only so routed groups can collapse below without starving the page; with
+    # steering off there is no collapsing, so the original band is the right one.
+    _steering = str(get_settings().routed_discovery).strip().lower() not in ("off", "0", "false", "no")
+    ranked, total, tie_truncated = catalog_store.rank_band(
+        query, cat, min(100, limit * 4) if _steering else limit)
     stats = await _observed_stats([ep["id"] for ep, _ in ranked])
     ranked = catalog_store.rerank(ranked, stats, cat)
     results = []
@@ -592,7 +596,7 @@ async def _catalog_search_impl(
             **({"routed": f"treg picks among {len(ep.get('routed_children') or [])} providers"
                           + (f" — {hidden[ep['id']]} more than shown here; catalog_get('{ep['id']}') ranks them all"
                              if ep["id"] in hidden else " below")}
-               if ep.get("kind") == "routed" else {}),
+               if _steering and ep.get("kind") == "routed" else {}),
             "usd_per_call": cost.get("usd"),
             # BOTH halves of tier 4's own truth, not just the price side: `platform_eligible` says
             # the row is priceable, `platform_key_for` says this deploy actually holds an enabled

--- a/src/treg/routers/catalog.py
+++ b/src/treg/routers/catalog.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
 from .. import audit, catalog_store, oauth_providers
+from ..config import get_settings
 from ..domain.catalog import stats as endpoint_stats
 
 
@@ -87,6 +88,11 @@ async def catalog_platform(slug: str, include_hidden: int = 0) -> dict:
     hidden_count = len([e for e in eps if e["kind"] in catalog_store.HIDDEN_KINDS])
     if not include_hidden:
         eps = [e for e in eps if e["kind"] not in catalog_store.HIDDEN_KINDS]
+    # The BROWSE view steers too — it sorts the routed parent to the top of its capability group —
+    # so it honours the same switch as search. Otherwise a deployment with routed discovery off
+    # would hide the row in search and still lead with it one click later.
+    if str(get_settings().routed_discovery).strip().lower() in ("off", "0", "false", "no"):
+        eps = [e for e in eps if e.get("kind") != "routed"]
     grouped: dict[str, list[dict]] = {}
     extended: list[dict] = []
     pairs: list[tuple[dict, dict]] = []

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2402,7 +2402,8 @@ async def llms_txt():
     if not f.exists():
         raise HTTPException(status_code=404, detail="llms.txt not bundled")
     base = get_settings().public_url.rstrip("/")
-    return PlainTextResponse(f.read_text(encoding="utf-8").replace("{BASE}", base), media_type="text/plain; charset=utf-8")
+    return PlainTextResponse(_strip_routed(f.read_text(encoding="utf-8")).replace("{BASE}", base),
+                             media_type="text/plain; charset=utf-8")
 
 
 @app.get("/robots.txt", include_in_schema=False)
@@ -2550,6 +2551,20 @@ async def selfhost_sh():
                              media_type="text/x-shellscript; charset=utf-8")
 
 
+def routed_discovery_on() -> bool:
+    """`TREG_ROUTED_DISCOVERY` — see catalog_store.group_routed. The agent-facing files honour it
+    too: a deployment that hides routed rows from search must not keep TEACHING agents to call
+    them, or the docs and the catalog disagree and the agent trusts the docs."""
+    return str(get_settings().routed_discovery).strip().lower() not in ("off", "0", "false", "no")
+
+
+def _strip_routed(text: str) -> str:
+    """Remove the `<!--routed-->…<!--/routed-->` blocks (and, when kept, just the markers)."""
+    if routed_discovery_on():
+        return text.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
+    return re.sub(r"<!--routed-->.*?<!--/routed-->\n?", "", text, flags=re.S)
+
+
 def _serve_md(name: str) -> PlainTextResponse:
     """Serve a bundled markdown file as inline text (so "open in new tab" shows it, not a download),
     with the serving domain templated in. Backs the 'copy markdown' buttons on the docs pages."""
@@ -2557,7 +2572,7 @@ def _serve_md(name: str) -> PlainTextResponse:
     if not f.exists():
         raise HTTPException(status_code=404, detail=f"{name} not bundled")
     base = get_settings().public_url.rstrip("/")
-    return PlainTextResponse(f.read_text(encoding="utf-8").replace("{BASE}", base),
+    return PlainTextResponse(_strip_routed(f.read_text(encoding="utf-8")).replace("{BASE}", base),
                              media_type="text/plain; charset=utf-8")
 
 

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -194,6 +194,7 @@ endpoint** through a treg-owned relay account — same request, same response sh
 real price — with `X-Treg-Served-Via: overflow:<name>` on the response (a team can opt out with
 `treg org overflow off`). Your own keys are never relayed.
 
+<!--routed-->
 **Routed endpoints — when you WANT treg to choose.** `treg.<capability>` rows (today:
 `treg.people.email.find`) are first-party endpoints generated from the providers of one capability.
 `POST /call/treg.people.email.find` with `{full_name, domain}` (or `first_name`+`last_name`+`domain`,
@@ -205,6 +206,7 @@ provider error OR a miss falls through to the next provider, cheapest first, wit
 ranked plan and prices before you spend.
 Call a specific provider's endpoint when you need a particular one.
 
+<!--/routed-->
 Money notes for agents:
 - The price is visible before you call (`treg catalog get`, or `estimated_cost_usd` in
   `GET {BASE}/catalog/endpoints/<id>/access`). No confirmation ritual — costs are fractions

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -102,12 +102,14 @@ Notes:
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
     (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
     `treg org overflow off`.
+<!--routed-->
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back
     on errors AND misses (cheapest first, within `X-Treg-Route-Max-Cost`, default $1), and returns
     `{output, raw, _treg.served_by, _treg.tried}` + `X-Treg-Served-By`. `X-Treg-Route-Waterfall: 0`
     stops at the first miss. `catalog_get treg.people.email.find` shows the plan and prices.
+<!--/routed-->
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Retrying a call without paying twice

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -784,6 +784,16 @@ async def test_routed_discovery_is_a_runtime_switch(clients: AsyncClient, enrich
         "steering off: search looks as it did before routing shipped"
     assert ids_off, "and it still returns the providers themselves"
 
+    # every OTHER discovery surface follows the same switch, or the deployment contradicts itself
+    plat = (await clients.get("/catalog/platforms/people")).json()
+    flat = json.dumps(plat)
+    assert "treg.people." not in flat, "browse view: no routed row while steering is off"
+    for path in ("/skill.md", "/llms.txt"):
+        body = (await clients.get(path)).text
+        assert "Routed endpoints" not in body, f"{path} must not teach what search hides"
+        assert "<!--routed" not in body, f"{path} leaked a marker"
+        assert "provider_capacity_unavailable" in body, f"{path} lost the unrelated overflow guidance"
+
     # …but the endpoint is untouched: still callable, still priced, still found by id
     r = await clients.get("/catalog/endpoints/treg.people.email.find")
     assert r.status_code == 200 and r.json()["endpoint"]["kind"] == "routed"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -764,3 +764,32 @@ async def test_the_geo_aware_child_wins_a_filtered_search_and_the_answer_says_wh
     assert d2["_treg"]["ignored_filters"] == ["country"], "the caller sent it; aviato has no place for it"
     assert r2.headers["X-Treg-Ignored-Filters"] == "country"
     assert d2["_treg"]["tried"][-1]["ignored_filters"] == ["country"], "same set in all three places"
+
+
+async def test_routed_discovery_is_a_runtime_switch(clients: AsyncClient, enrichment_on, monkeypatch):
+    """`TREG_ROUTED_DISCOVERY=off` stops search LEADING with `treg.<capability>` — nothing else.
+    The endpoints stay callable, priced and reachable by id; only the steering goes away, so a
+    deployment can answer "should every agent be pointed at the router by default" with traffic
+    instead of an argument, and can undo it without a redeploy."""
+    q = {"q": "find someone's work email from their name and company", "limit": 8}
+    on = (await clients.get("/catalog/search", params=q)).json()
+    ids_on = [r["id"] for r in on["results"]]
+    assert any(i.startswith("treg.") for i in ids_on), "steering on: the routed row is in the page"
+
+    monkeypatch.setenv("TREG_ROUTED_DISCOVERY", "off")
+    get_settings.cache_clear()
+    off = (await clients.get("/catalog/search", params=q)).json()
+    ids_off = [r["id"] for r in off["results"]]
+    assert not any(i.startswith("treg.") for i in ids_off), \
+        "steering off: search looks as it did before routing shipped"
+    assert ids_off, "and it still returns the providers themselves"
+
+    # …but the endpoint is untouched: still callable, still priced, still found by id
+    r = await clients.get("/catalog/endpoints/treg.people.email.find")
+    assert r.status_code == 200 and r.json()["endpoint"]["kind"] == "routed"
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"tomba": [(200, {"data": {"email": "p@stripe.com", "score": 99, "first_name": "Patrick",
+                                   "last_name": "Collison", "verification": {"status": "valid"}}})]}, []))
+    call = await clients.post(f"/call/{ROUTED}", json={"full_name": "Patrick Collison", "domain": "stripe.com"})
+    assert call.status_code == 200 and call.json()["_treg"]["served_by"] == "tomba.people.email.find"
+    get_settings.cache_clear()


### PR DESCRIPTION
Two questions got answered as one when routing shipped:

1. **Does the router answer well?** Measured — the people-search bench now puts the routed path at parity with the hand-written policy it replaces (PR #256), and treg at 65.2 ALL, tying Lessie.
2. **Should every agent be LED to it by default?** Only traffic answers that, and until it does, a deployment should be able to change its mind without a redeploy or a revert.

This is the switch for the second one.

## What it does

`TREG_ROUTED_DISCOVERY` — `on` by default (so merging changes nothing), `off` to stop steering. It covers **every surface that steers**:

| surface | on | off |
|---|---|---|
| search (`group_routed`, both MCP + HTTP) | routed row leads its capability group | hidden |
| browse (`/catalog/platforms/{slug}`) | routed sorted to top of each group | dropped |
| `/skill.md` | teaches routed endpoints | section stripped at serve time |
| `/llms.txt` | teaches routed endpoints | section stripped at serve time |

**Untouched, deliberately:** generation, pricing, `catalog get <id>`, `POST /call/<id>`. An agent that already holds the id keeps working — the switch changes what treg **recommends**, never what it **accepts**.

Dashboard flip, no redeploy — same shape as `TREG_PLATFORM_PROVIDERS` and `TREG_OVERFLOW_MODE`.

## Two decisions worth review

**Off *hides* routed rows from search rather than merely ungrouping them.** A routed row matches a keyword query on its own summary, so returning it unsorted would keep steering by the back door. Before #242 these rows did not exist in search at all, and that is the state `off` restores.

**The agent docs had to follow, or the deployment contradicts itself.** `install.sh` drops `skill.md` into every agent. With search gated but the docs untouched, agents would keep calling an endpoint the catalog no longer shows — and they would believe the file they were installed with over the search results.

## Why a switch and not a revert of #242

A `git revert` would also delete the overflow / `503 provider_capacity_unavailable` guidance in `skill.md` and `llms.txt` — that came from the capacity work, not from routing, and is still true. Hence `<!--routed-->…<!--/routed-->` markers around the routing paragraphs only; the markers are stripped in both modes, and a test asserts the overflow guidance survives with the flag off.

It would also throw away a router that measures at parity with a hand-tuned policy.

## Verified

```
on   → treg.people.search, apollo…, companyenrich…, findymail…   (4 routed rows)
off  → apollo…, companyenrich…, findymail…, icypeas…             (0 routed rows)
       skill.md "Routed endpoints" mentions: 0
       skill.md provider_capacity_unavailable: 1   ← unrelated guidance kept
       treg.people.search still resolves and still calls
```

One new test drives all four surfaces plus a live routed call with the flag off. Docs: `architecture/catalog.md` and `ops/deploy.md` (drift.sh maps `config.py` there, beside the other two runtime switches).

## Note

Turning discovery off does not un-teach agents that already have `skill.md` installed. Pair a flip with a skill.md update if that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01189rW3MxcaVTPqxqSZTQot