### PR TITLE
SEO: drop fake treg row, Hunter paste, possessive slugs

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -455,13 +455,27 @@ trial allowance with `max()` over the rows that have a `cost_view`; TikHub's Lin
 carries no cost at all, so on the comments job the generator was empty and the page 500ed past every
 green test (the tests render other jobs). `default=0` now; the cell prints "no dollar rate published".
 
-**Routed rows appear on the pages as a provider called treg** (2026-08-29). PR #242's first-party routed
-endpoints (`treg.<capability>`, `kind: routed`, `architecture/catalog.md` § Routing) are catalog rows
-on the capability, so `_uc_providers` lists them beside the children with the children's cheapest rate
-and "unverified". The template's "treg.to does not choose for you" line is now half true: the routed row
-is the explicit opt-in where it does choose, own keys first, naming the child that served. The five
-pages of 2026-08-29 say exactly that in a note; the earlier pages and the template line have not been
-revisited, which is a decision for whoever owns the routing copy.
+**Routed rows no longer appear on comparison tables** (2026-08-31). PR #242's first-party routed
+endpoints (`treg.<capability>`, `kind: routed`) were leaking into `_uc_providers` and appearing as a
+fake "treg" provider row on use-case comparison tables. `_uc_providers` now filters out `kind:routed`
+endpoints at the start, so only the real child providers appear. The public name is treg.to; a bare
+"treg" vendor row should never appear on any page.
+
+**Free own-key jobs use a filtered WHY_TREG** (2026-08-31). `WHY_TREG` contains cards like "One key,
+not 9 accounts" and "Already pay Hunter? Register it..." that are false for jobs running free on the
+user's own connected account (GA4, Search Console, YouTube Data API on your own channel). Those pages
+now render `WHY_TREG_OWN_KEY` instead, which keeps only the cards that stay true ("No code to write",
+"Nothing to integrate").
+
+**Possessive slugs 301 to clean slugs** (2026-08-31). Five use-case pages shipped with possessive slugs
+containing `-s-` (e.g. `get-a-video-s-transcript`, `a-company-s-email-format`). Before GSC indexed them,
+the keys in `USE_CASE_PAGES` were renamed to clean slugs (`youtube-transcript-api`, `company-email-format`,
+etc.) and `USE_CASE_REDIRECTS` maps old to new. The route checks `USE_CASE_REDIRECTS` first and 301s;
+the old slugs are not in the sitemap (only `USE_CASE_PAGES` keys appear) and the canonical is on the
+new slug. Redirects: `get-a-video-s-transcript` -> `youtube-transcript-api`,
+`a-channel-s-profile-and-lifetime-stats` -> `youtube-channel-stats`, `a-video-s-comments` ->
+`youtube-video-comments`, `a-business-s-reviews` -> `business-reviews`, `a-company-s-email-format` ->
+`company-email-format`.
 
 **The related-card test hard-coded the agent-page anchor** (2026-08-29). It asserted the email-finder
 page links to `/agents/chatgpt#`, which was only ever the fallback for a related label with no page;

--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -455,22 +455,32 @@ trial allowance with `max()` over the rows that have a `cost_view`; TikHub's Lin
 carries no cost at all, so on the comments job the generator was empty and the page 500ed past every
 green test (the tests render other jobs). `default=0` now; the cell prints "no dollar rate published".
 
-**Routed rows no longer appear on comparison tables** (2026-08-31). PR #242's first-party routed
-endpoints (`treg.<capability>`, `kind: routed`) were leaking into `_uc_providers` and appearing as a
-fake "treg" provider row on use-case comparison tables. `_uc_providers` now filters out `kind:routed`
-endpoints at the start, so only the real child providers appear. The public name is treg.to; a bare
-"treg" vendor row should never appear on any page.
+**Routed rows are off every public surface, not just comparison tables** (2026-08-31). PR #242's
+first-party routed endpoints (`treg.<capability>`, `kind: routed`) were leaking into `_uc_providers`
+as a fake "treg" provider row — and, found while fixing that, into every other public projection of
+the catalog: the agent-page menu counted "treg" as an extra provider on every routed job, the
+use-case hub's card metas did the same, `_provider_rows` published a self-referential `/tools/treg`
+page into the sitemap, and `_catalog_census` counted the 76 meta-rows on top of the children they
+delegate to. `_pub()` in `routers.web` is now the one filter every public page reads (hidden kinds
+plus routed), `/tools/treg` 404s (the all-rows-hidden fallback in `tools_provider` no longer
+resurrects routed rows), and the advertised tool count dropped accordingly (2,745 → 2,669). The
+public name is treg.to; a bare "treg" vendor row must never appear on any page —
+`test_routed_rows_never_surface_a_provider_named_treg` pins it.
 
