### PR TITLE
fix(capacity): read Apollo's 422 as out-of-credits; make overflow verify runnable by hand

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -451,6 +451,12 @@ shared plan" — `cost_view`, holds, caps and settlement needed zero changes. Wh
   method: `_resolve_marketplace_call` rejects a mismatch before relay. The only method the provider
   can reject is therefore treg's recorded method, so settling a `per_call` hold would charge the
   team for catalog metadata treg owns. `_NOT_THE_CALLERS_FAULT` makes that path release the hold.
+- **A 4xx that the signature table reads as OUR account running dry is never billable**, whatever
+  its status: Apollo says "out of credits" with a 422, which `per_call` would otherwise charge to
+  the caller as an input error - and, once overflow serves the same request through an aggregator,
+  charge them twice. `_platform_settle` asks `signatures.classify` before settling any platform-tier
+  4xx and releases the hold with reason `capacity_<kind>` (`test_apollo_out_of_credits_on_a_per_call_
+  endpoint_*` in `tests/test_capacity_overflow.py`).
 - **`shared_plan_recovery`** (`GET /admin/reconcile/shared-plans`): fee versus collected per
   treg-set rate, with `suggested_usd = fee ÷ measured calls` and an action at ±50% thresholds. It
   REPORTS; a human edits fx.yaml monthly. An auto-adjusting price would move under an agent's feet,

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -329,10 +329,14 @@ does not choose for the caller (charter): it names the options. The audit row is
 The signal comes from the call path itself as well as from the worker's sweep: after a tier-4 answer
 ≥ 400, `settle._note_capacity_signal` runs `domain.capacity.signatures.classify` on the vendor's
 status/headers/body. A `balance` or `quota` signature (findymail "Not enough credits", lusha's "Daily"
-429, hunter's "per billing period" 429, any bare 402, …) writes the exhausted mark through
+429, hunter's "per billing period" 429, Apollo's 422 "Insufficient credits", any bare 402, …) writes the exhausted mark through
 `domain.capacity.marks.mark_exhausted` — its own short session, **after** the settle closed the hold,
 never during flight — and the next call is refused without waiting for a sweep. A burst 429
