### PR TITLE
feat(admin): add HTTP endpoint to credit org balance

### DIFF
--- a/docs/context/architecture/super-admin.md
+++ b/docs/context/architecture/super-admin.md
@@ -67,6 +67,12 @@ endpoints are unaffected (they use `require_superadmin`).
   email); the three destructive user ops refuse (`409`) when demoting/suspending/deleting would drop the
   count of active (`is_superadmin and not suspended`) users to zero — so a superadmin can't self-lock the
   platform out of `/admin/*`. The env token bypasses the floor (it can always recover).
+- **Org credit:** `admin_credit_org` (`POST /admin/orgs/{org_id}/credit`) — the HTTP equivalent of
+  `scripts/manual_grant.py`. Credits an org with promotional balance through `money.grant()`, preserving
+  the invariant that balance = sum(blocks) - sum(holds). Requires `amount_usd`, `ref` (idempotency key —
+  a duplicate ref for the same org returns 409), and `reason`. Always uses `kind="promotional"` so the
+  credit burns before purchased (non-refundable marketing expense). The script remains valid for
+  airgapped / direct-DB ops, and the route removes the need to open Render Postgres IP allowlists.
 
 ## Model + migration
 `User` gains `is_superadmin` + `suspended`; `Org` gains `suspended` (booleans). The columns are part
@@ -75,5 +81,6 @@ of the Alembic baseline schema; a live DB picks up schema changes through the ex
 
 ## CLI (`interface/cli.md`)
 `treg admin login --token` (saves the env key), `admin stats|orgs|org <id>|users|tools|calls|health`,
-and `admin grant|revoke|suspend-user|rm-user|suspend-org|rm-org`. `_admin_client` sends the saved
+`admin grant|revoke|suspend-user|rm-user|suspend-org|rm-org`, and
+`admin credit <org_id> --amount-usd <n> --ref <ticket> --reason <text>`. `_admin_client` sends the saved
 `admin_token` if present, else the active org token (works for an `is_superadmin` user).

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -240,6 +240,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/admin/users/{user_id}', ('DELETE',), 'admin_delete_user'),
     ('/admin/orgs/{org_id}/suspend', ('POST',), 'admin_suspend_org'),
     ('/admin/orgs/{org_id}', ('DELETE',), 'admin_delete_org'),
+    ('/admin/orgs/{org_id}/credit', ('POST',), 'admin_credit_org'),
     ('/admin/reconcile/drift', ('GET',), 'admin_reconcile_drift'),
     ('/admin/reconcile/spend', ('GET',), 'admin_reconcile_spend'),
     ('/admin/reconcile/repeats', ('GET',), 'admin_reconcile_repeats'),

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -4377,6 +4377,15 @@ def cmd_admin_rm_org(args, cfg) -> None:
         _show(c.delete(f"/admin/orgs/{args.org_id}"))
 
 
+def cmd_admin_credit(args, cfg) -> None:
+    with _admin_client(cfg) as c:
+        _show(c.post(f"/admin/orgs/{args.org_id}/credit", json={
+            "amount_usd": args.amount_usd,
+            "ref": args.ref,
+            "reason": args.reason,
+        }))
+
+
 def cmd_oauth_providers(args, cfg) -> None:
     with _client(cfg) as c:
         _show(c.get("/oauth/providers"))
@@ -5709,6 +5718,13 @@ def build_parser() -> argparse.ArgumentParser:
     aso.add_argument("org_id", type=int, help="the org id"); aso.add_argument("--undo", action="store_true", help="un-suspend instead"); aso.set_defaults(fn=cmd_admin_suspend_org)
     aro = mk(ad, "rm-org", "Delete an org platform-wide.", "treg admin rm-org 2")
     aro.add_argument("org_id", type=int, help="the org id"); aro.set_defaults(fn=cmd_admin_rm_org)
+    acr = mk(ad, "credit", "Credit an org promotional balance (HTTP equivalent of scripts/manual_grant.py).",
+             "treg admin credit 2867 --amount-usd 100 --ref hs-1234 --reason 'goodwill comp'")
+    acr.add_argument("org_id", type=int, help="the org id to credit")
+    acr.add_argument("--amount-usd", dest="amount_usd", required=True, help="amount in USD (e.g. '100', '50.50')")
+    acr.add_argument("--ref", required=True, help="dedupe key (ticket id) — a repeat with the same ref refuses")
+    acr.add_argument("--reason", required=True, help="human explanation recorded on the ledger")
+    acr.set_defaults(fn=cmd_admin_credit)
     return p
 
 

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from decimal import Decimal, InvalidOperation
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -16,7 +17,8 @@ from sqlmodel import select
 from .. import reconcile
 from ..config import get_settings
 from ..infra.db import get_session, session_maker
