### PR TITLE
SEO: ChatGPT Connectors + Grok Bot MCP copy pass

### DIFF
--- a/docs/context/interface/seo.md
+++ b/docs/context/interface/seo.md
@@ -287,7 +287,7 @@ one motion, and promoting them would have committed four URL segments to a disti
 exists in a practitioner's head. The section builder orders rows by group and prints a divider row
 before each; the `.md` mirror sorts by the same order.
 
-**Hosted only.** The copy describes treg.to's own listings — the ChatGPT Plugins entry, the $1.00
+**Hosted only.** The copy describes treg.to's own listings — the ChatGPT Connectors entry, the $1.00
 grant — none of which is true of a self-hosted registry. `_hosted()` checks `public_url` against
 `PUBLIC_HOST_ALIASES`; elsewhere the route 404s and the sitemap omits the rows, rather than lie.
 

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -334,6 +334,7 @@ SETUP_LINE = "set up treg — {base}/llms.txt"
 AGENTS: dict[str, dict] = {
     "chatgpt": {
         "name": "ChatGPT",
+        "h1_noun": "Connector",
         "title": "ChatGPT Connector: call {n} APIs without keys | treg.to",
         "description": (
             "treg.to is a ChatGPT Connector that lets ChatGPT call {n} APIs across {p} platforms: "
@@ -605,6 +606,7 @@ USE_CASE_PAGES["find-creators-by-keyword"] = {
 }
 AGENTS["claude"] = {
     "name": "Claude",
+    "h1_noun": "MCP server",
     "title": "Claude MCP server: {n} APIs without keys | treg.to",
     "description": (
         "treg.to gives Claude {n} ready-to-call APIs across {p} platforms: work emails, LinkedIn profiles, creators, keyword volumes, backlinks, competitor ads. Priced per call at the provider's own rate with no markup and no provider signup."),
@@ -645,6 +647,7 @@ AGENTS["claude"] = {
 
 AGENTS["claude-code"] = {
     "name": "Claude Code",
+    "h1_noun": "MCP server",
     "title": "Claude Code MCP server: {n} APIs, no keys | treg.to",
     "description": (
         "treg.to gives Claude Code {n} ready-to-call APIs across {p} platforms: work emails, LinkedIn profiles, creators, keyword volumes, backlinks, competitor ads. Priced per call at the provider's own rate with no markup and no provider signup."),
@@ -685,6 +688,7 @@ AGENTS["claude-code"] = {
 
 AGENTS["cursor"] = {
     "name": "Cursor",
+    "h1_noun": "MCP server",
     "title": "Cursor MCP server: {n} APIs, no keys | treg.to",
     "description": (
         "treg.to gives Cursor {n} ready-to-call APIs across {p} platforms: work emails, LinkedIn profiles, creators, keyword volumes, backlinks, competitor ads. Priced per call at the provider's own rate with no markup and no provider signup."),
@@ -2663,6 +2667,7 @@ USE_CASE_PAGES["current-quote-for-a-ticker"] = {
 
 AGENTS["grok-bot"] = {
     "name": "Grok Bot",
+    "h1_noun": "MCP server",
     "title": "Grok MCP server: {n} tools without keys | treg.to",
     "description": (
         "treg.to is an MCP server that gives Grok Bot {n} tools across {p} platforms: find work "

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -10,7 +10,7 @@ Two rules the tests enforce:
   - every capability id named in USE_CASES must exist in the catalog — a job the catalog cannot do
     must not be advertised ("do not document what is not built"), and a renamed capability must
     fail the build rather than silently drop a row;
-  - the install copy describes the HOSTED treg.to (the ChatGPT Plugins listing, the $1.00 grant),
+  - the install copy describes the HOSTED treg.to (the ChatGPT Connectors listing, the $1.00 grant),
     so `api.py` serves these pages only on the reference hosts (`PUBLIC_HOST_ALIASES`).
 """
 
@@ -334,31 +334,32 @@ SETUP_LINE = "set up treg — {base}/llms.txt"
 AGENTS: dict[str, dict] = {
     "chatgpt": {
         "name": "ChatGPT",
-        "title": "ChatGPT plugin: call {n} APIs without keys | treg.to",
+        "title": "ChatGPT Connector: call {n} APIs without keys | treg.to",
         "description": (
-            "treg.to is a ChatGPT plugin that lets ChatGPT call {n} APIs across {p} platforms: "
+            "treg.to is a ChatGPT Connector that lets ChatGPT call {n} APIs across {p} platforms: "
             "find work emails, LinkedIn profiles, creators, keyword volumes, backlinks, competitor "
             "ads. Priced per call at the provider's own rate, with no markup and no provider signup."),
         # The one quotable sentence an answer engine should lift. Server-rendered first, under the H1.
         "definition": (
-            "treg.to is a ChatGPT plugin (and MCP server) that gives ChatGPT {n} ready-to-call APIs "
-            "across {p} platforms: SEO data, LinkedIn and people enrichment, Reddit, YouTube, "
+            "treg.to is a ChatGPT Connector (and MCP server) that gives ChatGPT {n} ready-to-call "
+            "APIs across {p} platforms: SEO data, LinkedIn and people enrichment, Reddit, YouTube, "
             "ads and e-commerce. Calls run on treg.to's own keys and are metered from a prepaid "
             "balance at the provider's rate with $0.000 markup. Every new team starts with $1.00 "
             "free, and there are no provider accounts to open."),
         # Steps shown as numbered HTML list items. Plain text; escaped by the route.
+        # {n} is interpolated from the catalog count at render time.
         "install_steps": [
-            "In ChatGPT, open <b>Plugins</b> in the left sidebar.",
-            "Search for <b>treg</b> and click <b>Install</b>. It is listed publicly as "
-            "“treg: Call 2,600 APIs without keys”.",
+            "In ChatGPT, open <b>Connectors</b> in the left sidebar.",
+            "Search for <b>treg</b> and click <b>Add</b>. The connector gives ChatGPT access to "
+            "{n} APIs without keys.",
             "Sign in when ChatGPT asks; your first team starts with $1.00 of free calls.",
             "Ask for what you want done. ChatGPT searches the catalog, tells you the price, and "
             "calls the endpoint. You never hold a provider key.",
         ],
-        "install_image": "/media/install/chatgpt-plugins.png",
-        "install_image_alt": "ChatGPT's Plugins directory with “treg” searched and its Install button",
-        "install_image_bar": "chatgpt.com  ·  Plugins",
-        "install_image_caption": "Steps 1 and 2: Plugins in the sidebar, search treg, Install.",
+        "install_image": "/media/install/chatgpt-connectors.png",
+        "install_image_alt": "ChatGPT's Connectors directory with treg searched and its Add button",
+        "install_image_bar": "chatgpt.com  ·  Connectors",
+        "install_image_caption": "Steps 1 and 2: Connectors in the sidebar, search treg, Add.",
         "faq": [
             ("Is treg.to free to use in ChatGPT?",
              "Installing is free and every new team starts with $1.00 of calls. After that, each call "
@@ -2662,33 +2663,34 @@ USE_CASE_PAGES["current-quote-for-a-ticker"] = {
 
 AGENTS["grok-bot"] = {
     "name": "Grok Bot",
-    "title": "Grok Bot plugin: call {n} APIs without keys | treg.to",
+    "title": "Grok MCP server: {n} tools without keys | treg.to",
     "description": (
-        "treg.to is a Grok Bot plugin that lets Grok call {n} APIs across {p} platforms: find work "
+        "treg.to is an MCP server that gives Grok Bot {n} tools across {p} platforms: find work "
         "emails, LinkedIn profiles, creators, keyword volumes, backlinks, competitor ads. Priced "
         "per call at the provider's own rate, with no markup and no provider signup."),
     "definition": (
-        "treg.to is a Grok Bot plugin (and MCP server) that gives Grok {n} ready-to-call APIs "
-        "across {p} platforms: SEO data, LinkedIn and people enrichment, Reddit, YouTube, ads and "
-        "e-commerce. Calls run on treg.to's own keys and are metered from a prepaid balance at the "
-        "provider's rate with $0.000 markup. Every new team starts with $1.00 free, and there are "
-        "no provider accounts to open."),
+        "treg.to is an MCP server for Grok Bot that gives it {n} ready-to-call tools across {p} "
+        "platforms: SEO data, LinkedIn and people enrichment, Reddit, YouTube, ads and e-commerce. "
+        "Calls run on treg.to's own keys and are metered from a prepaid balance at the provider's "
+        "rate with $0.000 markup. Every new team starts with $1.00 free, and there are no provider "
+        "accounts to open."),
+    # {n} is interpolated from the catalog count at render time.
     "install_steps": [
-        "In Grok Bot, click <b>Plugins</b> at the bottom of the left sidebar.",
-        "Search for <b>treg</b> and click <b>Add</b>. It is listed as “Treg: give your agent "
-        "2,600+ external API endpoints”, under the <b>MCP</b> category.",
+        "In Grok Bot, open <b>Tool Settings</b> (the gear icon next to Tools).",
+        "Under <b>MCP Connectors</b>, click <b>Add Remote</b> and paste "
+        "<b>https://treg.to/mcp</b>.",
         "Sign in when it asks; your first team starts with $1.00 of free calls.",
-        "Ask for what you want done in any chat. Grok searches the catalog, tells you the price, "
+        "Ask for what you want done. Grok searches the catalog ({n} tools), tells you the price, "
         "and calls the endpoint. You never hold a provider key.",
     ],
-    "install_image": "/media/install/grok-bot-plugins.png",
-    "install_image_alt": "Grok Bot's Plugins dialog with “treg” searched and the Treg plugin added",
-    "install_image_bar": "Grok Bot  ·  Plugins",
-    "install_image_caption": "Steps 1 and 2: Plugins in the sidebar, search treg, Add.",
+    "install_image": "/media/install/grok-bot-mcp.png",
+    "install_image_alt": "Grok Bot's Tool Settings with treg.to/mcp added as a remote MCP connector",
+    "install_image_bar": "Grok Bot  ·  Tool Settings",
+    "install_image_caption": "Steps 1 and 2: Tool Settings, Add Remote MCP connector, paste the URL.",
     "faq": [
         ("Can Grok Bot do lead generation with this?",
          "Yes, and it is the sequence most people ask for first. A research bot or a sales bot in "
-         "Grok Bot can browse, but browsing is not data. With the plugin it can build a company "
+         "Grok Bot can browse, but browsing is not data. With treg.to it can build a company "
          "list by industry, size or funding, find the decision maker at each one, find and verify a "
          "work email, and pull a recent news event for the opener. The whole sequence is on the "
          "workflows page above with the receipt from a real run. Each step is priced before the bot "
@@ -2713,10 +2715,10 @@ AGENTS["grok-bot"] = {
          "No. treg.to makes the upstream request on its own key and relays the answer, so Grok never "
          "holds a provider credential. If your team already pays for a provider, register that key "
          "and those calls are never metered."),
-        ("Is this an MCP server or a plugin?",
-         "Both, and they are the same thing here. Grok Bot installs it from its plugin directory; "
-         "underneath it is the same MCP server that Claude, ChatGPT, Cursor and the rest connect "
-         "to, answering the same token and the same catalog."),
+        ("Is this an MCP server?",
+         "Yes. treg.to is an MCP server that Grok Bot connects to as a remote MCP connector. It is "
+         "the same MCP server that Claude, ChatGPT, Cursor and the rest connect to, answering the "
+         "same token and the same catalog."),
         ("Does treg.to pick the provider for me?",
          "No. Where several providers do the same job they are shown side by side with prices and "
          "measured reliability, and Grok (or you) chooses. treg.to does not route or fail over "

--- a/src/treg/agent_pages.py
+++ b/src/treg/agent_pages.py
@@ -347,20 +347,18 @@ AGENTS: dict[str, dict] = {
             "ads and e-commerce. Calls run on treg.to's own keys and are metered from a prepaid "
             "balance at the provider's rate with $0.000 markup. Every new team starts with $1.00 "
             "free, and there are no provider accounts to open."),
-        # Steps shown as numbered HTML list items. Plain text; escaped by the route.
+        # Steps shown as numbered HTML list items. The setup line is the universal install.
         # {n} is interpolated from the catalog count at render time.
         "install_steps": [
-            "In ChatGPT, open <b>Connectors</b> in the left sidebar.",
-            "Search for <b>treg</b> and click <b>Add</b>. The connector gives ChatGPT access to "
-            "{n} APIs without keys.",
-            "Sign in when ChatGPT asks; your first team starts with $1.00 of free calls.",
+            "Give ChatGPT this line: <b>set up treg — https://treg.to/llms.txt</b>",
+            "ChatGPT reads the skill, signs you in, and is ready to call {n} APIs.",
             "Ask for what you want done. ChatGPT searches the catalog, tells you the price, and "
             "calls the endpoint. You never hold a provider key.",
         ],
-        "install_image": "/media/install/chatgpt-connectors.png",
-        "install_image_alt": "ChatGPT's Connectors directory with treg searched and its Add button",
-        "install_image_bar": "chatgpt.com  ·  Connectors",
-        "install_image_caption": "Steps 1 and 2: Connectors in the sidebar, search treg, Add.",
+        "install_image": "/media/install/chatgpt-setup.png",
+        "install_image_alt": "ChatGPT with the treg setup line pasted into the chat",
+        "install_image_bar": "chatgpt.com",
+        "install_image_caption": "Paste the setup line and ChatGPT handles the rest.",
         "faq": [
             ("Is treg.to free to use in ChatGPT?",
              "Installing is free and every new team starts with $1.00 of calls. After that, each call "
@@ -2681,17 +2679,15 @@ AGENTS["grok-bot"] = {
         "accounts to open."),
     # {n} is interpolated from the catalog count at render time.
     "install_steps": [
-        "In Grok Bot, open <b>Tool Settings</b> (the gear icon next to Tools).",
-        "Under <b>MCP Connectors</b>, click <b>Add Remote</b> and paste "
-        "<b>https://treg.to/mcp</b>.",
-        "Sign in when it asks; your first team starts with $1.00 of free calls.",
-        "Ask for what you want done. Grok searches the catalog ({n} tools), tells you the price, "
-        "and calls the endpoint. You never hold a provider key.",
+        "Give Grok this line: <b>set up treg — https://treg.to/llms.txt</b>",
+        "Grok reads the skill, signs you in, and is ready to call {n} tools.",
+        "Ask for what you want done. Grok searches the catalog, tells you the price, and "
+        "calls the endpoint. You never hold a provider key.",
     ],
-    "install_image": "/media/install/grok-bot-mcp.png",
-    "install_image_alt": "Grok Bot's Tool Settings with treg.to/mcp added as a remote MCP connector",
-    "install_image_bar": "Grok Bot  ·  Tool Settings",
-    "install_image_caption": "Steps 1 and 2: Tool Settings, Add Remote MCP connector, paste the URL.",
+    "install_image": "/media/install/grok-bot-setup.png",
+    "install_image_alt": "Grok Bot with the treg setup line pasted into the chat",
+    "install_image_bar": "Grok Bot",
+    "install_image_caption": "Paste the setup line and Grok handles the rest.",
     "faq": [
         ("Can Grok Bot do lead generation with this?",
          "Yes, and it is the sequence most people ask for first. A research bot or a sales bot in "

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -769,7 +769,7 @@ async def agent_page(request: Request, agent: str):
         f'<div class="trust" style="margin:0 0 18px"><a href="/">treg.to</a> / '
         f'<a href="/agents/{_esc_html(agent)}">{_esc_html(name)}</a></div>'
         f'<div class="kicker">{n} endpoints &middot; {p} platforms &middot; $0.000 markup</div>'
-        f'<h1>The {_esc_html(name)} plugin for <span class="roleslot" id="roleslot">'
+        f'<h1>The {_esc_html(name)} {_esc_html(spec.get("h1_noun", "plugin"))} for <span class="roleslot" id="roleslot">'
         f'<span class="rw" id="rolewheel">{roles}</span></span></h1>'
         f'<script type="application/json" id="roles-more">{more_roles}</script>'
         f'<div class="lede">{_esc_html(definition)}</div>'

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -467,7 +467,7 @@ async def catalog_page(slug: str):
 
 def _hosted() -> bool:
     """True on the reference deployment only. The agent pages describe treg.to's own listings (the
-    ChatGPT plugin, the OAuth connector, the free grant), none of which is true of a self-hosted
+    ChatGPT Connector, the OAuth connector, the free grant), none of which is true of a self-hosted
     registry, so off these hosts the pages do not exist rather than lie."""
     host = (urlsplit(get_settings().public_url).hostname or "").lower()
     return host in PUBLIC_HOST_ALIASES
@@ -623,7 +623,7 @@ _MD_ALT = '<link rel="alternate" type="text/markdown" href="{href}"/>'
 @app.get("/agents/{agent}.md", include_in_schema=False)
 @app.get("/agents/{agent}", include_in_schema=False)
 async def agent_page(request: Request, agent: str):
-    """One client: "I use ChatGPT, what can it do now?" A rotating "The ChatGPT plugin for <role>"
+    """One client: "I use ChatGPT, what can it do now?" A rotating "The ChatGPT Connector for <role>"
     hero, the install steps for that client, then the use-case menu: plain-words jobs under buyer
     categories, each priced from the catalog. The menu is `agent_pages.USE_CASES`, the same
     taxonomy the use-case pages hang from, so the agent page is the map of the whole site.
@@ -651,7 +651,7 @@ async def agent_page(request: Request, agent: str):
     definition = spec["definition"].format(n=n, p=p)
     menu = [(category, agent_pages.CATEGORY_PROMPTS.get(category, ""), _menu_rows(cat, category, jobs))
             for category, jobs in agent_pages.USE_CASES]
-    steps_text = [re.sub(r"<[^>]+>", "", st) for st in spec["install_steps"]]
+    steps_text = [re.sub(r"<[^>]+>", "", st).format(n=n) for st in spec["install_steps"]]
 
     if as_md:
         md = [f"# {title}", "", definition, "", f"## Install in {name}", ""]
@@ -684,12 +684,12 @@ async def agent_page(request: Request, agent: str):
         return PlainTextResponse("\n".join(md), media_type="text/markdown; charset=utf-8",
                                  headers={"Cache-Control": "public, max-age=600"})
 
-    # Only the FIRST role is in the H1 markup: a crawler reads "…plugin for SEO experts", not nine
+    # Only the FIRST role is in the H1 markup: a crawler reads "…Connector for SEO experts", not nine
     # roles run together. The rest ride in a JSON block and the script appends them.
     roles = f'<span class="ri on">{_esc_html(agent_pages.ROLES[0])}</span>'
     more_roles = json.dumps(list(agent_pages.ROLES[1:])).replace("<", "\\u003c")
     steps = "".join(
-        f'<div class="steplabel"><span class="n">{i}</span><b>{st}</b></div>'
+        f'<div class="steplabel"><span class="n">{i}</span><b>{st.format(n=n)}</b></div>'
         for i, st in enumerate(spec["install_steps"], 1))
     shot = (f'<div class="sample"><div class="sbar">{_esc_html(spec.get("install_image_bar") or name)}</div>'
             f'<img src="{_esc_html(spec["install_image"])}" alt="{_esc_html(spec["install_image_alt"])}" '

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -321,7 +321,7 @@ key - share access.
 
 ## MCP — connect an assistant
 
-Using ChatGPT? The plugin is in ChatGPT's Plugins directory (search "treg" → Install); the page
+Using ChatGPT? The connector is in ChatGPT's Connectors directory (search "treg" → Add); the page
 {BASE}/agents/chatgpt lists what it can do by job, with prices, and {BASE}/agents/chatgpt.md is the
 same page as Markdown.
 

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -55,7 +55,7 @@ async def test_chatgpt_page_hero_rotates_through_the_roles(clients: AsyncClient)
     server-rendered H1 so a crawler reads a complete sentence; the rest ride along for the JS."""
     html = (await clients.get("/agents/chatgpt")).text
     h1 = re.search(r"<h1[^>]*>(.*?)</h1>", html, re.S).group(1)
-    assert "ChatGPT plugin for" in h1 and html_mod.escape(agent_pages.ROLES[0]) in h1
+    assert "ChatGPT Connector for" in h1 and html_mod.escape(agent_pages.ROLES[0]) in h1
     # only ONE role in the H1 itself — the rest are appended by JS from data-more
     assert html_mod.escape(agent_pages.ROLES[1]) not in h1
     more = json.loads(re.search(r'<script type="application/json" id="roles-more">(.*?)</script>', html, re.S).group(1))

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -84,9 +84,9 @@ def test_every_use_case_capability_exists_in_the_catalog():
     assert not missing, missing
 
 
-async def test_chatgpt_page_install_block_names_the_plugins_directory(clients: AsyncClient):
+async def test_chatgpt_page_install_block_names_the_connectors_directory(clients: AsyncClient):
     html = (await clients.get("/agents/chatgpt")).text
-    assert "Plugins" in html and "Install" in html
+    assert "Connectors" in html and "Add" in html
     # never a CTA into the authenticated app: a logged-out /app visit bounces to the landing
     body = html.split("<body>", 1)[1].split("<footer>", 1)[0]
     assert 'href="/app"' not in body.replace('href="/agents/', "")

--- a/tests/test_agent_pages.py
+++ b/tests/test_agent_pages.py
@@ -84,9 +84,9 @@ def test_every_use_case_capability_exists_in_the_catalog():
     assert not missing, missing
 
 
-async def test_chatgpt_page_install_block_names_the_connectors_directory(clients: AsyncClient):
+async def test_chatgpt_page_install_block_has_the_setup_line(clients: AsyncClient):
     html = (await clients.get("/agents/chatgpt")).text
-    assert "Connectors" in html and "Add" in html
+    assert "set up treg" in html and "treg.to/llms.txt" in html
     # never a CTA into the authenticated app: a logged-out /app visit bounces to the landing
     body = html.split("<body>", 1)[1].split("<footer>", 1)[0]
     assert 'href="/app"' not in body.replace('href="/agents/', "")
@@ -271,10 +271,13 @@ async def test_agent_page_rows_carry_logos_and_free_badges(clients: AsyncClient)
 
 async def test_no_em_dashes_in_the_hand_written_copy():
     """House style: no em-dashes in page copy. The setup line is the product's literal command and
-    is the one exception."""
+    is the one exception (both the SETUP_LINE constant and its literal uses in install_steps)."""
     import inspect
     src = inspect.getsource(agent_pages)
-    body = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#") and "SETUP_LINE" not in l)
+    body = "\n".join(l for l in src.splitlines()
+                     if not l.lstrip().startswith("#")
+                     and "SETUP_LINE" not in l
+                     and "set up treg —" not in l)  # the literal setup line in install_steps
     # docstrings are not page copy; strip the module docstring
     body = body.split('"""', 2)[-1]
     assert "—" not in body, [l for l in body.splitlines() if "—" in l][:3]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Updates the ChatGPT and Grok Bot agent pages with proper install method and terminology.

**Primary install method (both pages):**
1. Give this to your agent: `set up treg — https://treg.to/llms.txt`
2. Agent reads the skill, signs you in, ready to call {n} APIs/tools
3. Ask for what you want done

The setup line em-dash is the allowed exception (it's the product's literal command).

**ChatGPT (`/agents/chatgpt`):**
- H1: "The ChatGPT Connector for SEO experts..."
- Title: "ChatGPT Connector: call {n} APIs without keys | treg.to"
- Install: universal setup line (not a Connectors tutorial)
- Catalog-backed `{n}` count

**Grok Bot (`/agents/grok-bot`):**
- H1: "The Grok Bot MCP server for SEO experts..."
- Title: "Grok MCP server: {n} tools without keys | treg.to" (targets "grok mcp" 140 US/mo)
- Install: universal setup line
- Catalog-backed `{n}` count

**Configurable H1 noun:**
- `h1_noun` field: ChatGPT = "Connector", others = "MCP server"

**Also updates:**
- `llms.txt`: "plugin" → "connector", "Plugins directory" → "Connectors directory"
- `docs/context/interface/seo.md`: "ChatGPT Plugins" → "ChatGPT Connectors"
- `routers/web.py`: formats `install_steps` with `{n}` from `catalog_census`
- Tests: updated to check for setup line, allow setup line em-dash

No hardcoded counts. treg.to. Em-dashes only in the setup line.

**Note:** PR #275 (SEO: the /agents hub, branch `seo/agents-hub`) should be merged after this copy pass.

## How it was tested

```bash
uv run pytest tests/test_agent_pages.py -q  # 142 passed
```

Verified:
- Both pages show setup line: `set up treg — https://treg.to/llms.txt`
- No hardcoded 2600
- Em-dashes only in setup line
- Catalog-backed `{n}` counts work

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0695bab5-057e-49d8-b8a9-c2df3caf3ca3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0695bab5-057e-49d8-b8a9-c2df3caf3ca3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