-(`retry-after ≤ 60 s`) or an unknown one only logs; step D′ smooths those. An `edge_block` (the
+(`retry-after ≤ 60 s`) or an unknown one only logs; step D′ smooths those. An `unrecorded` one — a
+4xx no row matched whose body still names credits/quota/balance — logs `unrecorded capacity-looking
+…` with the phrase and rides `tool_called` as `capacity_signal=unrecorded`, nothing else: the
+tripwire for a vendor whose out-of-credit answer is not in the table yet, which is how Apollo's 422
+went unseen on 2026-09-01. An `edge_block` (the
 vendor's CDN answered, not the vendor) marks nothing: one caller's request shape must not take the
 provider away from every other team. The kind is returned and rides the `tool_called` event as
 `capacity_signal`. That mark is the single

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -405,8 +405,9 @@ When the resolver already knows the account is out (the exhausted view) **and** 
 ladder skips the direct attempt entirely (`MarketplaceCall.skip_direct`): no parent hold, no vendor
 402, straight to the child — the plan's tier 4b.
 
-**An aggregator failure is data.** Its own 401/402/403 (or a vendor 402 relayed through it — seen live)
-releases the child hold, marks `overflow:<name>` unhealthy for 15 minutes, and answers the typed
+**An aggregator failure is data.** Its own 401/402/403, a malformed envelope, or a relayed vendor
+answer that is a 402 or that the signature table reads as that vendor's own out-of-credit dialect
+(Apollo's 422 through Orthogonal's dry Apollo account) releases the child hold, marks `overflow:<name>` unhealthy for 15 minutes, and answers the typed
 `provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call. Its
 stricter-schema refusal (`contract`) releases the child and lets the vendor's own answer stand.
 

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -345,7 +345,7 @@ other team. The kind rides the `tool_called` event as `capacity_signal`. Tiers 1
 and never consult the view: an org's own key running dry is the org's own answer, relayed
 unchanged. The vendor's 402 on THIS call is also relayed unchanged - the protection is for the
 next caller.
-An `unrecorded` signal — a 4xx no row matched whose body still names credits/quota/balance —
+An `unrecorded` signal - a 4xx no row matched whose body still names credits/quota/balance -
 is neither a strike nor a mark: it logs `unrecorded capacity-looking …` with the phrase and rides
 `tool_called` as `capacity_signal=unrecorded`, the tripwire for a vendor whose out-of-credit answer is
 not in the table yet (how Apollo's 422 went unseen on 2026-09-01).

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -405,10 +405,12 @@ When the resolver already knows the account is out (the exhausted view) **and** 
 ladder skips the direct attempt entirely (`MarketplaceCall.skip_direct`): no parent hold, no vendor
 402, straight to the child — the plan's tier 4b.
 
-**An aggregator failure is data.** Its own 401/402/403, a malformed envelope, or a relayed vendor
-answer that is a 402 or that the signature table reads as that vendor's own out-of-credit dialect
-(Apollo's 422 through Orthogonal's dry Apollo account) releases the child hold, marks `overflow:<name>` unhealthy for 15 minutes, and answers the typed
-`provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call. Its
+**An aggregator failure is data.** Its own 401/402/403 or a malformed envelope releases the child
+hold and marks `overflow:<name>` unhealthy for everyone; a relayed vendor answer the signature table
+reads as that vendor's own out-of-credit or quota dialect (`VENDOR_DRY`: a 402, Apollo's 422 through
+Orthogonal's dry Apollo account, a period 429) releases the child hold and marks
+`overflow:<name>:<provider>` only - one vendor's cap never takes the others offline. Either mark
+lasts 15 minutes, and the caller gets the typed `provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call. Its
 stricter-schema refusal (`contract`) releases the child and lets the vendor's own answer stand.
 
 **Shadow mode** (`TREG_OVERFLOW_MODE=shadow`): the aggregator is called, status / shape / cost logged

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -144,7 +144,7 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   credits"), recorded after 2026-09-01: eleven hours of `people.enrich` 422s with overflow on and
   not one attempt, because no row matched. Two guards against the next such vendor: `unrecorded`,
   a signal kind for a 4xx no row matched whose body still names credits/quota/balance (pattern =
-  the table's own phrases plus generic nouns) — never a mark, only a log line and
+  the table's own phrases plus generic nouns) - never a mark, only a log line and
   `capacity_signal=unrecorded` on `tool_called`; and the coverage guard in
   `tests/test_capacity_overflow_routes.py`, which fails when a `platform_key_*` provider has neither
   a table row nor an acknowledged gap. `edge_block` is the odd one out: the vendor's CDN refused the
@@ -164,14 +164,15 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   with the reason. `--max-usd` (default 2¢) is a per-route price cap, not a run budget: pricier
   routes are skipped, as are routes whose endpoint has no `test_request`. Without `--all` only
   enabled or previously-stamped rows are visited, so a never-verified pair never enters the rota;
-  run it with `--all`. Verify only STAMPS — `overflow sync` is what re-derives `enabled` from the
+  run it with `--all`. Verify only STAMPS - `overflow sync` is what re-derives `enabled` from the
   stamps, so **every verify is followed by a sync**; a route disabled by one failed verify is only
   re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
   completing (it used to exit 1 whenever any route failed, which made every Render run read
-  "failed"); it exits 1 only when it verified NOTHING (no route attempted, or every attempt
-  failed — keys revoked, aggregator down), so a schedule's failure notification still means
-  something. Spends real money; needs the aggregator keys in the env — a Render job, never the
-  dataplane. How it is scheduled and run by hand is in `ops/deploy.md` § Worker commands.
+  "failed"); it exits 1 for a failed RUN - an aggregator refused our key, ran dry or was
+  unreachable (`verify.aggregator_failed`; those routes are left as they are, never disabled), or
+  nothing was attempted at all - so a schedule's failure notification still means something.
+  Spends real money; needs the aggregator keys in the env - a Render job, never the dataplane.
+  How it is scheduled and run by hand is in `ops/deploy.md` § Worker commands.
 
 ## Protect, part one (step D) — refuse before reserve
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -172,10 +172,13 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   completing (it used to exit 1 whenever any route failed, which made every Render run read
   "failed"). `verify.verdict` is the one place that decides what a verification means: `passed`
   stamps; `failed` (contract refusal, relay non-2xx, a 2xx of a different shape) disables with the
-  reason; `aggregator` (`AGGREGATOR_SIDE` + `relay unreachable`: our key, its account, host or
-  envelope) and `inconclusive` (relay 2xx but nothing sound to compare with - no vendor key, the
-  direct call unreachable or non-2xx, which is exactly OUR account being dry, the moment these
-  routes exist for - or an async run still pending) leave the row untouched. The run exits 1 when
+  reason; `aggregator` (`AGGREGATOR_SIDE` + `relay unreachable` + `aggregator dry`, the last
+  being the vendor's own out-of-credit answer relayed through it: our key, its account, host or
+  envelope) leaves the row untouched; `inconclusive` (relay 2xx but nothing sound to compare with
+  - no vendor key, the direct call unreachable or non-2xx, which is exactly OUR account being dry,
+  the moment these routes exist for - or an async run still pending) never disables, and a relay
+  2xx among them still STAMPS, because the route demonstrably serves and an unstamped route would
+  be decayed by the next sync precisely while our account is dry. The run exits 1 when
   our key or the aggregator's balance was refused on any route, when every attempt was lost to
   the aggregator's side, or when nothing was attempted - so a schedule's failure notification
   means something and one timeout does not trip it.

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -155,8 +155,11 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   vendor request (Orthogonal `POST /run {api, path, query, body}`; Monid `POST /run {provider,
   endpoint, input}`), `parse()` unwraps the vendor status + body + the real in-band charge, and
   names who to blame when the aggregator itself refused (`AGGREGATOR_SIDE` = `aggregator_auth`,
-  `aggregator_balance`, `malformed` - the call path marks the aggregator unhealthy on them, the
-  verifier leaves the route alone;
+  `aggregator_balance`, `malformed` - the call path marks the aggregator unhealthy for everyone, the
+  verifier leaves the route alone; `VENDOR_DRY`, folded in by `with_vendor_verdict` from the
+  signature table - the one place a relayed body is read - is the aggregator's account for THIS
+  vendor (a relayed 402, Apollo's 422, a period 429): the call path marks
+  `overflow:<aggregator>:<provider>` only, so one vendor's cap never takes the others offline;
   `contract` = its stricter schema, no vendor call, no charge; `pending` = a Monid async run to
   poll). Fixtures are recorded bodies (PII hashed) in `tests/fixtures/aggregators/`; every fixture
   round-trips. Keys are passed in by the caller and never read, logged or stored here.
@@ -167,18 +170,18 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   routes are skipped, as are routes whose endpoint has no `test_request`. Without `--all` only
   enabled or previously-stamped rows are visited, so a never-verified pair never enters the rota;
   run it with `--all`. Verify only STAMPS - `overflow sync` is what re-derives `enabled` from the
-  stamps, so **every verify is followed by a sync**; a route disabled by one failed verify is only
-  re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
+  stamps, so every verify must be followed by a sync (by hand today, `ops/deploy.md`); a route
+  disabled by one failed verify is only re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
   completing (it used to exit 1 whenever any route failed, which made every Render run read
   "failed"). `verify.verdict` is the one place that decides what a verification means: `passed`
   stamps; `failed` (contract refusal, relay non-2xx, a 2xx of a different shape) disables with the
-  reason; `aggregator` (`AGGREGATOR_SIDE` + `relay unreachable` + `aggregator dry`, the last
-  being the vendor's own out-of-credit answer relayed through it: our key, its account, host or
-  envelope) leaves the row untouched; `inconclusive` (relay 2xx but nothing sound to compare with
-  - no vendor key, the direct call unreachable or non-2xx, which is exactly OUR account being dry,
-  the moment these routes exist for - or an async run still pending) never disables, and a relay
-  2xx among them still STAMPS, because the route demonstrably serves and an unstamped route would
-  be decayed by the next sync precisely while our account is dry. The run exits 1 when
+  reason; `aggregator` (`AGGREGATOR_SIDE` + `vendor_dry` + `relay unreachable`: our key, its
+  account, the vendor's own out-of-credit answer relayed through it, its host or envelope) leaves
+  the row untouched; `inconclusive` (relay 2xx but nothing sound to compare with - no vendor key,
+  the direct call unreachable or non-2xx, or an async run still pending) never disables. One
+  inconclusive still STAMPS: `direct dry`, our own account refusing in its recorded dialect - the
+  relay served, the shape cannot be checked for OUR reason, and an unstamped route would be decayed
+  by the next sync precisely while our account is dry. No key or a 401 does not stamp. The run exits 1 when
   our key or the aggregator's balance was refused on any route, when every attempt was lost to
   the aggregator's side, or when nothing was attempted - so a schedule's failure notification
   means something and one timeout does not trip it.

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -154,7 +154,9 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
 - **`infra/upstream/aggregators/`** — the envelopes, and nothing else: `build()` wraps the
   vendor request (Orthogonal `POST /run {api, path, query, body}`; Monid `POST /run {provider,
   endpoint, input}`), `parse()` unwraps the vendor status + body + the real in-band charge, and
-  names who to blame when the aggregator itself refused (`aggregator_auth`, `aggregator_balance`,
+  names who to blame when the aggregator itself refused (`AGGREGATOR_SIDE` = `aggregator_auth`,
+  `aggregator_balance`, `malformed` - the call path marks the aggregator unhealthy on them, the
+  verifier leaves the route alone;
   `contract` = its stricter schema, no vendor call, no charge; `pending` = a Monid async run to
   poll). Fixtures are recorded bodies (PII hashed) in `tests/fixtures/aggregators/`; every fixture
   round-trips. Keys are passed in by the caller and never read, logged or stored here.
@@ -168,9 +170,15 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   stamps, so **every verify is followed by a sync**; a route disabled by one failed verify is only
   re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
   completing (it used to exit 1 whenever any route failed, which made every Render run read
-  "failed"); it exits 1 for a failed RUN - an aggregator refused our key, ran dry or was
-  unreachable (`verify.aggregator_failed`; those routes are left as they are, never disabled), or
-  nothing was attempted at all - so a schedule's failure notification still means something.
+  "failed"). `verify.verdict` is the one place that decides what a verification means: `passed`
+  stamps; `failed` (contract refusal, relay non-2xx, a 2xx of a different shape) disables with the
+  reason; `aggregator` (`AGGREGATOR_SIDE` + `relay unreachable`: our key, its account, host or
+  envelope) and `inconclusive` (relay 2xx but nothing sound to compare with - no vendor key, the
+  direct call unreachable or non-2xx, which is exactly OUR account being dry, the moment these
+  routes exist for - or an async run still pending) leave the row untouched. The run exits 1 when
+  our key or the aggregator's balance was refused on any route, when every attempt was lost to
+  the aggregator's side, or when nothing was attempted - so a schedule's failure notification
+  means something and one timeout does not trip it.
   Spends real money; needs the aggregator keys in the env - a Render job, never the dataplane.
   How it is scheduled and run by hand is in `ops/deploy.md` § Worker commands.
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -159,7 +159,10 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   verifier leaves the route alone; `VENDOR_DRY`, folded in by `with_vendor_verdict` from the
   signature table - the one place a relayed body is read - is the aggregator's account for THIS
   vendor (a relayed 402, Apollo's 422, a period 429): the call path marks
-  `overflow:<aggregator>:<provider>` only, so one vendor's cap never takes the others offline;
+  `overflow:<aggregator>:<provider>` only, so one vendor's cap never takes the others offline.
+  Deliberately not the direct path's strike ladder: the mark is immediate and a flat 15 min, because
+  a relayed body carries no headers to tell a burst from a cap and the caller has already paid the
+  aggregator's round trip;
   `contract` = its stricter schema, no vendor call, no charge; `pending` = a Monid async run to
   poll). Fixtures are recorded bodies (PII hashed) in `tests/fixtures/aggregators/`; every fixture
   round-trips. Keys are passed in by the caller and never read, logged or stored here.
@@ -175,16 +178,20 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   completing (it used to exit 1 whenever any route failed, which made every Render run read
   "failed"). `verify.verdict` is the one place that decides what a verification means: `passed`
   stamps; `failed` (contract refusal, relay non-2xx, a 2xx of a different shape) disables with the
-  reason; `aggregator` (`AGGREGATOR_SIDE` + `vendor_dry` + `relay unreachable`: our key, its
-  account, the vendor's own out-of-credit answer relayed through it, its host or envelope) leaves
-  the row untouched; `inconclusive` (relay 2xx but nothing sound to compare with - no vendor key,
-  the direct call unreachable or non-2xx, or an async run still pending) never disables. One
-  inconclusive still STAMPS: `direct dry`, our own account refusing in its recorded dialect - the
-  relay served, the shape cannot be checked for OUR reason, and an unstamped route would be decayed
-  by the next sync precisely while our account is dry. No key or a 401 does not stamp. The run exits 1 when
-  our key or the aggregator's balance was refused on any route, when every attempt was lost to
-  the aggregator's side, or when nothing was attempted - so a schedule's failure notification
-  means something and one timeout does not trip it.
+  reason, and only when the direct leg proved the request (a direct 2xx beside a relay non-2xx or
+  a different shape, or a contract refusal); `aggregator` (`AGGREGATOR_SIDE`, `vendor_dry`,
+  unreachable: our key, its account, the vendor's own out-of-credit answer relayed through it, its
+  host or envelope) leaves the row untouched; `inconclusive` (no direct 2xx to compare with - no
+  key, 401, our own account dry, a stale test_request failing both legs - or a run still pending)
+  never disables. One inconclusive still STAMPS: `direct_dry` with a relay 2xx, our own account
+  refusing in its recorded dialect - the relay served, the shape cannot be checked for OUR reason,
+  and an unstamped route would be decayed by the next sync precisely while our account is dry.
+  The verdict is pure over `Verification`'s typed fields (`failure`, `direct_dry`, statuses); the
+  note is for people. The run exits 1 when OUR key or OUR prepaid balance was refused on any
+  route, when every attempt was lost to the aggregator's side, or when nothing was attempted - so
+  a schedule's failure notification means something and one timeout does not trip it. A vendor
+  pool dry on the aggregator's side (`vendor_dry`) is theirs to refill: it counts under
+  "aggregator errors" in the summary line and never fails the run by itself.
   Spends real money; needs the aggregator keys in the env - a Render job, never the dataplane.
   How it is scheduled and run by hand is in `ops/deploy.md` § Worker commands.
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -136,7 +136,14 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
 - **`signatures.py`** — the signature table: what a provider's error body means for OUR account
   (`balance` / `quota` → exhausted; `burst` → smoothed, never exhausted; `unknown` 429 → logged).
   Lusha's "Daily" 429 and Hunter's "per billing period" 429 are quota exhaustion wearing a 429;
-  a `retry-after ≤ 60 s` is a burst. `edge_block` is the odd one out: the vendor's CDN refused the
+  a `retry-after ≤ 60 s` is a burst. Apollo says "out of credits" with a **422** ("Insufficient
+  credits"), recorded after 2026-09-01: eleven hours of `people.enrich` 422s with overflow on and
+  not one attempt, because no row matched. Two guards against the next such vendor: `unrecorded`,
+  a signal kind for a 4xx no row matched whose body still names credits/quota/balance (pattern =
+  the table's own phrases plus generic nouns) — never a mark, only a log line and
+  `capacity_signal=unrecorded` on `tool_called`; and the coverage guard in
+  `tests/test_capacity_overflow_routes.py`, which fails when a `platform_key_*` provider has neither
+  a table row nor an acknowledged gap. `edge_block` is the odd one out: the vendor's CDN refused the
   request's shape (decided on headers, never the caller's UA), so it exhausts nothing, overflows
   nothing and alerts nothing; it exists so a chart can tell a bot-filtered UA family from a
   provider outage. Shared by the sweep, the future call-path trigger and alerts.
@@ -150,8 +157,17 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
 - **`verify.py`** + `treg-worker overflow verify` — the weekly re-verify: one cheap call per
   route through the aggregator (and, when we hold the vendor key, directly), compare the shape
   fingerprint (keys and list/leaf markers, values ignored), stamp `last_verified_at` or disable
-  with the reason. Spends real money (bounded by `--max-usd`, default 2¢); needs the aggregator
-  keys in the env — a Render cron, never the dataplane.
+  with the reason. `--max-usd` (default 2¢) is a per-route price cap, not a run budget: pricier
+  routes are skipped, as are routes whose endpoint has no `test_request`. Without `--all` only
+  enabled or previously-stamped rows are visited, so a never-verified pair never enters the rota;
+  run it with `--all`. Verify only STAMPS — `overflow sync` is what re-derives `enabled` from the
+  stamps, so **every verify is followed by a sync**; a route disabled by one failed verify is only
+  re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
+  completing (it used to exit 1 whenever any route failed, which made every Render run read
+  "failed"); it exits 1 only when it verified NOTHING (no route attempted, or every attempt
+  failed — keys revoked, aggregator down), so a schedule's failure notification still means
+  something. Spends real money; needs the aggregator keys in the env — a Render job, never the
+  dataplane. How it is scheduled and run by hand is in `ops/deploy.md` § Worker commands.
 
 ## Protect, part one (step D) — refuse before reserve
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -358,7 +358,8 @@ first as a cron service (`treg-capacity-sweep`, hourly), with the DB URL, Fernet
 **Running the overflow routine by hand** (until a Blueprint schedules verify → sync): two one-off
 jobs on the verify cron service, in order - `render jobs create <cron-id> --start-command
 "treg-worker overflow verify --all"`, then the same with `overflow sync` - and read the
-`verified/failed/skipped` line of the first and the `enabled` count of the second. Verify only
+`verified N, failed N, inconclusive N, aggregator errors N, skipped N` line of the first and the
+`enabled` count of the second. Verify only
 stamps; sync is what opens routes.
 
 Aggregator keys

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -340,10 +340,28 @@ base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 
 
 ## Worker commands and the capacity cron (2026-08-28)
 
-`treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands — today
-`capacity sweep` (see `ops/capacity.md`). `render.yaml` runs it as the cron service
-`treg-capacity-sweep` every hour, with the DB URL, Fernet key and every `TREG_PLATFORM_KEY_*` pulled
-from the web service via `fromService` — so a new platform key is added in ONE place. Aggregator keys
+`treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands —
+`capacity sweep` and `overflow verify --all` (see `ops/capacity.md`). `render.yaml` describes them as
+cron services (`treg-capacity-sweep` hourly), with the DB URL, Fernet key and every
+`TREG_PLATFORM_KEY_*` pulled from the web service via `fromService`.
+
+> **`render.yaml` is not applied (checked 2026-09-02).** No Render Blueprint is registered for this
+> repo — the web service, both cron jobs and the database were made in the dashboard, the web
+> service has auto-deploy off, and the live environment has drifted far from the file (87 variables
+> live vs 24 in the file; `TREG_OVERFLOW_MODE` is `on` live and `off` in the file). Treat the file
+> as a statement of intent until a Blueprint is registered — and register one only after the file
+> has been reconciled to the live services, because a Blueprint sync overwrites what it manages.
+> The overflow re-verify cron (`treg-overflow-verify`, Mondays 06:00 UTC, dashboard-made, command
+> `treg-worker overflow verify --all` since 2026-09-02) is deliberately absent from the file for
+> that reason.
+
+**Running the overflow routine by hand** (until a Blueprint schedules verify → sync): two one-off
+jobs on the verify cron service, in order — `render jobs create <cron-id> --start-command
+"treg-worker overflow verify --all"`, then the same with `overflow sync` — and read the
+`verified/failed/skipped` line of the first and the `enabled` count of the second. Verify only
+stamps; sync is what opens routes.
+
+Aggregator keys
 (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same
 way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
 govern the overflow child cycle (`ops/capacity.md`); the keys serve nothing while the mode is `off`.

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -341,8 +341,8 @@ base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 
 ## Worker commands and the capacity cron (2026-08-28)
 
 `treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands -
-`capacity sweep` and `overflow verify --all` (see `ops/capacity.md`). `render.yaml` describes them as
-cron services (`treg-capacity-sweep` hourly), with the DB URL, Fernet key and every
+`capacity sweep` and `overflow verify --all` (see `ops/capacity.md`). `render.yaml` describes only the
+first as a cron service (`treg-capacity-sweep`, hourly), with the DB URL, Fernet key and every
 `TREG_PLATFORM_KEY_*` pulled from the web service via `fromService`.
 
 > **`render.yaml` is not applied (checked 2026-09-02).** No Render Blueprint is registered for this

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -340,24 +340,24 @@ base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 
 
 ## Worker commands and the capacity cron (2026-08-28)
 
-`treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands —
+`treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands -
 `capacity sweep` and `overflow verify --all` (see `ops/capacity.md`). `render.yaml` describes them as
 cron services (`treg-capacity-sweep` hourly), with the DB URL, Fernet key and every
 `TREG_PLATFORM_KEY_*` pulled from the web service via `fromService`.
 
 > **`render.yaml` is not applied (checked 2026-09-02).** No Render Blueprint is registered for this
-> repo — the web service, both cron jobs and the database were made in the dashboard, the web
+> repo - the web service, both cron jobs and the database were made in the dashboard, the web
 > service has auto-deploy off, and the live environment has drifted far from the file (87 variables
 > live vs 24 in the file; `TREG_OVERFLOW_MODE` is `on` live and `off` in the file). Treat the file
-> as a statement of intent until a Blueprint is registered — and register one only after the file
+> as a statement of intent until a Blueprint is registered - and register one only after the file
 > has been reconciled to the live services, because a Blueprint sync overwrites what it manages.
 > The overflow re-verify cron (`treg-overflow-verify`, Mondays 06:00 UTC, dashboard-made, command
 > `treg-worker overflow verify --all` since 2026-09-02) is deliberately absent from the file for
 > that reason.
 
 **Running the overflow routine by hand** (until a Blueprint schedules verify → sync): two one-off
-jobs on the verify cron service, in order — `render jobs create <cron-id> --start-command
-"treg-worker overflow verify --all"`, then the same with `overflow sync` — and read the
+jobs on the verify cron service, in order - `render jobs create <cron-id> --start-command
+"treg-worker overflow verify --all"`, then the same with `overflow sync` - and read the
 `verified/failed/skipped` line of the first and the `enabled` count of the second. Verify only
 stamps; sync is what opens routes.
 

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -35,7 +35,7 @@ from ...domain.capacity import signatures as capacity_signatures
 from ...domain.capacity.routes_view import view as routes_view
 from ...domain.capacity.verify import shape
 from ...domain.capacity.view import view as capacity_view
-from ...infra.upstream.aggregators import AggregatorRequest, AggregatorResult, by_name
+from ...infra.upstream.aggregators import AggregatorRequest, AggregatorResult, by_name, AGGREGATOR_SIDE
 from ...timeutil import utcnow_naive
 from .resolve import MarketplaceCall
 from .reserve import _platform_reserve
@@ -275,8 +275,14 @@ async def _maybe_overflow_attempt(
     delta = (budget.actual_micro - budget.direct_micro
              if budget.actual_micro is not None else None)
     # --- decide ---
-    if res.failure in ("aggregator_auth", "aggregator_balance", "malformed") or res.upstream_status == 402:
-        why_agg = res.failure or "upstream 402 through the aggregator"
+    # The aggregator's OWN account for this vendor can be dry too, and the vendor says so in its
+    # own dialect (Apollo's 422), not only with a 402: ask the table before treating a relayed
+    # 4xx as an answer the caller should pay for.
+    relayed_dry = (res.failure is None and res.upstream_status is not None
+                   and capacity_signatures.is_exhausting(capacity_signatures.classify(
+                       mk.provider, res.upstream_status, None, res.upstream_body[:4096])))
+    if res.failure in AGGREGATOR_SIDE or res.upstream_status == 402 or relayed_dry:
+        why_agg = res.failure or f"upstream {res.upstream_status} through the aggregator"
         await capacity_marks.strike(
             f"overflow:{aggregator}", endpoint_id=None, kind="balance", immediate=True,
             resets_at=utcnow_naive().replace(microsecond=0) + timedelta(seconds=AGGREGATOR_UNHEALTHY_S),

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -35,7 +35,8 @@ from ...domain.capacity import signatures as capacity_signatures
 from ...domain.capacity.routes_view import view as routes_view
 from ...domain.capacity.verify import shape
 from ...domain.capacity.view import view as capacity_view
-from ...infra.upstream.aggregators import AggregatorRequest, AggregatorResult, by_name, AGGREGATOR_SIDE
+from ...infra.upstream.aggregators import (AGGREGATOR_SIDE, VENDOR_DRY, AggregatorRequest, AggregatorResult,
+                                            by_name, with_vendor_verdict)
 from ...timeutil import utcnow_naive
 from .resolve import MarketplaceCall
 from .reserve import _platform_reserve
@@ -237,7 +238,8 @@ async def _maybe_overflow_attempt(
         return None
     routes = routes_view.for_endpoint(mk.endpoint_id)
     routes = [r for r in routes if settings.overflow_key_for(r.aggregator)
-              and not capacity_view.is_exhausted(f"overflow:{r.aggregator}")]
+              and not capacity_view.is_exhausted(f"overflow:{r.aggregator}")
+              and not capacity_view.is_exhausted(f"overflow:{r.aggregator}:{mk.provider}")]
     if not routes:
         return None
     route = routes[0]
@@ -271,21 +273,19 @@ async def _maybe_overflow_attempt(
         )
     except httpx.RequestError as exc:
         res = AggregatorResult(None, b"", None, "malformed", f"{type(exc).__name__}: {exc}")
+    res = with_vendor_verdict(res, mk.provider)
     budget.actual_micro = int(res.cost_micro) if res.cost_micro is not None else None
     delta = (budget.actual_micro - budget.direct_micro
              if budget.actual_micro is not None else None)
     # --- decide ---
-    # The aggregator's OWN account for this vendor can be dry too, and the vendor says so in its
-    # own dialect (Apollo's 422), not only with a 402: ask the table before treating a relayed
-    # 4xx as an answer the caller should pay for. BALANCE only: the mark below takes the whole
-    # aggregator offline for every provider, which one vendor's daily quota must never do.
-    relayed = (capacity_signatures.classify(mk.provider, res.upstream_status, None, res.upstream_body[:4096])
-               if res.failure is None and res.upstream_status is not None else None)
-    relayed_dry = relayed is not None and relayed.kind == "balance"
-    if res.failure in AGGREGATOR_SIDE or res.upstream_status == 402 or relayed_dry:
-        why_agg = res.failure or f"upstream {res.upstream_status} through the aggregator"
+    if res.failure in AGGREGATOR_SIDE or res.failure == VENDOR_DRY:
+        why_agg = res.failure
+        # The aggregator itself (key, account, host, envelope) is out for everyone; its account
+        # for THIS vendor being dry (a relayed 402 / Apollo 422 / period 429) is out for this
+        # provider only - one vendor's daily cap must not take hunter and lusha offline too.
+        mark_key = f"overflow:{aggregator}" if res.failure in AGGREGATOR_SIDE else f"overflow:{aggregator}:{mk.provider}"
         await capacity_marks.strike(
-            f"overflow:{aggregator}", endpoint_id=None, kind="balance", immediate=True,
+            mark_key, endpoint_id=None, kind="balance", immediate=True,
             resets_at=utcnow_naive().replace(microsecond=0) + timedelta(seconds=AGGREGATOR_UNHEALTHY_S),
             note=f"{why_agg}: {res.detail[:80]}")
         capacity_view.invalidate()

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -277,10 +277,11 @@ async def _maybe_overflow_attempt(
     # --- decide ---
     # The aggregator's OWN account for this vendor can be dry too, and the vendor says so in its
     # own dialect (Apollo's 422), not only with a 402: ask the table before treating a relayed
-    # 4xx as an answer the caller should pay for.
-    relayed_dry = (res.failure is None and res.upstream_status is not None
-                   and capacity_signatures.is_exhausting(capacity_signatures.classify(
-                       mk.provider, res.upstream_status, None, res.upstream_body[:4096])))
+    # 4xx as an answer the caller should pay for. BALANCE only: the mark below takes the whole
+    # aggregator offline for every provider, which one vendor's daily quota must never do.
+    relayed = (capacity_signatures.classify(mk.provider, res.upstream_status, None, res.upstream_body[:4096])
+               if res.failure is None and res.upstream_status is not None else None)
+    relayed_dry = relayed is not None and relayed.kind == "balance"
     if res.failure in AGGREGATOR_SIDE or res.upstream_status == 402 or relayed_dry:
         why_agg = res.failure or f"upstream {res.upstream_status} through the aggregator"
         await capacity_marks.strike(

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -79,7 +79,7 @@ def _trigger(mk: MarketplaceCall, status: int, headers, body: bytes) -> str | No
     signal = capacity_signatures.classify(mk.provider, status, headers, body[:4096])
     if signal is None:
         return None
-    if signal.kind in ("balance", "quota"):
+    if capacity_signatures.is_exhausting(signal):
         return signal.kind
     if signal.kind == "burst":
         return "burst"

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -407,11 +407,12 @@ async def _platform_settle(
     if not mk.metered or not mk.call_id:
         return 0, None
     billable = status_code is not None and _platform_billable(status_code, mk.cost_type)
-    if billable and status_code >= 400 and mk.tier in ("platform", "platform-overflow"):
+    if billable and status_code >= 400 and mk.tier == "platform":
         # A 4xx the status set calls the caller's fault may still be OUR account running dry in a
         # vendor's own dialect (Apollo's 422 "Insufficient credits"). Ask the signature table before
         # charging: billing it would take the caller's money for treg's empty account, and once
-        # overflow serves the same request through an aggregator they would pay twice.
+        # overflow serves the same request through an aggregator they would pay twice. (The
+        # overflow child never reaches here with such a body: `with_vendor_verdict` diverts it.)
         signal = capacity_signatures.classify(mk.provider, status_code, headers, body[:4096])
         if capacity_signatures.is_exhausting(signal):
             billable, reason = False, f"capacity_{signal.kind}"

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -407,14 +407,14 @@ async def _platform_settle(
     if not mk.metered or not mk.call_id:
         return 0, None
     billable = status_code is not None and _platform_billable(status_code, mk.cost_type)
-    if billable and status_code >= 400 and mk.tier == "platform":
+    if billable and status_code >= 400 and mk.tier in ("platform", "platform-overflow"):
         # A 4xx the status set calls the caller's fault may still be OUR account running dry in a
         # vendor's own dialect (Apollo's 422 "Insufficient credits"). Ask the signature table before
         # charging: billing it would take the caller's money for treg's empty account, and once
         # overflow serves the same request through an aggregator they would pay twice.
         signal = capacity_signatures.classify(mk.provider, status_code, headers, body[:4096])
         if capacity_signatures.is_exhausting(signal):
-            billable, reason = False, reason or f"capacity_{signal.kind}"
+            billable, reason = False, f"capacity_{signal.kind}"
     # `observed_override`: the overflow child cycle knows its cost from the aggregator's envelope, not
     # from the vendor body — the caller pays exactly that (plan §4.3 step 5), whatever the vendor's
     # own billing shape. `overflow_spend` = (aggregator, adjustment from the budget reservation,

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -407,6 +407,14 @@ async def _platform_settle(
     if not mk.metered or not mk.call_id:
         return 0, None
     billable = status_code is not None and _platform_billable(status_code, mk.cost_type)
+    if billable and status_code >= 400 and mk.tier == "platform":
+        # A 4xx the status set calls the caller's fault may still be OUR account running dry in a
+        # vendor's own dialect (Apollo's 422 "Insufficient credits"). Ask the signature table before
+        # charging: billing it would take the caller's money for treg's empty account, and once
+        # overflow serves the same request through an aggregator they would pay twice.
+        signal = capacity_signatures.classify(mk.provider, status_code, headers, body[:4096])
+        if capacity_signatures.is_exhausting(signal):
+            billable, reason = False, reason or f"capacity_{signal.kind}"
     # `observed_override`: the overflow child cycle knows its cost from the aggregator's envelope, not
     # from the vendor body — the caller pays exactly that (plan §4.3 step 5), whatever the vendor's
     # own billing shape. `overflow_spend` = (aggregator, adjustment from the budget reservation,

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -534,6 +534,10 @@ async def _note_capacity_signal(mk: MarketplaceCall, status_code: int, headers, 
             logging.getLogger("treg.capacity").warning(
                 "edge block on %s (%s): the vendor's CDN answered, not the vendor",
                 mk.provider, mk.endpoint_id)
+        elif signal.kind == "unrecorded":  # a vendor phrase the table lacks: for a person to record
+            logging.getLogger("treg.capacity").warning(
+                "unrecorded capacity-looking %d from %s on %s: body says %r",
+                status_code, mk.provider, mk.endpoint_id, signal.detail)
         else:
             logging.getLogger("treg.capacity").info(
                 "rate signal on %s: %s retry_after=%s", mk.provider, signal.kind, signal.retry_after_s)

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -7,7 +7,8 @@ one thing everywhere. Pure functions over (provider, status, headers, body).
   balance  — the account is out of money/credits → exhausted until a top-up (no reset time)
   quota    — the period allowance is used up (a 429 wearing quota clothes) → exhausted until reset
   burst    — a genuine rate limit with a short retry-after → smoothed, NEVER exhausted
-  unknown  — a 429 we cannot classify → logged for classification (treated as burst: never refuse)
+  unknown  — a 429 we cannot classify and whose body names no capacity phrase → logged for
+             classification (treated as burst: never refuse)
   edge_block - the vendor's CDN refused the request's shape before the vendor's code saw it → NEVER
              exhausted, only recorded (so a chart can attribute it to a UA family)
   unrecorded - a 4xx no row matched whose body still names credits/quota/balance → NEVER exhausted,
@@ -50,11 +51,12 @@ _TABLE: list[tuple[str, int, str, str]] = [
 # period words, not capacity words, and stay out) plus word-bounded generic nouns. A bare
 # "insufficient", "quota" or "balance" would flag "insufficient parameters", "quotation mark" and
 # "unbalanced quotes" - a caller's error echoed back.
-_UNRECORDED = re.compile(r"\b(?:" + "|".join(
+_UNRECORDED = re.compile(r"\b(?:" + "|".join(dict.fromkeys(
     [p.lower() for _, st, p, _ in _TABLE if p and st != 429]
     + [r"insufficient (?:credits?|balance|funds)", r"out of credits?",
-       r"credits? (?:exhausted|remaining|left)", r"(?:account |api |credit )?(?:balance|quota)(?:(?: has been| is| was)? (?:exceeded|reached|exhausted)| limit)?",
-       r"payment required", r"upgrade your plan"]) + r")\b")
+       r"credits? (?:exhausted|remaining|left)",
+       r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",
+       r"upgrade your plan"])) + r")\b")
 
 
 @dataclass(frozen=True)

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -46,17 +46,20 @@ _TABLE: list[tuple[str, int, str, str]] = [
     ("*", 402, r"", "balance"),
 ]
 
-# The `unrecorded` tripwire: every BODY phrase the table already knows for some vendor (recording
-# one vendor's wording arms the tripwire for every other; the 429 rows' "daily"/"monthly" are
-# period words, not capacity words, and stay out) plus word-bounded generic nouns. A bare
-# "insufficient", "quota" or "balance" would flag "insufficient parameters", "quotation mark" and
-# "unbalanced quotes" - a caller's error echoed back.
-_UNRECORDED = re.compile(r"\b(?:" + "|".join(dict.fromkeys(
-    [f"(?:{p})" for _, st, p, _ in _TABLE if p and st != 429]  # grouped: a row's own `|` stays its own
-    + [r"insufficient (?:credits?|balance|funds)", r"out of credits?",
-       r"credits? (?:exhausted|remaining|left)",
-       r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",
-       r"upgrade your plan"])) + r")\b", re.IGNORECASE)
+# The `unrecorded` tripwire's vocabulary, hand-kept: every capacity PHRASE the table records for
+# some vendor (recording one vendor's wording arms the tripwire for every other) plus the generic
+# nouns. Period words from the 429 rows ("daily", "monthly", "per day") are NOT capacity words and
+# stay out; a bare "insufficient", "quota" or "balance" would flag "insufficient parameters",
+# "quotation mark" and "unbalanced quotes" - a caller's error echoed back. The test
+# `test_every_recorded_phrase_arms_the_tripwire` keeps this list and the table in step.
+CAPACITY_PHRASES = (
+    r"not enough credits", r"insufficient[ _]credits", r"nocreditsremaining", r"payment required",
+    r"reached your credit limit", r"exceeded the monthly request limit",
+    r"insufficient (?:credits?|balance|funds)", r"out of credits?", r"credits? (?:exhausted|remaining|left)",
+    r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",
+    r"upgrade your plan",
+)
+_UNRECORDED = re.compile(r"\b(?:" + "|".join(f"(?:{p})" for p in CAPACITY_PHRASES) + r")\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True)

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -7,7 +7,7 @@ one thing everywhere. Pure functions over (provider, status, headers, body).
   balance  — the account is out of money/credits → exhausted until a top-up (no reset time)
   quota    — the period allowance is used up (a 429 wearing quota clothes) → exhausted until reset
   burst    — a genuine rate limit with a short retry-after → smoothed, NEVER exhausted
-  unknown  — a 429 we cannot classify and whose body names no capacity phrase → logged for
+  unknown  - a 429 we cannot classify and whose body names no capacity phrase → logged for
              classification (treated as burst: never refuse)
   edge_block - the vendor's CDN refused the request's shape before the vendor's code saw it → NEVER
              exhausted, only recorded (so a chart can attribute it to a UA family)
@@ -52,7 +52,7 @@ _TABLE: list[tuple[str, int, str, str]] = [
 # "insufficient", "quota" or "balance" would flag "insufficient parameters", "quotation mark" and
 # "unbalanced quotes" - a caller's error echoed back.
 _UNRECORDED = re.compile(r"\b(?:" + "|".join(dict.fromkeys(
-    [p.lower() for _, st, p, _ in _TABLE if p and st != 429]
+    [f"(?:{p.lower()})" for _, st, p, _ in _TABLE if p and st != 429]  # grouped: a row's own `|` stays its own
     + [r"insufficient (?:credits?|balance|funds)", r"out of credits?",
        r"credits? (?:exhausted|remaining|left)",
        r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -10,7 +10,7 @@ one thing everywhere. Pure functions over (provider, status, headers, body).
   unknown  — a 429 we cannot classify → logged for classification (treated as burst: never refuse)
   edge_block - the vendor's CDN refused the request's shape before the vendor's code saw it → NEVER
              exhausted, only recorded (so a chart can attribute it to a UA family)
-  unrecorded — a 4xx no row matched whose body still names credits/quota/balance → NEVER exhausted,
+  unrecorded - a 4xx no row matched whose body still names credits/quota/balance → NEVER exhausted,
              only logged/counted: the tripwire for a vendor whose out-of-credit answer is not in
              the table yet (how Apollo's 422 went unseen for eleven hours, 2026-09-01)
   None     — not a capacity signal at all (caller-caused 4xx, 5xx, success)
@@ -45,18 +45,21 @@ _TABLE: list[tuple[str, int, str, str]] = [
     ("*", 402, r"", "balance"),
 ]
 
-# The `unrecorded` tripwire: every phrase the table already knows for SOME vendor (recording one
-# vendor's wording arms the tripwire for every other) plus the generic nouns. Nouns only — a bare
-# "insufficient" would flag "insufficient parameters", a caller error.
-_UNRECORDED = re.compile("|".join(
-    [p.lower() for _, _, p, _ in _TABLE if p]
-    + [r"insufficient (credits?|balance|funds)", r"out of credits?", r"quota", r"balance",
-       r"payment required", r"upgrade your plan"]))
+# The `unrecorded` tripwire: every BODY phrase the table already knows for some vendor (recording
+# one vendor's wording arms the tripwire for every other; the 429 rows' "daily"/"monthly" are
+# period words, not capacity words, and stay out) plus word-bounded generic nouns. A bare
+# "insufficient", "quota" or "balance" would flag "insufficient parameters", "quotation mark" and
+# "unbalanced quotes" - a caller's error echoed back.
+_UNRECORDED = re.compile(r"\b(?:" + "|".join(
+    [p.lower() for _, st, p, _ in _TABLE if p and st != 429]
+    + [r"insufficient (?:credits?|balance|funds)", r"out of credits?",
+       r"credits? (?:exhausted|remaining|left)", r"(?:account |api |credit )?(?:balance|quota)(?:(?: has been| is| was)? (?:exceeded|reached|exhausted)| limit)?",
+       r"payment required", r"upgrade your plan"]) + r")\b")
 
 
 @dataclass(frozen=True)
 class Signal:
-    kind: str                    # balance | quota | burst | unknown | edge_block
+    kind: str                    # balance | quota | burst | unknown | edge_block | unrecorded
     resets_at: datetime | None   # when the account serves again, if the provider told us
     retry_after_s: int | None    # for burst: how long the provider asked us to wait
     detail: str = ""
@@ -127,11 +130,12 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
             return Signal("burst", None, wait, detail=text[:120])
         if wait is not None:  # the provider named a long wait: a period allowance, not a burst
             return Signal("quota", now + timedelta(seconds=wait), None, detail=text[:120])
-        return Signal("unknown", None, None, detail=text[:120])
     if 400 <= status < 500 and status not in (401, 404):  # 401 is the key, 404 the resource
         m = _UNRECORDED.search(text_l)
         if m:  # detail is the PHRASE, never the body: a vendor's error often echoes the request back
             return Signal("unrecorded", None, None, detail=m.group(0))
+    if status == 429:
+        return Signal("unknown", None, None, detail=text[:120])
     return None
 
 
@@ -148,5 +152,5 @@ def _quota_reset(provider: str, kind: str, headers, now: datetime) -> datetime |
 
 def is_exhausting(signal: Signal | None) -> bool:
     """Does this signal mark the account exhausted? Only confirmed balance/quota signatures do;
-    burst, unknown and edge_block never refuse a call (plan §4.1)."""
+    burst, unknown, edge_block and unrecorded never refuse a call (plan §4.1)."""
     return signal is not None and signal.kind in ("balance", "quota")

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -125,6 +125,7 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
     """The capacity meaning of one upstream answer, or None when it has none."""
     now = now or utcnow_naive()
     text = body.decode("utf-8", "replace") if isinstance(body, bytes) else (body or "")
+    text_l = text.lower()
     provider = (provider or "").lower()
     if _edge_block(status, headers, text_l):  # before the table: a block page carries no vendor body to match
         return Signal("edge_block", None, None, detail=text[:120])

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -52,11 +52,11 @@ _TABLE: list[tuple[str, int, str, str]] = [
 # "insufficient", "quota" or "balance" would flag "insufficient parameters", "quotation mark" and
 # "unbalanced quotes" - a caller's error echoed back.
 _UNRECORDED = re.compile(r"\b(?:" + "|".join(dict.fromkeys(
-    [f"(?:{p.lower()})" for _, st, p, _ in _TABLE if p and st != 429]  # grouped: a row's own `|` stays its own
+    [f"(?:{p})" for _, st, p, _ in _TABLE if p and st != 429]  # grouped: a row's own `|` stays its own
     + [r"insufficient (?:credits?|balance|funds)", r"out of credits?",
        r"credits? (?:exhausted|remaining|left)",
        r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",
-       r"upgrade your plan"])) + r")\b")
+       r"upgrade your plan"])) + r")\b", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -115,14 +115,13 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
     """The capacity meaning of one upstream answer, or None when it has none."""
     now = now or utcnow_naive()
     text = body.decode("utf-8", "replace") if isinstance(body, bytes) else (body or "")
-    text_l = text.lower()
     provider = (provider or "").lower()
     if _edge_block(status, headers):  # before the table: a block page carries no vendor body to match
         return Signal("edge_block", None, None, detail=text[:120])
     for prov, st, pattern, kind in _TABLE:
         if st != status or prov not in ("*", provider):
             continue
-        if pattern and not re.search(pattern, text_l if pattern.islower() else text):
+        if pattern and not re.search(pattern, text, re.IGNORECASE):
             continue
         resets = _quota_reset(provider, kind, headers, now)
         return Signal(kind, resets, None, detail=text[:120])
@@ -133,9 +132,9 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
         if wait is not None:  # the provider named a long wait: a period allowance, not a burst
             return Signal("quota", now + timedelta(seconds=wait), None, detail=text[:120])
     if 400 <= status < 500 and status not in (401, 404):  # 401 is the key, 404 the resource
-        m = _UNRECORDED.search(text_l)
+        m = _UNRECORDED.search(text)
         if m:  # detail is the PHRASE, never the body: a vendor's error often echoes the request back
-            return Signal("unrecorded", None, None, detail=m.group(0))
+            return Signal("unrecorded", None, None, detail=m.group(0).lower())
     if status == 429:
         return Signal("unknown", None, None, detail=text[:120])
     return None

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -10,6 +10,9 @@ one thing everywhere. Pure functions over (provider, status, headers, body).
   unknown  — a 429 we cannot classify → logged for classification (treated as burst: never refuse)
   edge_block - the vendor's CDN refused the request's shape before the vendor's code saw it → NEVER
              exhausted, only recorded (so a chart can attribute it to a UA family)
+  unrecorded — a 4xx no row matched whose body still names credits/quota/balance → NEVER exhausted,
+             only logged/counted: the tripwire for a vendor whose out-of-credit answer is not in
+             the table yet (how Apollo's 422 went unseen for eleven hours, 2026-09-01)
   None     — not a capacity signal at all (caller-caused 4xx, 5xx, success)
 """
 
@@ -36,8 +39,19 @@ _TABLE: list[tuple[str, int, str, str]] = [
     ("lusha", 429, r"daily", "quota"),
     ("hunter", 429, r"per billing period", "quota"),
     ("apollo", 429, r"per (day|month)|daily|monthly", "quota"),
+    # Apollo: an empty credit pool is a 422 {"error": "Insufficient credits. Please upgrade your
+    # plan."} (ops/capacity.md, 2026-09-01). A 422 without the phrase is the caller's validation error.
+    ("apollo", 422, r"insufficient credits", "balance"),
     ("*", 402, r"", "balance"),
 ]
+
+# The `unrecorded` tripwire: every phrase the table already knows for SOME vendor (recording one
+# vendor's wording arms the tripwire for every other) plus the generic nouns. Nouns only — a bare
+# "insufficient" would flag "insufficient parameters", a caller error.
+_UNRECORDED = re.compile("|".join(
+    [p.lower() for _, _, p, _ in _TABLE if p]
+    + [r"insufficient (credits?|balance|funds)", r"out of credits?", r"quota", r"balance",
+       r"payment required", r"upgrade your plan"]))
 
 
 @dataclass(frozen=True)
@@ -114,6 +128,10 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
         if wait is not None:  # the provider named a long wait: a period allowance, not a burst
             return Signal("quota", now + timedelta(seconds=wait), None, detail=text[:120])
         return Signal("unknown", None, None, detail=text[:120])
+    if 400 <= status < 500 and status not in (401, 404):  # 401 is the key, 404 the resource
+        m = _UNRECORDED.search(text_l)
+        if m:  # detail is the PHRASE, never the body: a vendor's error often echoes the request back
+            return Signal("unrecorded", None, None, detail=m.group(0))
     return None
 
 

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -16,7 +16,7 @@ from datetime import datetime
 import httpx
 
 from ...timeutil import utcnow_naive
-from ...infra.upstream.aggregators import by_name
+from ...infra.upstream.aggregators import AGGREGATOR_SIDE, by_name
 
 
 def shape(obj, depth: int = 0):
@@ -52,12 +52,25 @@ class Verification:
         return bool(self.same_shape) and self.relay_status is not None and 200 <= self.relay_status < 300
 
 
-AGGREGATOR_FAILURES = ("aggregator_auth", "aggregator_balance", "relay unreachable")
-"""`note` prefixes that blame our key, the aggregator's account or its host - never this route."""
-
-
-def aggregator_failed(v: Verification) -> bool:
-    return v.note.startswith(AGGREGATOR_FAILURES)
+def verdict(v: Verification) -> str:
+    """What one verification means for its route (worker.py acts on it, nothing else decides):
+      passed       - relay 2xx and the same shape as the direct call → stamp `last_verified_at`
+      aggregator   - our key, the aggregator's account, its host or envelope (AGGREGATOR_SIDE,
+                     `relay unreachable`) → the ROUTE is untouched; the RUN failed
+      inconclusive - the relay answered 2xx but there was nothing sound to compare it with: no
+                     direct key, the direct call unreachable or non-2xx (our own account dry is
+                     exactly the moment these routes exist for), or an async run still pending
+                     → untouched, no stamp
+      failed       - the aggregator relayed but this route is wrong: contract refusal, relay
+                     non-2xx, or a 2xx of a different shape → disable with the reason"""
+    if v.passed:
+        return "passed"
+    if v.note.startswith(AGGREGATOR_SIDE + ("relay unreachable",)):
+        return "aggregator"
+    relay_ok = v.relay_status is not None and 200 <= v.relay_status < 300
+    if v.note.startswith("pending") or (relay_ok and (v.direct_status is None or not 200 <= v.direct_status < 300)):
+        return "inconclusive"
+    return "failed"
 
 
 async def relay_once(client: httpx.AsyncClient, route, key: str, query: dict, body: bytes | None,

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -16,7 +16,7 @@ from datetime import datetime
 import httpx
 
 from ...timeutil import utcnow_naive
-from ...infra.upstream.aggregators import AGGREGATOR_SIDE, by_name
+from ...infra.upstream.aggregators import AGGREGATOR_SIDE, VENDOR_DRY, by_name, with_vendor_verdict
 from . import signatures
 
 
@@ -57,18 +57,18 @@ def verdict(v: Verification) -> str:
     """What one verification means for its route (worker.py acts on it, nothing else decides):
       passed       - relay 2xx and the same shape as the direct call → stamp `last_verified_at`
       aggregator   - our key, the aggregator's account (its own refusal, or the vendor's
-                     out-of-credit answer relayed through it), its host or envelope
-                     (AGGREGATOR_SIDE, `relay unreachable`, `aggregator dry`) → the ROUTE is
-                     untouched; the RUN failed
+                     out-of-credit answer relayed through it, VENDOR_DRY), its host or envelope
+                     (AGGREGATOR_SIDE, `relay unreachable`) → the ROUTE is untouched; the RUN failed
       inconclusive - the relay answered 2xx but there was nothing sound to compare it with: no
-                     direct key, the direct call unreachable or non-2xx (our own account dry is
-                     exactly the moment these routes exist for), or an async run still pending
-                     → untouched, no stamp
+                     direct key, the direct call unreachable or non-2xx, or an async run still
+                     pending → untouched. `direct dry` (our own account, exactly the moment these
+                     routes exist for) still stamps in the worker: the relay served and the shape
+                     cannot be checked for OUR reason, and an unstamped route decays at the next sync
       failed       - the aggregator relayed but this route is wrong: contract refusal, relay
                      non-2xx, or a 2xx of a different shape → disable with the reason"""
     if v.passed:
         return "passed"
-    if v.note.startswith(AGGREGATOR_SIDE + ("relay unreachable", "aggregator dry")):
+    if v.note.startswith(AGGREGATOR_SIDE + (VENDOR_DRY, "relay unreachable")):
         return "aggregator"
     relay_ok = v.relay_status is not None and 200 <= v.relay_status < 300
     if v.note.startswith("pending") or (relay_ok and (v.direct_status is None or not 200 <= v.direct_status < 300)):
@@ -90,7 +90,7 @@ async def relay_once(client: httpx.AsyncClient, route, key: str, query: dict, bo
         polls += 1
         pr = await client.get(res.poll_url, headers={"Authorization": f"Bearer {key}"})
         res = agg.parse(pr.status_code, pr.content)
-    return res
+    return with_vendor_verdict(res, route.provider)
 
 
 async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tuple[str, dict, bytes | None] | None,
@@ -109,12 +109,6 @@ async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tu
     if res.failure or res.upstream_status is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note=f"{res.failure}: {res.detail}")
-    relayed = signatures.classify(route.provider, res.upstream_status, None, res.upstream_body[:4096])
-    if relayed is not None and relayed.kind == "balance":
-        # The aggregator's OWN account for this vendor is empty (a 402, or the vendor's dialect -
-        # Apollo's 422): the route is fine, the aggregator is dry.
-        return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
-                            res.cost_micro, None, note=f"aggregator dry: {relayed.detail[:80]}")
     if direct is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note="relay ok, direct not attempted")
@@ -124,7 +118,14 @@ async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tu
     except httpx.RequestError as exc:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note=f"direct unreachable: {type(exc).__name__}: {exc}")
-    same = shapes_match(dr.content, res.upstream_body) if 200 <= dr.status_code < 300 else None
+    if not 200 <= dr.status_code < 300:
+        # Our OWN account dry (the state these routes exist for) proves nothing against the route;
+        # any other direct failure (401, a bad test_request) is just no comparison.
+        ours = signatures.classify(route.provider, dr.status_code, dr.headers, dr.content[:4096])
+        why = "direct dry" if signatures.is_exhausting(ours) else f"direct {dr.status_code}"
+        return Verification(route.endpoint_id, route.aggregator, dr.status_code, res.upstream_status, None,
+                            res.cost_micro, None, note=f"{why}, relay {res.upstream_status}, no comparison")
+    same = shapes_match(dr.content, res.upstream_body)
     return Verification(route.endpoint_id, route.aggregator, dr.status_code, res.upstream_status, same,
                         res.cost_micro, now if same else None,
                         note="" if same else f"direct {dr.status_code}, relay {res.upstream_status}, shape differs")

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -47,10 +47,20 @@ class Verification:
     cost_micro: int | None
     verified_at: datetime | None
     note: str = ""
+    failure: str | None = None   # AggregatorResult.failure, or "unreachable" for a dead host; None = relayed
+    direct_dry: bool = False     # the direct leg was OUR account refusing in its recorded dialect
+
+    @property
+    def relay_ok(self) -> bool:
+        return self.relay_status is not None and 200 <= self.relay_status < 300
+
+    @property
+    def direct_ok(self) -> bool:
+        return self.direct_status is not None and 200 <= self.direct_status < 300
 
     @property
     def passed(self) -> bool:
-        return bool(self.same_shape) and self.relay_status is not None and 200 <= self.relay_status < 300
+        return bool(self.same_shape) and self.relay_ok
 
 
 def verdict(v: Verification) -> str:
@@ -58,22 +68,25 @@ def verdict(v: Verification) -> str:
       passed       - relay 2xx and the same shape as the direct call → stamp `last_verified_at`
       aggregator   - our key, the aggregator's account (its own refusal, or the vendor's
                      out-of-credit answer relayed through it, VENDOR_DRY), its host or envelope
-                     (AGGREGATOR_SIDE, `relay unreachable`) → the ROUTE is untouched; the RUN failed
-      inconclusive - the relay answered 2xx but there was nothing sound to compare it with: no
-                     direct key, the direct call unreachable or non-2xx, or an async run still
-                     pending → untouched. `direct dry` (our own account, exactly the moment these
-                     routes exist for) still stamps in the worker: the relay served and the shape
-                     cannot be checked for OUR reason, and an unstamped route decays at the next sync
-      failed       - the aggregator relayed but this route is wrong: contract refusal, relay
-                     non-2xx, or a 2xx of a different shape → disable with the reason"""
+                     (AGGREGATOR_SIDE, unreachable) → the ROUTE is untouched
+      failed       - the aggregator relayed and this route is shown wrong: a contract refusal, or
+                     a direct 2xx beside a relay non-2xx / a 2xx of a different shape → disable
+      inconclusive - nothing shows the route wrong, nothing proves it right: no direct 2xx to
+                     compare with (no key, unreachable, 401, our own account dry, a stale
+                     test_request that fails both legs), or an async run still pending → untouched.
+                     `direct_dry` with a relay 2xx still stamps in the worker: the relay served,
+                     the shape cannot be checked for OUR reason, and an unstamped route decays at
+                     the next sync exactly while our account is dry.
+    Pure over the typed fields; the note is for people."""
     if v.passed:
         return "passed"
-    if v.note.startswith(AGGREGATOR_SIDE + (VENDOR_DRY, "relay unreachable")):
+    if v.failure in AGGREGATOR_SIDE or v.failure in (VENDOR_DRY, "unreachable"):
         return "aggregator"
-    relay_ok = v.relay_status is not None and 200 <= v.relay_status < 300
-    if v.note.startswith("pending") or (relay_ok and (v.direct_status is None or not 200 <= v.direct_status < 300)):
+    if v.failure == "contract":
+        return "failed"
+    if v.failure is not None:  # pending, or a kind this module does not know yet
         return "inconclusive"
-    return "failed"
+    return "failed" if v.direct_ok else "inconclusive"
 
 
 async def relay_once(client: httpx.AsyncClient, route, key: str, query: dict, body: bytes | None,
@@ -104,11 +117,11 @@ async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tu
         res = await relay_once(client, route, key, q, body, path_params)
     except httpx.RequestError as exc:  # a dead aggregator host is a failed verification, not a crash
         return Verification(route.endpoint_id, route.aggregator, None, None, None, None, None,
-                            note=f"relay unreachable: {type(exc).__name__}: {exc}")
+                            note=f"relay unreachable: {type(exc).__name__}: {exc}", failure="unreachable")
     now = utcnow_naive()
     if res.failure or res.upstream_status is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
-                            res.cost_micro, None, note=f"{res.failure}: {res.detail}")
+                            res.cost_micro, None, note=f"{res.failure}: {res.detail}", failure=res.failure or "malformed")
     if direct is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note="relay ok, direct not attempted")
@@ -122,9 +135,11 @@ async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tu
         # Our OWN account dry (the state these routes exist for) proves nothing against the route;
         # any other direct failure (401, a bad test_request) is just no comparison.
         ours = signatures.classify(route.provider, dr.status_code, dr.headers, dr.content[:4096])
-        why = "direct dry" if signatures.is_exhausting(ours) else f"direct {dr.status_code}"
+        dry = signatures.is_exhausting(ours)
+        why = "direct dry" if dry else f"direct {dr.status_code}"
         return Verification(route.endpoint_id, route.aggregator, dr.status_code, res.upstream_status, None,
-                            res.cost_micro, None, note=f"{why}, relay {res.upstream_status}, no comparison")
+                            res.cost_micro, None, note=f"{why}, relay {res.upstream_status}, no comparison",
+                            direct_dry=dry)
     same = shapes_match(dr.content, res.upstream_body)
     return Verification(route.endpoint_id, route.aggregator, dr.status_code, res.upstream_status, same,
                         res.cost_micro, now if same else None,

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -52,6 +52,14 @@ class Verification:
         return bool(self.same_shape) and self.relay_status is not None and 200 <= self.relay_status < 300
 
 
+AGGREGATOR_FAILURES = ("aggregator_auth", "aggregator_balance", "relay unreachable")
+"""`note` prefixes that blame our key, the aggregator's account or its host - never this route."""
+
+
+def aggregator_failed(v: Verification) -> bool:
+    return v.note.startswith(AGGREGATOR_FAILURES)
+
+
 async def relay_once(client: httpx.AsyncClient, route, key: str, query: dict, body: bytes | None,
                      path_params: dict | None = None, *, max_polls: int = 20, poll_wait_s: float = 1.5):
     """One aggregator run, following an async run to its end. Returns the parsed result."""

--- a/src/treg/domain/capacity/verify.py
+++ b/src/treg/domain/capacity/verify.py
@@ -17,6 +17,7 @@ import httpx
 
 from ...timeutil import utcnow_naive
 from ...infra.upstream.aggregators import AGGREGATOR_SIDE, by_name
+from . import signatures
 
 
 def shape(obj, depth: int = 0):
@@ -55,8 +56,10 @@ class Verification:
 def verdict(v: Verification) -> str:
     """What one verification means for its route (worker.py acts on it, nothing else decides):
       passed       - relay 2xx and the same shape as the direct call → stamp `last_verified_at`
-      aggregator   - our key, the aggregator's account, its host or envelope (AGGREGATOR_SIDE,
-                     `relay unreachable`) → the ROUTE is untouched; the RUN failed
+      aggregator   - our key, the aggregator's account (its own refusal, or the vendor's
+                     out-of-credit answer relayed through it), its host or envelope
+                     (AGGREGATOR_SIDE, `relay unreachable`, `aggregator dry`) → the ROUTE is
+                     untouched; the RUN failed
       inconclusive - the relay answered 2xx but there was nothing sound to compare it with: no
                      direct key, the direct call unreachable or non-2xx (our own account dry is
                      exactly the moment these routes exist for), or an async run still pending
@@ -65,7 +68,7 @@ def verdict(v: Verification) -> str:
                      non-2xx, or a 2xx of a different shape → disable with the reason"""
     if v.passed:
         return "passed"
-    if v.note.startswith(AGGREGATOR_SIDE + ("relay unreachable",)):
+    if v.note.startswith(AGGREGATOR_SIDE + ("relay unreachable", "aggregator dry")):
         return "aggregator"
     relay_ok = v.relay_status is not None and 200 <= v.relay_status < 300
     if v.note.startswith("pending") or (relay_ok and (v.direct_status is None or not 200 <= v.direct_status < 300)):
@@ -106,6 +109,12 @@ async def verify_route(client: httpx.AsyncClient, route, *, key: str, direct: tu
     if res.failure or res.upstream_status is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note=f"{res.failure}: {res.detail}")
+    relayed = signatures.classify(route.provider, res.upstream_status, None, res.upstream_body[:4096])
+    if relayed is not None and relayed.kind == "balance":
+        # The aggregator's OWN account for this vendor is empty (a 402, or the vendor's dialect -
+        # Apollo's 422): the route is fine, the aggregator is dry.
+        return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
+                            res.cost_micro, None, note=f"aggregator dry: {relayed.detail[:80]}")
     if direct is None:
         return Verification(route.endpoint_id, route.aggregator, None, res.upstream_status, None,
                             res.cost_micro, None, note="relay ok, direct not attempted")

--- a/src/treg/infra/upstream/aggregators/__init__.py
+++ b/src/treg/infra/upstream/aggregators/__init__.py
@@ -15,7 +15,7 @@ never logged, never part of a result. No DB, no framework imports (import-linter
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 
 @dataclass(frozen=True)
@@ -31,6 +31,25 @@ AGGREGATOR_SIDE = ("aggregator_auth", "aggregator_balance", "malformed")
 """The `failure` kinds that blame the aggregator (our key, its account, its host or envelope), never
 the route or the vendor: the call path marks the aggregator unhealthy on them, the verifier leaves
 the route as it is. `contract` is this route's fault; `pending` is nobody's yet."""
+
+VENDOR_DRY = "vendor_dry"
+"""The aggregator relayed the vendor's own out-of-credit / quota answer (a 402, Apollo's 422, a
+period-cap 429): the AGGREGATOR'S account for THIS vendor is dry. Not the route's fault and not the
+whole aggregator's: the call path marks `overflow:<aggregator>:<provider>`, the verifier leaves
+the route as it is. Set by `with_vendor_verdict`, the one place a relayed body is read."""
+
+
+def with_vendor_verdict(res: "AggregatorResult", provider: str) -> "AggregatorResult":
+    """Fold the vendor's own capacity dialect into the result, so every consumer sees one
+    `failure` instead of re-classifying the relayed body. Keeps `cost_micro`: the aggregator may
+    have charged for the relay."""
+    from ....domain.capacity import signatures  # pure; the capacity domain imports this package back
+    if res.failure is not None or res.upstream_status is None:
+        return res
+    sig = signatures.classify(provider, res.upstream_status, None, res.upstream_body[:4096])
+    if not signatures.is_exhausting(sig):
+        return res
+    return replace(res, failure=VENDOR_DRY, detail=f"{sig.kind}: {sig.detail[:100]}")
 
 
 @dataclass(frozen=True)

--- a/src/treg/infra/upstream/aggregators/__init__.py
+++ b/src/treg/infra/upstream/aggregators/__init__.py
@@ -27,6 +27,12 @@ class AggregatorRequest:
     poll_url: str | None = None  # set by parse() on an async run, not by build()
 
 
+AGGREGATOR_SIDE = ("aggregator_auth", "aggregator_balance", "malformed")
+"""The `failure` kinds that blame the aggregator (our key, its account, its host or envelope), never
+the route or the vendor: the call path marks the aggregator unhealthy on them, the verifier leaves
+the route as it is. `contract` is this route's fault; `pending` is nobody's yet."""
+
+
 @dataclass(frozen=True)
 class AggregatorResult:
     """`failure` is None when the aggregator relayed the vendor's answer (whatever its status).

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -167,7 +167,12 @@ async def _overflow_verify(args) -> int:
             print(f"{'ok ' if v.passed else 'FAIL'} {r.endpoint_id} via {r.aggregator} "
                   f"direct={v.direct_status} relay={v.relay_status} cost={v.cost_micro} {v.note}")
     print(f"verified {passed}, failed {failed}, skipped {skipped}")
-    return 1 if failed else 0
+    # A failed ROUTE is a result (its row is disabled with the reason); only a run that verified
+    # NOTHING — no keys, empty table, aggregator down — is a failed run (ops/capacity.md).
+    if passed == 0:
+        print("overflow verify: nothing verified — check aggregator keys and route table", file=sys.stderr)
+        return 1
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -151,8 +151,8 @@ async def _overflow_verify(args) -> int:
                 if body is not None:
                     hdrs["Content-Type"] = "application/json"
             v = await V.verify_route(c, r, key=key, direct=direct, test_request=tr, direct_headers=hdrs)
-            if v.note.startswith(("aggregator_auth", "aggregator_balance", "vendor_dry")):
-                key_failures.append(v.note)  # a key, an account or a vendor pool: someone must top up
+            if v.failure in ("aggregator_auth", "aggregator_balance"):
+                key_failures.append(v.note)  # OUR key or OUR prepaid balance: someone here must act
             async with session_maker() as db:
                 row = await db.get(OverflowRoute, (r.endpoint_id, r.aggregator))
                 if row is None:
@@ -160,11 +160,11 @@ async def _overflow_verify(args) -> int:
                     continue
                 verdict = V.verdict(v)
                 tally[verdict] += 1
-                if verdict == "passed" or v.note.startswith("direct dry"):
-                    # Our own key dry: the relay served, the shape cannot be checked for OUR reason;
-                    # without the stamp `overflow sync` would decay the route after 7 days -
+                if verdict == "passed" or (verdict == "inconclusive" and v.direct_dry and v.relay_ok):
+                    # Our own key dry and the relay served: the shape cannot be checked for OUR
+                    # reason; without the stamp `overflow sync` would decay the route after 7 days -
                     # exactly while our account is dry, when it is needed. Any other inconclusive
-                    # (no key, 401, a bad test_request) is not evidence and does not stamp.
+                    # (no key, 401, a stale test_request) is not evidence and does not stamp.
                     row.last_verified_at = v.verified_at or utcnow_naive()
                 elif verdict == "failed" and row.enabled:
                     row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
@@ -176,9 +176,10 @@ async def _overflow_verify(args) -> int:
     print(f"verified {tally['passed']}, failed {tally['failed']}, inconclusive {tally['inconclusive']}, "
           f"aggregator errors {tally['aggregator']}, skipped {skipped}")
     # A failed ROUTE is a result (its row is disabled with the reason). A failed RUN is one that
-    # could not verify: our key refused or the aggregator dry on any route, every attempt lost
-    # to the aggregator's side (a host down for the whole run, not one timeout), or nothing
-    # attempted at all (ops/capacity.md).
+    # could not verify: our key or our balance refused on any route, every attempt lost to the
+    # aggregator's side (a host down for the whole run, not one timeout), or nothing attempted at
+    # all (ops/capacity.md). A vendor pool dry on the aggregator's side (VENDOR_DRY) is theirs to
+    # refill: counted under aggregator errors, never a failed run on its own.
     if attempted == 0 or key_failures or tally["aggregator"] == attempted:
         print("overflow verify: run failed - check aggregator keys, balances and the route table", file=sys.stderr)
         return 1

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -160,7 +160,11 @@ async def _overflow_verify(args) -> int:
                     continue
                 verdict = V.verdict(v)
                 tally[verdict] += 1
-                if verdict == "passed":
+                if verdict == "passed" or (verdict == "inconclusive" and v.relay_status is not None
+                                           and 200 <= v.relay_status < 300):
+                    # An inconclusive relay 2xx (our own key dry, no key) still proves the route
+                    # serves; without the stamp `overflow sync` would decay it after 7 days -
+                    # exactly while our account is dry, when it is needed.
                     row.last_verified_at = v.verified_at or utcnow_naive()
                 elif verdict == "failed" and row.enabled:
                     row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -112,7 +112,8 @@ async def _overflow_verify(args) -> int:
         rows = (await db.execute(select(OverflowRoute))).scalars().all()
     todo = [r for r in rows if args.all or r.enabled or r.last_verified_at]
     keys = {"orthogonal": s.overflow_key_orthogonal, "monid": s.overflow_key_monid}
-    passed = failed = skipped = unreachable = 0
+    tally = {"passed": 0, "failed": 0, "aggregator": 0, "inconclusive": 0}
+    skipped, key_failures = 0, []
     # One SHORT transaction per route. The first prod run (2026-08-28) kept a single session open
     # across every network round-trip: each `db.get` autoflushed the previous row's UPDATE, the row
     # locks piled up for minutes, and db.py's 5 s lock_timeout — there to keep the worker from
@@ -150,31 +151,33 @@ async def _overflow_verify(args) -> int:
                 if body is not None:
                     hdrs["Content-Type"] = "application/json"
             v = await V.verify_route(c, r, key=key, direct=direct, test_request=tr, direct_headers=hdrs)
+            if v.note.startswith(("aggregator_auth", "aggregator_balance")):
+                key_failures.append(v.note)
             async with session_maker() as db:
                 row = await db.get(OverflowRoute, (r.endpoint_id, r.aggregator))
                 if row is None:
                     skipped += 1
                     continue
-                if v.passed:
+                verdict = V.verdict(v)
+                tally[verdict] += 1
+                if verdict == "passed":
                     row.last_verified_at = v.verified_at or utcnow_naive()
-                    passed += 1
-                elif V.aggregator_failed(v):
-                    # Our key or the aggregator itself, not this route: leave the row as it is.
-                    unreachable += 1
-                else:
-                    failed += 1
-                    if row.enabled:
-                        row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
+                elif verdict == "failed" and row.enabled:
+                    row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
                 row.updated_at = utcnow_naive()
                 await db.commit()
-            tag = "ok " if v.passed else "AGG " if V.aggregator_failed(v) else "FAIL"
-            print(f"{tag} {r.endpoint_id} via {r.aggregator} "
+            print(f"{verdict:<12} {r.endpoint_id} via {r.aggregator} "
                   f"direct={v.direct_status} relay={v.relay_status} cost={v.cost_micro} {v.note}")
-    print(f"verified {passed}, failed {failed}, skipped {skipped}, aggregator errors {unreachable}")
+    attempted = sum(tally.values())
+    print(f"verified {tally['passed']}, failed {tally['failed']}, inconclusive {tally['inconclusive']}, "
+          f"aggregator errors {tally['aggregator']}, skipped {skipped}")
     # A failed ROUTE is a result (its row is disabled with the reason). A failed RUN is one that
-    # could not verify: an aggregator refused our key / ran dry / was unreachable, or nothing was
+    # could not verify: our key refused or the aggregator dry on any route, every attempt lost
+    # to the aggregator's side (a host down for the whole run, not one timeout), or nothing
     # attempted at all (ops/capacity.md).
-    if unreachable or passed + failed == 0:
+    keys_or_balance = any(
+        note.startswith(("aggregator_auth", "aggregator_balance")) for note in key_failures)
+    if attempted == 0 or keys_or_balance or tally["aggregator"] == attempted:
         print("overflow verify: run failed - check aggregator keys, balances and the route table", file=sys.stderr)
         return 1
     return 0

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -112,7 +112,7 @@ async def _overflow_verify(args) -> int:
         rows = (await db.execute(select(OverflowRoute))).scalars().all()
     todo = [r for r in rows if args.all or r.enabled or r.last_verified_at]
     keys = {"orthogonal": s.overflow_key_orthogonal, "monid": s.overflow_key_monid}
-    passed = failed = skipped = 0
+    passed = failed = skipped = unreachable = 0
     # One SHORT transaction per route. The first prod run (2026-08-28) kept a single session open
     # across every network round-trip: each `db.get` autoflushed the previous row's UPDATE, the row
     # locks piled up for minutes, and db.py's 5 s lock_timeout — there to keep the worker from
@@ -158,19 +158,24 @@ async def _overflow_verify(args) -> int:
                 if v.passed:
                     row.last_verified_at = v.verified_at or utcnow_naive()
                     passed += 1
+                elif V.aggregator_failed(v):
+                    # Our key or the aggregator itself, not this route: leave the row as it is.
+                    unreachable += 1
                 else:
                     failed += 1
                     if row.enabled:
                         row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
                 row.updated_at = utcnow_naive()
                 await db.commit()
-            print(f"{'ok ' if v.passed else 'FAIL'} {r.endpoint_id} via {r.aggregator} "
+            tag = "ok " if v.passed else "AGG " if V.aggregator_failed(v) else "FAIL"
+            print(f"{tag} {r.endpoint_id} via {r.aggregator} "
                   f"direct={v.direct_status} relay={v.relay_status} cost={v.cost_micro} {v.note}")
-    print(f"verified {passed}, failed {failed}, skipped {skipped}")
-    # A failed ROUTE is a result (its row is disabled with the reason); only a run that verified
-    # NOTHING — no keys, empty table, aggregator down — is a failed run (ops/capacity.md).
-    if passed == 0:
-        print("overflow verify: nothing verified — check aggregator keys and route table", file=sys.stderr)
+    print(f"verified {passed}, failed {failed}, skipped {skipped}, aggregator errors {unreachable}")
+    # A failed ROUTE is a result (its row is disabled with the reason). A failed RUN is one that
+    # could not verify: an aggregator refused our key / ran dry / was unreachable, or nothing was
+    # attempted at all (ops/capacity.md).
+    if unreachable or passed + failed == 0:
+        print("overflow verify: run failed - check aggregator keys, balances and the route table", file=sys.stderr)
         return 1
     return 0
 

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -151,8 +151,8 @@ async def _overflow_verify(args) -> int:
                 if body is not None:
                     hdrs["Content-Type"] = "application/json"
             v = await V.verify_route(c, r, key=key, direct=direct, test_request=tr, direct_headers=hdrs)
-            if v.note.startswith(("aggregator_auth", "aggregator_balance")):
-                key_failures.append(v.note)
+            if v.note.startswith(("aggregator_auth", "aggregator_balance", "vendor_dry")):
+                key_failures.append(v.note)  # a key, an account or a vendor pool: someone must top up
             async with session_maker() as db:
                 row = await db.get(OverflowRoute, (r.endpoint_id, r.aggregator))
                 if row is None:
@@ -160,11 +160,11 @@ async def _overflow_verify(args) -> int:
                     continue
                 verdict = V.verdict(v)
                 tally[verdict] += 1
-                if verdict == "passed" or (verdict == "inconclusive" and v.relay_status is not None
-                                           and 200 <= v.relay_status < 300):
-                    # An inconclusive relay 2xx (our own key dry, no key) still proves the route
-                    # serves; without the stamp `overflow sync` would decay it after 7 days -
-                    # exactly while our account is dry, when it is needed.
+                if verdict == "passed" or v.note.startswith("direct dry"):
+                    # Our own key dry: the relay served, the shape cannot be checked for OUR reason;
+                    # without the stamp `overflow sync` would decay the route after 7 days -
+                    # exactly while our account is dry, when it is needed. Any other inconclusive
+                    # (no key, 401, a bad test_request) is not evidence and does not stamp.
                     row.last_verified_at = v.verified_at or utcnow_naive()
                 elif verdict == "failed" and row.enabled:
                     row.enabled, row.disabled_reason = False, f"re-verify failed: {v.note}"[:200]
@@ -179,9 +179,7 @@ async def _overflow_verify(args) -> int:
     # could not verify: our key refused or the aggregator dry on any route, every attempt lost
     # to the aggregator's side (a host down for the whole run, not one timeout), or nothing
     # attempted at all (ops/capacity.md).
-    keys_or_balance = any(
-        note.startswith(("aggregator_auth", "aggregator_balance")) for note in key_failures)
-    if attempted == 0 or keys_or_balance or tally["aggregator"] == attempted:
+    if attempted == 0 or key_failures or tally["aggregator"] == attempted:
         print("overflow verify: run failed - check aggregator keys, balances and the route table", file=sys.stderr)
         return 1
     return 0

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -540,24 +540,29 @@ async def test_aggregator_relaying_the_vendors_own_out_of_credits_dialect_is_the
     assert await _balance(clients) == before and await _holds() == []
     assert {e.kind for e in await _rows(LedgerEntry) if e.kind != "grant"} == {"reserve", "release"}
     async with session_maker() as db:
-        lock = Lock.from_json(await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal"))
+        lock = Lock.from_json(await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal:apollo"))
+        whole = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
     assert lock.is_active(), "the aggregator's own Apollo account is dry: skip it for a while"
+    assert whole is None, "for Apollo only - hunter and lusha still overflow through Orthogonal"
 
 
 async def test_a_vendors_period_quota_through_the_aggregator_is_that_vendors_answer_not_an_aggregator_outage(
         clients: AsyncClient, overflow_on, monkeypatch):
-    """Apollo's daily cap on Orthogonal's account is Apollo's 429 for THIS caller. It must not mark
-    the whole aggregator unhealthy: that would take hunter, lusha and everyone else offline too."""
+    """Apollo's daily cap on Orthogonal's Apollo account: the aggregator is dry for APOLLO. The
+    child is released and Apollo skips Orthogonal for a while; hunter, lusha and everyone else
+    keep overflowing through it."""
     await _route(endpoint_id=APOLLO_SEARCH, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH, price_micro=10_000, ratio=0.38)
     monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
     relayed = {"success": False, "error": "Upstream returned status 429",
                "data": {"error": "You have exceeded the rate limit per day"}, "priceCents": 0}
     monkeypatch.setattr(O, "_send", _orthogonal([(429, relayed)], []))
+    before = await _balance(clients)
     r = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
-    assert r.status_code == 429 and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    assert r.status_code == 503 and await _balance(clients) == before
     async with session_maker() as db:
-        raw = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
-    assert raw is None or not Lock.from_json(raw).is_active(), "one vendor's quota is not the aggregator's outage"
+        whole = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
+        mine = Lock.from_json(await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal:apollo"))
+    assert whole is None and mine.is_active(), "one vendor's quota is not the aggregator's outage"
 
 
 async def test_apollo_validation_422_is_the_callers_and_never_overflows(clients: AsyncClient, overflow_on, monkeypatch):

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -544,6 +544,12 @@ async def test_aggregator_relaying_the_vendors_own_out_of_credits_dialect_is_the
         whole = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
     assert lock.is_active(), "the aggregator's own Apollo account is dry: skip it for a while"
     assert whole is None, "for Apollo only - hunter and lusha still overflow through Orthogonal"
+    # ...and the next Apollo call honours the mark: Orthogonal is not contacted, the only route
+    # is out, so the vendor's own (unbilled) answer stands
+    again = []
+    monkeypatch.setattr(O, "_send", _orthogonal([], again))
+    r2 = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
+    assert r2.status_code == 422 and again == [] and "X-Treg-Served-Via" not in r2.headers
 
 
 async def test_a_vendors_period_quota_through_the_aggregator_is_that_vendors_answer_not_an_aggregator_outage(

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -523,6 +523,27 @@ async def test_apollo_out_of_credits_on_a_per_call_endpoint_pays_the_aggregator_
     assert kinds == sorted([("reserve", parent), ("release", parent), ("reserve", f"{parent}:overflow"), ("settle", f"{parent}:overflow")])
 
 
+async def test_aggregator_relaying_the_vendors_own_out_of_credits_dialect_is_the_aggregators_dry_account(
+        clients: AsyncClient, overflow_on, monkeypatch):
+    """Orthogonal's Apollo account can be empty too, and Apollo says so with a 422, not a 402. The
+    child is released (never billed at the aggregator's price for a request no vendor served), the
+    aggregator is marked unhealthy, and the caller gets the typed 503 - not a 422 served 'via'."""
+    await _route(endpoint_id=APOLLO_SEARCH, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH, price_micro=10_000, ratio=0.38)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
+    seen = []
+    relayed = {"success": False, "error": "Upstream returned status 422", "data": json.loads(APOLLO_OUT_OF_CREDITS),
+               "priceCents": 1.0, "requestId": "run_c"}
+    monkeypatch.setattr(O, "_send", _orthogonal([(422, relayed)], seen))
+    before = await _balance(clients)
+    r = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
+    assert r.status_code == 503 and r.json()["detail"]["error"] == "provider_capacity_unavailable", r.text
+    assert await _balance(clients) == before and await _holds() == []
+    assert {e.kind for e in await _rows(LedgerEntry) if e.kind != "grant"} == {"reserve", "release"}
+    async with session_maker() as db:
+        lock = Lock.from_json(await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal"))
+    assert lock.is_active(), "the aggregator's own Apollo account is dry: skip it for a while"
+
+
 async def test_apollo_validation_422_is_the_callers_and_never_overflows(clients: AsyncClient, overflow_on, monkeypatch):
     await _route(endpoint_id=APOLLO_EP, provider="apollo", method="POST", path=APOLLO_PATH, price_micro=10_000, ratio=0.38)
     monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_VALIDATION))

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -24,6 +24,7 @@ from treg.domain.capacity.view import view as capacity_view
 from treg.models import Hold, LedgerEntry, OverflowRoute, OverflowSpend
 from treg.timeutil import utcnow_naive
 
+from test_capacity_overflow_routes import APOLLO_OUT_OF_CREDITS, APOLLO_VALIDATION
 from test_marketplace_call import EP, EP_MICRO, EP_PATH, _balance, _fake_relay, platform_on  # noqa: F401
 
 VENDOR_BODY = {"data": {"comments": [{"id": "1", "text": "hashed"}], "cursor": 20}}
@@ -39,11 +40,12 @@ def overflow_on(monkeypatch, platform_on):
     get_settings.cache_clear()
 
 
-async def _route(aggregator="orthogonal", price_micro=3_000, enabled=True):
+async def _route(aggregator="orthogonal", price_micro=3_000, enabled=True, *, endpoint_id=EP, provider="tikhub",
+                 method="GET", path=EP_PATH, ratio=3.0):
     async with session_maker() as db:
-        db.add(OverflowRoute(endpoint_id=EP, aggregator=aggregator, provider="tikhub", method="GET", path=EP_PATH,
-                             agg_slug="tikhub", agg_path=EP_PATH, agg_price_micro=price_micro, agg_unit="call",
-                             ratio=3.0, enabled=enabled, last_verified_at=utcnow_naive()))
+        db.add(OverflowRoute(endpoint_id=endpoint_id, aggregator=aggregator, provider=provider, method=method, path=path,
+                             agg_slug=provider, agg_path=path, agg_price_micro=price_micro, agg_unit="call",
+                             ratio=ratio, enabled=enabled, last_verified_at=utcnow_naive()))
         await db.commit()
     routes_view.invalidate()
     capacity_view.invalidate()
@@ -455,3 +457,43 @@ def test_cli_org_overflow_parses(monkeypatch):
         pytest.skip("no exposed parser builder")
     args = parser.parse_args(["org", "overflow", "off"])
     assert args.state == "off" and args.fn is not None
+
+
+# --- Apollo: "out of credits" is a 422, not a 402 (ops/capacity.md, 2026-09-01) --------------
+
+APOLLO_EP = "apollo.people.enrich"           # POST /people/match, 1 credit = $0.026 per hit
+APOLLO_PATH = "/people/match"
+APOLLO_PERSON = {"person": {"id": "p1", "name": "hashed", "email": "hashed"}, "request_id": 1}
+
+
+async def test_apollo_out_of_credits_422_on_tier4_overflows_through_orthogonal(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(endpoint_id=APOLLO_EP, provider="apollo", method="POST", path=APOLLO_PATH, price_micro=10_000, ratio=0.38)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
+    seen = []
+    envelope = {"success": True, "data": APOLLO_PERSON, "priceCents": 1.0, "requestId": "run_a",
+                "billing": {"chargedPriceCents": 1.0}}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, envelope)], seen))
+    before = await _balance(clients)
+    r = await clients.post(f"/call/{APOLLO_EP}", json={"email": "hashed@example.com"})
+    assert r.status_code == 200, r.text
+    assert r.json() == APOLLO_PERSON and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    assert r.headers["X-Treg-Cost-Micro"] == "10000" and before - await _balance(clients) == 10_000
+    assert len(seen) == 1 and seen[0].json["api"] == "apollo" and seen[0].json["path"] == APOLLO_PATH
+    assert seen[0].json["body"] == {"email": "hashed@example.com"}, "the caller's own request, relayed"
+    assert await _holds() == []
+    await audit.drain()
+    mine = [x for x in (await clients.get("/calls")).json() if x["tool_name"] == APOLLO_EP]
+    assert {x.get("credential_tier") for x in mine} == {"platform", "platform-overflow"}
+    async with session_maker() as db:
+        state = LatestState.from_json(await ratestore.kv_get(db, STATE_NS, "apollo"))
+    assert state.health == "exhausted", "the 422 was read as OUR account running dry, not the caller's mistake"
+
+
+async def test_apollo_validation_422_is_the_callers_and_never_overflows(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(endpoint_id=APOLLO_EP, provider="apollo", method="POST", path=APOLLO_PATH, price_micro=10_000, ratio=0.38)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_VALIDATION))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([], seen))
+    r = await clients.post(f"/call/{APOLLO_EP}", json={})
+    assert r.status_code == 422 and r.content == APOLLO_VALIDATION and seen == [], "relayed verbatim, no aggregator contacted"
+    assert "X-Treg-Served-Via" not in r.headers

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -544,6 +544,22 @@ async def test_aggregator_relaying_the_vendors_own_out_of_credits_dialect_is_the
     assert lock.is_active(), "the aggregator's own Apollo account is dry: skip it for a while"
 
 
+async def test_a_vendors_period_quota_through_the_aggregator_is_that_vendors_answer_not_an_aggregator_outage(
+        clients: AsyncClient, overflow_on, monkeypatch):
+    """Apollo's daily cap on Orthogonal's account is Apollo's 429 for THIS caller. It must not mark
+    the whole aggregator unhealthy: that would take hunter, lusha and everyone else offline too."""
+    await _route(endpoint_id=APOLLO_SEARCH, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH, price_micro=10_000, ratio=0.38)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
+    relayed = {"success": False, "error": "Upstream returned status 429",
+               "data": {"error": "You have exceeded the rate limit per day"}, "priceCents": 0}
+    monkeypatch.setattr(O, "_send", _orthogonal([(429, relayed)], []))
+    r = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
+    assert r.status_code == 429 and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    async with session_maker() as db:
+        raw = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
+    assert raw is None or not Lock.from_json(raw).is_active(), "one vendor's quota is not the aggregator's outage"
+
+
 async def test_apollo_validation_422_is_the_callers_and_never_overflows(clients: AsyncClient, overflow_on, monkeypatch):
     await _route(endpoint_id=APOLLO_EP, provider="apollo", method="POST", path=APOLLO_PATH, price_micro=10_000, ratio=0.38)
     monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_VALIDATION))

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -490,6 +490,39 @@ async def test_apollo_out_of_credits_422_on_tier4_overflows_through_orthogonal(c
     assert lock.strikes == 1 and not lock.is_active(), "the 422 was read as OUR account running dry: a strike, not the caller's mistake"
 
 
+APOLLO_SEARCH = "apollo.companies.search"      # POST /mixed_companies/search, per_call: a 4xx is normally billable
+APOLLO_SEARCH_PATH = "/mixed_companies/search"
+
+
+async def test_apollo_out_of_credits_on_a_per_call_endpoint_is_never_billed_to_the_caller(clients: AsyncClient, platform_on, monkeypatch):
+    """`per_call` bills a 422 as the caller's input error. Not this one: the table says it is OUR
+    account, so the hold is released, and the caller pays nothing for treg's empty pool."""
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
+    before = await _balance(clients)
+    r = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
+    assert r.status_code == 422 and r.content == APOLLO_OUT_OF_CREDITS
+    assert await _balance(clients) == before and await _holds() == []
+    entries = [e for e in await _rows(LedgerEntry) if e.kind != "grant"]
+    assert sorted(e.kind for e in entries) == ["release", "reserve"]
+    assert next(e for e in entries if e.kind == "release").meta.get("reason") == "capacity_balance"
+
+
+async def test_apollo_out_of_credits_on_a_per_call_endpoint_pays_the_aggregator_once(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(endpoint_id=APOLLO_SEARCH, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH, price_micro=10_000, ratio=0.38)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_OUT_OF_CREDITS))
+    seen = []
+    envelope = {"success": True, "data": {"organizations": [{"id": "o1"}]}, "priceCents": 1.0, "requestId": "run_b",
+                "billing": {"chargedPriceCents": 1.0}}
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, envelope)], seen))
+    before = await _balance(clients)
+    r = await clients.post(f"/call/{APOLLO_SEARCH}", json={"q_organization_name": "x"})
+    assert r.status_code == 200 and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    assert before - await _balance(clients) == 10_000, "the aggregator's price once; the parent 422 was released, not settled"
+    parent = r.headers["X-Treg-Call-Id"]
+    kinds = sorted((e.kind, e.call_id or "") for e in await _rows(LedgerEntry) if e.kind != "grant")
+    assert kinds == sorted([("reserve", parent), ("release", parent), ("reserve", f"{parent}:overflow"), ("settle", f"{parent}:overflow")])
+
+
 async def test_apollo_validation_422_is_the_callers_and_never_overflows(clients: AsyncClient, overflow_on, monkeypatch):
     await _route(endpoint_id=APOLLO_EP, provider="apollo", method="POST", path=APOLLO_PATH, price_micro=10_000, ratio=0.38)
     monkeypatch.setattr(call_service, "relay", _fake_relay(422, APOLLO_VALIDATION))

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -195,6 +195,17 @@ def test_apollo_says_out_of_credits_with_a_422():
     assert S.classify("hunter", 422, None, APOLLO_OUT_OF_CREDITS).kind == "unrecorded"
 
 
+def test_every_recorded_phrase_arms_the_tripwire():
+    """Recording one vendor's wording must arm the tripwire for every other: each literal body
+    phrase in `_TABLE` (the 429 rows carry period words, not capacity phrases) is in CAPACITY_PHRASES."""
+    import re as _re
+    for provider, status, pattern, kind in S._TABLE:
+        if not pattern or status == 429 or _re.escape(pattern) != pattern:
+            continue  # empty (the bare 402 row), a period word, or a regex we cannot use as a body
+        sig = S.classify("someone-else", 400, None, pattern.encode())
+        assert sig is not None and sig.kind == "unrecorded", f"{provider}'s phrase {pattern!r} does not arm the tripwire"
+
+
 def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
     """The next Apollo: a 4xx no row matched whose body still names credits/quota/balance. It is
     logged and counted (`capacity_signal=unrecorded`) and does nothing else."""
@@ -385,29 +396,24 @@ def test_verdict_disables_only_a_route_that_is_actually_wrong():
     """The verifier must never switch off the routes that exist to cover OUR key running dry, nor
     every route behind an aggregator that is having a bad morning."""
     assert V.verdict(_verification()) == "passed"
-    # our own account dry (the 2026-09-01 state), or no vendor key at all: nothing to compare with
-    assert V.verdict(_verification(direct_status=422, same_shape=None, verified_at=None,
-                                   note="direct dry, relay 200, no comparison")) == "inconclusive"
-    assert V.verdict(_verification(direct_status=401, same_shape=None, verified_at=None,
-                                   note="direct 401, relay 200, no comparison")) == "inconclusive"
-    assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
-                                   note="relay ok, direct not attempted")) == "inconclusive"
-    assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
-                                   note="direct unreachable: ConnectTimeout: x")) == "inconclusive"
-    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None,
-                                   note="pending: RUNNING")) == "inconclusive"
-    # the aggregator's side: key, account, host, envelope
-    for note in ("aggregator_auth: key rejected", "aggregator_balance: empty", "malformed: orthogonal: not JSON",
-                 "relay unreachable: ReadTimeout: x", "vendor_dry: quota: per day"):
+    # nothing to compare with: our own account dry (the 2026-09-01 state), a 401, no vendor key,
+    # the vendor host down, a stale test_request that fails both legs, an async run still pending
+    assert V.verdict(_verification(direct_status=422, same_shape=None, verified_at=None, direct_dry=True)) == "inconclusive"
+    assert V.verdict(_verification(direct_status=401, same_shape=None, verified_at=None)) == "inconclusive"
+    assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None)) == "inconclusive"
+    assert V.verdict(_verification(direct_status=None, relay_status=400, same_shape=None, verified_at=None)) == "inconclusive"
+    assert V.verdict(_verification(direct_status=401, relay_status=400, same_shape=None, verified_at=None)) == "inconclusive"
+    assert V.verdict(_verification(direct_status=422, relay_status=404, same_shape=None, verified_at=None, direct_dry=True)) == "inconclusive"
+    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None, failure="pending")) == "inconclusive"
+    # the aggregator's side: key, account, host, envelope, its vendor pool
+    for failure in ("aggregator_auth", "aggregator_balance", "malformed", "unreachable", "vendor_dry"):
         assert V.verdict(_verification(direct_status=None, relay_status=None, same_shape=None, verified_at=None,
-                                       note=note)) == "aggregator", note
-    # this route is wrong
-    assert V.verdict(_verification(same_shape=False, verified_at=None,
-                                   note="direct 200, relay 200, shape differs")) == "failed"
-    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None,
-                                   note="contract: Required parameters are missing")) == "failed"
-    assert V.verdict(_verification(relay_status=500, same_shape=None, verified_at=None,
-                                   note="direct 200, relay 500, shape differs")) == "failed"
+                                       failure=failure)) == "aggregator", failure
+    # this route is shown wrong: the direct leg proves the request, the relay does not match it
+    assert V.verdict(_verification(same_shape=False, verified_at=None)) == "failed"
+    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None, failure="contract")) == "failed"
+    assert V.verdict(_verification(relay_status=500, same_shape=None, verified_at=None)) == "failed"
+    assert V.verdict(_verification(relay_status=404, same_shape=None, verified_at=None)) == "failed"
 
 
 async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure():