-from ..models import ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, Membership, Org, Referral, Secret, Tool, User
+from ..domain import money
+from ..models import ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, LedgerEntry, Membership, Org, Referral, Secret, Tool, User
 from ..timeutil import as_naive as _as_naive
 from ..timeutil import utcnow_naive as _utcnow_naive
 from ..domain.identity.access import require_superadmin
@@ -650,3 +652,96 @@ async def admin_delete_org(
     await _cascade_delete_org(org, db)
     await db.commit()
     return {"deleted_org": org_id}
+
+
+def _usd_to_micro(amount_usd: str | int | float) -> int:
+    """USD string/number -> integer micro-USD. Uses Decimal to avoid float drift.
+
+    Rejects amounts that cannot be exactly represented in micro-USD (finer than 6 decimal places),
+    non-positive amounts, and non-numeric input.
+    """
+    try:
+        value = Decimal(str(amount_usd))
+    except InvalidOperation:
+        raise HTTPException(status_code=400, detail=f"amount_usd {amount_usd!r} is not a valid number")
+    if value <= 0:
+        raise HTTPException(status_code=400, detail="amount_usd must be positive")
+    micro = value * 1_000_000
+    if micro != micro.to_integral_value():
+        raise HTTPException(
+            status_code=400,
+            detail=f"amount_usd {amount_usd} is finer than micro-USD (6 decimal places); it cannot be represented exactly"
+        )
+    return int(micro)
+
+
+class CreditIn(BaseModel):
+    amount_usd: str | int | float
+    ref: str
+    reason: str
+
+
+@app.post("/admin/orgs/{org_id}/credit")
+async def admin_credit_org(
+    org_id: int, body: CreditIn, principal: str = Depends(require_superadmin), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """Credit an org with promotional balance — the HTTP equivalent of scripts/manual_grant.py.
+
+    The ONLY sanctioned way to credit balance through the API. Uses `money.grant()` under the hood,
+    which writes block + balance + ledger in one transaction, preserving the invariant that
+    `org.balance_micro == sum(block.remaining_micro) - sum(open hold.amount_micro)`.
+
+    Why `promotional` and not a custom kind: spend burns blocks in `money._KIND_ORDER` order, and an
+    unrecognized kind falls through to sort AFTER purchased credit. A comp should burn BEFORE the
+    customer's own money (it's a marketing expense), which is what `promotional` already does.
+
+    `ref` provides idempotency: a grant with the same ref for the same org is refused (409) rather than
+    double-credited. This is a best-effort scan of `meta.ref` in existing ledger entries — the same
+    sequential-reuse guard as scripts/manual_grant.py. It is NOT concurrency-safe: two simultaneous
+    requests with the same ref can both pass the scan. For an HTTP endpoint called by one ops person
+    at a time, that is acceptable; if it ever stops being true, the fix is a unique column.
+
+    Returns the org_id, credited amount, new balance, block id, and ref — enough for ops to confirm.
+    """
+    micro = _usd_to_micro(body.amount_usd)
+    ref = body.ref.strip()
+    reason = body.reason.strip()
+    if not ref:
+        raise HTTPException(status_code=400, detail="ref is required (ops ticket / idempotency key)")
+    if not reason:
+        raise HTTPException(status_code=400, detail="reason is required (human explanation)")
+
+    org = await db.get(Org, org_id)
+    if org is None:
+        raise HTTPException(status_code=404, detail="org not found")
+
+    prior = (await db.execute(
+        select(LedgerEntry).where(LedgerEntry.org_id == org_id, LedgerEntry.kind == "grant")
+    )).scalars().all()
+    clash = next((e for e in prior if (e.meta or {}).get("ref") == ref), None)
+    if clash is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"ref {ref!r} was already used for a grant to org {org_id} "
+                   f"(${clash.amount_micro / 1_000_000:.2f}, entry {clash.id}, {clash.created_at})"
+        )
+
+    block = await money.grant(
+        db, org_id, amount_micro=micro, kind="promotional", once=False,
+        meta={"ref": ref, "reason": reason, "source": "admin_credit_org", "principal": principal},
+    )
+    await db.commit()
+
+    if block is None:
+        raise HTTPException(status_code=500, detail="grant returned None unexpectedly")
+
+    await db.refresh(org)
+    return {
+        "org_id": org_id,
+        "amount_micro": micro,
+        "amount_usd": float(Decimal(str(micro)) / 1_000_000),
+        "balance_micro": org.balance_micro,
+        "balance_usd": float(Decimal(str(org.balance_micro)) / 1_000_000),
+        "block_id": block.id,
+        "ref": ref,
+    }

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -303,6 +303,39 @@
         "title": "CliApproveIn",
         "type": "object"
       },
