### PR TITLE
SEO: the /agents hub

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -234,13 +234,21 @@ favicon only resolves at 16px and falls back to a generic globe at 64.
 Per-platform cards (`/media/og/<slug>.png`) are a deliberate follow-up. Until then every catalog page
 points at the shared one.
 
-## The agent pages — `/agents/<agent>`
+## The agent pages — `/agents/<agent>`, and the hub at `/agents`
 
 "I use ChatGPT — what can it do now?" answered on one server-rendered URL per client. The first is
 `/agents/chatgpt`; the set is the keys of `agent_pages.AGENTS`, and nothing else (an unknown agent
 404s). They came out of the programmatic-SEO plan in `marketing/pseo-build-spec.md`: the measured
 demand is for the *agent* ("chatgpt connectors") and the *platform* ("linkedin api pricing"), never
 for "how to <job> in chatgpt", so the job list lives on the agent page as rows, not as URLs.
+
+**The hub at `/agents`** (2026-08-31) is one card per client off `AGENTS` — name, the `definition`
+sentence with the counts formatted in, a link. It exists because the discovery pass gave every
+surface an "Agents" nav link with nowhere to point it: the link went to `/agents/claude-code` (one
+client's page standing in for all of them) while the bare `/agents` URL 404ed. The nav now points
+at the hub, the agent pages' breadcrumb carries it as the parent (treg.to / Agents / <name>), and
+the sitemap lists it at 0.8 beside the other two hubs. Hosted-only and adtrack'd like everything
+else off `_page()`; no `.md` mirror, matching `/use-cases` and `/workflows`.
 
 **One skin for both page types.** The agent and use-case pages render with `usecase.css`, the
 landing-page skin the five outcome pages already use, passed to `_page(css=...)`: centered hero with

--- a/scripts/dump_surface.py
+++ b/scripts/dump_surface.py
@@ -24,6 +24,7 @@ def _configure_test_environment() -> None:
         "sh,echo,true,false,cat,sleep,treg-nonexistent-bin-xyz"
     )
     os.environ["TREG_PROXY_SSRF_CHECK"] = "false"
+    os.environ["TREG_CLAUDE_CONNECTOR_ENABLED"] = "true"
 
     for key in (
         "GOOGLE_CLIENT_ID",

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -48,6 +48,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/catalog/examples/{endpoint_id}', ('GET',), 'catalog_example'),
     ('/catalog', ('GET',), 'catalog_index'),
     ('/catalog/{slug}', ('GET',), 'catalog_page'),
+    ('/agents', ('GET',), 'agents_hub'),
     ('/agents/{agent}', ('GET',), 'agent_page'),
     ('/agents/{agent}.md', ('GET',), 'agent_page'),
     ('/use-cases/{category}/{job}', ('GET',), 'use_case_job_page_nested'),

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -162,7 +162,7 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
     # The job, workflow and agent pages exist on the hosted deployment only (`_hosted`): a
     # self-hosted registry must not put three 404s in its own footer.
     hub_links = ('<a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a>'
-                 '<a href="/agents/claude-code">Agents</a>' if _hosted() else "")
+                 '<a href="/agents">Agents</a>' if _hosted() else "")
     return HTMLResponse(f"""<!doctype html>
 <html lang="en">
 <head>
@@ -368,7 +368,7 @@ async def catalog_index():
                  + ('<p>Looking for a job rather than a platform? <a href="/use-cases">The use cases</a> '
                     'compare the providers that do one job, <a href="/workflows">the workflows</a> '
                     'chain several jobs into one prompt with the price of each step, and '
-                    '<a href="/agents/claude-code">the agent pages</a> show the whole menu for one '
+                    '<a href="/agents">the agent pages</a> show the whole menu for one '
                     'agent.</p>' if _hosted() else "")
                  + "".join(sections)
                  + f"<h2>The providers</h2><p>{len(prov_rows)} vendors serve this catalog, each "
@@ -620,6 +620,51 @@ document.querySelectorAll('button[data-copy]').forEach(function(b){
 _MD_ALT = '<link rel="alternate" type="text/markdown" href="{href}"/>'
 
 
+@app.get("/agents", include_in_schema=False)
+async def agents_hub():
+    """The hub the agent pages hang from. Until this existed the nav's "Agents" link pointed at one
+    client's page (/agents/claude-code) because there was nowhere else to point it, and the bare URL
+    404ed while every agent page's breadcrumb implied it existed."""
+    if not _hosted():
+        raise HTTPException(status_code=404, detail="not found")
+    base = get_settings().public_url.rstrip("/")
+    n_eps, n_plats = _catalog_census()
+    n, p = f"{n_eps:,}", str(n_plats)
+    def _blurb(defn: str) -> str:
+        # The card answers "which client, and does it install as a plugin or an MCP server" — the
+        # definition's opening clause. The counts already live on the meta line; printing the whole
+        # definition put them on every card twice and cut it mid-word at the length cap.
+        head = defn.split(" that gives ")[0]
+        if head == defn and len(defn) > 140:  # a future definition without the clause still fits
+            head = defn[:140].rsplit(" ", 1)[0]
+        return head.rstrip(".") + "."
+    cards = "".join(
+        f'<a class="pcard" href="/agents/{slug}"><h3>{_esc_html(spec["name"])}</h3>'
+        f'<p>{_esc_html(_blurb(spec["definition"].format(n=n, p=p)))}</p>'
+        f'<div class="meta">{n} tools &middot; {p} platforms</div></a>'
+        for slug, spec in agent_pages.AGENTS.items())
+    body = (
+        '<main class="wrap"><div class="phead">'
+        '<div class="crumbs"><a href="/">treg.to</a> / <a href="/agents">Agents</a></div>'
+        '<h1>The agents that can use treg.to</h1>'
+        '<p class="lede">One page per client: the install steps for that agent, then the menu of '
+        f'jobs it can do once connected. Every client gets the same {n} tools through one treg.to '
+        'key, at the provider&rsquo;s own rate with $0.000 markup.</p>'
+        f'</div><section class="cat"><div class="grid">{cards}</div></section>'
+        '<section class="cat"><h2>Everything else</h2><div class="cap"><p style="margin:0">The jobs '
+        'themselves are written up at <a href="/use-cases">/use-cases</a>, the multi-step versions '
+        'at <a href="/workflows">/workflows</a>, and the whole catalog is at '
+        '<a href="/catalog">/catalog</a>.</p></div></section></main>')
+    names = [s["name"] for s in agent_pages.AGENTS.values()]
+    ld = [{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "treg.to", "item": base + "/"},
+        {"@type": "ListItem", "position": 2, "name": "Agents", "item": base + "/agents"}]}]
+    return _page("Install treg.to in ChatGPT, Claude, Cursor or Grok",
+                 f"Install steps for {', '.join(names[:-1])} and {names[-1]}, and the menu of jobs "
+                 "each can do once connected. One treg.to key, no markup.",
+                 "/agents", body, ld)
+
+
 @app.get("/agents/{agent}.md", include_in_schema=False)
 @app.get("/agents/{agent}", include_in_schema=False)
 async def agent_page(request: Request, agent: str):