@@ -424,7 +430,7 @@ async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure()
         v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
                                  test_request={"body": {"email": "x@y.z"}}, direct_headers={})
     assert not v.passed and v.direct_status == 422 and v.relay_status == 200
-    assert v.note.startswith("direct dry"), "our account, in Apollo's dialect - the worker still stamps this"
+    assert v.direct_dry and v.relay_ok, "our account, in Apollo's dialect - the worker still stamps this"
     assert V.verdict(v) == "inconclusive", "the route still works; it is our account that is dry"
 
 
@@ -442,7 +448,7 @@ async def test_verify_route_reads_a_relayed_out_of_credits_answer_as_the_aggrega
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
         v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
                                  test_request={"body": {"email": "x@y.z"}}, direct_headers={})
-    assert v.relay_status == 422 and v.note.startswith("vendor_dry: balance")
+    assert v.relay_status == 422 and v.failure == "vendor_dry" and v.note.startswith("vendor_dry: balance")
     assert V.verdict(v) == "aggregator", "Orthogonal's Apollo account is empty; the route is not wrong"
 
 

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -207,6 +207,9 @@ def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
     assert S.classify("exa", 400, None, b"unbalanced quotes in query") is None
     assert S.classify("tikhub", 400, None, b"unterminated quotation mark") is None
     assert S.classify("twelvedata", 400, None, b"/balance_sheet: symbol parameter is missing") is None
