### PR TITLE
fix(onboarding): create the first team at sign-in, not via a browser POST

### DIFF
--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -153,11 +153,21 @@ dependencies, role comparison, and machine classification. Session signing and v
 `domain.identity.session`.
 - **Registration is shared across doors:** `application.signup.find_or_create_user(db, email)` finds a user or creates them
   — **the user ONLY, no auto personal org**. Every identity door calls
-  it (GitHub / Google callbacks, email OTP), so "first proof = registration" is identical. A brand-new
-  user therefore lands with **zero teams** and must name + create their first one (the dashboard's
-  mandatory welcome, or `treg org create`); their identity token is user-scoped so it works before any
-  org exists. **`create_org` uses `require_identity`, NOT `require_member`** — else a zero-org user could
-  never make their first team. See [api](../interface/api.md).
+  it (GitHub / Google callbacks, email OTP), so "first proof = registration" is identical. Their
+  identity token is user-scoped so it works before any org exists. **`create_org` uses
+  `require_identity`, NOT `require_member`** — else a zero-org user could never make their first
+  team. See [api](../interface/api.md).
+- **The first team is made at sign-in, not by the browser:** every browser door (GitHub / Google
+  callback, email OTP verify) then calls `application.signup.ensure_first_team(email, cookies…)`.
+  For a user with **zero memberships and no pending invite** it creates their first team via
+  `create_org` (name guessed from the email domain — `_default_team_name`: `sam@acme.dev` → "Acme",
+  generic inboxes use the local part), so the welcome modal only **renames** it (`PATCH /orgs/{id}`,
+  `rename_org`, admin+, display name only — the slug and every token stay stable). This exists
+  because some corporate secure-web-gateways silently swallow the modal's `POST /orgs` (GETs pass),
+  stranding signups on a spinner; the OAuth callback GET is the request that provably arrives. It
+  runs on **every** sign-in, so a previously stranded zero-team user self-heals at next login; a
+  user with a pending invite is skipped (they should join, not get a throwaway team) and it never
+  fails the login (errors are logged, swallowed).
 - **Code-free invites:** `my_invites` (`GET /invites/mine`, `require_identity`) lists pending invites for
   the caller's proven email; `accept_my_invite` (`POST /invites/{id}/accept`, `require_identity`) joins
   with no code (403 if `invite.email != user.email`, 409 if already a member). The code path stays.

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -166,7 +166,11 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   stamp `Org.ad_gclid`/`ad_click_id_type`/`ad_landing`/`ad_click_at` on the new org when present — see
   [ads-conversions](../architecture/ads-conversions.md).
   `create_org` (`POST /orgs`, `require_identity` so a
-  zero-org user can make their first team) + `list_orgs` (`GET /orgs`,
+  zero-org user can make their first team; browser sign-ins normally don't need it — every login
+  door calls `ensure_first_team`, which auto-creates a first team for a zero-org, zero-invite user,
+  see [multi-tenancy](../architecture/multi-tenancy.md)) + `rename_org` (`PATCH /orgs/{id}`, admin+,
+  display name only — slug stays stable; the welcome modal names the auto-created team with it)
+  + `list_orgs` (`GET /orgs`,
   each org carries a `tool_count` — one grouped query — so the dashboard can land on the org with tools;
   its `active` flag follows `require_member`'s precedence — per-org membership token, else `X-Treg-Org`,
   else a team-pinned identity token's own `org` claim — so `treg login --token <pinned key>` lands on the

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -300,10 +300,14 @@ Server side (`domain.identity.access`): `require_identity` (who, from token OR s
   with **mutations** (`_adm` helper): `admGrant`/`admSuspendUser`/`admDeleteUser`,
   `admSuspendOrg`/`admDeleteOrg` (inline-confirm deletes). Self-actions are hidden for the current user
   (`u.email===me`) to prevent lockout.
-- **First-run onboarding** — a brand-new user has **zero teams** (no auto personal org), so `maybeOnboard`
-  shows a **mandatory "name your team" welcome** (`welcome.*`; team name pre-suggested from the email
+- **First-run onboarding** — sign-in auto-creates a brand-new user's first team server-side
+  (`ensure_first_team`; corporate gateways swallow browser POSTs), so `maybeOnboard` shows a
+  **mandatory "name your team" welcome** (`welcome.*`) that usually **renames** that team
+  (`welcome.renameOrg` → `PATCH /orgs/{id}`; falls back to create — name pre-suggested from the email
   domain via `_suggestTeamName`). Step 0 is NOT dismissable — no skip, survives Escape/backdrop — the only
-  action is `welcomeCreate` (`POST /orgs`, marks onboarded). Three more steps follow **inside the same
+  action is `welcomeCreate` (rename or `POST /orgs` under a 15s abort-timeout; a blocked network
+  advances renames anyway and shows a "firewall may be blocking this" error on creates; marks
+  onboarded). Three more steps follow **inside the same
   modal**: an **agent picker** (`welcome.step===1` — OpenClaw / Hermes Agent / Claude.ai / Claude Code /
   Codex, plus a "More" expander with opencode / pi / Cursor / Gemini CLI / Other; LobeHub icons via
   unpkg, theme-aware light/dark variants through `agentIcon`) with Skip/Next; the **setup block**

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -304,7 +304,9 @@ Server side (`domain.identity.access`): `require_identity` (who, from token OR s
   (`ensure_first_team`; corporate gateways swallow browser POSTs), so `maybeOnboard` shows a
   **mandatory "name your team" welcome** (`welcome.*`) that usually **renames** that team
   (`welcome.renameOrg` → `PATCH /orgs/{id}`; falls back to create — name pre-suggested from the email
-  domain via `_suggestTeamName`). Step 0 is NOT dismissable — no skip, survives Escape/backdrop — the only
+  domain via `_suggestTeamName`). For first-run rename scenarios, `loadAll` early-returns after
+  fetching `/orgs` and `/invites/mine` (skipping `/tools`, `/health`, `/bundles`) so the modal
+  appears immediately. Step 0 is NOT dismissable — no skip, survives Escape/backdrop — the only
   action is `welcomeCreate` (rename or `POST /orgs` under a 15s abort-timeout; a blocked network
   advances renames anyway and shows a "firewall may be blocking this" error on creates; marks
   onboarded). Three more steps follow **inside the same

--- a/docs/context/interface/onboarding.md
+++ b/docs/context/interface/onboarding.md
@@ -138,8 +138,16 @@ After a first **human** `treg login`, `_maybe_offer_onboarding` prompts `[Y/n]` 
 The old docked "Getting started" stepper (`onb.*` state, `.onb-panel`/`.onb-push`/`.onb-shift`) is
 **removed** — its content had drifted from the product and it kept re-appearing after signup. First-run
 now is a **four-step welcome modal**: boot reads `onboarded` from `/auth/me`; `maybeOnboard()` opens it
-only for a non-onboarded session with **no team yet**. Step 0 names the team (`welcomeCreate` → `POST /orgs`,
-marks onboarded via `/onboard/skip`); step 1 asks **which agent you're using** (picker with LobeHub icons,
+for a non-onboarded session. Since the server auto-creates the first team at sign-in
+(`ensure_first_team` — some corporate gateways swallow browser POSTs, see
+[multi-tenancy](../architecture/multi-tenancy.md)), step 0 usually **renames** that team
+(`welcome.renameOrg` set → `PATCH /orgs/{id}`, button reads "Continue →"); a user with no team at all
+(declined an invite) still gets the create form (`welcomeCreate` → `POST /orgs`). Both paths mark
+onboarded via `/onboard/skip` (fire-and-forget) and both writes run under a **15s `AbortController`
+timeout**: a hung/reset request (`AbortError`/`TypeError`) advances anyway in rename mode (the team
+exists; a lost rename must not block onboarding) and, in create mode, surfaces a
+"firewall may be blocking this — try a phone hotspot" error instead of an endless spinner.
+Step 1 asks **which agent you're using** (picker with LobeHub icons,
 skippable); step 2 shows the per-agent **setup block** — the setup line and the team+token as ONE
 copyable unit (`welcomeSetupFull` copies the real token; `welcomeSetupMasked` renders it masked with a
 Show/Hide-key toggle, `startTokenShow`); step 3 is **"Try it out"** — a "waiting for your agent" status (pulsing `.wc-waitdot`, no 🎉), the

--- a/src/treg/application/signup.py
+++ b/src/treg/application/signup.py
@@ -14,7 +14,8 @@ from ..domain import referrals
 from ..domain.governance.teams import _make_org_membership, _slugify
 from ..domain.identity.access import _is_machine_email, _norm_email
 from ..infra.db import session_maker
-from ..models import Org, User
+from ..models import Invite, Membership, Org, User
+from ..timeutil import as_naive as _as_naive
 from ..timeutil import utcnow_naive as _utcnow_naive
 
 
@@ -214,6 +215,67 @@ async def register_user(
         # Both org-creating doors redeem because both end with a person owning a fresh team.
         await _redeem_referral(db, referral_cookie, user, org)
         return response
+
+
+# Domains that identify a person, not a company — a team named "Gmail" helps nobody, so the
+# local part is the better seed there. Mirrors _suggestTeamName in web/index.html.
+_GENERIC_EMAIL_DOMAINS = {
+    "gmail", "googlemail", "outlook", "hotmail", "live", "msn", "yahoo", "icloud", "me", "mac",
+    "proton", "protonmail", "pm", "aol", "qq", "163", "126", "foxmail", "gmx", "yandex", "hey",
+    "fastmail", "zoho", "mail", "email", "duck",
+}
+
+
+def _default_team_name(email: str) -> str:
+    """A friendly default team name from an email: sam@acme.dev → "Acme", sam@gmail.com → "Sam"."""
+    local, _, host = email.partition("@")
+    domain = host.split(".")[0].strip()
+    base = local.strip() if not domain or domain.lower() in _GENERIC_EMAIL_DOMAINS else domain
+    base = base.strip(".-_") or local.strip() or "My team"
+    return (base[:1].upper() + base[1:])[:80]
+
+
+async def ensure_first_team(
+    *, email: str, ad_cookie: str, utm_cookie: str, referral_cookie: str,
+) -> None:
+    """Auto-create a first team, server-side, for a browser sign-in that has none.
+
+    Exists because the welcome modal's POST /orgs never arrives from behind some corporate
+    secure-web-gateways (they let GETs through and silently swallow cross-origin POSTs to
+    young/uncategorized domains), which stranded real signups on an endless "Creating…" spinner.
+    The OAuth callback GET demonstrably passes those networks, so the team is made HERE and the
+    welcome modal only renames it. Runs on every browser sign-in, so a previously stranded
+    zero-team user self-heals on their next login.
+
+    Deliberately skipped for a user with a pending invite: they should JOIN their teammate's
+    org, not be handed a throwaway one (the dashboard offers that choice). Fire-and-forget:
+    a login must never fail because this could not run.
+    """
+    try:
+        async with session_maker() as db:
+            user = (
+                await db.execute(select(User).where(User.email == _norm_email(email)))
+            ).scalar_one_or_none()
+            if user is None or demo_sandbox.is_sandbox_user(user):
+                return
+            has_org = (
+                await db.execute(select(Membership.id).where(Membership.user_id == user.id).limit(1))
+            ).first()
+            if has_org:
+                return
+            invites = (
+                await db.execute(select(Invite).where(
+                    Invite.email == user.email, Invite.status == "pending"))
+            ).scalars().all()
+            now = _utcnow_naive()
+            if any(inv.expires_at is None or _as_naive(inv.expires_at) >= now for inv in invites):
+                return
+        await create_org(
+            user=user, name=_default_team_name(user.email),
+            ad_cookie=ad_cookie, utm_cookie=utm_cookie, referral_cookie=referral_cookie,
+        )
+    except Exception as exc:  # noqa: BLE001 — the sign-in itself must still succeed
+        logging.getLogger("treg").warning("first-team auto-create failed for %s: %s", email, exc)
 
 
 async def create_org(

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -156,6 +156,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/orgs/{org_id}/balance', ('GET',), 'org_balance'),
     ('/orgs/{org_id}/tag-keys', ('GET',), 'list_tag_keys'),
     ('/orgs/{org_id}/usage/by-tag', ('GET',), 'usage_by_tag'),
+    ('/orgs/{org_id}', ('PATCH',), 'rename_org'),
     ('/orgs/{org_id}/settings', ('GET',), 'get_org_settings'),
     ('/orgs/{org_id}/settings', ('PATCH',), 'set_org_settings'),
     ('/orgs/{org_id}/budgets', ('GET',), 'list_tag_budgets'),

--- a/src/treg/routers/auth.py
+++ b/src/treg/routers/auth.py
@@ -32,6 +32,7 @@ from ..domain.identity.access import require_identity
 from ..domain.identity.mcp_oauth import REFRESH_TTL_S
 from ..models import User
 from .auth_helpers import _is_https, _remember_oauth_return, _same_origin
+from .signup_cookies import REFERRAL_COOKIE
 from .web import _esc_html
 
 # The app alias preserves the moved handlers' original @app.post decorator text byte-for-byte.
@@ -94,6 +95,9 @@ async def auth_email_verify(
         verified = await auth_use_cases.verify_email_login(body.email, body.code)
     except auth_use_cases.EmailAuthError as exc:
         raise _email_http_error(exc) from exc
+    # Same first-team guarantee as the OAuth doors (this one is a POST, so a POST-blocking network
+    # never reaches it — but a user who signed up here and signs in via OAuth later must not differ).
+    await _ensure_first_team(request, verified.email)
     resp = JSONResponse({"token": verified.token, "email": verified.email})
     resp.set_cookie(sess.COOKIE, verified.session_cookie, httponly=True,
                     samesite="lax", secure=_is_https(request), max_age=sess.TTL_SECONDS)
@@ -224,6 +228,19 @@ def _auth_page(headline: str, sub: str = "", *, ok: bool = True, status: int = 2
     return HTMLResponse(html, status_code=status)
 
 
+async def _ensure_first_team(request: Request, email: str) -> None:
+    """A browser sign-in with no team gets one made server-side, on this GET. The welcome modal's
+    own POST /orgs never arrives from behind some corporate secure-web-gateways (GETs pass, POSTs
+    are silently swallowed), which stranded signups on a spinner — so the team is created here and
+    the modal only renames it. Never fails the login (the use case swallows its own errors)."""
+    await signup.ensure_first_team(
+        email=email,
+        ad_cookie=request.cookies.get("treg_ad") or "",
+        utm_cookie=request.cookies.get("treg_utm") or "",
+        referral_cookie=request.cookies.get(REFERRAL_COOKIE) or "",
+    )
+
+
 def _finish_oauth_login(request: Request, user: User, st: tuple | None) -> RedirectResponse:
     """After a GitHub/Google callback proves an identity: set the browser session cookie, then either
     land on the dashboard (a plain browser login) or bounce to /login?cli=<id> so a `treg login`
@@ -257,6 +274,7 @@ async def auth_github_callback(
         )
     except auth_use_cases.SocialLoginError as exc:
         return _social_login_failure(exc)
+    await _ensure_first_team(request, proof.user.email)
     return _finish_oauth_login(request, proof.user, proof.cli_state)
 
 
@@ -285,6 +303,7 @@ async def auth_google_callback(
         )
     except auth_use_cases.SocialLoginError as exc:
         return _social_login_failure(exc)
+    await _ensure_first_team(request, proof.user.email)
     return _finish_oauth_login(request, proof.user, proof.cli_state)
 
 

--- a/src/treg/routers/orgs.py
+++ b/src/treg/routers/orgs.py
@@ -1317,6 +1317,23 @@ async def usage_by_tag(
     }
 
 
+@app.patch("/orgs/{org_id}")
+async def rename_org(
+    org_id: int, body: OrgIn,
+    caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),
+) -> dict:
+    """Rename a team — display name only; the slug (and every token and URL bound to it) stays
+    stable. Admin+. Exists because the first team is now auto-created at sign-in with a name
+    guessed from the email domain, and the welcome modal names it properly with this."""
+    _require_admin_of(org_id, caller)
+    name = (body.name or "").strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="give the team a name")
+    caller.org.name = name[:80]
+    await db.commit()
+    return {"org": caller.org.slug, "org_id": org_id, "name": caller.org.name}
+
+
 @app.get("/orgs/{org_id}/settings")
 async def get_org_settings(
     org_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session),

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -6111,6 +6111,13 @@ createApp({
         }
         if(this.sessionMode){ this.pendingInvites=await this.api('/invites/mine').catch(()=>[]); }  // BEFORE the no-orgs early return: an invited user has 0 orgs but DOES have a pending invite — maybeOnboard needs it to offer joining instead of forcing create-team
         if(!this.myOrgs.length){ this.tools=[]; this.bundles=[]; this.health={}; return; }  // brand-new user: no team yet → the mandatory welcome (maybeOnboard) creates the first one; skip org-scoped fetches (they'd 400). finally{} clears loading.
+        // First-run rename scenario (ensure_first_team auto-created the team at sign-in): skip the
+        // org-scoped fetches — maybeOnboard will show the welcome modal immediately, and welcomeCreate
+        // reloads everything after naming the team. Without this, the user waits for /tools etc.
+        if(!this.onboarded && this.sessionMode && !this.pendingInvites.length){
+          const real=this.myOrgs.filter(o=>!this.isPersonal(o) && !o.demo);
+          if(real.length===1){ this.tools=[]; this.bundles=[]; this.health={}; return; }
+        }
         if(this.sessionMode && (!this.activeSlug || !this.myOrgs.some(o=>o.slug===this.activeSlug)) && this.myOrgs.length){
           // Land on the org that actually has tools (most first). Tie / all-empty -> prefer a TEAM over
           // the personal org (first-run confusion killer). Fixes: imports living in the personal space

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -3541,9 +3541,10 @@ product, including per-customer usage tracking and billing.</pre>
           <template v-if="welcome.step===0">
             <div style="color:var(--accent);font-size:15px;letter-spacing:.5px;margin-bottom:12px">▚ treg</div>
             <h2 style="margin:0 0 8px;font-size:20px">Welcome{{me?', '+me.split('@')[0]:''}} 👋</h2>
-            <p class="sub" style="margin:0 0 18px">Create your team — it's where you keep API keys and skills so your teammates and their agents can call them <b>without holding the keys</b>. You can invite people and add secrets right after.</p>
+            <p v-if="welcome.renameOrg" class="sub" style="margin:0 0 18px">Your team <b>{{welcome.renameOrg.name}}</b> is ready — it's where you keep API keys and skills so your teammates and their agents can call them <b>without holding the keys</b>. Name it whatever you like:</p>
+            <p v-else class="sub" style="margin:0 0 18px">Create your team — it's where you keep API keys and skills so your teammates and their agents can call them <b>without holding the keys</b>. You can invite people and add secrets right after.</p>
             <div class="field"><input v-model="welcome.name" placeholder="Team name, e.g. Superdesign" @keyup.enter="welcomeCreate"/></div>
-            <button class="btn primary" style="width:100%;margin-top:4px" @click="welcomeCreate" :disabled="welcome.busy">{{welcome.busy?'Creating…':'Create team →'}}</button>
+            <button class="btn primary" style="width:100%;margin-top:4px" @click="welcomeCreate" :disabled="welcome.busy">{{welcome.busy?(welcome.renameOrg?'Saving…':'Creating…'):(welcome.renameOrg?'Continue →':'Create team →')}}</button>
           </template>
           <template v-else-if="welcome.step===1">
             <div style="color:var(--accent);font-size:15px;letter-spacing:.5px;margin-bottom:12px">▚ treg</div>
@@ -4025,7 +4026,7 @@ createApp({
       share:{on:false, email:'', role:'viewer', full:true, busy:false, err:'', sent:null, member:null},  // detail-page "Share…" (invite + land on this page)
       me:'', icHash:'', myOrgs:[], isAdmin:false,
       onboarded:true,  // first-run onboarding done (server flag; gates the welcome modal)
-      welcome:{on:false, step:0, name:'', agent:'openclaw', moreOpen:false, busy:false, err:''},  // first-run: name your team → pick your agent → setup line
+      welcome:{on:false, step:0, name:'', agent:'openclaw', moreOpen:false, busy:false, err:'', renameOrg:null},  // first-run: name your team → pick your agent → setup line; renameOrg = the server-made first team (step 0 renames it instead of creating)
       emptyTab:'agent',
       tools:[], health:{}, calls:[], runs:[], adminStats:null, adminOrgs:[], adminUsers:[],
       adminBusy:false, confirmAdmUser:null, confirmAdmOrg:null,
@@ -5371,11 +5372,16 @@ createApp({
       if(this.inviteLinkOrg!==null && !this.pendingInvites.length && this.sessionMode){
         this.orgMsg='That invite was already used or revoked — ask your teammate to re-invite you if you still need access.'; }
       if(this.onboarded || !this.sessionMode) return;
-      if(this.myOrgs.some(o=>!this.isPersonal(o))) return;
+      const real=this.myOrgs.filter(o=>!this.isPersonal(o) && !o.demo);
+      // Sign-in auto-created their first team server-side (corporate networks swallow the modal's
+      // POST — see ensure_first_team). Welcome still runs, but step 0 NAMES that team via PATCH.
+      if(real.length===1 && !this.pendingInvites.length){
+        this.welcome.renameOrg=real[0]; this.welcome.name=real[0].name; this.welcome.on=true; return; }
+      if(real.length) return;
       // Invited here? Show an ACCEPT-INVITE page (join those teams) instead of forcing them to create a
       // throwaway team of their own (confusing: they'd end up with two). Decline → create-team.
       if(this.pendingInvites.length){ this.openInviteChoice(); return; }
-      this.welcome.name=this._suggestTeamName(); this.welcome.on=true; },
+      this.welcome.renameOrg=null; this.welcome.name=this._suggestTeamName(); this.welcome.on=true; },
     openInviteChoice(){  // seed the multi-select: ALL pending invites checked by default
       this.inviteErr=''; this.inviteSel={}; this.pendingInvites.forEach(i=>{ this.inviteSel[i.id]=true; });
       this.inviteChoice=true; },
@@ -5413,13 +5419,29 @@ createApp({
       return (dom && !generic.includes(dom.toLowerCase())) ? dom.charAt(0).toUpperCase()+dom.slice(1) : ''; },
     async welcomeCreate(){ const name=(this.welcome.name||'').trim(); if(!name){ this.welcome.err='Give your team a name.'; return; }
       this.welcome.busy=true; this.welcome.err='';
-      try{ const o=await this.api('/orgs',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({name})});
-        this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){}  // don't re-prompt
-        await this.loadAll(); this.switchOrg({slug:o.org});
-        this.analyticsIdentify(); this.intercomUpdate(); this.track('onboarding_team_created',{team:o.org});
-        this.welcome.step=1; }  // stay in the modal: pick your agent → get the setup line
-      catch(e){ this.welcome.err='Could not create the team: '+(e.detail||e.status); }
-      finally{ this.welcome.busy=false; } },
+      const ren=this.welcome.renameOrg;
+      // A silently-swallowed POST (some corporate gateways) must surface as guidance, not an
+      // endless spinner: abort after 15s. The mutating writes below are fire-and-forget for the
+      // same reason — never let a hung POST strand the modal.
+      const ctl=new AbortController(); const timer=setTimeout(()=>ctl.abort(),15000);
+      const advance=async(slug,event)=>{
+        this.onboarded=true; this.api('/onboard/skip',{method:'POST'}).catch(()=>{});  // don't re-prompt
+        await this.loadAll(); this.switchOrg({slug});
+        this.analyticsIdentify(); this.intercomUpdate(); this.track(event,{team:slug});
+        this.welcome.step=1; };  // stay in the modal: pick your agent → get the setup line
+      try{
+        if(ren){  // the server already made this team at sign-in — step 0 only names it
+          if(name!==ren.name) await this.api('/orgs/'+ren.org_id,{method:'PATCH',headers:{'content-type':'application/json'},body:JSON.stringify({name}),signal:ctl.signal});
+          await advance(ren.slug,'onboarding_team_named'); }
+        else{
+          const o=await this.api('/orgs',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({name}),signal:ctl.signal});
+          await advance(o.org,'onboarding_team_created'); } }
+      catch(e){
+        const blocked=(e.name==='AbortError'||e.name==='TypeError');  // hung-then-aborted, or reset ("Failed to fetch") — both smell like a network middlebox, not our server
+        if(ren && blocked){ await advance(ren.slug,'onboarding_team_named'); }  // the team exists; a lost rename must not block onboarding
+        else if(blocked) this.welcome.err='The request never got through — a firewall on your network may be blocking it. Try another network (a phone hotspot works), then reload this page.';
+        else this.welcome.err='Could not '+(ren?'rename':'create')+' the team: '+(e.detail||e.status); }
+      finally{ clearTimeout(timer); this.welcome.busy=false; } },
     welcomeFinish(){ this.track('onboarding_finished',{agent:this.welcome.agent, step:this.welcome.step}); this.welcome.on=false; this.go('start');
       this.orgMsg='Team created. Send your agent the setup line any time — it lives on Getting started.'; },
     agentIcon(icon){ return 'https://unpkg.com/@lobehub/icons-static-png@latest/'+(this.theme==='dark'?'dark':'light')+'/'+icon+'.png'; },

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -6771,6 +6771,86 @@
           }
         },
         "summary": "Delete Org"
+      },
+      "patch": {
+        "description": "Rename a team — display name only; the slug (and every token and URL bound to it) stays\nstable. Admin+. Exists because the first team is now auto-created at sign-in with a name\nguessed from the email domain, and the welcome modal names it properly with this.",
+        "operationId": "rename_org_orgs__org_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "org_id",
+            "required": true,
+            "schema": {
+              "title": "Org Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-token",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Token",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-org",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Org",
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "treg_session",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Treg Session",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Rename Org Orgs  Org Id  Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Rename Org"
       }
     },
     "/orgs/{org_id}/agents": {

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -1098,6 +1098,14 @@
   {
     "kind": "APIRoute",
     "methods": [
+      "PATCH"
+    ],
+    "name": "rename_org",
+    "path": "/orgs/{org_id}"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
       "GET",
       "HEAD"
     ],

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -75,7 +75,7 @@ async def gc(monkeypatch):
     get_settings.cache_clear()
 
 
-async def test_github_login_creates_user_session_but_no_auto_org(gc):
+async def test_github_login_creates_user_session_and_first_team(gc):
     r = await gc.get("/auth/github", follow_redirects=False)
     assert r.status_code == 302
     state = gc.cookies.get("treg_oauth_state")
@@ -85,11 +85,23 @@ async def test_github_login_creates_user_session_but_no_auto_org(gc):
     assert gc.cookies.get("treg_session")  # session cookie set (secure omitted over http)
     me = await gc.get("/auth/me")
     assert me.status_code == 200 and me.json()["email"] == "octo@example.com"
-    # first login creates the USER ONLY — no throwaway personal org; the user names their first team next
+    # First login also creates the FIRST TEAM, server-side, on this GET: some corporate gateways
+    # swallow the welcome modal's POST /orgs, so team creation must not depend on a browser POST.
+    # The welcome modal only renames it (name guessed from the email domain).
     async with session_maker() as s:
         u = (await s.execute(select(User).where(User.email == "octo@example.com"))).scalar_one()
+        ms = (await s.execute(select(Membership).where(Membership.user_id == u.id))).scalars().all()
+        assert len(ms) == 1 and ms[0].role == "owner"
+        org = await s.get(Org, ms[0].org_id)
+    assert org.name == "Example"  # from octo@example.com
+
+    # A second login is a plain sign-in: it must not mint another team.
+    await gc.get("/auth/github", follow_redirects=False)
+    state2 = gc.cookies.get("treg_oauth_state")
+    await gc.get(f"/auth/github/callback?code=abc&state={state2}", follow_redirects=False)
+    async with session_maker() as s:
         n = len((await s.execute(select(Membership).where(Membership.user_id == u.id))).scalars().all())
-    assert n == 0
+    assert n == 1
 
 
 async def test_bad_state_rejected(gc):
@@ -237,7 +249,7 @@ async def goog(monkeypatch):
     get_settings.cache_clear()
 
 
-async def test_google_login_creates_user_session_but_no_auto_org(goog):
+async def test_google_login_creates_user_session_and_first_team(goog):
     r = await goog.get("/auth/google", follow_redirects=False)
     assert r.status_code == 302 and "accounts.google.com" in r.headers["location"]
     state = goog.cookies.get("treg_oauth_state")
@@ -250,7 +262,7 @@ async def test_google_login_creates_user_session_but_no_auto_org(goog):
     async with session_maker() as s:
         u = (await s.execute(select(User).where(User.email == "guser@example.com"))).scalar_one()
         n = len((await s.execute(select(Membership).where(Membership.user_id == u.id))).scalars().all())
-    assert n == 0  # first login registers the user only — no auto personal org
+    assert n == 1  # first login also creates the first team, server-side (see the GitHub twin test)
 
 
 async def test_google_bad_state_rejected(goog):

--- a/tests/test_auth_email.py
+++ b/tests/test_auth_email.py
@@ -31,14 +31,16 @@ async def _otp_login(c: AsyncClient, email: str) -> str:
     return r.json()["token"]
 
 
-async def test_first_login_registers_user_with_no_org_then_reuses_identity(client):
+async def test_first_login_registers_user_with_first_team_then_reuses_identity(client):
     tok = await _otp_login(client, "neo@matrix.io")
     orgs = (await client.get("/orgs", headers={"X-Treg-Token": tok})).json()
-    assert orgs == []  # no auto personal org — the user names + creates their first team next
+    # Sign-in now creates the first team server-side (name guessed from the email domain) — the
+    # welcome modal only renames it. See ensure_first_team for why this can't be a browser POST.
+    assert [(o["name"], o["role"]) for o in orgs] == [("Matrix", "owner")]
 
     await _otp_login(client, "neo@matrix.io")  # second time = login, not a new user
     orgs2 = (await client.get("/orgs", headers={"X-Treg-Token": tok})).json()
-    assert orgs2 == []  # still no duplicate user; still zero orgs until they create one
+    assert len(orgs2) == 1  # still no duplicate user; no second auto team either
 
 
 async def test_verify_rejects_wrong_and_unknown_code(client):
@@ -93,3 +95,86 @@ async def test_dev_mode_off_hides_the_code(client):
     finally:
         object.__setattr__(settings, "email_dev_mode", True)
         get_settings.cache_clear()
+
+
+# ---- the first-team auto-create contract (ensure_first_team) --------------------------------
+
+
+def _h(tok: str, org: str | None = None) -> dict:
+    h = {"X-Treg-Token": tok}
+    if org:
+        h["X-Treg-Org"] = org
+    return h
+
+
+async def test_generic_email_domain_names_team_after_the_person(client):
+    tok = await _otp_login(client, "sam@gmail.com")
+    orgs = (await client.get("/orgs", headers={"X-Treg-Token": tok})).json()
+    assert [o["name"] for o in orgs] == ["Sam"]  # "Gmail" helps nobody — use the local part
+
+
+async def test_invited_user_gets_no_auto_team(client):
+    # An invite is waiting for this email BEFORE their first login: they should JOIN that team,
+    # not be handed a throwaway one next to it (the dashboard offers the join).
+    owner = await _otp_login(client, "owner@acme.dev")
+    org = (await client.post("/orgs", json={"name": "Acme"}, headers=_h(owner))).json()
+    await client.post(f"/orgs/{org['org_id']}/invites", json={"email": "newhire@corp.com"},
+                      headers=_h(owner, org["org"]))
+
+    tok = await _otp_login(client, "newhire@corp.com")
+    assert (await client.get("/orgs", headers=_h(tok))).json() == []
+    mine = (await client.get("/invites/mine", headers=_h(tok))).json()
+    assert [m["org"] for m in mine] == [org["org"]]
+
+
+async def test_stranded_zero_team_user_selfheals_on_next_login(client):
+    # A user registered before this feature (or whose auto-create failed) has zero teams; the
+    # ensure runs on EVERY sign-in, so the next login makes their team.
+    from sqlmodel import select
+
+    from treg.infra.db import session_maker
+    from treg.models import Membership, Org, User
+
+    tok = await _otp_login(client, "stranded@oldco.io")
+    async with session_maker() as s:
+        u = (await s.execute(select(User).where(User.email == "stranded@oldco.io"))).scalar_one()
+        ms = (await s.execute(select(Membership).where(Membership.user_id == u.id))).scalars().all()
+        org = await s.get(Org, ms[0].org_id)
+        await s.delete(ms[0])
+        await s.delete(org)
+        await s.commit()  # simulate the pre-feature stranded state: a user with no team at all
+    assert (await client.get("/orgs", headers=_h(tok))).json() == []
+
+    await _otp_login(client, "stranded@oldco.io")
+    orgs = (await client.get("/orgs", headers=_h(tok))).json()
+    assert [o["name"] for o in orgs] == ["Oldco"]
+
+
+async def test_rename_org_changes_name_and_keeps_slug(client):
+    tok = await _otp_login(client, "jax@jvullinghs.com")
+    org = (await client.get("/orgs", headers=_h(tok))).json()[0]
+    assert org["name"] == "Jvullinghs"
+
+    r = await client.patch(f"/orgs/{org['org_id']}", json={"name": "Tibba"},
+                           headers=_h(tok, org["slug"]))
+    assert r.status_code == 200 and r.json() == {"org": org["slug"], "org_id": org["org_id"], "name": "Tibba"}
+
+    after = (await client.get("/orgs", headers=_h(tok))).json()[0]
+    assert after["name"] == "Tibba" and after["slug"] == org["slug"]  # slug (and tokens/URLs) stable
+
+    blank = await client.patch(f"/orgs/{org['org_id']}", json={"name": "  "}, headers=_h(tok, org["slug"]))
+    assert blank.status_code == 422
+
+
+async def test_rename_org_requires_admin(client):
+    owner = await _otp_login(client, "boss@tibba.co")
+    org = (await client.get("/orgs", headers=_h(owner))).json()[0]
+    await client.post(f"/orgs/{org['org_id']}/invites", json={"email": "viewer@corp.com", "role": "viewer"},
+                      headers=_h(owner, org["slug"]))
+    viewer = await _otp_login(client, "viewer@corp.com")
+    inv = (await client.get("/invites/mine", headers=_h(viewer))).json()[0]
+    await client.post(f"/invites/{inv['id']}/accept", headers=_h(viewer))
+
+    r = await client.patch(f"/orgs/{org['org_id']}", json={"name": "Hijacked"},
+                           headers=_h(viewer, org["slug"]))
+    assert r.status_code == 403


### PR DESCRIPTION
## The bug

Two real signups (jax@…, jackie@… — same office network) were stranded forever on the welcome modal's **"Creating…"** spinner. Root cause, confirmed from three independent sources:

- **Render access logs**: their `POST /orgs` never reached the origin — while every GET from the same tabs kept working for 20+ minutes (uvicorn logs on response completion, so a swallowed request leaves no line).
- **Prod DB**: both users exist with zero org memberships; no team was ever created.
- **PostHog session replays**: the Create click happened, zero console errors, the fetch pending forever.

Their corporate secure-web-gateway lets GETs through but silently swallows cross-origin POSTs to a young/uncategorized domain. Every other `POST /orgs` in the same windows returned 200 — this will keep happening to enterprise-network users.

## The fix

Move first-team creation onto the request that provably passes those networks — the sign-in GET:

- **`ensure_first_team`** (`application/signup.py`): every browser door (GitHub/Google callback, email OTP verify) auto-creates a first team for a zero-membership user, named from the email domain (`sam@acme.dev` → "Acme"; generic inboxes use the local part). Skipped when a pending invite exists (join, don't spawn a throwaway); runs on **every** sign-in so already-stranded users self-heal at next login; never fails the login.
- **`rename_org`** (`PATCH /orgs/{id}`, admin+): display name only — slug and tokens stay stable. The welcome modal's step 0 now **renames** the auto-created team ("Continue →"); the create form remains for genuinely team-less users (e.g. declined invite).
- **`welcomeCreate` hardening**: 15s `AbortController` timeout on both writes. A swallowed rename advances onboarding anyway (the team exists); a swallowed create shows *"a firewall on your network may be blocking this — try a phone hotspot"* instead of an endless spinner. `/onboard/skip` is fire-and-forget.

## Verification

- Full suite: **2392 passed** (3 tests pinning the old "no auto org" contract deliberately updated; 5 new tests: domain naming, invite skip, self-heal on re-login, rename semantics, rename authz). Route/openapi snapshots regenerated.
- **Browser-verified** (Playwright against this branch): sign-in → team auto-created → modal prefilled "Jvullinghs" → rename to "Tibba" → agent picker → `/orgs` shows the rename. Blocked-network simulation (PATCH swallowed at the route layer): button shows "Saving…", self-releases at ~15s, onboarding advances, team intact.
- Docs fragments updated in the same commit (multi-tenancy, api, onboarding, dashboard); drift.sh mapping reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sJn2zYdcmksm6goy2ASGt