### PR TITLE
feat(oauth): add Intercom as hosted OAuth provider

### DIFF
--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -369,6 +369,9 @@ class Settings(BaseSettings):
     linkedin_client_id: str = ""
     linkedin_client_secret: str = ""
 
+    intercom_oauth_client_id: str = ""
+    intercom_oauth_client_secret: str = ""
+
     slack_client_id: str = ""
     slack_client_secret: str = ""
     x_client_id: str = ""

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -678,6 +678,34 @@ SLACK = OAuthProvider(
     identity_label_path="team",
 )
 
+INTERCOM = OAuthProvider(
+    service="intercom",
+    display_name="Intercom",
+    auth_uri="https://app.intercom.com/oauth",
+    token_uri="https://api.intercom.io/auth/eagle/token",
+    # Intercom grants permissions through the Developer Hub, not via URL scopes — the `scope` param
+    # is ignored at consent. We list one capability that reflects what the app has in its manifest.
+    # Documented scopes include read_conversations, write_conversations, read_admins, read_tags,
+    # write_tags — these are for reference; the connected workspace gets whatever the app was granted.
+    scopes={"manage": ["read_conversations", "write_conversations", "read_admins", "read_tags", "write_tags"]},
+    client_id_setting="intercom_oauth_client_id",
+    client_secret_setting="intercom_oauth_client_secret",
+    category="Community",
+    summary="Read and reply to conversations in your Intercom workspace.",
+    base_url="https://api.intercom.io",
+    docs_url="https://developers.intercom.com/docs/references/rest-api/api.intercom.io",
+    auth_params={},  # Intercom rejects Google's access_type/prompt
+    # Intercom requires a version header on every request; without it calls fail with a version error.
+    required_headers=(("Intercom-Version", "2.14"),),
+    resource_label="workspace",
+    probe_path="/me",
+    # /me returns the admin and their workspace (app). The workspace id_code is the stable identifier;
+    # app.name is the human-readable workspace name.
+    identity_path="/me",
+    identity_id_path="app.id_code",
+    identity_label_path="app.name",
+)
+
 X = OAuthProvider(
     service="x",
     display_name="X (Twitter)",
@@ -2400,7 +2428,7 @@ REGISTRY: dict[str, OAuthProvider] = {
     for p in (
         GOOGLE_SEARCH_CONSOLE, GOOGLE_ANALYTICS, GOOGLE_BUSINESS_PROFILE, GOOGLE_TAG_MANAGER,
         GOOGLE_ADS, YOUTUBE,
-        LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
+        LINKEDIN, SLACK, INTERCOM, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
@@ -2497,6 +2525,12 @@ SCOPE_LABELS: dict[str, str] = {
     "profile": "See your name and profile picture",
     "email": "See your email address",
     "w_member_social": "Post, comment and react as you",
+    # Intercom (scopes set in Developer Hub; these labels are for documentation and consent display)
+    "read_conversations": "Read conversations and messages",
+    "write_conversations": "Reply to conversations and send messages",
+    "read_admins": "See admins in the workspace",
+    "read_tags": "See tags and segments",
+    "write_tags": "Create and manage tags",
     # X
     "tweet.read": "Read posts and timelines",
     "users.read": "See profiles, including your own",

--- a/src/treg/web/logos/intercom.svg
+++ b/src/treg/web/logos/intercom.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2C6.477 2 2 6.144 2 11.25c0 2.87 1.433 5.433 3.667 7.125v3.375a.25.25 0 0 0 .392.206l3.517-2.423c.773.163 1.583.217 2.424.217 5.523 0 10-4.144 10-9.25S17.523 2 12 2z" fill="#0066FF"/>
+  <rect x="6.5" y="8" width="1.5" height="5" rx="0.75" fill="#fff"/>
+  <rect x="9.25" y="6.5" width="1.5" height="8" rx="0.75" fill="#fff"/>
+  <rect x="12" y="8" width="1.5" height="5" rx="0.75" fill="#fff"/>
+  <rect x="14.75" y="6.5" width="1.5" height="8" rx="0.75" fill="#fff"/>
+</svg>

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -40,7 +40,7 @@ def _q(payload: dict) -> dict:
 def test_every_provider_is_registered():
     assert set(P.REGISTRY) == {
         "google-search-console", "google-analytics", "google-business-profile", "google-tag-manager",
-        "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
+        "google-ads", "youtube", "linkedin", "slack", "intercom", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
@@ -263,6 +263,53 @@ async def test_linkedin_does_not_get_googles_consent_params(clients: AsyncClient
         assert q["client_id"] == ["li-cid"]
         assert "access_type" not in q and "prompt" not in q, "LinkedIn rejects Google's params"
         assert "w_member_social" in q["scope"][0]
+    finally:
+        get_settings.cache_clear()
+
+
+# ---- Intercom ---------------------------------------------------------------------------------
+def test_intercom_has_one_capability():
+    """Intercom grants permissions through the Developer Hub, not URL scopes. There is no read-only
+    capability worth offering — a connection acts on the whole workspace with whatever the app has."""
+    assert P.INTERCOM.capabilities == ["manage"]
+    assert P.INTERCOM.default_capability == "manage"
+
+
+def test_intercom_requires_version_header():
+    """Intercom requires Intercom-Version on every request; without it calls fail. The header is
+    frozen at 2.14 so the proxy can inject it automatically."""
+    assert P.INTERCOM.required_headers == (("Intercom-Version", "2.14"),)
+
+
+def test_intercom_uses_its_own_credentials():
+    """Intercom OAuth is separate from the Intercom Messenger widget — the client_id/secret come
+    from intercom_oauth_*, not from intercom_app_id/secret (the Messenger HMAC pair)."""
+    assert P.INTERCOM.client_id_setting == "intercom_oauth_client_id"
+    assert P.INTERCOM.client_secret_setting == "intercom_oauth_client_secret"
+
+
+async def test_intercom_does_not_get_googles_consent_params(clients: AsyncClient, monkeypatch):
+    monkeypatch.setenv("TREG_INTERCOM_OAUTH_CLIENT_ID", "ic-cid")
+    monkeypatch.setenv("TREG_INTERCOM_OAUTH_CLIENT_SECRET", "ic-csec")
+    get_settings.cache_clear()
+    try:
+        d = (await clients.post("/oauth/start", json={"provider": "intercom"})).json()
+        q = _q(d)
+        assert q["client_id"] == ["ic-cid"]
+        assert "access_type" not in q and "prompt" not in q, "Intercom rejects Google's params"
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_intercom_unconfigured_when_credentials_empty(clients: AsyncClient, monkeypatch):
+    monkeypatch.setenv("TREG_INTERCOM_OAUTH_CLIENT_ID", "")
+    monkeypatch.setenv("TREG_INTERCOM_OAUTH_CLIENT_SECRET", "")
+    get_settings.cache_clear()
+    try:
+        rows = {p["service"]: p for p in (await clients.get("/oauth/providers")).json()}
+        assert rows["intercom"]["configured"] is False
+        r = await clients.post("/oauth/start", json={"provider": "intercom"})
+        assert r.status_code == 422 and "not configured" in r.text
     finally:
         get_settings.cache_clear()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Adds Intercom as a hosted OAuth provider, matching the pattern of LinkedIn/X/Instagram. Users can connect their Intercom workspace via treg's OAuth app without bringing their own credentials.

**Key details:**
- Auth URL: `https://app.intercom.com/oauth`
- Token URL: `https://api.intercom.io/auth/eagle/token`
- Required header: `Intercom-Version: 2.14` on all API calls
- Identity from `/me` endpoint (workspace `app.id_code` and `app.name`)
- Token exchange uses POST form body (not basic auth)
- No refresh tokens — Intercom access tokens are long-lived until revoked

**Does NOT touch:**
- The existing Intercom Messenger settings (`intercom_app_id`/`intercom_secret`/`TREG_INTERCOM_APP_ID`/`TREG_INTERCOM_SECRET`)
- The existing BYO bearer path in `providers.py`

## Required follow-up action

**Jason must add the redirect URI to the Intercom Developer Hub app:**

```
https://treg.to/oauth/callback
```

This is treg's standard callback — no new per-provider route. Until the redirect URI is registered, the OAuth flow will fail with an "invalid redirect" error from Intercom.

After registering the redirect URI, set these environment variables on Render:
- `TREG_INTERCOM_OAUTH_CLIENT_ID`
- `TREG_INTERCOM_OAUTH_CLIENT_SECRET`

## How it was tested

```bash
uv run pytest -q  # 2392 passed, 4 skipped
uv run pytest tests/test_oauth_providers_m3.py -q  # 36 passed (includes 5 Intercom-specific tests)
```

Tests verify:
- Intercom is in the registry
- Single "manage" capability (Intercom grants permissions in Developer Hub, not via URL scopes)
- `Intercom-Version: 2.14` required header is set
- Uses its own `intercom_oauth_client_id`/`_secret` settings (not the Messenger HMAC pair)
- Doesn't get Google's `access_type`/`prompt` params
- Shows as unconfigured when credentials are empty

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [ ] Updated the relevant `docs/context/` fragment (if a subsystem changed) — *OAuth providers are not separately documented in docs/context/*
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da18c04-686c-4823-aee2-5e007d0a8818?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da18c04-686c-4823-aee2-5e007d0a8818&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