+    assert S.classify("tikhub", 400, None, b'{"error":"field balance is required"}') is None
+    assert S.classify("tikhub", 400, None, b"quota must be an integer") is None
+    assert S.classify("someone", 403, None, b"Your API quota limit was reached").kind == "unrecorded"
     # a rowless vendor saying it with a 429 and no retry-after trips the same wire, not `unknown`
     sig = S.classify("serpstat", 429, None, b'{"error":"Your monthly quota has been exhausted"}')
     assert sig.kind == "unrecorded" and sig.detail == "quota has been exhausted"
@@ -362,6 +365,55 @@ def test_shape_empty_vs_nonempty_list_differs_but_both_empty_match():
     assert V.shapes_match(no_jobs, both_empty) is True, "both-empty lists must have same shape"
     assert V.shape({"jobs": []}) == {"jobs": []}
     assert V.shape({"jobs": [{"id": "x"}]}) == {"jobs": [{"id": "leaf"}]}
+
+
+def _verification(**kw) -> V.Verification:
+    base = dict(endpoint_id="e", aggregator="orthogonal", direct_status=200, relay_status=200, same_shape=True,
+                cost_micro=1, verified_at=utcnow_naive(), note="")
+    return V.Verification(**{**base, **kw})
+
+
+def test_verdict_disables_only_a_route_that_is_actually_wrong():
+    """The verifier must never switch off the routes that exist to cover OUR key running dry, nor
+    every route behind an aggregator that is having a bad morning."""
+    assert V.verdict(_verification()) == "passed"
+    # our own account dry (the 2026-09-01 state), or no vendor key at all: nothing to compare with
+    assert V.verdict(_verification(direct_status=422, same_shape=None, verified_at=None,
+                                   note="direct 422, relay 200, shape differs")) == "inconclusive"
+    assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
+                                   note="relay ok, direct not attempted")) == "inconclusive"
+    assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
+                                   note="direct unreachable: ConnectTimeout: x")) == "inconclusive"
+    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None,
+                                   note="pending: RUNNING")) == "inconclusive"
+    # the aggregator's side: key, account, host, envelope
+    for note in ("aggregator_auth: key rejected", "aggregator_balance: empty", "malformed: orthogonal: not JSON",
+                 "relay unreachable: ReadTimeout: x"):
+        assert V.verdict(_verification(direct_status=None, relay_status=None, same_shape=None, verified_at=None,
+                                       note=note)) == "aggregator", note
+    # this route is wrong
+    assert V.verdict(_verification(same_shape=False, verified_at=None,
+                                   note="direct 200, relay 200, shape differs")) == "failed"
+    assert V.verdict(_verification(relay_status=None, same_shape=None, verified_at=None,
+                                   note="contract: Required parameters are missing")) == "failed"
+    assert V.verdict(_verification(relay_status=500, same_shape=None, verified_at=None,
+                                   note="direct 200, relay 500, shape differs")) == "failed"
+
+
+async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure():
+    import httpx
+    r = _route(aggregator="orthogonal", agg_slug="apollo", agg_path="/people/match", method="POST", path="/people/match")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "api.orthogonal.dev" or "/run" in request.url.path:
+            return httpx.Response(200, json={"success": True, "data": {"person": {"id": "p"}}, "priceCents": 1.0})
+        return httpx.Response(422, json={"error": "Insufficient credits. Please upgrade your plan."})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
+        v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
+                                 test_request={"body": {"email": "x@y.z"}}, direct_headers={})
+    assert not v.passed and v.direct_status == 422 and v.relay_status == 200
+    assert V.verdict(v) == "inconclusive", "the route still works; it is our account that is dry"
 
 
 async def test_verify_route_marks_same_shape_and_polls_async_runs():

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -180,6 +180,55 @@ def test_signature_table_classifies_balance_quota_and_burst():
     assert S.is_exhausting(S.classify("findymail", 402, {}, b"x")) and not S.is_exhausting(None)
 
 