@@ -857,7 +902,8 @@ async def agent_page(request: Request, agent: str):
                                    "provider's own rate with no markup; every new team starts with $1.00 free."}},
         {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [
             {"@type": "ListItem", "position": 1, "name": "treg.to", "item": base + "/"},
-            {"@type": "ListItem", "position": 2, "name": name, "item": f"{base}/agents/{agent}"}]},
+            {"@type": "ListItem", "position": 2, "name": "Agents", "item": base + "/agents"},
+            {"@type": "ListItem", "position": 3, "name": name, "item": f"{base}/agents/{agent}"}]},
         {"@context": "https://schema.org", "@type": "FAQPage", "mainEntity": [
             {"@type": "Question", "name": q,
              "acceptedAnswer": {"@type": "Answer", "text": a}} for q, a in spec["faq"]]},
@@ -2682,6 +2728,7 @@ async def sitemap_xml():
     # hand-written copy, which is what changes between deploys.
     if _hosted():
         copy_day = _iso_day(Path(agent_pages.__file__).stat().st_mtime)
+        add("/agents", copy_day, "0.8")
         for slug in agent_pages.AGENTS:
             add(f"/agents/{slug}", copy_day, "0.8")
         add("/use-cases", copy_day, "0.8")

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -882,7 +882,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
     </div>
     <nav class="foot-cols" aria-label="Site">
       <div class="foot-col"><div class="lab">Explore</div>
-        <a href="/catalog">Catalog</a><!--hosted--><a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a><a href="/agents/claude-code">Agents</a><!--/hosted--></div>
+        <a href="/catalog">Catalog</a><!--hosted--><a href="/use-cases">Use cases</a><a href="/workflows">Workflows</a><a href="/agents">Agents</a><!--/hosted--></div>
       <div class="foot-col"><div class="lab">Build</div>
         <a href="/tutorial">Docs</a><a href="/docs">API</a><a href="/llms.txt">llms.txt</a><a href="https://github.com/superdesigndev/treg" target="_blank" rel="noopener">GitHub ↗</a></div>
       <div class="foot-col"><div class="lab">Company</div>

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -113,6 +113,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "agents_hub",
+    "path": "/agents"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "agent_page",
     "path": "/agents/{agent}"
   },

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -128,9 +128,24 @@ async def test_agent_pages_are_hosted_only(monkeypatch):
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
             assert (await c.get("/agents/chatgpt")).status_code == 404
