### PR TITLE
fix(web): remove duplicate treg logo from sidebar

### DIFF
--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -1338,8 +1338,7 @@ a:hover{text-decoration-color:var(--muted)}
     <div class="layout" :class="{solo:publicCatalog}">
       <nav class="side" :class="{'mob-open':mobileNav}" v-if="!publicCatalog">
         <!-- Mobile close button (hidden on desktop) -->
-        <div style="display:flex;align-items:center;margin-bottom:8px">
-          <span class="brand" style="font-size:14px">▚ treg</span>
+        <div style="display:flex;align-items:center;justify-content:flex-end;margin-bottom:8px">
           <button class="mob-close" @click="mobileNav=false" aria-label="Close navigation">✕</button>
         </div>
         <!-- ORG (top): name → settings · ▾ → switch -->


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Removes the redundant treg wordmark (`▚ treg`) from the sidebar on the authed dashboard. The header logo remains unchanged.

**Markup removed from `src/treg/web/index.html` (line 1342):**
```html
<span class="brand" style="font-size:14px">▚ treg</span>
```

This was duplicating the header brand visible in the top bar, causing the "double logo" issue Jason reported.

## How it was tested

- Ran `python3 -m pytest tests/test_seo.py tests/test_walking_skeleton.py -v` — 78 passed
- Visual: sidebar no longer shows the treg wordmark; header still does
- The mobile close button container was adjusted to `justify-content:flex-end` to keep the close button right-aligned

## Checklist

- [x] `uv run pytest -q` passes locally (web/HTML tests pass; MCP/OAuth errors are pre-existing env issues)
- [x] Added or updated tests for the change (if it affects behavior) — no tests asserted the sidebar brand
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed) — UI-only, no subsystem change
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1649b8f1-e778-4c5e-a61b-861ffb45eb77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1649b8f1-e778-4c5e-a61b-861ffb45eb77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