-**Free own-key jobs use a filtered WHY_TREG** (2026-08-31). `WHY_TREG` contains cards like "One key,
-not 9 accounts" and "Already pay Hunter? Register it..." that are false for jobs running free on the
-user's own connected account (GA4, Search Console, YouTube Data API on your own channel). Those pages
-now render `WHY_TREG_OWN_KEY` instead, which keeps only the cards that stay true ("No code to write",
-"Nothing to integrate").
+**Pages with a free own-account row use a filtered WHY_TREG** (2026-08-31). `WHY_TREG` contains
+cards like "One key, not 9 accounts" and "Already pay Hunter? Register it..." that are false
+wherever the reader's own connected account does the job. That is the short own-account pages (GA4,
+Search Console) — and also the YouTube comparison pages whose official Data API row is a $0.00
+own-account row, so the condition is `any(p["free"] for p in provs)`, not "short form only" (the
+first cut missed the YouTube pages). Those pages render `WHY_TREG_OWN_KEY` instead, keeping only the
+cards that stay true ("No code to write", "Nothing to integrate").
 
 **Possessive slugs 301 to clean slugs** (2026-08-31). Five use-case pages shipped with possessive slugs
 containing `-s-` (e.g. `get-a-video-s-transcript`, `a-company-s-email-format`). Before GSC indexed them,
 the keys in `USE_CASE_PAGES` were renamed to clean slugs (`youtube-transcript-api`, `company-email-format`,
-etc.) and `USE_CASE_REDIRECTS` maps old to new. The route checks `USE_CASE_REDIRECTS` first and 301s;
+etc.) and `USE_CASE_REDIRECTS` maps old to new. The flat route checks `USE_CASE_REDIRECTS` first and 301s, and the nested legacy route resolves
+through the same map before its own lookup (it used to reject a renamed slug first, turning the
+promised 301 into a 404 on the nested shape);
 the old slugs are not in the sitemap (only `USE_CASE_PAGES` keys appear) and the canonical is on the
 new slug. Redirects: `get-a-video-s-transcript` -> `youtube-transcript-api`,
 `a-channel-s-profile-and-lifetime-stats` -> `youtube-channel-stats`, `a-video-s-comments` ->

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -304,7 +304,8 @@ PROVIDER_DOMAINS: dict[str, str] = {
     "youtube": "youtube.com", "akta": "akta.pro",
 }
 
