### PR TITLE
refactor(stage5-pr1): startup data writes move to an explicit release phase

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -192,6 +192,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/ledger.py` | architecture/money.md |
 | `src/treg/localproxy.py` | architecture/local-proxy.md |
 | `src/treg/localrun.py` | architecture/local-run.md |
+| `src/treg/maintenance.py` | ops/deploy.md |
 | `src/treg/mcp.py` | architecture/mcp-oauth.md |
 | `src/treg/mcp_install.py` | interface/skill.md |
 | `src/treg/mcp_oauth.py` | architecture/mcp-oauth.md |
@@ -298,5 +299,5 @@ Regenerate via `scripts/build-map.py`.
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
 | `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py` |
-| `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
+| `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `maintenance.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Or run the server directly, without tmux:
 
 ```bash
 uv sync                        # create the venv from uv.lock (pulls the server deps for dev)
+uv run python -m treg upgrade  # prepare schema + run idempotent release tasks without serving
 uv run python -m treg          # serve on 0.0.0.0:18790 (add --reload for dev)
 uv run python -m treg keygen   # print a fresh Fernet key for TREG_SECRET_KEY
 ```

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -51,7 +51,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Provider capacity — knowing what treg's own vendor accounts have left](ops/capacity.md) | shipped (steps B–F built; production rollout = the shadow week, then TREG_OVERFLOW_MODE=on) | __init__.py, collectors.py, policy.py, sweep.py, … |
-| [Running & deploying the server](ops/deploy.md) | shipped | pyproject.toml, __main__.py, worker.py, selfhost.sh, … |
+| [Running & deploying the server](ops/deploy.md) | shipped | pyproject.toml, __main__.py, maintenance.py, worker.py, … |
 
 ## Reference
 

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -208,8 +208,10 @@ module symbols:
   both, but `/call/` resolution is per-HOST, so without a second row the agent is walled off (admin
   path on the data host → Google 404; admin host → treg "no registered tool"; 13 calls/7 orgs observed
   stuck there). The extra (`<connection>-admin`) binds the SAME secret, upserts idempotently on
-  connect/reconnect, and `_backfill_provider_extra_tools` runs after `init_db()` on every startup to
-  heal older connections automatically. The backfill is registry-generic: it scans provider-attributed
+  connect/reconnect, and `_backfill_provider_extra_tools` runs after `init_db()` in the ordered release
+  upgrade phase to heal older connections automatically. The default `python -m treg` serve command runs
+  that phase before Uvicorn; raw ASGI deployments run `python -m treg upgrade` once per release. The
+  backfill is registry-generic: it scans provider-attributed
   Secrets, requires the corresponding main Tool to be bound to that Secret, then calls the same extra
   upsert, so adding a future `extra_tools` entry needs no one-off migration. Revoke already sweeps the
   companions (any tool whose only binding was the deleted credential goes). `resource_example` closes the loop from the

--- a/docs/context/architecture/composition.md
+++ b/docs/context/architecture/composition.md
@@ -80,9 +80,15 @@ architecture test separately pins the dataplane/control startup split and backgr
 
 | Role | HTTP routes and mounts | Background tasks | Startup checks |
 |---|---|---|---|
