### PR TITLE
fix(overflow): classify verify failures to prevent flake-driven mass disables

### DIFF
--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -152,6 +152,17 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   fingerprint (keys and list/leaf markers, values ignored), stamp `last_verified_at` or disable
   with the reason. Spends real money (bounded by `--max-usd`, default 2¢); needs the aggregator
   keys in the env — a Render cron, never the dataplane.
+  
+  **Verification outcomes** (`VerifyOutcome` enum, `classify_verification()`): a verification is
+  classified into one of four outcomes to decide whether to disable a route. **PASS** = both sides
+  2xx with matching shapes (updates `last_verified_at`). **FLAKE** = transient vendor/aggregator
+  error (malformed JSON, 5xx, 429, network errors, 4xx-vs-4xx) — don't disable or count as fail.
+  **SKIP** = can't verify (contract miss from incomplete test_request, pending async run, no direct
+  key) — don't count. **FAIL** = real 200/200 shape mismatch — the only case that disables the
+  route. The cron exits 0 when only flakes/skips, exit 1 only when real FAILs exist.
+  
+  **`treg-worker overflow reenable-if-flake [--dry-run]`** — re-enables routes disabled by
+  flake-like reasons (malformed, 5xx, 429, contract, network errors). Use `--dry-run` to preview.
 
 ## Protect, part one (step D) — refuse before reserve
 

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -12,11 +12,84 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 
 import httpx
 
 from ...timeutil import utcnow_naive
 from ...infra.upstream.aggregators import by_name
+
+
+class VerifyOutcome(str, Enum):
+    """Classification of a verification result — determines whether to disable the route.
+
+    PASS  — Both sides 2xx with matching shapes; update last_verified_at.
+    FLAKE — Transient vendor/aggregator error (5xx, 429, malformed, network). Don't disable.
+    SKIP  — Can't verify (contract, pending, no direct key). Don't count as pass or fail.
+    FAIL  — Real shape mismatch at 200/200. Disable the route.
+    """
+    PASS = "pass"
+    FLAKE = "flake"
+    SKIP = "skip"
+    FAIL = "fail"
+
+
+def classify_verification(v: "Verification") -> VerifyOutcome:
+    """Classify a Verification result into one of the four outcomes.
+
+    This classifier is intentionally conservative: only 200/200 shape mismatches cause FAIL.
+    Transient aggregator issues (malformed, 5xx, 429) are FLAKE. Contract misses are SKIP.
+    """
+    if v.passed:
+        return VerifyOutcome.PASS
+
+    if v.relay_status is None:
+        if v.note.startswith("relay unreachable:"):
+            return VerifyOutcome.FLAKE
+        if "malformed" in v.note or "not JSON" in v.note:
+            return VerifyOutcome.FLAKE
+        if "contract:" in v.note:
+            return VerifyOutcome.SKIP
+        if "pending" in v.note:
+            return VerifyOutcome.SKIP
+        return VerifyOutcome.FLAKE
+
+    if v.relay_status >= 500:
+        return VerifyOutcome.FLAKE
+
+    if v.relay_status == 429:
+        return VerifyOutcome.FLAKE
+
+    if v.direct_status is None:
+        if "direct not attempted" in v.note or "direct unreachable:" in v.note:
+            return VerifyOutcome.SKIP
+        if v.note.startswith("relay ok"):
+            return VerifyOutcome.SKIP
+        return VerifyOutcome.SKIP
+
+    if v.direct_status >= 500:
+        return VerifyOutcome.FLAKE
+
+    if v.direct_status == 429:
+        return VerifyOutcome.FLAKE
+
+    if 200 <= v.direct_status < 300 and 200 <= v.relay_status < 300:
+        if v.same_shape is False:
+            return VerifyOutcome.FAIL
+        if v.same_shape is None:
+            return VerifyOutcome.FLAKE
+        return VerifyOutcome.PASS
+
+    if (400 <= v.direct_status < 500) and (400 <= v.relay_status < 500):
+        return VerifyOutcome.FLAKE
+
+    if (200 <= v.direct_status < 300) and (v.relay_status >= 500):
+        return VerifyOutcome.FLAKE
+
+    if (200 <= v.relay_status < 300) and (v.direct_status >= 500):
+        return VerifyOutcome.FLAKE
+
+    return VerifyOutcome.FAIL
 
 
 def shape(obj, depth: int = 0):