+      "CreditIn": {
+        "properties": {
+          "amount_usd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Amount Usd"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "ref": {
+            "title": "Ref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "amount_usd",
+          "ref",
+          "reason"
+        ],
+        "title": "CreditIn",
+        "type": "object"
+      },
       "DenyRuleIn": {
         "properties": {
           "host": {
@@ -2035,6 +2068,78 @@
           }
         },
         "summary": "Admin Org Detail"
+      }
+    },
+    "/admin/orgs/{org_id}/credit": {
+      "post": {
+        "description": "Credit an org with promotional balance — the HTTP equivalent of scripts/manual_grant.py.\n\nThe ONLY sanctioned way to credit balance through the API. Uses `money.grant()` under the hood,\nwhich writes block + balance + ledger in one transaction, preserving the invariant that\n`org.balance_micro == sum(block.remaining_micro) - sum(open hold.amount_micro)`.\n\nWhy `promotional` and not a custom kind: spend burns blocks in `money._KIND_ORDER` order, and an\nunrecognized kind falls through to sort AFTER purchased credit. A comp should burn BEFORE the\ncustomer's own money (it's a marketing expense), which is what `promotional` already does.\n\n`ref` provides idempotency: a grant with the same ref for the same org is refused (409) rather than\ndouble-credited. This is a best-effort scan of `meta.ref` in existing ledger entries — the same\nsequential-reuse guard as scripts/manual_grant.py. It is NOT concurrency-safe: two simultaneous\nrequests with the same ref can both pass the scan. For an HTTP endpoint called by one ops person\nat a time, that is acceptable; if it ever stops being true, the fix is a unique column.\n\nReturns the org_id, credited amount, new balance, block id, and ref — enough for ops to confirm.",
+        "operationId": "admin_credit_org_admin_orgs__org_id__credit_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "title": "Org Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-token",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Token",
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "treg_session",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Treg Session",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreditIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Admin Credit Org Admin Orgs  Org Id  Credit Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Credit Org"
       }
     },
     "/admin/orgs/{org_id}/suspend": {

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -1804,6 +1804,14 @@
   {
     "kind": "APIRoute",
     "methods": [
+      "POST"
+    ],
+    "name": "admin_credit_org",
+    "path": "/admin/orgs/{org_id}/credit"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
       "GET",
       "HEAD"
     ],

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlmodel import select
 
 from conftest import make_upstream
 
 from treg.api import app
 from treg.config import get_settings
-from treg.infra.db import reset_db
+from treg.infra.db import reset_db, session_maker
+from treg.models import CreditBlock, LedgerEntry
 
 ADMIN = "ENV-ADMIN-SECRET"
 
@@ -113,3 +115,148 @@ async def test_delete_user_cascades_empty_orgs(c):
     r = (await c.delete(f"/admin/users/{uid}", headers=_a())).json()
     assert o1["org_id"] in r["deleted_empty_orgs"]  # a@x.dev solely owned Org One
     assert (await c.get("/tools", headers=_h(o1["token"]))).status_code == 401
+
+
+# ---- admin credit org: the HTTP equivalent of scripts/manual_grant.py ----
+
+async def test_admin_credit_org_happy_path(c):
+    """A superadmin can credit an org, and the money goes through money.grant()."""
+    u1, o1, *_ = await _seed(c)
+    org_id = o1["org_id"]
+
+    r = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "50",
+        "ref": "hs-1234",
+        "reason": "goodwill comp for issue",
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["org_id"] == org_id
+    assert body["amount_micro"] == 50_000_000
+    assert body["amount_usd"] == 50.0
+    assert body["ref"] == "hs-1234"
+    assert body["block_id"]
+    promo = get_settings().promo_grant_micro
+    assert body["balance_micro"] == promo + 50_000_000
+
+    async with session_maker() as db:
+        block = (await db.execute(
+            select(CreditBlock).where(CreditBlock.id == body["block_id"])
+        )).scalars().first()
+        assert block is not None
+        assert block.kind == "promotional"
+        assert block.amount_micro == 50_000_000
+        assert block.remaining_micro == 50_000_000
+
+        entries = (await db.execute(
+            select(LedgerEntry).where(LedgerEntry.org_id == org_id, LedgerEntry.kind == "grant")
+        )).scalars().all()
+        admin_grant = [e for e in entries if (e.meta or {}).get("ref") == "hs-1234"]
+        assert len(admin_grant) == 1
+        assert admin_grant[0].amount_micro == 50_000_000
+        assert admin_grant[0].meta["reason"] == "goodwill comp for issue"
+        assert admin_grant[0].meta["source"] == "admin_credit_org"
+        assert admin_grant[0].meta["principal"] == "env-admin"
+
+
+async def test_admin_credit_org_duplicate_ref_is_409(c):
+    """A repeated ref for the same org refuses (409) — no double-crediting."""
+    _, o1, *_ = await _seed(c)
+    org_id = o1["org_id"]
+
+    first = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "25",
+        "ref": "dup-ticket-99",
+        "reason": "first grant",
+    })
+    assert first.status_code == 200, first.text
+
+    second = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "25",
+        "ref": "dup-ticket-99",
+        "reason": "second attempt with same ref",
+    })
+    assert second.status_code == 409
+    assert "dup-ticket-99" in second.json()["detail"]
+
+    async with session_maker() as db:
+        entries = (await db.execute(
+            select(LedgerEntry).where(LedgerEntry.org_id == org_id, LedgerEntry.kind == "grant")
+        )).scalars().all()
+        refs = [(e.meta or {}).get("ref") for e in entries]
+        assert refs.count("dup-ticket-99") == 1
+
+
+async def test_admin_credit_org_non_superadmin_is_403(c):
+    """A regular user cannot use the credit endpoint."""
+    u1, o1, *_ = await _seed(c)
+    r = await c.post(f"/admin/orgs/{o1['org_id']}/credit", headers=_h(u1["token"]), json={
+        "amount_usd": "10",
+        "ref": "test",
+        "reason": "test",
+    })
+    assert r.status_code == 403
+
+
+async def test_admin_credit_org_unknown_org_is_404(c):
+    """Crediting a non-existent org returns 404."""
+    r = await c.post("/admin/orgs/999999/credit", headers=_a(), json={
+        "amount_usd": "10",
+        "ref": "test",
+        "reason": "test",
+    })
+    assert r.status_code == 404
+
+
+async def test_admin_credit_org_invalid_amount_is_400(c):
+    """Various invalid amounts are rejected."""
+    _, o1, *_ = await _seed(c)
+    org_id = o1["org_id"]
+
+    for bad in ["-10", "0", "abc", "10.0000001"]:
+        r = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+            "amount_usd": bad,
+            "ref": f"test-{bad}",
+            "reason": "test",
+        })
+        assert r.status_code == 400, f"expected 400 for {bad!r}, got {r.status_code}: {r.text}"
+
+
+async def test_admin_credit_org_missing_ref_or_reason_is_400(c):
+    """ref and reason are both required."""
+    _, o1, *_ = await _seed(c)
+    org_id = o1["org_id"]
+
+    r = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "10",
+        "ref": "",
+        "reason": "has reason",
+    })
+    assert r.status_code == 400
+    assert "ref" in r.json()["detail"]
+
+    r = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "10",
+        "ref": "has-ref",
+        "reason": "",
+    })
+    assert r.status_code == 400
+    assert "reason" in r.json()["detail"]
+
+
+async def test_admin_credit_org_uses_promotional_kind(c):
+    """The credit is always promotional (burns before purchased, non-refundable)."""
+    _, o1, *_ = await _seed(c)
+    org_id = o1["org_id"]
+
+    r = await c.post(f"/admin/orgs/{org_id}/credit", headers=_a(), json={
+        "amount_usd": "100",
+        "ref": "promo-check",
+        "reason": "checking kind",
+    })
+    assert r.status_code == 200
+    block_id = r.json()["block_id"]
+
+    async with session_maker() as db:
+        block = await db.get(CreditBlock, block_id)
+        assert block.kind == "promotional"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Adds `POST /admin/orgs/{org_id}/credit` — a superadmin HTTP endpoint that credits an org with promotional balance using `money.grant()`. This is the HTTP equivalent of `scripts/manual_grant.py`, enabling ops to comp customers from any machine without opening Render Postgres IP allowlists.

