### PR TITLE
fix(api): answer a typed 503 when the database is unreachable, not an anonymous 500

### DIFF
--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -33,7 +33,8 @@ attaches concern routers at compatibility-sensitive registration points, and cal
 EOF so the deployed `treg.api:app` import path remains the default `all` role.
 
 The factory owns concrete assembly: the three core pure-ASGI middleware registrations, the optional
-V2 path normalizer, five exception handlers, static mounts, optional MCP mounts and lifespans,
+V2 path normalizer, nine exception handlers (four of them one DB-unavailable adapter registered per
+class), static mounts, optional MCP mounts and lifespans,
 GET-to-HEAD widening, the OpenAPI wrapper that hides
 implied HEAD operations, shared HTTP client creation, startup work, shutdown drains, and the Ads
 conversion worker. Registration order is compatibility behavior. The four stage-0 snapshots stay
@@ -49,7 +50,9 @@ than appearing in the role's always-running background-task manifest. The lifesp
 shutdown first unbinds it from MCP, then calls `aclose()`, which refuses new refreshes and cancels the
 shared Task before database and HTTP resources disappear.
 
-`bootstrap_handlers.py` owns the app-wide pool-saturation and HTTP-exception adapters. The composition
+`bootstrap_handlers.py` owns the app-wide pool-saturation, DB-unavailable and HTTP-exception
+adapters (the DB-unavailable one answers the same typed 503 with `"reason": "db_unavailable"`;
+detail in [deploy](../ops/deploy.md) and [api](../interface/api.md)). The composition
 root supplies the call-specific `_stamp_call_exit` callback from `routers/call.py` before registration;
 the callback owns call ids, refusal classification, audit fallback, and idempotency-label release.
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -227,7 +227,9 @@ The API builds a single-binding tool from flat fields via `_flat_binding()`; inj
 [auth-secrets](auth-secrets.md).
 
 ## Async DB (`db.py`)
-One async SQLAlchemy engine (`_engine`, Postgres pool 5 + 10 overflow per instance, `pool_timeout=5`)
+One async SQLAlchemy engine (`_engine`, Postgres pool sized per process via `TREG_DB_POOL_SIZE` /
+`TREG_DB_MAX_OVERFLOW` — defaults 5 + 3 overflow, `pool_timeout=5` hardcoded; see
+[deploy](../ops/deploy.md))
 + a public `session_maker` (the audit writer opens its own session here; so do the post-relay
 bookkeeping steps of `/call/` — the request session is committed before the relay so none of them
 ever waits on it, see [proxy-model](proxy-model.md) § Connection discipline). `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` —

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -637,7 +637,14 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   (+ `ensure_fresh`) → **`db.commit()` — the DB phase ends here; a call in flight holds no pooled
   connection** → `relay()` → `audit.record_call`. A pool that has no slot within 5 s answers
   `503 {"treg_saturated": true}` + `Retry-After: 2` (`_pool_saturated`, the handler for
-  `sqlalchemy.exc.TimeoutError`) rather than a 30 s wait and an anonymous 500. A **platform binding** carries no `secret_id`
+  `sqlalchemy.exc.TimeoutError`) rather than a 30 s wait and an anonymous 500. The database being
+  UNREACHABLE shares that contract with `"reason": "db_unavailable"` added (`_db_unavailable`,
+  registered for `OperationalError`/`InterfaceError`/`DisconnectionError` AND the raw builtin
+  `ConnectionRefusedError` - on this stack a Postgres TCP refusal escapes asyncpg untranslated, the
+  2026-08-29 outage). DBAPIErrors count only when `connection_invalidated` or `orig` is an
+  `OSError`; a statement-level failure (deadlock, lock/statement timeout) re-raises and keeps its
+  500. Both 503 exits stamp `X-Treg-Call-Id`, the audit row and the idempotency release via
+  `_stamp_call_exit`, and both deliberately omit `X-Treg-Error` (the typed flag is the signal). A **platform binding** carries no `secret_id`
   (its value comes from settings at relay time), so secret-loading now skips `secret_id is None`. Detail
   in [proxy-model](../architecture/proxy-model.md).
   `call_catalog_endpoint` (`* /catalog/call/{rest:path}`, hidden from public OpenAPI) is the narrower

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -35,19 +35,36 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
   SQLite, `init_db` raises (an ephemeral key would make every stored secret undecryptable after a
   restart — silent total loss). On SQLite dev it only logs a warning.
 - **Postgres pool hygiene:** for non-SQLite URLs the async engine adds `pool_pre_ping=True`,
