### PR TITLE
fix(web): mobile layout for tut-head hero section

### DIFF
--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -486,6 +486,7 @@ addEventListener('load', function(){
     .side{border-right:0;border-bottom:1px solid var(--line);min-width:0} main{min-width:0}
     .side-acct{margin-top:12px}  /* on mobile the sidebar is a top strip - don't push account to the bottom */
     h1,.tut-head,.brand{overflow-wrap:anywhere}
+    .tut-head{flex-wrap:wrap} .tut-head>div:first-child{flex:1 1 100%} .tut-actions{flex:1 1 auto;justify-content:flex-start;margin-left:0}
     table{display:block;overflow-x:auto;white-space:nowrap}td,th{word-break:break-word}
     /* header wraps instead of forcing horizontal page scroll: the search drops to its own full-width
        row and the flex spacer is removed so brand/org/theme/avatar/sign-out fit the viewport. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes the mobile layout where the `.tut-head` hero text ("2,800+ tools for agents" and its description) was being squeezed into an extremely narrow column, with words wrapping mid-word.

The root cause: `.tut-head` is a flex container with `.tut-actions` (the three buttons) using `margin-left:auto` to push right. On mobile viewports, the flex items competed for horizontal space without wrapping, leaving the text div almost no room.

**Fix:**
- Add `flex-wrap:wrap` to `.tut-head` on mobile (`@media max-width:760px`)
- Make the text div (first child) take full width with `flex:1 1 100%`
- Reset `.tut-actions` to `margin-left:0` and `justify-content:flex-start` so buttons wrap to their own full-width row

This affects:
- Catalog hero ("2,800+ tools for agents")
- Provider integration pages
- Tools/Skills pages
- Org settings
- All tutorial headers

## Before

The text column was squeezed to ~60px width, causing extreme word wrapping where "2,800+ tools for agents" wrapped as "2,8 / 00+ / too / ls / for / ag / ent / s" across multiple lines. The buttons stayed side-by-side with the text, stealing most of the viewport width.

## After (Playwright screenshot at 375px viewport)

Text takes full width, buttons wrap below:

[After - fixed mobile layout](https://cursor.com/agents/bc-bcb4493e-c90c-4e01-88e7-16feee5ad4b3/artifacts?path=%2Fworkspace%2Fscreenshots%2Fmobile-catalog-viewport-fixed.png)

## How it was tested

1. `uv run pytest -q` - all 2336 tests pass
2. `tests/test_dashboard_markup.py` - all 95 CSS/markup structural tests pass
3. Playwright screenshot at iPhone viewport (375×812px) confirms the fix

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior) — No new tests needed; this is a CSS-only fix to existing responsive behavior, and `test_dashboard_markup.py` verifies the CSS rules exist
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed) — N/A, pure CSS fix
- [x] No secrets in the diff (keys, tokens, `.env` values)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcb4493e-c90c-4e01-88e7-16feee5ad4b3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb4493e-c90c-4e01-88e7-16feee5ad4b3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