The endpoint:
- Validates `amount_usd` (positive, exactly representable in micro-USD)
- Requires `ref` (idempotency key — a duplicate ref for the same org returns 409) and `reason` (human explanation recorded on ledger)
- Uses only `money.grant()` with `kind="promotional"` (burns before purchased credit, per `_KIND_ORDER`)
- Records principal, ref, reason, and source on ledger meta
- Returns org_id, amount, new balance, block_id, and ref for ops confirmation

Also adds:
- CLI command: `treg admin credit <org_id> --amount-usd <n> --ref <ticket> --reason <text>`

The script remains valid for airgapped/prod-DB ops.

## How it was tested

```bash
uv run --frozen python -m pytest tests/test_admin.py -v  # 15 passed
uv run --frozen python -m pytest tests/test_surface_snapshot.py tests/test_app_roles.py -v  # all passed
```

New tests cover:
- Happy path: credits via money.grant(), block + ledger + balance agree
- Duplicate ref is 409 and does not double-credit
- Non-superadmin is 403
- Unknown org is 404
- Invalid amounts are 400 (negative, zero, non-numeric, finer than micro-USD)
- Missing ref or reason is 400
- Promotional kind is always used

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa09a726-7c04-4b65-82ec-60f5706b61ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa09a726-7c04-4b65-82ec-60f5706b61ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

