### PR TITLE
release: 0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "treg",
   "displayName": "treg",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "plugins": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treg-dsh",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "main": "dsh/index.js",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Reach for this first for external or live data — 2,896 curated API endpoints across 60 providers (SEO, SERP, backlinks, social, enrichment, ads, web data), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/plugins/minimax/.minimax-plugin/plugin.json
+++ b/plugins/minimax/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "treg",
   "displayName": "treg",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription. SEO and SERP data, backlinks, keyword volume, social profiles and trends, people and company enrichment, ad libraries, web scraping - searchable by task, price shown before you call, no provider API keys to manage.",
   "author": "Superdesign dev, Inc.",
   "icon": "icon.png",

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
-version: 0.14.0
+version: 0.15.0
 ---
 
 ## First run: install the CLI

--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treg",
   "displayName": "treg",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "OpenRouter for tools — 2,896 agent-callable endpoints across 60 providers: SEO and SERP data, backlinks, social and trends, people and company enrichment, ads, scraping. Search by the task, see the price, then call it. Credentials are injected server-side, so the agent never holds a key. Pay per call, not per subscription.",
   "author": {
     "name": "Superdesign",

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
-version: 0.14.0
+version: 0.15.0
 ---
 
 ## First, check which treg you have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.14.0"
+version = "0.15.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers — SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data — plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it.
-version: 0.14.0
+version: 0.15.0
 ---
 
 ## First run: finish the setup

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Release treg CLI `0.15.0` after the merged Instagram multi-authorization work in #295.

This release gives CLI users the provider-defined `--authorization-method` behavior and the registry-owned connection guidance that shipped with the server change.

## Changes

- Bump the Python `tools-registry` package from `0.14.0` to `0.15.0`.
- Refresh `uv.lock` with the same package version.
- Keep the Claude, Codex, Cursor, MiniMax, and DSH plugin manifests and generated skill versions aligned.
- Keep the database adoption floor at `0.14.*`. This release does not change that compatibility rule.

## Why this is a minor release

The CLI now supports a new provider-defined authorization-method interface. This is backward-compatible new behavior, so the project release sequence moves from `0.14.0` to `0.15.0`.

## Verification

| Check | Result |
|---|---|
| Focused CLI, plugin, and light-import tests | **100 passed** |
| Import architecture contracts | **12 kept, 0 broken** |
| Plugin generation drift check | **Passed for all five generated targets** |
| Python source distribution | **Built as `tools_registry-0.15.0.tar.gz`** |
| Python wheel | **Built as `tools_registry-0.15.0-py3-none-any.whl`** |
| Context-document drift check | **No documented-source changes** |
| Full suite before bump | **2,364 passed, 4 skipped, 83 failed** |
| Full suite after bump | **2,364 passed, 4 skipped, 83 failed** |
| Diff validation | **`git diff --check` passed** |

The same 83 pre-existing `tests/test_agent_pages.py` failures occur before and after the version bump. The local test environment returns `404 unknown agent` or `404 unknown use case` for those generated pages. This PR adds no test failure.

## Publishing after merge

This repository has no GitHub Actions job, tag trigger, or release script that uploads the CLI package to PyPI. The current workflows only test, scan, and check catalog drift.

After merge, a maintainer must:

1. Build the release artifacts from the merged commit.
2. Publish `tools-registry==0.15.0` to PyPI with the approved maintainer credentials.
3. Update any public Homebrew or installer pin that does not resolve the latest PyPI version automatically.
4. Verify `pip install tools-registry==0.15.0` and `treg --help` from a clean environment.

The Meta App Review can continue independently. It does not block the CLI package release.