@@ -50,6 +123,11 @@ class Verification:
     @property
     def passed(self) -> bool:
         return bool(self.same_shape) and self.relay_status is not None and 200 <= self.relay_status < 300
+
+    @property
+    def outcome(self) -> VerifyOutcome:
+        """The classified outcome of this verification."""
+        return classify_verification(self)
 
 
 async def relay_once(client: httpx.AsyncClient, route, key: str, query: dict, body: bytes | None,

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -112,7 +112,7 @@ async def _overflow_verify(args) -> int:
         rows = (await db.execute(select(OverflowRoute))).scalars().all()
     todo = [r for r in rows if args.all or r.enabled or r.last_verified_at]
     keys = {"orthogonal": s.overflow_key_orthogonal, "monid": s.overflow_key_monid}
-    passed = failed = skipped = 0
+    passed = failed = skipped = flaked = 0
     # One SHORT transaction per route. The first prod run (2026-08-28) kept a single session open
     # across every network round-trip: each `db.get` autoflushed the previous row's UPDATE, the row
     # locks piled up for minutes, and db.py's 5 s lock_timeout — there to keep the worker from
@@ -150,24 +150,89 @@ async def _overflow_verify(args) -> int:
                 if body is not None:
                     hdrs["Content-Type"] = "application/json"
             v = await V.verify_route(c, r, key=key, direct=direct, test_request=tr, direct_headers=hdrs)
+            outcome = v.outcome
             async with session_maker() as db:
                 row = await db.get(OverflowRoute, (r.endpoint_id, r.aggregator))
                 if row is None:
                     skipped += 1
                     continue
-                if v.passed:
+                if outcome == V.VerifyOutcome.PASS:
                     row.last_verified_at = v.verified_at or utcnow_naive()
                     passed += 1
-                else:
+                elif outcome == V.VerifyOutcome.FLAKE:
+                    flaked += 1
+                elif outcome == V.VerifyOutcome.SKIP:
+                    skipped += 1
+                else:  # FAIL
                     failed += 1
                     if row.enabled:
                         row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
                 row.updated_at = utcnow_naive()
                 await db.commit()
-            print(f"{'ok ' if v.passed else 'FAIL'} {r.endpoint_id} via {r.aggregator} "
+            label = {"pass": "ok ", "flake": "flak", "skip": "skip", "fail": "FAIL"}[outcome.value]
+            print(f"{label} {r.endpoint_id} via {r.aggregator} "
                   f"direct={v.direct_status} relay={v.relay_status} cost={v.cost_micro} {v.note}")
-    print(f"verified {passed}, failed {failed}, skipped {skipped}")
+    print(f"verified {passed}, failed {failed}, flaked {flaked}, skipped {skipped}")
     return 1 if failed else 0
+
+
+# Patterns in disabled_reason that indicate flake, not real failure.
+_FLAKE_PATTERNS = (
+    "malformed:",
+    "not JSON",
+    "relay 5",  # relay 502, 503, etc.
+    "relay 429",
+    "direct 5",  # direct 502, 503, etc.
+    "direct 429",
+    "relay unreachable:",
+    "direct unreachable:",
+    "contract:",  # test_request incomplete
+)
+
+
+def _is_flake_reason(reason: str | None) -> bool:
+    """Return True if the disabled_reason looks like a transient/flake issue."""
+    if not reason:
+        return False
+    reason_lower = reason.lower()
+    return any(p.lower() in reason_lower for p in _FLAKE_PATTERNS)
+
+
+async def _overflow_reenable_if_flake(args) -> int:
+    """Re-enable routes that were disabled due to transient/flake errors.
+
+    This command identifies OverflowRoutes disabled with flake-like reasons (malformed, 5xx, 429,
+    network errors, contract misses) and re-enables them. Use --dry-run to preview without changes.
+    """
+    from sqlalchemy import select
+    from .infra.db import session_maker, verify_db
+    from .models import OverflowRoute
+    from .timeutil import utcnow_naive
+
+    await verify_db()
+    async with session_maker() as db:
+        rows = (await db.execute(select(OverflowRoute).where(OverflowRoute.enabled == False))).scalars().all()  # noqa: E712
+    candidates = [(r.endpoint_id, r.aggregator, r.disabled_reason)
+                  for r in rows if _is_flake_reason(r.disabled_reason)]
+    if not candidates:
+        print("no routes disabled by flake-like reasons")
+        return 0
+    print(f"found {len(candidates)} routes disabled by flake-like reasons:")
+    for eid, agg, reason in candidates:
+        print(f"  {eid} via {agg}: {reason}")
+    if args.dry_run:
+        print("(dry run — no changes made)")
+        return 0
+    async with session_maker() as db:
+        for eid, agg, _ in candidates:
+            row = await db.get(OverflowRoute, (eid, agg))
+            if row is not None and not row.enabled:
+                row.enabled = True
+                row.disabled_reason = None
+                row.updated_at = utcnow_naive()
+        await db.commit()
+    print(f"re-enabled {len(candidates)} routes")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -188,6 +253,9 @@ def main(argv: list[str] | None = None) -> int:
     ver.add_argument("--all", action="store_true", help="every row, not only enabled/previously verified")
     ver.add_argument("--max-usd", type=float, default=0.02, help="skip routes priced above this")
     ver.set_defaults(fn=_overflow_verify)
+    reen = ovsub.add_parser("reenable-if-flake", help="re-enable routes disabled by transient errors")
+    reen.add_argument("--dry-run", action="store_true", help="list candidates without changing them")
+    reen.set_defaults(fn=_overflow_reenable_if_flake)
     args = ap.parse_args(argv)
     _need_server()
     return asyncio.run(args.fn(args))

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -341,5 +341,90 @@ def test_worker_cli_parses_overflow_commands(monkeypatch):
         seen.update(vars(args)); return 0
     monkeypatch.setattr(worker, "_overflow_sync", fake)
     monkeypatch.setattr(worker, "_overflow_verify", fake)
+    monkeypatch.setattr(worker, "_overflow_reenable_if_flake", fake)
     assert worker.main(["overflow", "sync", "--live"]) == 0 and seen["live"] is True
     assert worker.main(["overflow", "verify", "--max-usd", "0.05"]) == 0 and seen["max_usd"] == 0.05
+    assert worker.main(["overflow", "reenable-if-flake", "--dry-run"]) == 0 and seen["dry_run"] is True
+
+
+# ---- verification classifier -------------------------------------------------------------------
+
+
+def test_verify_outcome_classify_pass():
+    """A verification with same_shape=True and relay 2xx is PASS."""
+    v = V.Verification("x", "y", 200, 200, True, 1000, utcnow_naive())
+    assert v.outcome == V.VerifyOutcome.PASS
+    assert v.passed
+
+
+def test_verify_outcome_classify_fail_200_200_shape_differs():
+    """200/200 with different shapes is FAIL — the only case that disables."""
+    v = V.Verification("x", "y", 200, 200, False, 1000, None, note="direct 200, relay 200, shape differs")
+    assert v.outcome == V.VerifyOutcome.FAIL
+    assert not v.passed
+
+
+def test_verify_outcome_classify_flake_malformed():
+    """Malformed (non-JSON from aggregator) is FLAKE — don't disable."""
+    v = V.Verification("x", "y", None, None, None, None, None, note="malformed: monid: not JSON")
+    assert v.outcome == V.VerifyOutcome.FLAKE
+
+
+def test_verify_outcome_classify_flake_relay_5xx():
+    """Relay 5xx (502, 503, etc.) is FLAKE — don't disable."""
+    v = V.Verification("x", "y", 200, 502, None, None, None, note="direct 200, relay 502, shape differs")
+    assert v.outcome == V.VerifyOutcome.FLAKE
+    v2 = V.Verification("x", "y", None, 503, None, None, None, note="relay 503")
+    assert v2.outcome == V.VerifyOutcome.FLAKE
+
+
+def test_verify_outcome_classify_flake_429():
+    """429 on either side is FLAKE — rate limiting is transient."""
+    v_relay = V.Verification("x", "y", 200, 429, None, None, None, note="direct 200, relay 429")
+    assert v_relay.outcome == V.VerifyOutcome.FLAKE
+    v_direct = V.Verification("x", "y", 429, 200, None, None, None, note="direct 429, relay 200")
+    assert v_direct.outcome == V.VerifyOutcome.FLAKE
+
+
+def test_verify_outcome_classify_flake_4xx_vs_4xx():
+    """4xx vs 4xx (e.g. 400/400, 403/403) is FLAKE — error bodies differ across accounts."""
+    v = V.Verification("x", "y", 400, 400, False, 0, None, note="direct 400, relay 400, shape differs")
+    assert v.outcome == V.VerifyOutcome.FLAKE
+    v2 = V.Verification("x", "y", 403, 422, False, 0, None, note="direct 403, relay 422, shape differs")
+    assert v2.outcome == V.VerifyOutcome.FLAKE
+
+
+def test_verify_outcome_classify_skip_contract():
+    """Contract miss (test_request incomplete) is SKIP — don't count as pass or fail."""
+    v = V.Verification("x", "y", None, None, None, 0, None, note="contract: Required parameters are missing")
+    assert v.outcome == V.VerifyOutcome.SKIP
+
+
+def test_verify_outcome_classify_skip_pending():
+    """Pending async run (never completed) is SKIP."""
+    v = V.Verification("x", "y", None, None, None, None, None, note="pending: RUNNING")
+    assert v.outcome == V.VerifyOutcome.SKIP
+
+
+def test_verify_outcome_classify_skip_no_direct():
+    """No direct key available (relay ok, direct not attempted) is SKIP."""
+    v = V.Verification("x", "y", None, 200, None, 1000, None, note="relay ok, direct not attempted")
+    assert v.outcome == V.VerifyOutcome.SKIP
+
+
+def test_verify_outcome_classify_flake_relay_unreachable():
+    """Network error reaching aggregator is FLAKE."""
+    v = V.Verification("x", "y", None, None, None, None, None, note="relay unreachable: ConnectError: ...")
+    assert v.outcome == V.VerifyOutcome.FLAKE
+
+
+def test_flake_reason_patterns():
+    """_is_flake_reason identifies flake-like disabled_reason patterns."""
+    assert worker._is_flake_reason("re-verify failed: malformed: monid: not JSON")
+    assert worker._is_flake_reason("re-verify failed: direct 200, relay 502, shape differs")
+    assert worker._is_flake_reason("re-verify failed: direct 429, relay 200")
+    assert worker._is_flake_reason("re-verify failed: relay unreachable: ConnectError")
+    assert worker._is_flake_reason("re-verify failed: contract: Required parameters")
+    assert not worker._is_flake_reason("re-verify failed: direct 200, relay 200, shape differs")
+    assert not worker._is_flake_reason("not in the current sync")
+    assert not worker._is_flake_reason(None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes the `treg-overflow-verify` cron job (job-dabtno6k1f9s73dhtf2g on 2026-09-02) that exited 1 and disabled 145 OverflowRoutes due to transient vendor/aggregator errors. The cron should not page Slack or disable routes for vendor flakes.

**Incident buckets handled:**
1. **Relay flake / malformed** — tikhub.* via monid returned HTML mid-run → now FLAKE
2. **5xx on relay vs 2xx on direct** — scrapecreators, tomba endpoints → now FLAKE
3. **429 on either side** — rate limiting → now FLAKE
4. **Contract miss** — test_request incomplete → now SKIP
5. **4xx vs 4xx** — error bodies differ across accounts → now FLAKE
6. **True 200/200 shape differs** — remains FAIL (only case that disables)

**Changes:**
- Add `VerifyOutcome` enum (PASS, FLAKE, SKIP, FAIL) in `verify.py`
- Add `classify_verification()` function to determine outcome
- Update `_overflow_verify` to use classifier and count flakes separately
- Exit 0 when only flakes/skips, exit 1 only when real FAILs
- Add `overflow reenable-if-flake` command to recover routes disabled by flake

**Re-enabling disabled routes:**
Routes disabled by flake-like reasons can be recovered with:
```bash
treg-worker overflow reenable-if-flake --dry-run  # preview
treg-worker overflow reenable-if-flake            # apply
```

## How it was tested

```bash
uv run pytest tests/test_capacity_overflow_routes.py -v  # 26 passed
uv run pytest -q  # 2458 passed, 4 skipped
```

New tests cover all classifier buckets:
- PASS: 200/200 matching shapes
- FAIL: 200/200 shape differs
- FLAKE: malformed, 5xx, 429, 4xx-vs-4xx, network errors
- SKIP: contract, pending, no direct key

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e817a743-2e59-41b3-89da-531a82c148b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e817a743-2e59-41b3-89da-531a82c148b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