-            assert "/agents/chatgpt" not in (await c.get("/sitemap.xml")).text
+            assert (await c.get("/agents")).status_code == 404
+            assert "/agents" not in (await c.get("/sitemap.xml")).text
     finally:
         get_settings.cache_clear()
+
+
+async def test_agents_hub_lists_every_agent(clients: AsyncClient):
+    """The nav's "Agents" link pointed at /agents/claude-code because no hub existed, and the bare
+    /agents URL 404ed while pages linked toward it. One card per client, the nav points here, and
+    the sitemap carries it."""
+    r = await clients.get("/agents")
+    assert r.status_code == 200, r.text[:200]
+    html = r.text
+    for slug, spec in agent_pages.AGENTS.items():
+        assert f'href="/agents/{slug}"' in html, slug
+        assert spec["name"] in html, slug
+    assert 'href="/agents"' in (await clients.get("/agents/chatgpt")).text  # nav + breadcrumb parent
+    assert f"<loc>{_base()}/agents</loc>" in (await clients.get("/sitemap.xml")).text
 
 
 # ------------------------------------------------------------------ use-case pages (the spokes)
@@ -352,7 +367,7 @@ async def test_use_cases_hub_lists_every_written_page(clients: AsyncClient):
 
 # Every page that ships, not a hand-kept list: this set grows by 59 as the use-case pages land, and
 # a title that overflows is invisible in exactly the way nobody notices during review.
-ALL_PAGES = ([f"/agents/{a}" for a in agent_pages.AGENTS] + ["/use-cases", "/workflows"]
+ALL_PAGES = ([f"/agents/{a}" for a in agent_pages.AGENTS] + ["/agents", "/use-cases", "/workflows"]
              + [f"/use-cases/{j}" for j in agent_pages.USE_CASE_PAGES]
              + [f"/workflows/{w}" for w in agent_pages.WORKFLOWS])
 
@@ -639,6 +654,7 @@ def test_workflow_copy_has_no_em_dashes():
 
 @pytest.mark.parametrize("path", [
     "/agents/chatgpt",
+    "/agents",
     "/use-cases/verify-an-email",
     "/use-cases",
     "/workflows",

--- a/tests/test_seo.py
+++ b/tests/test_seo.py
@@ -404,7 +404,7 @@ async def test_favicon_is_the_mono_mark(clients: AsyncClient):
 # the three hubs, /catalog names them in its crawlable prerender, a provider page names the jobs
 # it serves, and a job page names the workflows that chain it.
 
-HUBS = ('href="/use-cases"', 'href="/workflows"', 'href="/agents/claude-code"')
+HUBS = ('href="/use-cases"', 'href="/workflows"', 'href="/agents"')
 
 
 async def test_every_surface_links_the_three_hubs(clients: AsyncClient):


### PR DESCRIPTION
## What

\`/agents\` 404ed while every surface linked toward it: the discovery pass (#234) added an "Agents" link to the nav and footer, but with no hub to point at it went to \`/agents/claude-code\` — one client's page standing in for all five. This PR adds the hub:

- **\`GET /agents\`** — one card per client off \`agent_pages.AGENTS\` (name, the definition's opening clause, the catalog counts), crumbs, BreadcrumbList, cross-links to \`/use-cases\`, \`/workflows\` and \`/catalog\`. Hosted-only, adtrack'd, no \`.md\` mirror — all matching the other two hubs.
- The nav, the landing footer and the \`/catalog\` prerender now link \`/agents\` instead of \`/agents/claude-code\`.
- Agent pages' breadcrumb JSON-LD carries the hub as parent (treg.to / Agents / ChatGPT).
- Sitemap row at 0.8 beside the other hubs; route registered in the bootstrap ownership table; snapshots regenerated.
- Tests: hub listing test, hosted-only 404, \`/agents\` added to the title/description-length and adtrack parametrizations, HUBS constant updated.
- \`docs/context/interface/seo.md\` updated in the same commit.

## Drive-by fix

\`scripts/dump_surface.py\` says it mirrors \`tests/conftest.py\` but was missing \`TREG_CLAUDE_CONNECTOR_ENABLED=true\` — regenerating snapshots without it silently drops the \`/mcp/v2\` mount and the connector middleware from the baselines. One line added so the script is deterministic.

## Found by reading the rendered page

The first cut printed each definition truncated at 140 chars — mid-word cuts ("enrichmen…") and the 2,745/82 counts repeated three times per card. The card blurb is now the definition's opening clause (which client, plugin vs MCP server), with the counts only on the meta line. Tests were green both ways.

Full suite: 2,384 passed, 4 skipped. After merge: \`/agents\` should be included in the IndexNow run and the GSC indexing requests that are still pending from #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZEo61YXvfwUC84WmTJbaU