-# Why go through treg.to at all: (lead, one short line). Same on every use-case page.
+# Why go through treg.to at all: (lead, one short line). Same on every use-case page, except for
+# free own-key jobs where the metering/multi-account cards are misleading.
 WHY_TREG: tuple[tuple[str, str], ...] = (
     ("One key, not 9 accounts", "treg.to holds the provider keys. Neither you nor the agent sees them."),
     ("Price before the call", "The provider's own rate, $0.000 markup, from a prepaid balance."),
@@ -313,6 +314,25 @@ WHY_TREG: tuple[tuple[str, str], ...] = (
     ("Switch by changing a word", "Another provider is a different word in the prompt, not a new integration."),
     ("Nothing to integrate", "No SDK, no OAuth dance per vendor, no seats."),
 )
+
+# The subset of WHY_TREG that applies to free own-key jobs (Google Search Console, GA4, YouTube Data
+# API on your own account, etc). "9 accounts" and "Hunter" are false when the call runs free on the
+# user's own connected account, so we keep only the cards that stay true.
+WHY_TREG_OWN_KEY: tuple[tuple[str, str], ...] = (
+    ("No code to write", "Connect once, keep the token server side, and call from any agent."),
+    ("Nothing to integrate", "No SDK, no OAuth dance per vendor, no seats."),
+)
+
+# 301 redirects from old possessive slugs to clean slugs. These pages shipped before GSC indexing,
+# so redirect now while they are still largely unindexed. The old slugs are not in the sitemap
+# (they are not keys of USE_CASE_PAGES) and the canonical is on the new slug.
+USE_CASE_REDIRECTS: dict[str, str] = {
+    "get-a-video-s-transcript": "youtube-transcript-api",
+    "a-channel-s-profile-and-lifetime-stats": "youtube-channel-stats",
+    "a-video-s-comments": "youtube-video-comments",
+    "a-business-s-reviews": "business-reviews",
+    "a-company-s-email-format": "company-email-format",
+}
 
 # The client used as the example throughout the use-case pages. One constant, so the pages are a
 # template rather than ChatGPT-specific prose.
@@ -1075,7 +1095,7 @@ USE_CASE_PAGES["enrich-a-company"] = {
 }
 
 
-USE_CASE_PAGES["get-a-video-s-transcript"] = {
+USE_CASE_PAGES["youtube-transcript-api"] = {
     "label": "Get a video's transcript",
     "sentence": "YouTube transcript API: a video's captions as plain text",
     "title": "YouTube transcript API: {n} providers compared | treg.to",
@@ -1275,7 +1295,7 @@ USE_CASE_PAGES["video-details-views-and-stats"] = {
                 "A channel's profile and lifetime stats", "Search videos and channels by keyword"),
 }
 
-USE_CASE_PAGES["a-channel-s-profile-and-lifetime-stats"] = {
+USE_CASE_PAGES["youtube-channel-stats"] = {
     "label": "A channel's profile and lifetime stats",
     "sentence": "YouTube channel stats API: subscribers, total views and profile",
     "title": "YouTube channel stats API: {n} providers | treg.to",
@@ -1472,7 +1492,7 @@ USE_CASE_PAGES["search-videos-and-channels-by-keyword"] = {
                 "Trending videos", "Find creators by keyword"),
 }
 
-USE_CASE_PAGES["a-video-s-comments"] = {
+USE_CASE_PAGES["youtube-video-comments"] = {
     "label": "A video's comments",
     "sentence": "YouTube comment scraper: every comment on a video, as data",
     "title": "YouTube comment scraper API: {n} providers | treg.to",
@@ -2374,7 +2394,7 @@ USE_CASE_PAGES["your-google-business-profile-reviews-and-reply-to-them"] = {
                 "Search terms that surfaced your listing on Maps", "Search Console: clicks, impressions and top queries"),
 }
 
-USE_CASE_PAGES["a-business-s-reviews"] = {
+USE_CASE_PAGES["business-reviews"] = {
     "label": "A business's reviews",
     "sentence": "Review scraper API: a business's reviews from Tripadvisor, Trustpilot and Yelp, as data",
     "title": "Tripadvisor, Trustpilot and Yelp reviews API | treg.to",
@@ -4524,7 +4544,7 @@ WORKFLOWS["find-and-verify-a-lead-list"] = {
 }
 
 
-USE_CASE_PAGES["a-company-s-email-format"] = {
+USE_CASE_PAGES["company-email-format"] = {
     "label": "A company's email format",
     "sentence": "Company email format finder: the pattern a domain uses, so a name becomes an address",
     "title": "Company email format finder API, by domain | treg.to",

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -473,10 +473,18 @@ def _hosted() -> bool:
     return host in PUBLIC_HOST_ALIASES
 
 
+def _pub(e: dict) -> bool:
+    """An endpoint the PUBLIC pages may count or list: hidden utility kinds out, and the
+    `kind: routed` meta-rows (PR #242) out with them — a routed row delegates to children that
+    are already on the page, so anywhere public it double-counts and surfaces a provider named
+    "treg", which the brand rules say must never appear as a vendor."""
+    return e["kind"] not in catalog_store.HIDDEN_KINDS and e.get("kind") != "routed"
+
+
 def _catalog_census() -> tuple[int, int]:
     """(browse-surface endpoint count, platform count): the two numbers the agent pages state."""
     cat = catalog_store.load()
-    browse = [e for e in cat.endpoints if e["kind"] not in catalog_store.HIDDEN_KINDS]
+    browse = [e for e in cat.endpoints if _pub(e)]
     return len(browse), len({e["platform"] for e in browse})
 
 
@@ -554,7 +562,7 @@ def _jobs_by_provider() -> dict[str, list[tuple[str, str]]]:
     out: dict[str, list[tuple[str, str]]] = {}
     for slug, spec in agent_pages.USE_CASE_PAGES.items():
         provs = {e["provider"] for cid in _use_case_caps(spec["label"])
-                 for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS}
+                 for e in cat.for_capability(cid) if _pub(e)}
         for p in provs:
             out.setdefault(p, []).append((slug, spec["sentence"]))
     return out
@@ -583,13 +591,13 @@ def _menu_rows(cat, category: str, jobs) -> list[dict]:
     Markdown renderings of the agent page so the two can never list different jobs."""
     rows = []
     for label, caps in jobs:
-        eps = [e for cid in caps for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+        eps = [e for cid in caps for e in cat.for_capability(cid) if _pub(e)]
         if not eps:  # the test forbids this, but a page must never render an empty promise
             continue
         prices = [c["usd"] for e in eps if (c := cat.cost_view(e.get("cost"), e.get("provider"))) and c["usd"]]
         plats, seen = [], set()
         for cid in caps:
-            ceps = [e for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+            ceps = [e for e in cat.for_capability(cid) if _pub(e)]
             if not ceps:
                 continue
             slug = ceps[0]["platform"]
@@ -950,6 +958,9 @@ async def use_case_job_page_nested(category: str, job: str):
     answers is free, and a moved URL that does not is the whole cost of a taxonomy change."""
     md = job.endswith(".md")
     slug = job[:-3] if md else job
+    # A renamed slug must keep redirecting from its nested shape too — this handler used to
+    # reject it before consulting the map, which turned the promised 301 into a 404.
+    slug = agent_pages.USE_CASE_REDIRECTS.get(slug.lower(), slug)
     if slug not in agent_pages.USE_CASE_PAGES:
         raise HTTPException(status_code=404, detail="unknown use case")
     return RedirectResponse(f"/use-cases/{slug}{'.md' if md else ''}", status_code=301)
@@ -1002,7 +1013,7 @@ async def use_case_job_page(request: Request, job: str,
     agent_slug, agent_name = _uc_agent()
     cat_label = _job_category(spec["label"])
     caps = _use_case_caps(spec["label"])
-    eps = [e for cid in caps for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+    eps = [e for cid in caps for e in cat.for_capability(cid) if _pub(e)]
     if not eps:
         raise HTTPException(status_code=404, detail="no endpoints for this job")
     job_workflows = _workflows_for_caps(caps)
@@ -1094,9 +1105,10 @@ async def use_case_job_page(request: Request, job: str,
               f"Setup line (paste into any agent): `{setup}`", "",
               f'Then ask: "{spec["prompt"]}"', ""]
         md += [f"- **{t}** {d}" for t, d in spec["prompt_why"]]
-        # Free own-key jobs (GA4, Search Console, YouTube on your own account) are never metered, so
-        # the "9 accounts" and "Hunter" cards are false; use the own-key subset instead.
-        own_key_free = form == "short" and provs[0]["free"]
+        # Any page with a free own-account row (GA4, Search Console short pages, and the YouTube
+        # comparisons where the official Data API is a $0.00 row) drops the metering cards: "9
+        # accounts" and "Hunter" are false wherever the reader's own account does the job.
+        own_key_free = any(p["free"] for p in provs)
         why_treg = agent_pages.WHY_TREG_OWN_KEY if own_key_free else agent_pages.WHY_TREG
         md += ["", "## Why go through treg.to", ""] + [f"- **{t}** {d}" for t, d in why_treg]
         if trial_single:
@@ -1184,9 +1196,10 @@ async def use_case_job_page(request: Request, job: str,
 
     why_cards = "".join(f'<div class="card"><h4>{_esc_html(t)}</h4><p>{_esc_html(d)}</p></div>'
                         for t, d in spec["prompt_why"])
-    # Free own-key jobs (GA4, Search Console, YouTube on your own account) are never metered, so
-    # the "9 accounts" and "Hunter" cards are false; use the own-key subset instead.
-    own_key_free = form == "short" and provs[0]["free"]
+    # Any page with a free own-account row (GA4, Search Console short pages, and the YouTube
+    # comparisons where the official Data API is a $0.00 row) drops the metering cards: "9
+    # accounts" and "Hunter" are false wherever the reader's own account does the job.
+    own_key_free = any(p["free"] for p in provs)
     why_treg = agent_pages.WHY_TREG_OWN_KEY if own_key_free else agent_pages.WHY_TREG
     treg_cards = "".join(f'<div class="card"><h4>{_esc_html(t)}</h4><p>{_esc_html(d)}</p></div>'
                          for t, d in why_treg)
@@ -1461,7 +1474,7 @@ async def use_cases_hub():
     for j, spec in agent_pages.USE_CASE_PAGES.items():
         label = _job_category(spec["label"])
         caps = _use_case_caps(spec["label"])
-        eps = [e for cid in caps for e in cat.for_capability(cid) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+        eps = [e for cid in caps for e in cat.for_capability(cid) if _pub(e)]
         nprov = len({e["provider"] for e in eps})
         prices = [cv["usd"] for e in eps if (cv := cat.cost_view(e.get("cost"), e.get("provider"))) and cv["usd"]]
         meta = (f"{nprov} provider{'s' if nprov != 1 else ''} &middot; from {_esc_html(_usd_short(min(prices)))}"
@@ -1512,7 +1525,7 @@ async def _wf_steps(cat, observations: endpoint_stats.EndpointObservationReader,
     price per billing unit, how many providers do the step, and the observed stats when any."""
     out = []
     for name, cap, asks, ep_id, why in spec["steps"]:
-        eps = [e for e in cat.for_capability(cap) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+        eps = [e for e in cat.for_capability(cap) if _pub(e)]
         used = next((e for e in eps if e["id"] == ep_id), None)
         cv = cat.cost_view(used.get("cost"), used.get("provider")) if used else None
         usd = cv["usd"] if cv and cv["usd"] else None
@@ -1826,7 +1839,7 @@ def _provider_rows() -> list[dict]:
     cat = catalog_store.load()
     rows = []
     for service in sorted({e["provider"] for e in cat.endpoints}):
-        eps = [e for e in cat.for_provider(service) if e["kind"] not in catalog_store.HIDDEN_KINDS]
+        eps = [e for e in cat.for_provider(service) if _pub(e)]
         if not eps:
             continue
         rows.append({
@@ -1911,7 +1924,12 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
     # never the request's. (Same idiom as the use-case pages; it is also what reads as a taint
     # kill to CodeQL, which cannot see _esc_html as a sanitizer.)
     svc = all_eps[0]["provider"]
-    eps = [e for e in all_eps if e["kind"] not in catalog_store.HIDDEN_KINDS] or all_eps
+    eps = [e for e in all_eps if _pub(e)] or [e for e in all_eps if e.get("kind") != "routed"]
+    if not eps:
+        # The first-party "treg" pseudo-provider is nothing but routed meta-rows. Without this a
+        # self-referential /tools/treg page rendered (and reached the sitemap) — the fallback above
+        # resurrects hidden kinds for providers whose real rows are all utility, never routed ones.
+        raise HTTPException(status_code=404, detail=f"unknown provider {service!r}")
     display = _provider_display(svc)
     esc_d = _esc_html(display)
     base = get_settings().public_url.rstrip("/")

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -878,6 +878,11 @@ _UNIT_WORDS = {"per_success": "found", "per_call": "call", "per_result": "result
 def _uc_providers(cat, eps: list[dict], obs: dict) -> list[dict]:
     """One row per provider for this job: cheapest priced endpoint, best-sampled observed stats,
     the union of its accepted inputs, and the platform it serves."""
+    # Routed endpoints (kind:routed) are the first-party meta-rows that delegate to children; they
+    # appear as provider "treg" and must not show as a row in comparison tables. Filter them here
+    # rather than at each call site, since every use-case comparison needs the same exclusion.
+    eps = [e for e in eps if e.get("kind") != "routed"]
+
     def usd(e):
         cv = cat.cost_view(e.get("cost"), e.get("provider"))
         return cv["usd"] if cv and cv["usd"] else None
@@ -976,6 +981,11 @@ async def use_case_job_page(request: Request, job: str,
             raise HTTPException(status_code=404, detail=f"{legacy} not bundled")
         # no-cache: these are edited against live campaign data and must never serve stale.
         return FileResponse(page, headers={"Cache-Control": "no-cache"})
+    # Possessive slugs that shipped before GSC indexing: redirect to the clean slug with 301 so
+    # the canonical stays clean and search engines update before indexing the old URL.
+    redirect_to = agent_pages.USE_CASE_REDIRECTS.get(raw.lower())
+    if redirect_to:
+        return RedirectResponse(f"/use-cases/{redirect_to}" + (".md" if as_md else ""), status_code=301)
     # Same rule as `agent_page`: the slug reaches the canonical and the JSON-LD, so it comes from
     # the table's own key, and a differently-cased URL is redirected rather than duplicated.
     key = next((k for k in agent_pages.USE_CASE_PAGES if k == raw.lower()), None)
@@ -1084,7 +1094,11 @@ async def use_case_job_page(request: Request, job: str,
               f"Setup line (paste into any agent): `{setup}`", "",
               f'Then ask: "{spec["prompt"]}"', ""]
         md += [f"- **{t}** {d}" for t, d in spec["prompt_why"]]
-        md += ["", "## Why go through treg.to", ""] + [f"- **{t}** {d}" for t, d in agent_pages.WHY_TREG]
+        # Free own-key jobs (GA4, Search Console, YouTube on your own account) are never metered, so
+        # the "9 accounts" and "Hunter" cards are false; use the own-key subset instead.
+        own_key_free = form == "short" and provs[0]["free"]
+        why_treg = agent_pages.WHY_TREG_OWN_KEY if own_key_free else agent_pages.WHY_TREG
+        md += ["", "## Why go through treg.to", ""] + [f"- **{t}** {d}" for t, d in why_treg]
         if trial_single:
             e0 = provs[0]["eps"][0]
             md += ["", "## How it works", "",
@@ -1170,8 +1184,12 @@ async def use_case_job_page(request: Request, job: str,
 
     why_cards = "".join(f'<div class="card"><h4>{_esc_html(t)}</h4><p>{_esc_html(d)}</p></div>'
                         for t, d in spec["prompt_why"])
+    # Free own-key jobs (GA4, Search Console, YouTube on your own account) are never metered, so
+    # the "9 accounts" and "Hunter" cards are false; use the own-key subset instead.
+    own_key_free = form == "short" and provs[0]["free"]
+    why_treg = agent_pages.WHY_TREG_OWN_KEY if own_key_free else agent_pages.WHY_TREG
     treg_cards = "".join(f'<div class="card"><h4>{_esc_html(t)}</h4><p>{_esc_html(d)}</p></div>'
-                         for t, d in agent_pages.WHY_TREG)
+                         for t, d in why_treg)
 
     def price_cell(p: dict) -> str:
         if p["usd"]:

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -164,8 +164,10 @@ async def test_use_case_page_answers_the_four_questions_in_order(clients: AsyncC
 
 async def test_use_case_page_compares_one_row_per_provider_with_every_endpoint_collapsed(clients: AsyncClient):
     cat = catalog_store.load()
+    # Routed endpoints (kind:routed) are filtered out of the comparison table so they don't appear
+    # as a fake "treg" provider row. Match that filter here.
     eps = [e for e in cat.for_capability("people.email.find")
-           if e["kind"] not in catalog_store.HIDDEN_KINDS]
+           if e["kind"] not in catalog_store.HIDDEN_KINDS and e.get("kind") != "routed"]
     provs = {e["provider"] for e in eps}
     assert len(provs) >= 2
     html = (await clients.get(USECASE)).text

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -45,7 +45,10 @@ async def test_chatgpt_page_counts_come_from_the_catalog(clients: AsyncClient):
     """The title's tool count is computed, never typed — the landing, llms.txt and the schema had
     drifted to three different numbers before this rule existed."""
     cat = catalog_store.load()
-    n = sum(1 for e in cat.endpoints if e["kind"] not in catalog_store.HIDDEN_KINDS)
+    # Mirrors web._pub: routed meta-rows delegate to children already counted, so the
+    # advertised total excludes them along with the hidden kinds.
+    n = sum(1 for e in cat.endpoints
+            if e["kind"] not in catalog_store.HIDDEN_KINDS and e.get("kind") != "routed")
     html = (await clients.get("/agents/chatgpt")).text
     assert f"{n:,}" in re.search(r"<title>(.*?)</title>", html).group(1)
 
@@ -665,3 +668,47 @@ async def test_pages_off_the_shared_shell_carry_adtrack(clients: AsyncClient, pa
     html = r.text
     assert html.count('<script src="/adtrack.js"></script>') == 1, (
         f"{path} must load adtrack.js exactly once")
+
+
+async def test_possessive_slug_redirects_hold_in_every_shape_they_were_live(clients: AsyncClient):
+    """The five renamed slugs 301 from the flat form, the .md form, and the nested form that
+    shipped first — the nested handler used to reject a renamed slug before consulting the map,
+    turning the promised 301 into a 404. The old slugs also leave the sitemap with the rename."""
+    sitemap = (await clients.get("/sitemap.xml")).text
+    for old, new in agent_pages.USE_CASE_REDIRECTS.items():
+        assert new in agent_pages.USE_CASE_PAGES, (old, new)
+        r = await clients.get(f"/use-cases/{old}", follow_redirects=False)
+        assert r.status_code == 301 and r.headers["location"] == f"/use-cases/{new}", old
+        r = await clients.get(f"/use-cases/{old}.md", follow_redirects=False)
+        assert r.status_code == 301 and r.headers["location"] == f"/use-cases/{new}.md", old
+        r = await clients.get(f"/use-cases/anything/{old}", follow_redirects=False)
+        assert r.status_code == 301 and r.headers["location"] == f"/use-cases/{new}", old
+        assert f"/use-cases/{old}<" not in sitemap and f"{old}</loc>" not in sitemap, old
+        assert f"{_base()}/use-cases/{new}" in sitemap, new
+
+
+async def test_own_account_pages_do_not_carry_the_metering_cards(clients: AsyncClient):
+    """"One key, not 9 accounts" and "Already pay Hunter?" are false wherever the reader's own
+    connected account does the job — the short own-account pages, and the YouTube comparisons
+    whose official Data API row is $0.00 on the reader's own quota."""
+    for path in ("/use-cases/search-console-queries", "/use-cases/video-details-views-and-stats"):
+        html = (await clients.get(path)).text
+        assert "Already pay Hunter" not in html, path
+        assert "not 9 accounts" not in html, path
+    # and a fully metered job keeps the full pitch
+    assert "Already pay Hunter" in (await clients.get(USECASE)).text
+
+
+async def test_routed_rows_never_surface_a_provider_named_treg(clients: AsyncClient):
+    """PR #242's `kind: routed` meta-rows delegate to children that are already listed, so on any
+    public surface they double-count and print a vendor named "treg" (the brand is treg.to, and
+    treg is not a vendor). `_pub` is the one filter every public page reads, and the provider grid
+    feeds both the sitemap and /catalog's prerender — so /tools/treg must not exist."""
+    from treg.routers.web import _provider_rows, _pub
+    cat = catalog_store.load()
+    routed = [e for e in cat.endpoints if e.get("kind") == "routed"]
+    assert routed, "no routed rows in the catalog — retire this test's premise"
+    assert not any(_pub(e) for e in routed)
+    assert "treg" not in {r["service"] for r in _provider_rows()}
+    assert (await clients.get("/tools/treg")).status_code == 404
+    assert "/tools/treg<" not in (await clients.get("/sitemap.xml")).text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes three bugs on the use-case job pages:

1. **Fake treg provider row**: `kind:routed` endpoints were leaking into `_uc_providers`, causing a fake "treg" row to appear in comparison tables (e.g. on `/use-cases/find-professional-emails`). Now filtered out at the start of the function.

2. **False Hunter/9-accounts boilerplate**: The `WHY_TREG` cards include "One key, not 9 accounts" and "Already pay Hunter?..." which are false for free own-key jobs like Google Search Console, GA4, YouTube Data API on your own account. These pages now use `WHY_TREG_OWN_KEY` which only includes the applicable cards.

3. **Possessive slug 301s**: Five use-case pages shipped with `-s-` possessive slugs before GSC indexing:
   - `get-a-video-s-transcript` → `youtube-transcript-api`
   - `a-channel-s-profile-and-lifetime-stats` → `youtube-channel-stats`
   - `a-video-s-comments` → `youtube-video-comments`
   - `a-business-s-reviews` → `business-reviews`
   - `a-company-s-email-format` → `company-email-format`

   Keys in `USE_CASE_PAGES` are renamed to clean slugs, `USE_CASE_REDIRECTS` maps old to new for 301s. Old slugs are not in sitemap (only `USE_CASE_PAGES` keys appear) and canonical is on the new slug.

## How it was tested

- `uv run pytest tests/test_agent_pages.py` - all 142 tests pass
- `uv run pytest tests/test_seo.py` - all 68 tests pass  
- `uv run pytest tests/ -q` - full suite passes (2381 passed, 4 skipped)
- Updated test to match new `kind:routed` filter

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8208eea3-c1a7-42e3-bd34-1b043332cd49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8208eea3-c1a7-42e3-bd34-1b043332cd49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

