### PR TITLE
fix(money): lost block draws, influencersclub over-billing, nested page-size

### DIFF
--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -322,12 +322,16 @@ def _body_limit(body: bytes) -> int | None:
         val = doc.get(name)  # one row per item: moz targets, dataforseo keywords, companyenrich domains, brightdata urls
         if isinstance(val, list) and val:
             return len(val)
-    pagination = doc.get("pagination")  # icypeas / lusha: {"pagination": {"size": 10}}
-    if isinstance(pagination, dict):
-        for name in _LIMIT_PARAMS:
-            val = pagination.get(name)
-            if isinstance(val, int) and not isinstance(val, bool) and val > 0:
-                return val
+    # icypeas / lusha: {"pagination": {"size": 10}}; influencersclub: {"paging": {"limit": 10}} —
+    # the miss on `paging` left discovery reserving the 20-row default whatever the caller asked
+    # (found live 2026-08-30, the same calls whose settle over-billed).
+    for envelope in ("pagination", "paging"):
+        nested = doc.get(envelope)
+        if isinstance(nested, dict):
+            for name in _LIMIT_PARAMS:
+                val = nested.get(name)
+                if isinstance(val, int) and not isinstance(val, bool) and val > 0:
+                    return val
     return items
 
 

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -191,6 +191,14 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
         data = doc.get("data")
         n = len(data) if isinstance(data, list) else (1 if data else 0)
         return n * mk.unit_micro
+    if provider == "influencersclub" and mk.cost_type == "per_result" and mk.unit_micro > 0:
+        # Discovery bills per creator RETURNED and the rows live under `accounts` — invisible to
+        # the generic counters, so every call settled at the 20-row default estimate (found live
+        # 2026-08-30: 66 searches, ~10 rows each, billed as 20 each — a 2.08x overcharge). An
+        # envelope without `accounts` (an error shape) counts zero: pay-per-result means an answer
+        # with no rows costs nothing.
+        rows = doc.get("accounts")
+        return (sum(item is not None for item in rows) if isinstance(rows, list) else 0) * mk.unit_micro
     if provider == "dataforseo":
         cost = doc.get("cost")
         if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:

--- a/src/treg/domain/money/__init__.py
+++ b/src/treg/domain/money/__init__.py
@@ -436,8 +436,13 @@ async def _consume_blocks(
     """
     if amount_micro <= 0:
         return 0, 0
+    # FOR UPDATE: two concurrent settles both read remaining=100, both subtract in memory, last
+    # write wins and one draw is LOST — the blocks then show more credit than the ledger's truth
+    # (found live 2026-08-30: $1.70 of draws lost under an agent's parallel burst, org 2867).
+    # Postgres locks the rows; SQLite ignores FOR UPDATE and is single-writer anyway.
     blocks = (await db.execute(
         select(CreditBlock).where(CreditBlock.org_id == org_id, CreditBlock.remaining_micro > 0)
+        .with_for_update()
     )).scalars().all()
     blocks.sort(key=lambda b: (_KIND_ORDER.get(b.kind, 99), b.created_at or _now(), b.id))
     left, consumed = amount_micro, 0

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1665,3 +1665,54 @@ def test_hunter_people_enrich_accepts_linkedin_handle_without_email():
     assert not qp["email"].get("required") and not qp["linkedin_handle"].get("required")
     assert "linkedin_handle" in ep["input"]["note"]
     assert not any(v.get("required") for v in qp.values() if isinstance(v, dict))
+
+
+# ---------------------------------------------------------------------------------------------
+# 2026-08-30 billing forensics (org 2867): three fixes pinned
+
+def test_body_limit_reads_nested_paging():
+    # influencersclub discovery: {"paging": {"limit": 10}} must beat the 20-row default.
+    from treg.application.call.resolve import _body_limit
+    assert _body_limit(json.dumps({"paging": {"limit": 10}, "filters": {}}).encode()) == 10
+    assert _body_limit(json.dumps({"pagination": {"size": 7}}).encode()) == 7
+    assert _body_limit(json.dumps({"filters": {}}).encode()) is None
+
+
+def test_influencersclub_settle_counts_accounts():
+    from types import SimpleNamespace
+    from treg.application.call.settle import _observed_cost_micro
+    mk = SimpleNamespace(cost_type="per_result", unit_micro=5980, billed_oauth=False,
+                         endpoint_id="influencersclub.creators.search", provider="influencersclub")
+    body = json.dumps({"total": 634, "limit": 10,
+                       "accounts": [{"user_id": i} for i in range(10)]}).encode()
+    # 10 creators returned → 10 × 5,980µ$ = $0.0598, NOT the 20-row estimate ($0.1196)
+    assert _observed_cost_micro(mk, body) == 59_800
+    # an envelope with no rows costs nothing
+    assert _observed_cost_micro(mk, json.dumps({"detail": "quota"}).encode()) == 0
+
+
+async def test_concurrent_settles_never_lose_a_block_draw(clients: AsyncClient):
+    """The $1.70 drift: parallel settles both read a block's remaining, last write wins, one draw
+    is lost — blocks then show MORE credit than the ledger's truth. The FOR UPDATE row lock makes
+    parallel draws serialize; after N concurrent settles the block must equal the ledger."""
+    import asyncio
+    from treg.domain import money
+    from treg.db import session_maker
+    from treg.models import CreditBlock
+    from sqlalchemy import select
+
+    org_id = (await clients.get("/orgs")).json()[0]["org_id"]
+
+    async def one(i: int):
+        async with session_maker() as db:
+            await money.reserve(db, org_id, "x.y", 10_000, call_id=f"drift-{i}")
+        async with session_maker() as db:
+            await money.settle(db, f"drift-{i}", 10_000)
+
+    await asyncio.gather(*[one(i) for i in range(8)])
+    async with session_maker() as s:
+        blocks = (await s.execute(select(CreditBlock).where(CreditBlock.org_id == org_id))).scalars().all()
+        drawn = sum(b.amount_micro - b.remaining_micro for b in blocks)
+    # 8 settles × margin(10,000µ$) each must ALL be drawn from the blocks — none lost.
+    from treg.domain.money import with_margin
+    assert drawn == 8 * with_margin(10_000)


### PR DESCRIPTION
Full fix for the org-2867 billing report: FOR UPDATE on credit-block draws (parallel settles lost $1.70 of draws — the balance-vs-blocks display mismatch), a settle adapter counting influencersclub's accounts rows (every discovery call billed the 20-row default: 2.08x overcharge, $4.10), and paging.limit read at reserve time. Pinned by unit tests plus an 8-way concurrent-settle test; 227 tests green on real Postgres locally.