+# Apollo API reference, "422 Unprocessable Entity": the body an empty credit pool gets (live 2026-09-01).
+APOLLO_OUT_OF_CREDITS = b'{"error": "Insufficient credits. Please upgrade your plan."}'
+# The SAME status for a caller's mistake — must never read as our account running dry.
+APOLLO_VALIDATION = b'{"error": "Please provide at least one of: first_name, last_name, email"}'
+
+
+def test_apollo_says_out_of_credits_with_a_422():
+    sig = S.classify("apollo", 422, None, APOLLO_OUT_OF_CREDITS)
+    assert sig.kind == "balance" and S.is_exhausting(sig) and sig.resets_at is None
+    assert S.classify("apollo", 422, None, APOLLO_VALIDATION) is None
+    # Rows are per provider: a 422 is a validation status almost everywhere else.
+    assert S.classify("hunter", 422, None, APOLLO_OUT_OF_CREDITS).kind == "unrecorded"
+
+
+def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
+    """The next Apollo: a 4xx no row matched whose body still names credits/quota/balance. It is
+    logged and counted (`capacity_signal=unrecorded`) and does nothing else."""
+    sig = S.classify("someone", 403, None, b'{"message":"Your quota has been exceeded"}')
+    assert sig.kind == "unrecorded" and sig.detail == "quota" and not S.is_exhausting(sig)
+    # a phrase recorded for ONE vendor arms the tripwire for every other
+    assert S.classify("someone", 400, None, b"Not enough credits").kind == "unrecorded"
+    assert S.classify("someone", 422, None, b'{"error":"insufficient parameters: first_name"}') is None
+    assert S.classify("someone", 401, None, b'{"error":"insufficient credits"}') is None, "401 is the key"
+    assert S.classify("someone", 404, None, b'{"error":"no balance found for id"}') is None
+    assert S.classify("someone", 500, None, b'{"error":"balance service down"}') is None
+
+
+# Platform providers whose out-of-credit answer nobody has recorded in `_TABLE` yet. An acknowledged
+# gap, not a claim the vendor never runs dry: their 4xx trips `unrecorded` instead.
+_UNRECORDED_SIGNATURE = {
+    "apify", "aviato", "branddev", "brightdata", "coingecko", "coresignal", "crustdata", "dataforseo",
+    "diffbot", "exa", "fiber_ai", "finnhub", "icypeas", "influencersclub", "justoneapi", "marketstack",
+    "moz", "oceanio", "pdl", "scrapecreators", "seranking", "serpapi", "serpstat", "spyfu", "tiingo",
+    "tikhub", "tomba", "twelvedata",
+}
+
+
+def test_every_platform_provider_has_a_recorded_or_acknowledged_signature():
+    """The guard. A provider gains a `platform_key_*` slot → record how it says "out of credits"
+    (a row in `_TABLE`) or add it above knowingly. Silence is how Apollo's 422 went unseen."""
+    from treg.domain.capacity.collectors import all_platform_providers
+    slots = set(all_platform_providers())
+    recorded = {p for p, *_ in S._TABLE if p != "*"}
+    missing = slots - recorded - _UNRECORDED_SIGNATURE
+    assert not missing, f"record how these say 'out of credits' or acknowledge them: {sorted(missing)}"
+    stale = (_UNRECORDED_SIGNATURE & recorded) | (_UNRECORDED_SIGNATURE - slots)
+    assert not stale, f"acknowledged providers that are now recorded or gone: {sorted(stale)}"
+
+
 _CF_PAGE = (b"<!DOCTYPE html><html><head><title>Access denied | api.example.com used Cloudflare "
             b"to restrict access</title></head><body>Error 1010</body></html>")
 

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -223,7 +223,7 @@ def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
 # gap, not a claim the vendor never runs dry: their 4xx trips `unrecorded` instead.
 _UNRECORDED_SIGNATURE = {
     "apify", "aviato", "branddev", "brightdata", "coingecko", "coresignal", "crustdata", "dataforseo",
-    "diffbot", "exa", "fiber_ai", "finnhub", "icypeas", "influencersclub", "justoneapi", "marketstack",
+    "diffbot", "exa", "fiber-ai", "finnhub", "icypeas", "influencersclub", "justoneapi", "marketstack",
     "moz", "oceanio", "pdl", "scrapecreators", "seranking", "serpapi", "serpstat", "spyfu", "tiingo",
     "tikhub", "tomba", "twelvedata",
 }