-  `pool_recycle=300`, sizing (`pool_size=5`, `max_overflow=10` — per instance; a rolling deploy runs two
-  against a basic-plan Postgres ceiling of ~100, the 2026-08-15 outage) and `pool_timeout=5`. A request
-  that gets no slot in 5 s is answered `503 {"treg_saturated": true}` with `Retry-After: 2` (api.py
-  `_pool_saturated`) instead of SQLAlchemy's default 30 s wait and an anonymous 500. 15 slots is plenty
-  because a `/call/` holds no connection during its upstream round trip — `call_tool` commits before
-  `relay()`; holding one there deadlocked 15 concurrent calls for 30 s on 2026-08-24 (see
+  `pool_recycle=300`, env-tunable sizing (`TREG_DB_POOL_SIZE` / `TREG_DB_MAX_OVERFLOW`, defaults 5+3)
+  and a hardcoded `pool_timeout=5` (it encodes the typed-503 contract, not capacity). The per-component
+  budget: web 8 (5+3) x 2 during a rolling deploy + the capacity-sweep cron at 1+0 (pinned in
+  render.yaml) = 17 worst case; alembic already runs on NullPool (alembic/env.py). The ceiling is ~100
+  nominal on current flexible plans (97 on legacy plans; Render reserves some connections), but on the
+  basic-256mb instance the 256MB of memory is the binding constraint in practice - DB phases are
+  millisecond-scale, so 8 slots per web process absorb any realistic burst (the 2026-08-15 outage was
+  20+40 x 2 starving the whole database). A request that gets no slot in 5 s is answered
+  `503 {"treg_saturated": true}` with `Retry-After: 2` (bootstrap_handlers `_pool_saturated`) instead of
+  SQLAlchemy's default 30 s wait and an anonymous 500. The slots are plenty because a `/call/` holds no
+  connection during its upstream round trip - `call_tool` commits before `relay()`; holding one there
+  deadlocked 15 concurrent calls for 30 s on 2026-08-24 (see
   [proxy-model](../architecture/proxy-model.md) § Connection discipline).
+- **Database unreachable → the same typed 503:** when Postgres itself is down (TCP refusal, or an
+  established connection dies), `_db_unavailable` answers the SAME `503 {"treg_saturated": true}`
+  contract with `"reason": "db_unavailable"` added, so existing client retry branches fire and
+  incidents are greppable in Render logs (logger `treg`, one warning line per hit). It is registered
+  for the SQLAlchemy classes AND the raw builtin `ConnectionRefusedError` - on sqlalchemy 2.0.51 +
+  asyncpg 0.31.0 a Postgres TCP refusal escapes untranslated (the 2026-08-29 outage surfaced as
+  anonymous 500s). Statement-level OperationalErrors (deadlock, lock/statement timeout) re-raise and
+  keep their 500: only `connection_invalidated` or an `OSError` `orig` counts as the DB being down.
 
 ## Config (`config.py`)
 `Settings` (pydantic-settings, env prefix `TREG_`, reads `.env`), cached via `get_settings()`:
 - `database_url` — default `sqlite+aiosqlite:///./treg.db` (SQLite dev, Postgres on Render, same code).
   A `field_validator` rewrites a bare `postgres://` / `postgresql://` URL → `postgresql+asyncpg://`, so
   Render's `fromDatabase`-injected URL works unedited (the async engine needs the asyncpg driver).
+- `db_pool_size` / `db_max_overflow` - per-process Postgres pool sizing (defaults 5+3, ignored on
+  SQLite). The knob that lets each service size its own pool: the web service keeps the defaults, the
+  capacity-sweep cron pins `TREG_DB_POOL_SIZE=1` / `TREG_DB_MAX_OVERFLOW=0` in render.yaml.
 - `secret_key` — the Fernet key; empty → an ephemeral key is minted at startup (secrets won't survive a
   restart). See [auth-secrets](../architecture/auth-secrets.md).
 - `public_url` — default `https://treg.to`; the reference deployment is cut over in STAGES —

--- a/render.yaml
+++ b/render.yaml
@@ -179,6 +179,14 @@ services:
           type: web
           name: treg
           envVarName: TREG_SECRET_KEY
+      # The sweep never holds more than one DB connection at a time: init_db's connection returns
+      # to the pool before the single session opens, the collector fan-out is HTTP-only, and every
+      # write is sequential on that one session. 1+0 gives Postgres' 256MB back to the web service,
+      # and any future accidental parallelization surfaces immediately via the 5s pool timeout.
+      - key: TREG_DB_POOL_SIZE
+        value: "1"
+      - key: TREG_DB_MAX_OVERFLOW
+        value: "0"
       - key: TREG_OVERFLOW_KEY_ORTHOGONAL
         fromService:
           type: web

--- a/scripts/dump_surface.py
+++ b/scripts/dump_surface.py
@@ -24,6 +24,7 @@ def _configure_test_environment() -> None:
         "sh,echo,true,false,cat,sleep,treg-nonexistent-bin-xyz"
     )
     os.environ["TREG_PROXY_SSRF_CHECK"] = "false"