-| `all` | The complete surface, including `/run`, static files, `/mcp`, and the flagged `/mcp/v2` | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client, enabled MCP lifespans |
-| `dataplane` | `/call/{rest:path}`, `/catalog/call/{rest:path}`, MCP mounts, and their resource metadata; no `/run`, static files, docs, or OpenAPI | None | DB init, provider-tool backfill, HTTP client, enabled MCP lifespans |
-| `control` | Everything except the calling surfaces; includes OAuth issuance, `/run`, and static files | Ads conversion worker when enabled | DB init, provider-tool backfill, single-user bootstrap, HTTP client |
+| `all` | The complete surface, including `/run`, static files, `/mcp`, and the flagged `/mcp/v2` | Ads conversion worker when enabled | DB init, HTTP client, enabled MCP lifespans |
+| `dataplane` | `/call/{rest:path}`, `/catalog/call/{rest:path}`, MCP mounts, and their resource metadata; no `/run`, static files, docs, or OpenAPI | None | DB init, HTTP client, enabled MCP lifespans |
+| `control` | Everything except the calling surfaces; includes OAuth issuance, `/run`, and static files | Ads conversion worker when enabled | DB init, HTTP client |
+
+No role lifespan performs a data backfill or provisions the local single user. The explicit
+`python -m treg upgrade` release phase owns content-driven backfills; the default `python -m treg`
+serve path adds single-user provisioning before Uvicorn starts. Raw ASGI operators must run the
+upgrade command separately on every release. `init_db()` remains in the lifespan temporarily until
+the later Stage 5 migration-execution PR.
 
 MCP is calling traffic (the refactor plan's role table assigns `mcp.py` to the dataplane), so a future
 dataplane deployment serves agents on both entry points. OAuth token issuance - consent pages and the

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -230,7 +230,9 @@ The API builds a single-binding tool from flat fields via `_flat_binding()`; inj
 One async SQLAlchemy engine (`_engine`, Postgres pool 5 + 10 overflow per instance, `pool_timeout=5`)
 + a public `session_maker` (the audit writer opens its own session here; so do the post-relay
 bookkeeping steps of `/call/` — the request session is committed before the relay so none of them
-ever waits on it, see [proxy-model](proxy-model.md) § Connection discipline). `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` —
+ever waits on it, see [proxy-model](proxy-model.md) § Connection discipline). The public
+`dispose_engine()` closes pooled connections before an explicit maintenance event loop exits, so a
+later server loop cannot inherit connections bound to the closed loop. `init_db()` creates tables **and runs the guarded orgs migration** (`_migrate_to_orgs` -
 see [multi-tenancy](multi-tenancy.md)); that migration also does the small additive `ADD COLUMN` steps for
 columns added after a table shipped (e.g. `tool.examples`, `tool.cli` for local runs, `org.public_demo`
 (A15), the seven `secret` connection-metadata columns (A16), and the eight `pendingoauth` marketplace/quirk

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -140,7 +140,7 @@ rejects on HTTP status by default.
    `token_endpoint_auth_method="client_secret_basic"` (X, Pinterest — ALSO persisted into the token blob
    so refresh speaks the same dialect), `extra_tools` for a vendor that splits one product across hosts
    (GA4's admin/data split — each extra host provisions a companion Tool on the same secret; the
-   generic `_backfill_provider_extra_tools` startup pass gives existing connections newly-added
+   generic `_backfill_provider_extra_tools` release-upgrade pass gives existing connections newly-added
    companions automatically), and
    `resource_example` to stamp a ready-made call onto the tool once the user picks their resource.
 5. **NON-STANDARD OAuth is not free.** TikTok Ads (`app_id`/`auth_code`, JSON-body token exchange, `code==0`

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -63,11 +63,13 @@ related:
 `bootstrap.create_app()` assembles the combined route table into FastAPI roles.
 `api.app` remains the deployed, backward-compatible `all` role. Everything the CLI + skill do is one
 HTTP call over this. The factory lifespan
-runs `init_db()`, then `_backfill_provider_extra_tools()` (the idempotent repair for provider registry
-`extra_tools` added after a connection was created), and creates the shared keepalive
+runs `init_db()` and creates the shared keepalive
 `httpx.AsyncClient` at `app.state.http` (and `audit.drain()`s on shutdown). It also starts the Google Ads conversion uploader (`adsconv.worker`) as
 a background task, but only when `adsconv.enabled()` — see
 [ads-conversions](../architecture/ads-conversions.md).
+Content-driven provider companion backfills run in the explicit `python -m treg upgrade` release
+phase, outside every app role's lifespan. The default `python -m treg` entrypoint also provisions the
+guarded local single-user identity before Uvicorn starts.
 
 ## WAF escape hatch — `X-Treg-Body-Encoding`
 Some hosting edges (Cloudflare, including Render's) 403 any request whose **body** matches an

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -4,6 +4,7 @@ status: shipped
 sources:
   - pyproject.toml
   - src/treg/__main__.py
+  - src/treg/maintenance.py
   - src/treg/worker.py
   - src/treg/web/selfhost.sh
   - src/treg/config.py
@@ -22,15 +23,33 @@ related:
 # Running & deploying
 
 ## Entry point (`__main__.py`)
-`python -m treg` → `main()` → `uvicorn.run("treg.api:app", host="0.0.0.0", port=int($PORT or 18790))`
-(`--reload` optional). It honors `$PORT` (Render/Heroku route + health-check that port). `python -m treg
-keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
-`bootstrap.create_app(role="all")`; the compatibility import and deployed behavior are unchanged.
+`python -m treg upgrade` runs the explicit release phase: `maintenance.upgrade()` first calls the
+idempotent `init_db()`, then runs the ordered, idempotent release-task registry. The registry currently
+contains the provider companion-tool backfill. It does not provision a single-user identity, so a hosted
+pre-deploy command cannot accidentally create a local owner.
+
+The default `python -m treg` serve path runs that same upgrade phase and then
+`api._bootstrap_single_user()`, then disposes the async engine inside the pre-serve event loop before calling
+`uvicorn.run("treg.api:app", host="0.0.0.0", port=int($PORT or 18790))` (`--reload` optional). It honors
+`$PORT` (Render/Heroku route + health-check that port). `python -m treg keygen` prints a Fernet key for
+`TREG_SECRET_KEY` without importing the server maintenance stack. `treg.api:app` is
+`bootstrap.create_app(role="all")`.
+
+The FastAPI lifespan still calls `init_db()` until the later Stage 5 migration-execution PR. That
+idempotent second call is harmless, and role startup manifests no longer contain data backfills or
+single-user provisioning. Operators serving `treg.api:app` directly through a raw ASGI command must run
+`python -m treg upgrade` once for every release. Render needs no Blueprint change because its existing
+`startCommand: python -m treg` already executes the pre-serve phase.
+
+Both pre-Uvicorn entry paths dispose the engine before their `asyncio.run()` loop closes: the default
+serve path does so after single-user bootstrap, and `python -m treg upgrade` does so after all release
+tasks. The next event loop therefore creates fresh pooled connections instead of receiving connections
+bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly does not dispose the engine.
 
 ## Startup safety (`db.py init_db`)
 - **Migration execution is unchanged:** Alembic ships in the `[server]` extra and has a validated
   current-schema baseline, but startup still runs `init_db`. No existing database is stamped or
-  upgraded through Alembic in stage 1; that execution switch is reserved for refactor stage 5.
+  upgraded through Alembic yet; that execution switch remains a later refactor Stage 5 PR.
 - **Fails loud on a missing key + real DB:** if `TREG_SECRET_KEY` is empty and `database_url` isn't
   SQLite, `init_db` raises (an ephemeral key would make every stored secret undecryptable after a
   restart — silent total loss). On SQLite dev it only logs a warning.
@@ -106,7 +125,7 @@ keygen` prints a Fernet key for `TREG_SECRET_KEY`. `treg.api:app` is
   [api](../interface/api.md).
 - **Frictionless local mode** (`single_user`, `single_user_token_file`): `curl {BASE}/selfhost.sh | sh`
   brings up a registry on the caller's own machine that they are **already signed into** — no account,
-  email or password. `lifespan` calls `_bootstrap_single_user()`, which idempotently creates the
+  email or password. The default serve pre-phase calls `_bootstrap_single_user()`, which idempotently creates the
   `you@local.treg` owner + `personal` team and writes the token (0600) for the installer to hand to the
   CLI; the token is **stable across restarts** (re-minted only if the file is deleted), and `dashboard()`
   attaches a session when there is none. It adopts an org **only through a membership this identity

--- a/scripts/dump_surface.py
+++ b/scripts/dump_surface.py
@@ -151,11 +151,6 @@ def _lifespan() -> dict[str, Any]:
         ],
         "startup": [
             {"action": "await", "task": "treg.db.init_db"},
-            {
-                "action": "await",
-                "task": "treg.api._backfill_provider_extra_tools",
-            },
-            {"action": "await", "task": "treg.api._bootstrap_single_user"},
             {"action": "create", "task": "app.state.http (httpx.AsyncClient)"},
         ],
     }

--- a/src/treg/__main__.py
+++ b/src/treg/__main__.py
@@ -1,9 +1,28 @@
-"""`python -m treg` — run the server, or `python -m treg keygen` for a Fernet key."""
+"""`python -m treg` - run the server and its explicit maintenance commands."""
 
 from __future__ import annotations
 
 import os
 import sys
+
+
+async def _prepare_serve() -> None:
+    """Apply release maintenance, then provision this local box when single-user mode allows it."""
+    # Both imports are deliberately lazy so `python -m treg keygen` stays on the light path.
+    from . import api, maintenance
+    from .db import dispose_engine
+
+    await maintenance.upgrade()
+    await api._bootstrap_single_user()
+    await dispose_engine()
+
+
+async def _run_upgrade() -> None:
+    from . import maintenance
+    from .db import dispose_engine
+
+    await maintenance.upgrade()
+    await dispose_engine()
 
 
 def main() -> None:
@@ -13,7 +32,17 @@ def main() -> None:
         print(new_key())
         return
 
+    if len(sys.argv) > 1 and sys.argv[1] == "upgrade":
+        import asyncio
+
+        asyncio.run(_run_upgrade())
+        print("treg upgrade complete")
+        return
+
+    import asyncio
     import uvicorn
+
+    asyncio.run(_prepare_serve())
 
     # Honor $PORT (Render/Heroku set it and route/health-check that port) — a hard-coded port makes
     # the deploy unreachable. Falls back to the local dev port.

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -62,11 +62,8 @@ from .routers.web import LOCAL_USER_EMAIL, _WEB_DIR
 from .timeutil import utcnow_naive as _utcnow_naive
 
 # ---- compatibility re-exports --------------------------------------------------------------
-# bootstrap addresses these through this module: the role startup manifests resolve
-# "treg.api._backfill_provider_extra_tools" by dotted string, and _mount_static reads the
-# static dirs off `api_module`. Everything else moved code once re-exported here now lives at -
-# and is imported from - its real home.
-from .application.connect import _backfill_provider_extra_tools  # noqa: F401
+# _mount_static reads these directories off `api_module`. Everything else once re-exported here
+# now lives in, and is imported from, its real home.
 from .routers.web import _LOGO_DIR, _MEDIA_DIR, _TOUR_DIR, _VENDOR_DIR  # noqa: F401
 
 

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -269,21 +269,16 @@ ROLE_BACKGROUND_TASKS: dict[AppRole, tuple[str, ...]] = {
 ROLE_STARTUP_CHECKS: dict[AppRole, tuple[str, ...]] = {
     "all": (
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
-        "treg.api._bootstrap_single_user",
         "app.state.http",
         "treg.mcp.mcp_lifespan",
     ),
     "dataplane": (
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
         "app.state.http",
         "treg.mcp.mcp_lifespan",
     ),
     "control": (
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
-        "treg.api._bootstrap_single_user",
         "app.state.http",
     ),
 }
@@ -409,13 +404,10 @@ def _route_manifest(routes: Sequence[BaseRoute]) -> list[str]:
     return result
 
 
-def _lifespan(api_module, role: AppRole):
+def _lifespan(role: AppRole):
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         await init_db()
-        await api_module._backfill_provider_extra_tools()
-        if role != "dataplane":
-            await api_module._bootstrap_single_user()
 
         limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
         app.state.http = httpx.AsyncClient(
@@ -478,7 +470,7 @@ def create_app(role: AppRole = "all") -> FastAPI:
     app = FastAPI(
         title="treg",
         version="0.0.1",
-        lifespan=_lifespan(api_module, role),
+        lifespan=_lifespan(role),
         openapi_url="/openapi.json" if expose_docs else None,
         docs_url="/docs/api" if expose_docs else None,
         redoc_url=None,

--- a/src/treg/db.py
+++ b/src/treg/db.py
@@ -650,6 +650,10 @@ async def reset_db() -> None:
         await conn.run_sync(SQLModel.metadata.create_all)
 
 
+async def dispose_engine() -> None:
+    await _engine.dispose()
+
+
 async def get_session() -> AsyncIterator[AsyncSession]:
     async with session_maker() as session:
         yield session

--- a/src/treg/maintenance.py
+++ b/src/treg/maintenance.py
@@ -1,0 +1,27 @@
+"""Explicit, ordered maintenance tasks run once per release before serving."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from .application.connect import _backfill_provider_extra_tools
+from .db import init_db
+
+
+ReleaseTask = tuple[str, Callable[[], Awaitable[int]]]
+
+# Content-driven tasks stay in a stable order so every release applies the same repairs before
+# new code serves traffic. Task bodies remain with their owning subsystem; this is orchestration.
+RELEASE_TASKS: tuple[ReleaseTask, ...] = (
+    ("provider companion tools", _backfill_provider_extra_tools),
+)
+
+
+async def upgrade() -> None:
+    """Prepare the schema, then run every idempotent release task in order."""
+    await init_db()
+    logger = logging.getLogger("treg.maintenance")
+    for name, task in RELEASE_TASKS:
+        changed = await task()
+        logger.info("upgrade task %s complete: %d row(s) created", name, changed)

--- a/tests/snapshots/lifespan.json
+++ b/tests/snapshots/lifespan.json
@@ -36,14 +36,6 @@
       "task": "treg.db.init_db"
     },
     {
-      "action": "await",
-      "task": "treg.api._backfill_provider_extra_tools"
-    },
-    {
-      "action": "await",
-      "task": "treg.api._bootstrap_single_user"
-    },
-    {
       "action": "create",
       "task": "app.state.http (httpx.AsyncClient)"
     }

--- a/tests/test_app_roles.py
+++ b/tests/test_app_roles.py
@@ -53,21 +53,16 @@ _EXPECTED_BACKGROUND_TASKS = {
 _EXPECTED_STARTUP_CHECKS = {
     "all": [
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
-        "treg.api._bootstrap_single_user",
         "app.state.http",
         "treg.mcp.mcp_lifespan",
     ],
     "dataplane": [
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
         "app.state.http",
         "treg.mcp.mcp_lifespan",
     ],
     "control": [
         "treg.db.init_db",
-        "treg.api._backfill_provider_extra_tools",
-        "treg.api._bootstrap_single_user",
         "app.state.http",
     ],
 }

--- a/tests/test_call_architecture.py
+++ b/tests/test_call_architecture.py
@@ -201,8 +201,9 @@ def test_startup_manifests_keep_dataplane_and_control_work_separate() -> None:
         "dataplane": (),
         "control": ("treg.adsconv.worker",),
     }
-    assert "treg.api._bootstrap_single_user" not in bootstrap.ROLE_STARTUP_CHECKS["dataplane"]
-    assert "treg.api._bootstrap_single_user" in bootstrap.ROLE_STARTUP_CHECKS["control"]
+    for checks in bootstrap.ROLE_STARTUP_CHECKS.values():
+        assert "treg.api._backfill_provider_extra_tools" not in checks
+        assert "treg.api._bootstrap_single_user" not in checks
     assert "treg.mcp.mcp_lifespan" in bootstrap.ROLE_STARTUP_CHECKS["dataplane"]
     assert "treg.mcp.mcp_lifespan" not in bootstrap.ROLE_STARTUP_CHECKS["control"]
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -16,6 +16,7 @@ from sqlmodel import select
 
 from treg import api as A
 from treg import crypto, oauth
+from treg.application.connect import _backfill_provider_extra_tools
 from treg.config import get_settings
 from treg.db import session_maker
 from treg.models import Secret, Tool
@@ -705,9 +706,9 @@ async def test_split_host_reconnect_rebinds_extras_without_duplicating(clients: 
     assert len(admins) == 1, "reconnecting must rebind the extra tool, not pile up duplicates"
 
 
-async def test_startup_backfills_missing_split_host_tool_idempotently(
+async def test_upgrade_backfills_missing_split_host_tool_idempotently(
         clients: AsyncClient, treg_google_app):
-    """A pre-split-host GA4 connection heals on boot without requiring another consent."""
+    """A pre-split-host GA4 connection heals on release upgrade without another consent."""
     st = await _connect_byo(clients, provider="google-analytics", name="google-analytics")
     async with session_maker() as db:
         old_admin = (await db.execute(
@@ -716,16 +717,16 @@ async def test_startup_backfills_missing_split_host_tool_idempotently(
         await db.delete(old_admin)
         await db.commit()
 
-    assert await A._backfill_provider_extra_tools() == 1
+    assert await _backfill_provider_extra_tools() == 1
     tools = [t for t in (await clients.get("/tools")).json()
              if t["name"] == "google-analytics-admin"]
     assert len(tools) == 1
     assert tools[0]["bindings"][0]["secret_id"] == st["secret_id"]
 
-    assert await A._backfill_provider_extra_tools() == 0
+    assert await _backfill_provider_extra_tools() == 0
     tools = [t for t in (await clients.get("/tools")).json()
              if t["name"] == "google-analytics-admin"]
-    assert len(tools) == 1, "re-running startup must not duplicate the companion"
+    assert len(tools) == 1, "re-running the upgrade must not duplicate the companion"
 
 
 async def test_revoke_removes_the_extra_tool_too(clients: AsyncClient, treg_google_app):

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,199 @@
+"""Release maintenance runs explicitly before serving, never inside an app lifespan."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+import textwrap
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _env(tmp_path: Path, *, single_user: bool = False) -> tuple[dict[str, str], Path, Path]:
+    database = tmp_path / "upgrade.db"
+    token_file = tmp_path / "local-token"
+    env = os.environ.copy()
+    env.update({
+        "TREG_DATABASE_URL": f"sqlite+aiosqlite:///{database}",
+        "TREG_PUBLIC_URL": "http://localhost:18790",
+        "TREG_SINGLE_USER": "true" if single_user else "false",
+        "TREG_SINGLE_USER_TOKEN_FILE": str(token_file),
+        "TREG_CLAUDE_CONNECTOR_ENABLED": "false",
+    })
+    return env, database, token_file
+
+
+def _run(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args], cwd=ROOT, env=env, text=True,
+        capture_output=True, timeout=90, check=False,
+    )
+
+
+def _upgrade(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return _run(["-m", "treg", "upgrade"], env)
+
+
+def _seed_connection(env: dict[str, str]) -> None:
+    script = textwrap.dedent(
+        """
+        import asyncio
+
+        from treg import oauth_providers
+        from treg.db import init_db, session_maker
+        from treg.models import Org, Secret, Tool
+
+        async def seed():
+            await init_db()
+            provider = oauth_providers.get("google-analytics")
+            assert provider is not None
+            async with session_maker() as db:
+                org = Org(name="Upgrade Test", slug="upgrade-test")
+                db.add(org)
+                await db.flush()
+                secret = Secret(
+                    org_id=org.id,
+                    name="google-analytics",
+                    owner="owner@example.test",
+                    kind="oauth",
+                    value="unused-encrypted-placeholder",
+                    provider="google-analytics",
+                )
+                db.add(secret)
+                await db.flush()
+                db.add(Tool(
+                    org_id=org.id,
+                    name="google-analytics",
+                    owner="owner@example.test",
+                    base_url=provider.base_url,
+                    host="analyticsdata.googleapis.com",
+                    bindings=[{"secret_id": secret.id}],
+                ))
+                await db.commit()
+
+        asyncio.run(seed())
+        """
+    )
+    result = _run(["-c", script], env)
+    assert result.returncode == 0, result.stderr
+
+
+def _companion_count(database: Path) -> int:
+    with sqlite3.connect(database) as db:
+        return db.execute(
+            "SELECT COUNT(*) FROM tool WHERE name = 'google-analytics-admin'"
+        ).fetchone()[0]
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_real_serve_path_can_query_database_after_pre_serve_maintenance(tmp_path):
+    env, _, token_file = _env(tmp_path, single_user=True)
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    env.update({"PORT": str(port), "TREG_PUBLIC_URL": base_url})
+    stdout_path = tmp_path / "server.stdout"
+    stderr_path = tmp_path / "server.stderr"
+    ready = False
+    request_status = None
+    request_detail = "request was not attempted"
+
+    with stdout_path.open("w") as stdout, stderr_path.open("w") as stderr:
+        process = subprocess.Popen(
+            [sys.executable, "-m", "treg"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        try:
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if process.poll() is not None:
+                    break
+                try:
+                    with urllib.request.urlopen(f"{base_url}/meta", timeout=1) as response:
+                        ready = response.status == 200
+                except (OSError, urllib.error.URLError):
+                    pass
+                if ready and token_file.exists():
+                    break
+                time.sleep(0.1)
+
+            if ready and token_file.exists():
+                request = urllib.request.Request(
+                    f"{base_url}/tools",
+                    headers={"X-Treg-Token": token_file.read_text().strip()},
+                )
+                try:
+                    with urllib.request.urlopen(request, timeout=10) as response:
+                        request_status = response.status
+                        request_detail = response.read().decode(errors="replace")
+                except urllib.error.HTTPError as exc:
+                    request_status = exc.code
+                    request_detail = exc.read().decode(errors="replace")
+                except (OSError, urllib.error.URLError) as exc:
+                    request_detail = repr(exc)
+        finally:
+            if process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=10)
+
+    server_stderr = stderr_path.read_text()
+    assert ready, f"server never became ready\nserver stderr:\n{server_stderr}"
+    assert token_file.exists(), f"single-user token was not written\nserver stderr:\n{server_stderr}"
+    assert request_status == 200, (
+        f"GET /tools returned {request_status}: {request_detail}\n"
+        f"server stderr:\n{server_stderr}"
+    )
+
+
+def test_upgrade_on_a_fresh_database_creates_schema_without_provisioning_a_user(tmp_path):
+    env, database, token_file = _env(tmp_path, single_user=True)
+
+    result = _upgrade(env)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "treg upgrade complete"
+    with sqlite3.connect(database) as db:
+        tables = {row[0] for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )}
+        users = db.execute('SELECT COUNT(*) FROM "user"').fetchone()[0]
+    assert {"org", "secret", "tool"} <= tables
+    assert users == 0
+    assert not token_file.exists(), "hosted upgrade must never provision the local user"
+
+
+def test_upgrade_backfills_companions_and_is_idempotent(tmp_path):
+    env, database, _ = _env(tmp_path)
+    initial = _upgrade(env)
+    assert initial.returncode == 0, initial.stderr
+    _seed_connection(env)
+    assert _companion_count(database) == 0
+
+    first = _upgrade(env)
+    assert first.returncode == 0, first.stderr
+    assert _companion_count(database) == 1
+
+    second = _upgrade(env)
+    assert second.returncode == 0, second.stderr
+    assert _companion_count(database) == 1
+

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -197,3 +197,27 @@ def test_upgrade_backfills_companions_and_is_idempotent(tmp_path):
     assert second.returncode == 0, second.stderr
     assert _companion_count(database) == 1
 
+
+def test_app_lifespan_does_not_run_release_backfills(tmp_path):
+    env, database, _ = _env(tmp_path)
+    _seed_connection(env)
+    assert _companion_count(database) == 0
+    script = textwrap.dedent(
+        """
+        import asyncio
+
+        from treg.bootstrap import create_app
+
+        async def start_and_stop():
+            app = create_app("all")
+            async with app.router.lifespan_context(app):
+                pass
+
+        asyncio.run(start_and_stop())
+        """
+    )
+
+    result = _run(["-c", script], env)
+
+    assert result.returncode == 0, result.stderr
+    assert _companion_count(database) == 0

--- a/tests/test_single_user.py
+++ b/tests/test_single_user.py
@@ -10,7 +10,8 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlmodel import select
 
-from treg import api, session as sess
+from treg import api, maintenance, session as sess
+from treg.__main__ import _prepare_serve
 from treg.api import LOCAL_ORG_NAME, LOCAL_USER_EMAIL, app
 from treg.config import Settings, get_settings
 from treg.db import reset_db, session_maker
@@ -44,7 +45,24 @@ def test_it_is_off_unless_explicitly_asked_for():
     assert get_settings().single_user_ok is False, "the default deployment must never be no-login"
 
 
-# ---- the bootstrap ----------------------------------------------------------------------------
+async def test_serve_pre_phase_upgrades_before_provisioning(monkeypatch):
+    calls = []
+
+    async def upgrade():
+        calls.append("upgrade")
+
+    async def bootstrap():
+        calls.append("bootstrap")
+
+    monkeypatch.setattr(maintenance, "upgrade", upgrade)
+    monkeypatch.setattr(api, "_bootstrap_single_user", bootstrap)
+
+    await _prepare_serve()
+
+    assert calls == ["upgrade", "bootstrap"]
+
+
+# ---- the serve pre-phase -----------------------------------------------------------------------
 @pytest.fixture
 async def local(tmp_path, monkeypatch):
     """A server in single-user mode, with the token file in a temp dir."""
@@ -52,7 +70,7 @@ async def local(tmp_path, monkeypatch):
     token_file = tmp_path / "local-token"
     monkeypatch.setattr(api, "get_settings", lambda: _settings(single_user_token_file=str(token_file)))
     monkeypatch.setattr(web, "get_settings", api.get_settings)
-    await api._bootstrap_single_user()
+    await _prepare_serve()
     yield token_file
 
 
@@ -71,8 +89,8 @@ async def test_bootstrap_creates_the_owner_and_writes_the_token(local):
 async def test_the_token_is_stable_across_restarts(local):
     """Rotating on every boot would break the CLI config the installer just wrote."""
     first = local.read_text()
-    await api._bootstrap_single_user()
-    await api._bootstrap_single_user()
+    await _prepare_serve()
+    await _prepare_serve()
     assert local.read_text() == first
 
 
@@ -80,7 +98,7 @@ async def test_a_deleted_token_file_is_re_minted(local):
     """The one case where rotating is right: the user lost the file and needs a way back in."""
     first = local.read_text()
     local.unlink()
-    await api._bootstrap_single_user()
+    await _prepare_serve()
     assert local.exists() and local.read_text() != first
 
 
@@ -105,7 +123,7 @@ async def test_the_dashboard_opens_already_signed_in(local):
 # ---- and the same routes must stay closed on a normal deployment ------------------------------
 async def test_a_normal_deployment_bootstraps_nothing_and_signs_nobody_in():
     await reset_db()
-    await api._bootstrap_single_user()  # default settings → guard refuses
+    await _prepare_serve()  # default settings means the guard refuses
     async with session_maker() as s:
         assert (await s.execute(select(User).where(User.email == LOCAL_USER_EMAIL))).scalar_one_or_none() is None
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:


### PR DESCRIPTION
Stage 5, PR 1 of 3 (see the stage-5 plan): role startup manifests stop writing data. The two
per-boot writes - the provider companion-tool backfill and guarded single-user provisioning -
leave the FastAPI lifespan for an explicit pre-serve release phase.

## What changed

- New `treg.maintenance`: an ordered registry of idempotent release tasks (today: the provider
  companion backfill), orchestrated by `upgrade()` after an idempotent `init_db()`. Task bodies
  stay in their owning subsystems; this is orchestration only.
- New `python -m treg upgrade`: runs the release phase without serving and never provisions a
  user, so a hosted pre-deploy command cannot create a local owner.
- The default `python -m treg` serve path runs upgrade, then `_bootstrap_single_user()`, then
  disposes the engine, before uvicorn starts. Render needs no change: its startCommand is
  already `python -m treg`.
- `ROLE_STARTUP_CHECKS` for all three roles now carry only `init_db`, the HTTP client, and MCP
  lifespans. `init_db` stays until PR 2 switches migration execution to Alembic.
- `db.dispose_engine()` (the one `db.py` touch): the pre-serve phase runs in its own event
  loop; without disposal, pooled asyncpg connections bound to that closed loop are inherited
  by uvicorn's loop and the first DB-touching request fails with "got Future attached to a
  different loop". Reproduced against real Postgres and verified fixed, both in-process and
  through the real serve path.

## Intentional behavior changes

1. The companion backfill and single-user provisioning no longer run when an app is created
   in-process (`create_app`/lifespan); they run only via `python -m treg` (pre-serve) or
   `python -m treg upgrade`. Operators serving `treg.api:app` through a raw ASGI command must
   run `python -m treg upgrade` once per release (documented in ops/deploy.md).
2. New `python -m treg upgrade` subcommand.
3. The serve path disposes the DB engine after the pre-serve phase (new connections are opened
   lazily in uvicorn's loop; no visible behavior change, listed for completeness).

Everything not listed above is behavior-identical.

## Verification

- Full suite: 2322 passed, 4 skipped (includes new subprocess E2E: fresh-DB upgrade, companion
  backfill idempotence, upgrade-never-provisions-a-user, lifespan-negative, and a real
  `python -m treg` serve boot that queries the DB).
- Import contracts: 11 kept, 0 broken.
- Live check against a throwaway Postgres 16: two-loop repro fails pre-fix with the exact
  loop-binding error, passes with disposal; real serve boot answers a token-validated DB query
  cleanly with zero loop errors in the log.