@@ -232,8 +232,15 @@ _UNRECORDED_SIGNATURE = {
 def test_every_platform_provider_has_a_recorded_or_acknowledged_signature():
     """The guard. A provider gains a `platform_key_*` slot → record how it says "out of credits"
     (a row in `_TABLE`) or add it above knowingly. Silence is how Apollo's 422 went unseen."""
+    from treg.config import platform_setting_name
     from treg.domain.capacity.collectors import all_platform_providers
-    slots = set(all_platform_providers())
+    from treg.domain.catalog import store as catalog_store
+    # Slot spelling is not provider spelling (`fiber_ai` vs `fiber-ai`); rows match `mk.provider`,
+    # the catalog id, so the guard must speak that or a row written to satisfy it never fires.
+    settings = {"platform_key_" + s for s in all_platform_providers()}
+    catalog_ids = {e["provider"] for e in catalog_store.load().endpoints}
+    slots = {p for p in catalog_ids if platform_setting_name(p) in settings}
+    assert len(slots) == len(settings), f"a key slot with no catalog provider: {sorted(settings - {platform_setting_name(p) for p in slots})}"
     recorded = {p for p, *_ in S._TABLE if p != "*"}
     missing = slots - recorded - _UNRECORDED_SIGNATURE
     assert not missing, f"record how these say 'out of credits' or acknowledge them: {sorted(missing)}"
@@ -414,6 +421,24 @@ async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure()
                                  test_request={"body": {"email": "x@y.z"}}, direct_headers={})
     assert not v.passed and v.direct_status == 422 and v.relay_status == 200
     assert V.verdict(v) == "inconclusive", "the route still works; it is our account that is dry"
