### PR TITLE
chore: PR4 follow-ups - dead aliases and stale paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,15 +7,15 @@
 
 "area:proxy":
   - changed-files:
-      - any-glob-to-any-file: 'src/treg/proxy.py'
+      - any-glob-to-any-file: 'src/treg/infra/upstream/relay.py'
 
 "area:auth-secrets":
   - changed-files:
       - any-glob-to-any-file:
-          - 'src/treg/injectors.py'
+          - 'src/treg/infra/upstream/injectors.py'
           - 'src/treg/crypto.py'
           - 'src/treg/oauth.py'
-          - 'src/treg/session.py'
+          - 'src/treg/domain/identity/session.py'
           - 'src/treg/email.py'
           - 'src/treg/health.py'
           - 'src/treg/ratestore.py'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ This file orients an AI agent (Claude Code, Codex, Cursor, …) working in this 
 
 ## Do not touch (without reading the fragment first)
 
-- **The faithful-relay contract** (`src/treg/proxy.py`): the proxy alters only hop-by-hop headers, treg's
+- **The faithful-relay contract** (`src/treg/infra/upstream/relay.py`): the proxy alters only hop-by-hop headers, treg's
   own control headers, and the injected credential — never add upstream-specific modeling or buffering.
 - **Security guards that look redundant on purpose**: the `expose_dev_code` double-guard (dev OTP only on
   local sqlite), the call-time SSRF check, the fail-loud missing-Fernet-key startup check, and the

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -363,10 +363,8 @@ records), `budget_dim`/`budget_val` (the indexed copy of the primary pair) and `
 idempotency) and `daily_cap_micro` (the team's own spend ceiling, 0 = follow the deployment default).
 `Membership` gains `pinned_tags`.
 
-Migrations `A30`-`A32` in `src/treg/infra/db.py` add the columns, guarded as usual; `TagSpend` and `TagBudget` are new
-tables and need no DDL. Note `A31` also required adding the two new NOT NULL `org` columns to the raw
-`INSERT INTO org` in the legacy `(B)` backfill: a column `create_all` builds from a SQLModel default is
-NOT NULL with **no server default**, so raw SQL must supply it (ops/deploy.md §migration portability).
+The columns are part of the Alembic baseline schema (the legacy startup migrations that once added
+them are deleted); `TagSpend` and `TagBudget` are ordinary baseline tables.
 
 ## `Referral` — one invitation, and what it owes
 

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -159,8 +159,8 @@ that savepoint - the caller's other staged work survives - and its re-SELECT ret
 committed block, the same answer as the sequential path. The loser's flush blocks until the winner's
 transaction commits, which is why the caller must commit promptly after `topup` returns. The
 application-level SELECT is an optimisation, not the guarantee — two concurrent deliveries of one
-PaymentIntent both miss it. (Fixed in #45; the migration is `db.py` A28, placed above the `(B)` legacy
-block because that block returns early on a fresh database — precisely the one that needs it.)
+PaymentIntent both miss it. (Fixed in #45; the unique constraint is part of the Alembic baseline
+schema — the legacy startup migration that once added it is deleted.)
 
 ## Stripe (`application/billing.py` and `infra/stripe.py`)
 

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -127,7 +127,7 @@ Why this is load-bearing: secret loads auto-begin a transaction on the request s
 uses separate short read and CAS-write phases around connection-free token-endpoint I/O. SQLAlchemy keeps
 an open transaction's connection checked out until the next commit; carrying that transaction through the
 upstream round trip would make `_platform_settle` need a second connection. Two per in-flight call
-against the 15-slot pool (`db.py`: 5 + 10 overflow) deadlocked at 15 concurrent calls: every settle
+against the 15-slot pool (`infra/db.py`: 5 + 10 overflow) deadlocked at 15 concurrent calls: every settle
 waited on a slot that only another waiting call could free, until `pool_timeout` killed one (a bare
 500, or a settle that forfeited its charge and left the hold to the reaper) and the rest cascaded — so
 every call in a burst "took 30 s" while the provider had answered in under a second. Reproduced live

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ server = [
     "cryptography>=43",
     "pydantic-settings>=2.5",
     "pyyaml>=6",   # the endpoint catalog's data files (src/treg/catalog/*.yaml) — server-side only
-    "stripe>=12",  # balance top-ups (src/treg/billing.py) — the payment rail, server-side only
+    "stripe>=12",  # balance top-ups (src/treg/infra/stripe.py) — the payment rail, server-side only
     "mcp>=2",      # the MCP front door (src/treg/mcp.py) — server-side only; pulls httpx2 ALONGSIDE
                    # httpx (they coexist), so the light CLI's dependency set is untouched
 ]

--- a/src/treg/application/billing.py
+++ b/src/treg/application/billing.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import sys
 from datetime import datetime, timezone
 from typing import Awaitable, Callable
 
@@ -52,8 +51,6 @@ from ..infra import stripe as stripe_adapter
 from ..models import CreditBlock, LedgerEntry, Membership, Org, User
 
 
-# _run_autotopup retains its relative local import; removing the alias breaks task-owned sessions.
-sys.modules.setdefault("treg.application.db", _db)
 
 log = logging.getLogger("treg.application.billing")
 

--- a/src/treg/application/billing.py
+++ b/src/treg/application/billing.py
@@ -52,7 +52,7 @@ from ..models import CreditBlock, LedgerEntry, Membership, Org, User
 
 
 
-log = logging.getLogger("treg.application.billing")
+log = logging.getLogger("treg.billing")
 
 MICRO_PER_CENT = 10_000
 MICRO_PER_USD = 1_000_000

--- a/src/treg/application/call/reserve.py
+++ b/src/treg/application/call/reserve.py
@@ -50,7 +50,7 @@ async def _enforce_trial_allowance(caller: Caller, provider: str, db: AsyncSessi
                 CallRecord.status_code >= 200, CallRecord.status_code < 300,
                 CallRecord.created_at >= day_start))).scalar_one()
     except Exception as exc:  # noqa: BLE001 — cannot verify the pool ⇒ do not drain it
-        logging.getLogger("treg.domain.money").warning(
+        logging.getLogger("treg.ledger").warning(
             "trial-allowance check failed for org %s / %s: %s", caller.org_id, provider, exc)
         raise ReservationFailed("trial_allowance_unavailable", status_code=429, detail=(
             f"cannot verify today's {provider} trial usage right now — retry shortly, or use "
@@ -75,7 +75,7 @@ async def _enforce_platform_daily_cap(caller: Caller, add_micro: int, db: AsyncS
     try:
         spent = await ledger.spent_today(db, caller.org_id)
     except Exception as exc:  # noqa: BLE001 — cannot verify the ceiling ⇒ do not spend
-        logging.getLogger("treg.domain.money").warning(
+        logging.getLogger("treg.ledger").warning(
             "platform daily-cap check failed for org %s: %s", caller.org_id, exc)
         raise ReservationFailed("platform_cap_unavailable", status_code=429, detail=(
             "cannot verify today's platform spend right now — refusing to spend the team balance "
@@ -154,7 +154,7 @@ async def _enforce_tag_budgets(caller: Caller, meta: CallMeta, db: AsyncSession,
             raise ReservationFailed(
                 kind, status_code=exc.status_code, detail=exc.detail) from exc
         except Exception as exc:  # noqa: BLE001 — cannot verify a ceiling ⇒ do not spend
-            logging.getLogger("treg.domain.money").warning(
+            logging.getLogger("treg.ledger").warning(
                 "tag budget check failed for org %s (%s=%s): %s", caller.org_id, dim, val, exc)
             raise ReservationFailed("tag_budget_unavailable", status_code=429, detail={
                 "error": "tag_budget_unavailable", "dim": dim, "val": val,

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -449,7 +449,7 @@ async def _platform_settle(
             await asyncio.sleep(0.5)
             charged = await _close()
     except Exception as exc:  # noqa: BLE001 — loudly, but never into the caller's response
-        logging.getLogger("treg.domain.money").error(
+        logging.getLogger("treg.ledger").error(
             "settle/release failed for call %s (%s, status %s): %s",
             call_id, mk.endpoint_id, status_code, exc, exc_info=True)
     return charged, observed
@@ -471,7 +471,7 @@ async def _finish_cancelled_call(
             try:
                 await response.close()
             except (Exception, asyncio.CancelledError):  # noqa: BLE001
-                logging.getLogger("treg.infra.upstream.relay").error(
+                logging.getLogger("treg.proxy").error(
                     "upstream close failed for cancelled call %s", call_ref, exc_info=True)
         if mk is not None and mk.metered:
             # `ledger.reserve` may have committed without returning, so `mk.call_id` is not an
@@ -493,7 +493,7 @@ async def _finish_cancelled_call(
                         )
                     await cleanup_db.commit()
             except (Exception, asyncio.CancelledError):  # noqa: BLE001
-                logging.getLogger("treg.domain.money").error(
+                logging.getLogger("treg.ledger").error(
                     "cancellation release failed for call %s", call_ref, exc_info=True)
         try:
             await _release_idempotent_claim(claim)

--- a/src/treg/routers/resources.py
+++ b/src/treg/routers/resources.py
@@ -16,7 +16,6 @@ from sqlmodel import select
 
 from .. import convert as _convert
 from .. import crypto, health, sandbox as demo_sandbox
-from ..infra import db as _db
 from .. import providers as _providers
 from .. import skills as _skills
 from ..config import get_settings
@@ -46,7 +45,6 @@ crud_router = app
 sys.modules.setdefault("treg.routers.providers", _providers)
 sys.modules.setdefault("treg.routers.convert", _convert)
 sys.modules.setdefault("treg.routers.skills", _skills)
-sys.modules.setdefault("treg.routers.db", _db)
 
 
 def _require_tool_use_http(caller: Caller, tool: Tool) -> None:


### PR DESCRIPTION
Follow-ups to #271 from two review rounds, every item confirmed against the code before fixing.

## Round 1 (e8c3586)
1. `routers/resources.py`: the `treg.routers.db` sys.modules alias and the `_db` import that fed it are dead; a preseeded sys.modules entry outranks the path finder, so a future real `routers/db.py` would silently resolve to `infra/db`.
2. `application/billing.py`: the `treg.application.db` alias is unreachable and its comment described a premise PR4 removed. `_db` itself stays (six live call sites); `import sys` retires with the alias.
3. `AGENTS.md`: the faithful-relay pointer named deleted `proxy.py`; now `infra/upstream/relay.py`.
4. `data-model.md`: a passage still narrated the deleted A30-A32 legacy startup migrations.
5. `proxy-model.md`: the pool reference used db.py's pre-move path.

## Round 2 (093b256)
1. **Logger names revert to their contract names** - the PR4 sweep renamed `treg.ledger`, `treg.proxy`, and `treg.billing` to full module paths, an UNDECLARED behavior change in #271 (its "Intentional behavior changes: None" was wrong on this point) sitting on exactly the settle/release, cancel-release, and cap-check failure paths where external log filters, alerts, and grep hook in. Reverted to the short functional names the rest of the pipeline uses: a logger name is an observability contract and does not follow code location.
2. `.github/labeler.yml`: `area:proxy` pointed at deleted `proxy.py` (the label could never fire again - the silent kind of breakage); `area:auth-secrets` listed the deleted `injectors.py` and `session.py` shims, leaving the area's two most sensitive files unlabeled. Globs now follow the moved files.
3. `pyproject.toml`: the stripe dependency comment named deleted `billing.py`; now `infra/stripe.py`.
4. `money.md`: the payment-ref uniqueness note cited "db.py A28 above the (B) legacy block" - both deleted; the constraint is Alembic-baseline.

## Intentional behavior changes
The round-2 logger revert - which restores the pre-#271 observable behavior, making #271's own "no behavior changes" declaration true again. Nothing else: both dead aliases have zero consumers by grep.

Verification: full suite 2345 passed / 4 skipped after each round (`set -o pipefail`), import contracts 11 kept; no test pins the reverted logger names.