+    os.environ["TREG_CLAUDE_CONNECTOR_ENABLED"] = "true"
 
     for key in (
         "GOOGLE_CLIENT_ID",

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -12,6 +12,7 @@ import httpx
 from fastapi import FastAPI
 from fastapi.routing import APIRoute, request_response
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy.exc import DisconnectionError, InterfaceError, OperationalError
 from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.routing import BaseRoute, Mount
@@ -494,6 +495,14 @@ def create_app(role: AppRole = "all") -> FastAPI:
     app.add_exception_handler(OverflowError, api_module._id_out_of_range)
     bootstrap_handlers._stamp_call_exit = call_routes._stamp_call_exit
     app.add_exception_handler(PoolTimeoutError, bootstrap_handlers._pool_saturated)
+    # The database being unreachable shares the saturated contract (reason: db_unavailable). The
+    # builtin ConnectionRefusedError is MANDATORY: on this stack (sqlalchemy 2.0.51 + asyncpg
+    # 0.31.0) a Postgres TCP refusal escapes RAW - the asyncpg dialect translates no OSError - so
+    # the SQLAlchemy classes alone miss the actual outage failure (2026-08-29). No collision with
+    # upstream provider failures: httpx connect errors are absorbed in application/call/service.py,
+    # and httpx exceptions do not subclass the builtin ConnectionError.
+    for db_down in (OperationalError, InterfaceError, DisconnectionError, ConnectionRefusedError):
+        app.add_exception_handler(db_down, bootstrap_handlers._db_unavailable)
     app.add_exception_handler(StarletteHTTPException, bootstrap_handlers._mark_treg_own_errors)
 
     _include_role_routes(app, api_module, role)

--- a/src/treg/bootstrap_handlers.py
+++ b/src/treg/bootstrap_handlers.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import Request
 from fastapi.exception_handlers import http_exception_handler
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -15,6 +17,20 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 _stamp_call_exit: Any
 
 
+async def _saturated_503(request: Request, body: dict[str, Any]) -> JSONResponse:
+    """Answer a typed saturation 503 (`treg_saturated` + `Retry-After: 2`) with /call/ bookkeeping.
+
+    A saturation 503 is answered HERE, not through `_mark_treg_own_errors`, so it needs its own
+    join key, row and label release. Without them the one failure mode a burst actually produces
+    (#181) is the one a caller cannot report and `/calls` cannot show. `X-Treg-Error` stays off:
+    the typed `treg_saturated` flag is this exit's signal, and the header is documented as the
+    HTTPException handler's (interface/api.md)."""
+    resp = JSONResponse({**body, "treg_saturated": True},
+                        status_code=503, headers={"Retry-After": "2"})
+    if request.url.path.startswith("/call/"):
+        await _stamp_call_exit(request, resp, 503)
+    return resp
+
 async def _pool_saturated(request: Request, exc: PoolTimeoutError) -> JSONResponse:
     """The DB pool had no connection to give within `pool_timeout` (db.py). That is treg being
     saturated, not the caller's fault and not the provider's — so say so, typed, and fast. Before this
@@ -22,17 +38,30 @@ async def _pool_saturated(request: Request, exc: PoolTimeoutError) -> JSONRespon
     `500 Internal Server Error` after a 30 s wait, which an agent cannot tell from a provider bug.
     `treg_saturated` is the key a retrying client should branch on; `Retry-After` is how long to wait
     before doing so."""
-    resp = JSONResponse(
-        {"detail": "treg's database pool is saturated — retry in a moment", "treg_saturated": True},
-        status_code=503, headers={"Retry-After": "2"})
-    # A saturation 503 is answered HERE, not through `_mark_treg_own_errors`, so it needs its own
-    # join key, row and label release. Without them the one failure mode a burst actually produces
-    # (#181) is the one a caller cannot report and `/calls` cannot show. `X-Treg-Error` stays off:
-    # the typed `treg_saturated` flag above is this exit's signal, and the header is documented as
-    # the HTTPException handler's (interface/api.md).
-    if request.url.path.startswith("/call/"):
-        await _stamp_call_exit(request, resp, 503)
-    return resp
+    return await _saturated_503(
+        request, {"detail": "treg's database pool is saturated — retry in a moment"})
+
+async def _db_unavailable(request: Request, exc: Exception) -> JSONResponse:
+    """The database itself is unreachable - Postgres refused the TCP connection, or an established
+    connection died mid-request. The 2026-08-29 outage: asyncpg's error translation has no OSError
+    entry, so a refused connection escapes as a RAW `builtins.ConnectionRefusedError` (not an
+    OperationalError), matched no handler, and surfaced as an anonymous 500 with no X-Treg-Call-Id,
+    no audit row and a leaked idempotency claim. Same shape as `_pool_saturated`: `treg_saturated`
+    stays the key a retrying client branches on; `reason` distinguishes DB-down from pool queueing."""
+    if isinstance(exc, DBAPIError) and not (
+        getattr(exc, "connection_invalidated", False)
+        or isinstance(getattr(exc, "orig", None), OSError)
+    ):
+        # A statement-level failure (deadlock, lock/statement timeout - `orig` is a Postgres error,
+        # not an OSError, and the connection is still good) is a bug to surface, not the database
+        # being down. Re-raise so it keeps today's 500 via ServerErrorMiddleware.
+        raise exc
+    logging.getLogger("treg").warning(
+        "database unavailable - answered a typed 503: path=%s reason=db_unavailable exc=%r",
+        request.url.path, exc)
+    return await _saturated_503(
+        request, {"detail": "treg's database is unavailable - retry in a moment",
+                  "reason": "db_unavailable"})
 
 async def _mark_treg_own_errors(request: Request, exc: StarletteHTTPException):
     """Tag treg's OWN refusals on `/call/` with `X-Treg-Error`, then answer exactly as before.
@@ -56,4 +85,5 @@ async def _mark_treg_own_errors(request: Request, exc: StarletteHTTPException):
 
 # Preserve the frozen composition snapshot until the Stage 4 close-out refreshes module paths.
 _pool_saturated.__module__ = "treg.api"
+_db_unavailable.__module__ = "treg.api"
 _mark_treg_own_errors.__module__ = "treg.api"

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -37,6 +37,15 @@ class Settings(BaseSettings):
     # SQLite locally, Postgres on Render — same code path, just swap the URL.
     database_url: str = "sqlite+aiosqlite:///./treg.db"
 
+    # Postgres pool sizing, per process (TREG_DB_POOL_SIZE / TREG_DB_MAX_OVERFLOW; ignored on
+    # SQLite). The defaults size the WEB service; the capacity-sweep cron pins 1+0 in render.yaml.
+    # 8 slots bound concurrent DB PHASES, which are millisecond-scale (a /call/ holds no pooled
+    # connection during its upstream round trip) - the binding constraint on the basic-256mb
+    # Postgres is its 256MB of memory, not the nominal connection ceiling. Sustained saturation
+    # surfaces as the typed 503, not silence. Sizing arithmetic in db.py.
+    db_pool_size: int = 5
+    db_max_overflow: int = 3
+
     @field_validator("database_url")
     @classmethod
     def _async_pg_driver(cls, v: str) -> str:

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -21,22 +21,30 @@ from .config import get_settings
 # On a real (non-SQLite) DB, add production pool hygiene: pre-ping to drop dead connections
 # (Postgres/PgBouncer close idle ones → otherwise a post-idle request 500s) and a recycle window,
 # sized against the relay's concurrency so bursts don't starve the pool + time out.
-_db_url = get_settings().database_url
+_settings = get_settings()
+_db_url = _settings.database_url
 _engine_kwargs: dict = {"future": True}
 if "sqlite" not in _db_url:
-    # 5+10, not the 20+40 this shipped with. The pool is PER INSTANCE, and a rolling deploy runs two
-    # instances against one Postgres — 60 each meant 120 potential connections against a basic-plan
-    # ceiling of ~100, so a deploy could starve the database with no bug anywhere. 15 is generous for
-    # an async app on this plan; saturation now surfaces as our own pool queueing (visible, bounded)
-    # rather than Postgres refusing connections for everyone (the 2026-08-15 outage).
+    # Sizing is env-tunable per service (TREG_DB_POOL_SIZE / TREG_DB_MAX_OVERFLOW, defaults 5+3 in
+    # config.py; the capacity-sweep cron pins 1+0 in render.yaml). History: this shipped at 20+40.
+    # The pool is PER INSTANCE, and a rolling deploy runs two instances against one Postgres - 60
+    # each meant 120 potential connections against a ~100 ceiling, so a deploy could starve the
+    # database with no bug anywhere (the 2026-08-15 outage); 5+10 fixed that. The current budget:
+    # web 8 (5+3) x 2 during a rolling deploy + cron 1 = 17 against the basic-256mb ceiling (~100
+    # nominal on current flexible plans - Render reserves some connections, and in practice the
+    # 256MB of RAM is the binding constraint, not the nominal count). Saturation surfaces as our
+    # own pool queueing (visible, bounded) rather than Postgres refusing connections for everyone.
     #
-    # `pool_timeout` 5 s, not SQLAlchemy's default 30: a request that cannot get a slot is treg
-    # saturated, and the caller should hear that fast and typed (api.py maps the TimeoutError to a
-    # `503 treg_saturated` with Retry-After) rather than sit 30 s and receive an anonymous 500. The
-    # slot count itself only bounds concurrent DB PHASES, which are milliseconds — a /call/ holds no
-    # connection during its upstream round trip (call_tool commits before relay()). Holding one
-    # there is what turned 15 concurrent calls into a 30 s deadlock on 2026-08-24.
-    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300, pool_size=5, max_overflow=10,
+    # `pool_timeout` stays HARDCODED at 5 s, not SQLAlchemy's default 30 - it encodes the typed-503
+    # contract, not capacity. A request that cannot get a slot is treg saturated, and the caller
+    # should hear that fast and typed (api.py maps the TimeoutError to a `503 treg_saturated` with
+    # Retry-After) rather than sit 30 s and receive an anonymous 500. The slot count itself only
+    # bounds concurrent DB PHASES, which are milliseconds - a /call/ holds no connection during its
+    # upstream round trip (call_tool commits before relay()). Holding one there is what turned 15
+    # concurrent calls into a 30 s deadlock on 2026-08-24.
+    _engine_kwargs.update(pool_pre_ping=True, pool_recycle=300,
+                          pool_size=_settings.db_pool_size,
+                          max_overflow=_settings.db_max_overflow,
                           pool_timeout=5)
 _engine = create_async_engine(_db_url, **_engine_kwargs)
 # Public: the audit writer opens its own session here (off the request path — rule #2).

--- a/tests/snapshots/composition.json
+++ b/tests/snapshots/composition.json
@@ -19,6 +19,22 @@
     {
       "exception": "sqlalchemy.exc.TimeoutError",
       "handler": "treg.api._pool_saturated"
+    },
+    {
+      "exception": "sqlalchemy.exc.OperationalError",
+      "handler": "treg.api._db_unavailable"
+    },
+    {
+      "exception": "sqlalchemy.exc.InterfaceError",
+      "handler": "treg.api._db_unavailable"
+    },
+    {
+      "exception": "sqlalchemy.exc.DisconnectionError",
+      "handler": "treg.api._db_unavailable"
+    },
+    {
+      "exception": "builtins.ConnectionRefusedError",
+      "handler": "treg.api._db_unavailable"
     }
   ],
   "middleware": [

--- a/tests/test_call_pool_discipline.py
+++ b/tests/test_call_pool_discipline.py
@@ -21,7 +21,7 @@ import os
 import time
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -38,6 +38,7 @@ from treg.models import CallRecord, Hold
 from test_marketplace_call import EP, EP_MICRO, platform_on  # noqa: F401 — fixture reuse
 from test_mcp import _call_tool, mcp_session
 
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 
 
@@ -136,6 +137,64 @@ async def test_a_saturated_pool_answers_a_typed_503_not_an_anonymous_500(
     assert r.status_code == 503, r.text
     assert r.json()["treg_saturated"] is True
     assert r.headers.get("Retry-After") == "2"
+
+
+async def test_a_refused_db_connection_answers_the_same_typed_503(
+    clients: AsyncClient, monkeypatch,
+):
+    """The 2026-08-29 outage: Postgres refusing the TCP connection surfaces from asyncpg as a RAW
+    builtins.ConnectionRefusedError (the dialect's error translation has no OSError entry), NOT an
+    OperationalError. Before the fix it matched no handler and escaped as an anonymous 500 with no
+    X-Treg-Call-Id, no audit row and a leaked idempotency claim."""
+    async def _db_down(*args, **kwargs):
+        raise ConnectionRefusedError(61, "Connection refused")
+
+    monkeypatch.setattr(call_service, "_resolve_call", _db_down)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["treg_saturated"] is True
+    assert body["reason"] == "db_unavailable"
+    assert r.headers.get("Retry-After") == "2"
+    assert r.headers.get("X-Treg-Call-Id"), "the exit must carry the id that joins the audit row"
+
+
+async def test_an_invalidated_connection_error_answers_the_same_typed_503(
+    clients: AsyncClient, monkeypatch,
+):
+    """A wrapped OperationalError whose connection died (connection_invalidated, or orig an OSError)
+    is the database being unreachable, not a statement bug - same 503 contract."""
+    async def _conn_dropped(*args, **kwargs):
+        raise OperationalError(
+            "SELECT 1", None, OSError(61, "Connection refused"), connection_invalidated=True)
+
+    monkeypatch.setattr(call_service, "_resolve_call", _conn_dropped)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["treg_saturated"] is True
+    assert body["reason"] == "db_unavailable"
+    assert r.headers.get("Retry-After") == "2"
+    assert r.headers.get("X-Treg-Call-Id")
+
+
+async def test_a_statement_level_operational_error_keeps_its_500(
+    clients: AsyncClient, monkeypatch,
+):
+    """A deadlock or lock/statement timeout (orig is an asyncpg Postgres error, not an OSError, and
+    the connection is still good) is a bug to surface, not the DB being down - it must NOT be
+    converted into a retryable 503."""
+    async def _deadlock(*args, **kwargs):
+        raise OperationalError("UPDATE hold SET ...", None, Exception("deadlock detected"))
+
+    monkeypatch.setattr(call_service, "_resolve_call", _deadlock)
+    # raise_app_exceptions=False so ServerErrorMiddleware's plain 500 is observable as a response.
+    transport = ASGITransport(app=A.app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://registry",
+                           headers={"X-Treg-Token": clients.headers["X-Treg-Token"]}) as c:
+        r = await c.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 500, r.text
+    assert "treg_saturated" not in r.text
 
 
 @pytest.mark.skipif(

--- a/tests/test_walking_skeleton.py
+++ b/tests/test_walking_skeleton.py
@@ -115,17 +115,13 @@ async def test_meta_reports_the_released_version(clients: AsyncClient):
 def test_the_pool_cannot_outnumber_postgres_during_a_deploy():
     """A rolling deploy runs TWO instances against one database. At 20+40 each, that was 120
     potential connections against a basic-plan ceiling of ~100 — a deploy could starve Postgres with
-    no bug anywhere, which is exactly what happened on 2026-08-15. Two instances of the current
-    numbers must stay comfortably under a 97-connection ceiling."""
-    import re
-    from pathlib import Path
+    no bug anywhere, which is exactly what happened on 2026-08-15. Sizing is now env-tunable
+    (TREG_DB_POOL_SIZE / TREG_DB_MAX_OVERFLOW), so this pins the SHIPPED defaults: two instances of
+    them must stay comfortably under a 97-connection ceiling."""
+    from treg.config import Settings
 
-    import treg.db as db
-
-    src = Path(db.__file__).read_text()
-    m = re.search(r"pool_size=(\d+), max_overflow=(\d+)", src)
-    assert m, "expected explicit pool bounds for the postgres path"
-    per_instance = int(m.group(1)) + int(m.group(2))
+    fields = Settings.model_fields
+    per_instance = fields["db_pool_size"].default + fields["db_max_overflow"].default
     assert per_instance * 2 <= 90, (
         f"two deploy-time instances could hold {per_instance * 2} connections — "
         "that is how the 2026-08-15 outage started")


### PR DESCRIPTION
## What & why

The 2026-08-29 outage: Postgres refusing the TCP connection escapes asyncpg **untranslated** as a raw `builtins.ConnectionRefusedError` (the asyncpg dialect's error translation has no OSError entry), matched no exception handler, and surfaced as an anonymous 500 - no `X-Treg-Call-Id`, no audit row, and a leaked idempotency claim.

- New `_db_unavailable` handler in `bootstrap_handlers.py`, registered for `OperationalError` / `InterfaceError` / `DisconnectionError` **and** the raw builtin `ConnectionRefusedError`. It answers the **same typed contract** as pool saturation - `503 {"treg_saturated": true}` + `Retry-After: 2` - with `"reason": "db_unavailable"` added, so existing client retry branches fire unchanged and incidents are greppable in Render logs (one `treg` warning line per hit).
- **Statement-level failures keep their 500**: a wrapped `DBAPIError` counts as DB-down only when `connection_invalidated` or `orig` is an `OSError`. A deadlock or lock/statement timeout re-raises - a bug must not become a retryable 503.
- Both 503 exits share `_saturated_503`, which stamps `X-Treg-Call-Id`, the audit row and the idempotency release via `_stamp_call_exit`. No collision with upstream provider failures: httpx connect errors are absorbed in `application/call/service.py` and httpx exceptions do not subclass the builtin `ConnectionError`.
- **Pool sizing becomes env-tunable per service** (`TREG_DB_POOL_SIZE` / `TREG_DB_MAX_OVERFLOW`, defaults 5+3; `pool_timeout=5` stays hardcoded - it encodes the typed-503 contract, not capacity). The capacity-sweep cron pins 1+0 in `render.yaml`; worst-case budget is web 8 x 2 (rolling deploy) + cron 1 = 17 connections.
- Docs fragments (composition, api, deploy, data-model) and the frozen composition snapshot updated in the same commit; `dump_surface.py` now sets `TREG_CLAUDE_CONNECTOR_ENABLED` to match `tests/conftest.py` so snapshot regeneration is reproducible.

## Verification

- Three new tests in `tests/test_call_pool_discipline.py`:
  - a raw `ConnectionRefusedError` from the DB phase answers the typed 503 with `reason: db_unavailable` and a stamped `X-Treg-Call-Id`;
  - an invalidated-connection `OperationalError` answers the same 503;
  - a statement-level `OperationalError` (deadlock) still surfaces as a 500 with no `treg_saturated` flag.
  All three pass. (Some pre-existing tests in this file are flaky when the file is run standalone - they fail identically on `main`, unrelated to this change.)
- `tests/test_surface_snapshot.py` passes against the updated composition snapshot (4 handlers = one adapter registered per class).
- `test_the_pool_cannot_outnumber_postgres_during_a_deploy` now pins the shipped `Settings` defaults instead of regex-reading `db.py`; passes.
- Docs drift check run (`drift.sh`); every mapped fragment reviewed, the one stale mention (`data-model.md` pool numbers) fixed in the same commit.

## Out of scope / follow-ups

- No retry-at-the-edge or health-based load shedding: the caller still owns retries (`Retry-After: 2` is the hint), consistent with the existing saturation contract.
- The Stage 4 close-out still owns refreshing handler `__module__` paths in the frozen composition snapshot; this PR keeps the `treg.api` aliasing convention.