+
+
+async def test_verify_route_reads_a_relayed_out_of_credits_answer_as_the_aggregators_dry_account():
+    import httpx
+    r = _route(aggregator="orthogonal", agg_slug="apollo", agg_path="/people/match", method="POST", path="/people/match",
+               provider="apollo")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/run" in request.url.path:  # Orthogonal relays Apollo's 422 with its body
+            return httpx.Response(422, json={"success": False, "error": "Upstream returned status 422",
+                                             "data": {"error": "Insufficient credits. Please upgrade your plan."}, "priceCents": 1.0})
+        return httpx.Response(200, json={"person": {"id": "p"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
+        v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
+                                 test_request={"body": {"email": "x@y.z"}}, direct_headers={})
+    assert v.relay_status == 422 and v.note.startswith("aggregator dry")
+    assert V.verdict(v) == "aggregator", "Orthogonal's Apollo account is empty; the route is not wrong"
 
 
 async def test_verify_route_marks_same_shape_and_polls_async_runs():

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -182,7 +182,7 @@ def test_signature_table_classifies_balance_quota_and_burst():
 
 # Apollo API reference, "422 Unprocessable Entity": the body an empty credit pool gets (live 2026-09-01).
 APOLLO_OUT_OF_CREDITS = b'{"error": "Insufficient credits. Please upgrade your plan."}'
-# The SAME status for a caller's mistake — must never read as our account running dry.
+# The SAME status for a caller's mistake - must never read as our account running dry.
 APOLLO_VALIDATION = b'{"error": "Please provide at least one of: first_name, last_name, email"}'
 
 
@@ -198,10 +198,19 @@ def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
     """The next Apollo: a 4xx no row matched whose body still names credits/quota/balance. It is
     logged and counted (`capacity_signal=unrecorded`) and does nothing else."""
     sig = S.classify("someone", 403, None, b'{"message":"Your quota has been exceeded"}')
-    assert sig.kind == "unrecorded" and sig.detail == "quota" and not S.is_exhausting(sig)
+    assert sig.kind == "unrecorded" and sig.detail == "quota has been exceeded" and not S.is_exhausting(sig)
     # a phrase recorded for ONE vendor arms the tripwire for every other
     assert S.classify("someone", 400, None, b"Not enough credits").kind == "unrecorded"
     assert S.classify("someone", 422, None, b'{"error":"insufficient parameters: first_name"}') is None
+    # echoes of a caller's own request: period words, path names, half-words
+    assert S.classify("coingecko", 400, None, b'{"error":"invalid interval: daily"}') is None
+    assert S.classify("exa", 400, None, b"unbalanced quotes in query") is None
+    assert S.classify("tikhub", 400, None, b"unterminated quotation mark") is None
+    assert S.classify("twelvedata", 400, None, b"/balance_sheet: symbol parameter is missing") is None
+    # a rowless vendor saying it with a 429 and no retry-after trips the same wire, not `unknown`
+    sig = S.classify("serpstat", 429, None, b'{"error":"Your monthly quota has been exhausted"}')
+    assert sig.kind == "unrecorded" and sig.detail == "quota has been exhausted"
+    assert S.classify("scrapecreators", 429, None, b"slow down").kind == "unknown"
     assert S.classify("someone", 401, None, b'{"error":"insufficient credits"}') is None, "401 is the key"
     assert S.classify("someone", 404, None, b'{"error":"no balance found for id"}') is None
     assert S.classify("someone", 500, None, b'{"error":"balance service down"}') is None

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -160,6 +160,7 @@ def test_route_for_orders_orthogonal_first():
 def test_signature_table_classifies_balance_quota_and_burst():
     assert S.classify("findymail", 402, {}, b'{"message":"Not enough credits"}').kind == "balance"
     assert S.classify("thecompaniesapi", 403, {}, b'{"code":"noCreditsRemaining"}').kind == "balance"
+    assert S.classify("thecompaniesapi", 403, {}, b'{"code":"nocreditsremaining"}').kind == "balance", "rows match any case"
     assert S.classify("lusha", 400, {}, b"You have reached your credit limit").kind == "balance"
     assert S.classify("anyone", 402, {}, b"").kind == "balance"
     now = utcnow_naive().replace(hour=10)
@@ -386,7 +387,9 @@ def test_verdict_disables_only_a_route_that_is_actually_wrong():
     assert V.verdict(_verification()) == "passed"
     # our own account dry (the 2026-09-01 state), or no vendor key at all: nothing to compare with
     assert V.verdict(_verification(direct_status=422, same_shape=None, verified_at=None,
-                                   note="direct 422, relay 200, shape differs")) == "inconclusive"
+                                   note="direct dry, relay 200, no comparison")) == "inconclusive"
+    assert V.verdict(_verification(direct_status=401, same_shape=None, verified_at=None,
+                                   note="direct 401, relay 200, no comparison")) == "inconclusive"
     assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
                                    note="relay ok, direct not attempted")) == "inconclusive"
     assert V.verdict(_verification(direct_status=None, same_shape=None, verified_at=None,
@@ -395,7 +398,7 @@ def test_verdict_disables_only_a_route_that_is_actually_wrong():
                                    note="pending: RUNNING")) == "inconclusive"
     # the aggregator's side: key, account, host, envelope
     for note in ("aggregator_auth: key rejected", "aggregator_balance: empty", "malformed: orthogonal: not JSON",
-                 "relay unreachable: ReadTimeout: x"):
+                 "relay unreachable: ReadTimeout: x", "vendor_dry: quota: per day"):
         assert V.verdict(_verification(direct_status=None, relay_status=None, same_shape=None, verified_at=None,
                                        note=note)) == "aggregator", note
     # this route is wrong
@@ -409,7 +412,8 @@ def test_verdict_disables_only_a_route_that_is_actually_wrong():
 
 async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure():
     import httpx
-    r = _route(aggregator="orthogonal", agg_slug="apollo", agg_path="/people/match", method="POST", path="/people/match")
+    r = _route(aggregator="orthogonal", agg_slug="apollo", agg_path="/people/match", method="POST", path="/people/match",
+               provider="apollo")
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.host == "api.orthogonal.dev" or "/run" in request.url.path:
@@ -420,6 +424,7 @@ async def test_verify_route_with_our_own_key_dry_is_inconclusive_not_a_failure()
         v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
                                  test_request={"body": {"email": "x@y.z"}}, direct_headers={})
     assert not v.passed and v.direct_status == 422 and v.relay_status == 200
+    assert v.note.startswith("direct dry"), "our account, in Apollo's dialect - the worker still stamps this"
     assert V.verdict(v) == "inconclusive", "the route still works; it is our account that is dry"
 
 
@@ -437,7 +442,7 @@ async def test_verify_route_reads_a_relayed_out_of_credits_answer_as_the_aggrega
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as c:
         v = await V.verify_route(c, r, key="K", direct=("https://api.apollo.io/api/v1/people/match", {}, b"{}"),
                                  test_request={"body": {"email": "x@y.z"}}, direct_headers={})
-    assert v.relay_status == 422 and v.note.startswith("aggregator dry")
+    assert v.relay_status == 422 and v.note.startswith("vendor_dry: balance")
     assert V.verdict(v) == "aggregator", "Orthogonal's Apollo account is empty; the route is not wrong"
 
 

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -47,6 +47,7 @@ PLATFORM_KEYS = {  # never a real key: a test that leaked one into an assertion 
     "SCRAPECREATORS": "PLATFORM-SC-KEY",
     "DATAFORSEO": "PLATFORM-DFS-KEY",
     "BRIGHTDATA": "PLATFORM-BD-KEY",
+    "APOLLO": "PLATFORM-APOLLO-KEY",
 }
 
 
@@ -55,7 +56,7 @@ def platform_on(monkeypatch):
     """Turn tier 4 on the way a deploy does: keys in the environment AND the provider allow-listed."""
     for name, value in PLATFORM_KEYS.items():
         monkeypatch.setenv(f"TREG_PLATFORM_KEY_{name}", value)
-    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub,scrapecreators,dataforseo,brightdata")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub,scrapecreators,dataforseo,brightdata,apollo")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -56,7 +56,7 @@ def platform_on(monkeypatch):
     """Turn tier 4 on the way a deploy does: keys in the environment AND the provider allow-listed."""
     for name, value in PLATFORM_KEYS.items():
         monkeypatch.setenv(f"TREG_PLATFORM_KEY_{name}", value)
-    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "tikhub,scrapecreators,dataforseo,brightdata,apollo")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", ",".join(k.lower() for k in PLATFORM_KEYS))
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()


### PR DESCRIPTION
## Why

Apollo answers an empty credit pool with **HTTP 422** `{"error": "Insufficient credits. Please upgrade your plan."}`, not a 402. From 2026-09-01 20:16Z to 09-02 07:50Z every `apollo.people.enrich` call on treg's key got that 422 (~600 across all clients, `people.search` stayed 200) with `TREG_OVERFLOW_MODE=on`, both aggregator keys set and routes enabled — and not one overflow attempt. The signature table had no row for it, so nothing marked the account exhausted and nothing triggered the child cycle.

A second gap sat behind the first: `apollo.people.enrich` had never been verified, and the weekly `treg-overflow-verify` cron (dashboard-made) had never reported a successful run and could not — the worker exited 1 whenever any route failed.

## What

- **signatures**: Apollo 422 row, phrase-matched. A validation 422 stays the caller's.
- **signatures**: `unrecorded` is a new signal kind returned by `classify`: a 4xx no row matched whose body still names credits/quota/balance (pattern = the union of every phrase the table already knows for any vendor, plus the generic nouns). Marks, refuses and overflows nothing; the call path logs the matched phrase (never the body) and it rides `tool_called` as `capacity_signal=unrecorded` — the tripwire for the next unrecorded vendor, queryable in PostHog.
- **tests**: coverage guard — a provider with a `platform_key_*` slot must have a table row or sit in the test's acknowledged-gap set (28 today), so the Apollo silence cannot repeat unnoticed.
- **settle (money)**: a platform-tier 4xx the signature table reads as OUR account running dry is released, never settled, whatever the cost type. Before: Apollo's 422 on a `per_call` endpoint was billed to the caller as an input error, and once overflow served it, billed again at the aggregator. Release reason `capacity_<kind>`; two tests pin it (overflow off: caller pays nothing; overflow on: the aggregator's price exactly once).
- **overflow**: a relayed vendor answer the table reads as dry (balance kind only: one vendor's period quota through the aggregator is that vendor's 429 for this caller, never an outage for every provider behind the aggregator) (Apollo's 422 through Orthogonal's own dry Apollo account) is the aggregator's failure - child released, aggregator marked unhealthy, typed 503 - never a 422 served "via" at the aggregator's price. `AGGREGATOR_SIDE` is the one list of aggregator-blamed failure kinds, shared with the verifier.
- **verify**: `Verification` carries typed `failure` and `direct_dry`; `verdict` is pure over them. A route is `failed` only when the direct leg proved the request (direct 2xx beside a relay non-2xx or a different shape) or on a contract refusal; `vendor_dry`, an aggregator-side failure or an unreachable host is `aggregator` (route untouched); anything without a direct 2xx to compare against is `inconclusive` (untouched). The one inconclusive that still stamps is our own account dry *with* a relay 2xx, so the next sync cannot decay a working route while our account is dry. A relay 2xx with nothing sound to compare against (no vendor key, direct call unreachable or non-2xx - our own account dry, exactly what the routes exist for - or a pending async run) is `inconclusive` and leaves the row untouched; an aggregator-side failure leaves it untouched too; only a route that is actually wrong is disabled.
- **worker**: `overflow verify` exits 0 after completing (a failed route is a disabled row with its reason, not a failed run) and 1 for a failed run: OUR key or OUR balance refused on any route, every attempt lost to the aggregator's side, or nothing attempted (one timeout does not trip it; a vendor pool dry on the aggregator's side is theirs to refill and only counts under "aggregator errors").
- **tests**: Apollo out-of-credits 422 on tier 4 overflows through Orthogonal end to end (real call path, real endpoint, ledger parent+child, exhausted mark); a validation 422 is relayed verbatim and never contacts an aggregator.
- **docs**: `ops/capacity.md` (verify must be followed by sync; how to run both by hand), `ops/deploy.md` (**`render.yaml` is not applied** — no Blueprint is registered for this repo, the live env has drifted from it; do not register one before reconciling), `architecture/proxy-model.md`.

Deliberately **not** in this PR after review: a `render.yaml` cron block (the file is not applied, and a copied block would have lacked `TREG_PLATFORM_KEY_APOLLO`); a verify-then-sync schedule (run by hand for the next few weeks — the dashboard cron's command was switched to `overflow verify --all` on 2026-09-02).

## Operational context

Run by hand on 2026-09-02 before this PR: `overflow verify --all` (461 rows: verified 192, failed 145, skipped 134) then `overflow sync` (87 enabled, Apollo `people.enrich` / `people.search` / `companies.enrich` / `companies.search` via Orthogonal among them).

## Rollout

After merge, run `overflow verify --all` then `overflow sync` by hand and read the new summary line (`verified / failed / inconclusive / aggregator errors / skipped`) against the last run (192 / 145 / 134, 87 enabled). The verdict logic has only run under tests so far. Then watch `capacity_signal=unrecorded` in PostHog for a day.

## Review

`/code-review` on the seventh revision: the our-account-dry stamp also stamped a relay 404 (a note-prefix check short-circuited the failed branch); a relay non-2xx with no direct comparison disabled a route; `vendor_dry` failed the whole run; the outcome was carried as free text and re-derived by prefix in three places; the settle guard's platform-overflow arm was unreachable; the tripwire vocabulary was a side effect of row status codes; two doc lines were stale.

`/code-review` on the sixth revision: a relayed quota answer disabled a correct route; any inconclusive relay 2xx stamped without a comparison; a relayed balance answer locked the whole aggregator; the same relayed body was classified in three places with three predicates; table rows matched case-sensitively while the tripwire did not; two doc sentences described things as built or automatic that are not. Still deferred: classifying the primary response in three places (settle, strike, trigger).

`/code-review` on the fifth revision: the verifier read a relayed out-of-credit answer as a wrong route; an inconclusive verification never stamped, so sync decayed routes precisely while our account was dry; the relayed-dry mark took the whole aggregator offline on one vendor's daily quota; the tripwire spliced raw row regexes without grouping; the coverage guard compared slot spelling (`fiber_ai`) to rows keyed on catalog ids (`fiber-ai`). Still deferred: classifying the same response in four places.

`/code-review` on the fourth revision: the out-of-credit guard now covers the overflow child; the verifier no longer disables Apollo routes because our own Apollo key is dry, nor every route behind an aggregator that returned a malformed envelope; the tripwire's bare `balance`/`quota` no longer match; a single timeout no longer fails the run.

`/code-review` on the third revision (after merging main's #300 breaker): fixed the double-billing of a `per_call` out-of-credit 4xx (above), the tripwire's over-broad vocabulary (it inherited the 429 rows' "daily"/"monthly" and matched "quotation"/"unbalanced"; now body-phrase rows only, word-bounded), the verify run-failure rule (aggregator-level failures were disabling routes and exiting 0), a rowless vendor's quota 429 landing in `unknown` instead of `unrecorded`, stale kind lists, em dashes in added prose, and the hand-kept provider allow-list in `platform_on`. Left for a separate PR: the capability waterfall in `route.py` classifies a relayed 4xx by status alone, so an out-of-credit 422 reads as the caller's fault when overflow does not serve it.

`/simplify` (reuse / simplification / efficiency / altitude) on the second revision: the tripwire moved from a sibling function only `settle` called into `classify` itself as the `unrecorded` kind (so all three classify call sites see it and it reaches the audit funnel); its vocabulary is now derived from the table instead of hand-copied; the acknowledged-gap set moved out of domain code into the test that asserts on it; the Apollo signature tests joined the existing signature section; the Apollo E2E tests reuse `_route`/`platform_on` instead of cloning them; dead exit-code condition and repeated incident narrative removed.

Codex reviewed the first revision; addressed: missing Apollo key in the copied cron block and the missing sync step (both by dropping the blueprint cron and documenting the by-hand routine), all-zero exit code hiding a systemic failure, bare `insufficient` in the tripwire, raw body in the log, `_secret` suffix heuristic in the guard. Not changed: the Apollo row stays a phrase match (a JSON-field anchor was judged more machinery than the risk warrants; no evidence Apollo emits a caller-caused 422 with that phrase).

## Verification

- `uv run --frozen python -m pytest -q`: 2457 passed (the one failure, `test_postgres_reset`, is gated on `TREG_TEST_DB_URL` and ran only because the suite was pointed at a private sqlite file to avoid a concurrent run)
- `drift.sh origin/main..HEAD`: flagged fragments reviewed and updated
