### PR TITLE
feat(retention): add retention purge for CallRecord/RunRecord/SearchMiss

### DIFF
--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -322,6 +322,23 @@ handler on root and directly on `uvicorn.error` (Uvicorn's default parent does n
 then removes it after shutdown drain. `bootstrap_handlers._pool_saturated` calls `capture_fault` directly
 because its typed 503 is handled before Uvicorn would log it.
 
+## Retention purge (`domain/retention.py`)
+
+`CallRecord`, `RunRecord`, and `SearchMiss` grow unbounded. Evidence columns (`error_request`,
+`error_response`) already expire after 14 days via `admin._purge_expired_error_evidence`, but that
+only overwrites with `<expired>` — the rows themselves stay, and TOAST-sized JSON doesn't reclaim
+space until the row is deleted.
+
+`treg-worker retention purge [--days 90] [--batch 5000] [--no-vacuum] [--dry-run]` deletes rows
+older than the retention window (default 90 days) in batches of 5,000 to avoid long ACCESS EXCLUSIVE
+locks on hot tables. After deletes, `VACUUM ANALYZE` runs per table so Postgres can reuse the dead
+tuple space (not return it to the OS — that requires `VACUUM FULL`, which locks exclusively and
+never runs from this worker).
+
+**Never purged:** `Org`, `User`, `Membership`, `Secret`, `Tool`, `Bundle`, `CreditBlock`,
+`LedgerEntry`, `Hold`, `TagSpend`, `TagBudget`, `CapabilityPin`, `DenyRule`, `AdConversion`, or
+anything in `domain/money`. The worker's `PURGEABLE_TABLES` constant is the closed allow-list.
+
 > **Tenancy:** every resource noun carries `org_id`; access is scoped to the caller's org. Details:
 > [multi-tenancy](multi-tenancy.md).
 

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -341,12 +341,26 @@ base. Verified on the dev server before merge: reserve $0.007 → settle $0.009 
 ## Worker commands and the capacity cron (2026-08-28)
 
 `treg-worker` (console script, `[server]` extra) hosts the scheduled maintainer commands — today
-`capacity sweep` (see `ops/capacity.md`). `render.yaml` runs it as the cron service
-`treg-capacity-sweep` every hour, with the DB URL, Fernet key and every `TREG_PLATFORM_KEY_*` pulled
-from the web service via `fromService` — so a new platform key is added in ONE place. Aggregator keys
-(`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same
-way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
-govern the overflow child cycle (`ops/capacity.md`); the keys serve nothing while the mode is `off`.
+`capacity sweep` (see `ops/capacity.md`) and `retention purge`. `render.yaml` runs capacity sweep as
+the cron service `treg-capacity-sweep` every hour, with the DB URL, Fernet key and every
+`TREG_PLATFORM_KEY_*` pulled from the web service via `fromService` — so a new platform key is added
+in ONE place. Aggregator keys (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the
+web service and flow the same way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and
+`TREG_OVERFLOW_DAILY_BUDGET_USD` (20) govern the overflow child cycle (`ops/capacity.md`); the keys
+serve nothing while the mode is `off`.
+
+### Retention purge
+
+`treg-worker retention purge [--days 90] [--batch 5000] [--no-vacuum] [--dry-run]` deletes
+`CallRecord`, `RunRecord`, and `SearchMiss` rows older than the retention window. See
+`architecture/data-model.md` § "Retention purge". Run it manually first to clear the backlog, then
+weekly via a Render cron (start command: `treg-worker retention purge`). Only the DB URL and Fernet
+key are required — no platform keys.
+
+**One-off prod invocation after merge:** shell into the Render web service (or create a one-off
+job) and run `treg-worker retention purge --dry-run` first to confirm the expected delete count,
+then `treg-worker retention purge` to execute. For a large backlog, batch size 5000 keeps each
+transaction short.
 
 ## A `src/treg/infra/db.py` change needs a Postgres-shaped deploy plan
 

--- a/src/treg/domain/retention.py
+++ b/src/treg/domain/retention.py
@@ -1,0 +1,165 @@
+"""Retention purge for unbounded audit tables — `treg-worker retention purge`.
+
+CallRecord and RunRecord grow without bound. Evidence columns already expire after 14 days
+(see routers/admin.py `_purge_expired_error_evidence`), but the rows themselves are never deleted,
+and TOAST-sized JSON doesn't reclaim space until the row is gone. SearchMiss is similar.
+
+This module deletes rows older than the retention window in small batches to avoid long locks on
+hot tables. After deletes, a non-blocking VACUUM marks dead space as reusable (the OS sees it free
+only after VACUUM FULL, but VACUUM FULL takes an ACCESS EXCLUSIVE lock — never in prod from this
+worker, see the PR description).
+
+NEVER touches: Org, User, Membership, Secret, Tool, Bundle, CreditBlock, LedgerEntry, Hold,
+TagSpend, TagBudget, CapabilityPin, DenyRule, AdConversion, or anything in domain/money.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import CallRecord, RunRecord, SearchMiss
+from ..timeutil import utcnow_naive
+
+RETENTION_DAYS_DEFAULT = 90
+BATCH_SIZE_DEFAULT = 5000
+
+_log = logging.getLogger("treg.retention")
+
+
+@dataclass
+class PurgeResult:
+    """What one purge pass deleted."""
+    table: str
+    deleted: int
+    cutoff: datetime
+    batches: int
+
+
+async def purge_table(
+    db: AsyncSession,
+    model: type,
+    *,
+    retention_days: int = RETENTION_DAYS_DEFAULT,
+    batch_size: int = BATCH_SIZE_DEFAULT,
+    dry_run: bool = False,
+) -> PurgeResult:
+    """Delete rows older than retention_days in batches. Returns the total deleted count.
+
+    Uses a subquery-based DELETE with LIMIT to avoid scanning the whole table per batch.
+    Each batch commits separately, so progress is durable and the table is never locked for long.
+    """
+    cutoff = utcnow_naive() - timedelta(days=retention_days)
+    table_name = model.__tablename__
+    total_deleted = 0
+    batches = 0
+
+    while True:
+        if dry_run:
+            count_q = select(func.count()).select_from(model).where(model.created_at < cutoff)
+            count = (await db.execute(count_q)).scalar() or 0
+            return PurgeResult(table=table_name, deleted=count, cutoff=cutoff, batches=0)
+
+        id_subq = (
+            select(model.id)
+            .where(model.created_at < cutoff)
+            .order_by(model.id)
+            .limit(batch_size)
+        ).subquery()
+        stmt = delete(model).where(model.id.in_(select(id_subq.c.id)))
+        result = await db.execute(stmt)
+        deleted = result.rowcount or 0
+        await db.commit()
+
+        total_deleted += deleted
+        batches += 1
+
+        if deleted == 0:
+            break
+        _log.info("purge %s: batch %d deleted %d rows (total %d)", table_name, batches, deleted, total_deleted)
+
+    return PurgeResult(table=table_name, deleted=total_deleted, cutoff=cutoff, batches=batches)
+
+
+async def vacuum_table(table_name: str, *, analyze: bool = True) -> None:
+    """Run a non-blocking VACUUM on the table. VACUUM cannot run inside a transaction, so we
+    create a fresh connection with AUTOCOMMIT. This reclaims dead tuple space for reuse (but not
+    to the OS — that requires VACUUM FULL which takes an ACCESS EXCLUSIVE lock, never here).
+    """
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from ..config import get_settings
+
+    db_url = get_settings().database_url
+    if "sqlite" in db_url:
+        _log.debug("VACUUM skipped (SQLite)")
+        return
+
+    engine = create_async_engine(db_url, isolation_level="AUTOCOMMIT")
+    try:
+        cmd = f"VACUUM ANALYZE {table_name}" if analyze else f"VACUUM {table_name}"
+        _log.info("running %s", cmd)
+        async with engine.connect() as conn:
+            await conn.execute(text(cmd))
+    finally:
+        await engine.dispose()
+
+
+@dataclass
+class RetentionPurgeResult:
+    """Summary of a full retention purge run."""
+    results: list[PurgeResult]
+    vacuumed: list[str]
+
+    @property
+    def total_deleted(self) -> int:
+        return sum(r.deleted for r in self.results)
+
+    def summary(self) -> str:
+        lines = ["Retention purge complete:"]
+        for r in self.results:
+            lines.append(f"  {r.table}: {r.deleted:,} rows deleted in {r.batches} batches (cutoff {r.cutoff.date()})")
+        if self.vacuumed:
+            lines.append(f"  VACUUM ANALYZE: {', '.join(self.vacuumed)}")
+        lines.append(f"  Total: {self.total_deleted:,} rows")
+        return "\n".join(lines)
+
+
+PURGEABLE_TABLES: tuple[type, ...] = (CallRecord, RunRecord, SearchMiss)
+
+
+async def run_retention_purge(
+    db: AsyncSession,
+    *,
+    retention_days: int = RETENTION_DAYS_DEFAULT,
+    batch_size: int = BATCH_SIZE_DEFAULT,
+    vacuum: bool = True,
+    dry_run: bool = False,
+) -> RetentionPurgeResult:
+    """Purge all audit tables and optionally VACUUM. The main entry point for the worker."""
+    results: list[PurgeResult] = []
+    vacuumed: list[str] = []
+
+    for model in PURGEABLE_TABLES:
+        result = await purge_table(
+            db, model, retention_days=retention_days, batch_size=batch_size, dry_run=dry_run
+        )
+        results.append(result)
+        _log.info(
+            "purge %s: %d rows deleted (cutoff %s, %d batches)",
+            result.table, result.deleted, result.cutoff.date(), result.batches,
+        )
+
+    if vacuum and not dry_run:
+        for model in PURGEABLE_TABLES:
+            table_name = model.__tablename__
+            try:
+                await vacuum_table(table_name, analyze=True)
+                vacuumed.append(table_name)
+            except Exception as exc:
+                _log.warning("VACUUM %s failed: %s", table_name, exc)
+
+    return RetentionPurgeResult(results=results, vacuumed=vacuumed)

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -3,6 +3,7 @@
     treg-worker capacity sweep [--only provider,...] [--json]
     treg-worker overflow sync [--live]          # seed (+ live aggregator catalogs) → overflow_route
     treg-worker overflow verify [--all] [--max-usd 0.02]   # weekly re-verify of enabled routes
+    treg-worker retention purge [--days 90] [--batch 5000] [--no-vacuum] [--dry-run]
 
 Not the light `treg` CLI: these need the server extra (DB, platform keys in the env) and make
 outbound calls to third parties, so they run as Render cron jobs with the server's env — never as
@@ -170,6 +171,26 @@ async def _overflow_verify(args) -> int:
     return 1 if failed else 0
 
 
+async def _retention_purge(args) -> int:
+    """Delete aged rows from CallRecord, RunRecord, SearchMiss. Runs VACUUM after deletes."""
+    from .infra.db import session_maker, verify_db
+    from .domain.retention import run_retention_purge, RETENTION_DAYS_DEFAULT, BATCH_SIZE_DEFAULT
+
+    await verify_db()
+    async with session_maker() as db:
+        result = await run_retention_purge(
+            db,
+            retention_days=args.days,
+            batch_size=args.batch,
+            vacuum=not args.no_vacuum,
+            dry_run=args.dry_run,
+        )
+    print(result.summary())
+    if args.dry_run:
+        print("\n(dry run — no rows were actually deleted)")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(prog="treg-worker", description=__doc__)
     sub = ap.add_subparsers(dest="group", required=True)
@@ -188,6 +209,15 @@ def main(argv: list[str] | None = None) -> int:
     ver.add_argument("--all", action="store_true", help="every row, not only enabled/previously verified")
     ver.add_argument("--max-usd", type=float, default=0.02, help="skip routes priced above this")
     ver.set_defaults(fn=_overflow_verify)
+    # retention subparser
+    ret = sub.add_parser("retention", help="audit table retention and purge")
+    retsub = ret.add_subparsers(dest="cmd", required=True)
+    purge = retsub.add_parser("purge", help="delete CallRecord/RunRecord/SearchMiss older than --days")
+    purge.add_argument("--days", type=int, default=90, help="retention window in days (default 90)")
+    purge.add_argument("--batch", type=int, default=5000, help="rows to delete per batch (default 5000)")
+    purge.add_argument("--no-vacuum", action="store_true", help="skip VACUUM ANALYZE after deletes")
+    purge.add_argument("--dry-run", action="store_true", help="report what would be deleted without deleting")
+    purge.set_defaults(fn=_retention_purge)
     args = ap.parse_args(argv)
     _need_server()
     return asyncio.run(args.fn(args))

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,281 @@
+"""Retention purge: CallRecord/RunRecord/SearchMiss aged out, money tables untouched."""
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import func, select
+
+from treg.domain.retention import (
+    BATCH_SIZE_DEFAULT,
+    PURGEABLE_TABLES,
+    RETENTION_DAYS_DEFAULT,
+    purge_table,
+    run_retention_purge,
+)
+from treg.infra.db import session_maker
+from treg.models import (
+    CallRecord,
+    CreditBlock,
+    LedgerEntry,
+    Org,
+    RunRecord,
+    SearchMiss,
+    TagSpend,
+    User,
+)
+from treg.timeutil import utcnow_naive
+
+
+@pytest.fixture
+async def seeded_db(clients):
+    """Seed the database with test rows for retention purge testing."""
+    now = utcnow_naive()
+    old = now - timedelta(days=RETENTION_DAYS_DEFAULT + 10)
+    recent = now - timedelta(days=RETENTION_DAYS_DEFAULT - 10)
+
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).limit(1))).scalar_one()
+
+        for i in range(5):
+            db.add(CallRecord(
+                org_id=org.id,
+                user_email=f"old-{i}@test.com",
+                tool_name="test.tool",
+                method="GET",
+                path="/test",
+                status_code=200,
+                created_at=old,
+            ))
+        for i in range(3):
+            db.add(CallRecord(
+                org_id=org.id,
+                user_email=f"recent-{i}@test.com",
+                tool_name="test.tool",
+                method="GET",
+                path="/test",
+                status_code=200,
+                created_at=recent,
+            ))
+
+        for i in range(4):
+            db.add(RunRecord(
+                org_id=org.id,
+                user_email=f"old-run-{i}@test.com",
+                bundle_name="test.bundle",
+                argv=[],
+                exit_code=0,
+                duration_ms=100,
+                created_at=old,
+            ))
+        for i in range(2):
+            db.add(RunRecord(
+                org_id=org.id,
+                user_email=f"recent-run-{i}@test.com",
+                bundle_name="test.bundle",
+                argv=[],
+                exit_code=0,
+                duration_ms=100,
+                created_at=recent,
+            ))
+
+        for i in range(6):
+            db.add(SearchMiss(query=f"old query {i}", source="api", created_at=old))
+        for i in range(2):
+            db.add(SearchMiss(query=f"recent query {i}", source="api", created_at=recent))
+
+        await db.commit()
+
+    return {"old_calls": 5, "recent_calls": 3, "old_runs": 4, "recent_runs": 2,
+            "old_misses": 6, "recent_misses": 2}
+
+
+async def test_purge_deletes_old_callrecords(seeded_db):
+    """CallRecord rows older than retention window are deleted."""
+    async with session_maker() as db:
+        result = await purge_table(db, CallRecord, retention_days=RETENTION_DAYS_DEFAULT)
+
+    assert result.deleted == seeded_db["old_calls"]
+    assert result.table == "callrecord"
+
+    async with session_maker() as db:
+        remaining = (await db.execute(select(func.count()).select_from(CallRecord))).scalar()
+        assert remaining == seeded_db["recent_calls"]
+
+
+async def test_purge_deletes_old_runrecords(seeded_db):
+    """RunRecord rows older than retention window are deleted."""
+    async with session_maker() as db:
+        result = await purge_table(db, RunRecord, retention_days=RETENTION_DAYS_DEFAULT)
+
+    assert result.deleted == seeded_db["old_runs"]
+    assert result.table == "runrecord"
+
+    async with session_maker() as db:
+        remaining = (await db.execute(select(func.count()).select_from(RunRecord))).scalar()
+        assert remaining == seeded_db["recent_runs"]
+
+
+async def test_purge_deletes_old_searchmiss(seeded_db):
+    """SearchMiss rows older than retention window are deleted."""
+    async with session_maker() as db:
+        result = await purge_table(db, SearchMiss, retention_days=RETENTION_DAYS_DEFAULT)
+
+    assert result.deleted == seeded_db["old_misses"]
+    assert result.table == "searchmiss"
+
+    async with session_maker() as db:
+        remaining = (await db.execute(select(func.count()).select_from(SearchMiss))).scalar()
+        assert remaining == seeded_db["recent_misses"]
+
+
+async def test_purge_respects_custom_retention_days(seeded_db):
+    """A shorter retention window deletes more rows."""
+    short_window = RETENTION_DAYS_DEFAULT - 20
+
+    async with session_maker() as db:
+        result = await purge_table(db, CallRecord, retention_days=short_window)
+
+    total_calls = seeded_db["old_calls"] + seeded_db["recent_calls"]
+    assert result.deleted == total_calls
+
+    async with session_maker() as db:
+        remaining = (await db.execute(select(func.count()).select_from(CallRecord))).scalar()
+        assert remaining == 0
+
+
+async def test_purge_dry_run_deletes_nothing(seeded_db):
+    """Dry run reports count but deletes nothing."""
+    async with session_maker() as db:
+        result = await purge_table(db, CallRecord, retention_days=RETENTION_DAYS_DEFAULT, dry_run=True)
+
+    assert result.deleted == seeded_db["old_calls"]
+    assert result.batches == 0
+
+    async with session_maker() as db:
+        remaining = (await db.execute(select(func.count()).select_from(CallRecord))).scalar()
+        assert remaining == seeded_db["old_calls"] + seeded_db["recent_calls"]
+
+
+async def test_purge_batch_size(seeded_db):
+    """Batching deletes rows in chunks."""
+    async with session_maker() as db:
+        result = await purge_table(db, CallRecord, retention_days=RETENTION_DAYS_DEFAULT, batch_size=2)
+
+    assert result.deleted == seeded_db["old_calls"]
+    assert result.batches >= 3
+
+
+async def test_run_retention_purge_all_tables(seeded_db):
+    """Full purge run deletes from all purgeable tables."""
+    async with session_maker() as db:
+        result = await run_retention_purge(db, retention_days=RETENTION_DAYS_DEFAULT, vacuum=False)
+
+    assert result.total_deleted == (
+        seeded_db["old_calls"] + seeded_db["old_runs"] + seeded_db["old_misses"]
+    )
+    assert len(result.results) == len(PURGEABLE_TABLES)
+
+    async with session_maker() as db:
+        calls = (await db.execute(select(func.count()).select_from(CallRecord))).scalar()
+        runs = (await db.execute(select(func.count()).select_from(RunRecord))).scalar()
+        misses = (await db.execute(select(func.count()).select_from(SearchMiss))).scalar()
+
+    assert calls == seeded_db["recent_calls"]
+    assert runs == seeded_db["recent_runs"]
+    assert misses == seeded_db["recent_misses"]
+
+
+async def test_money_tables_never_touched(clients):
+    """CreditBlock, LedgerEntry, TagSpend, Org must NEVER be purged."""
+    from uuid import uuid4
+    now = utcnow_naive()
+    old = now - timedelta(days=RETENTION_DAYS_DEFAULT + 100)
+
+    async with session_maker() as db:
+        org = (await db.execute(select(Org).limit(1))).scalar_one()
+        user = (await db.execute(select(User).limit(1))).scalar_one()
+
+        block_id = uuid4().hex
+        db.add(CreditBlock(
+            id=block_id,
+            org_id=org.id,
+            kind="promotional",
+            amount_micro=1_000_000,
+            remaining_micro=1_000_000,
+            created_at=old,
+        ))
+
+        entry_id = uuid4().hex
+        db.add(LedgerEntry(
+            id=entry_id,
+            org_id=org.id,
+            block_id=block_id,
+            kind="grant",
+            amount_micro=1_000_000,
+            created_at=old,
+        ))
+
+        db.add(TagSpend(
+            org_id=org.id,
+            dim="customer",
+            val="cust_123",
+            hold_id=uuid4().hex,
+            settled=True,
+            amount_micro=100,
+            created_at=old,
+        ))
+
+        await db.commit()
+
+    async with session_maker() as db:
+        result = await run_retention_purge(db, retention_days=RETENTION_DAYS_DEFAULT, vacuum=False)
+
+    assert result.total_deleted == 0
+
+    async with session_maker() as db:
+        blocks = (await db.execute(select(func.count()).select_from(CreditBlock))).scalar()
+        entries = (await db.execute(select(func.count()).select_from(LedgerEntry))).scalar()
+        tags = (await db.execute(select(func.count()).select_from(TagSpend))).scalar()
+        orgs = (await db.execute(select(func.count()).select_from(Org))).scalar()
+
+    assert blocks >= 1
+    assert entries >= 1
+    assert tags >= 1
+    assert orgs >= 1
+
+
+async def test_purgeable_tables_are_exactly_audit_tables():
+    """The PURGEABLE_TABLES constant contains exactly the right models."""
+    assert set(PURGEABLE_TABLES) == {CallRecord, RunRecord, SearchMiss}
+
+
+async def test_purge_empty_table(clients):
+    """Purging an already-empty table is a no-op."""
+    async with session_maker() as db:
+        result = await purge_table(db, SearchMiss, retention_days=1)
+
+    assert result.deleted == 0
+    assert result.batches == 1
+
+
+async def test_retention_default_is_90_days():
+    """The default retention window is 90 days."""
+    assert RETENTION_DAYS_DEFAULT == 90
+
+
+async def test_batch_default_is_5000():
+    """The default batch size is 5000 rows."""
+    assert BATCH_SIZE_DEFAULT == 5000
+
+
+async def test_purge_result_summary(seeded_db):
+    """The summary method produces readable output."""
+    async with session_maker() as db:
+        result = await run_retention_purge(db, retention_days=RETENTION_DAYS_DEFAULT, vacuum=False)
+
+    summary = result.summary()
+    assert "Retention purge complete:" in summary
+    assert "callrecord:" in summary
+    assert "runrecord:" in summary
+    assert "searchmiss:" in summary
+    assert "Total:" in summary


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Adds `treg-worker retention purge` to delete aged rows from unbounded audit tables (`CallRecord`, `RunRecord`, `SearchMiss`), reclaiming disk space on the 90%-full prod Postgres (`treg-db`). 

The existing evidence column expiry (14-day overwrite with `<expired>`) doesn't reclaim TOAST-sized JSON—only DELETE + VACUUM does. This worker deletes in batches of 5,000 to avoid long ACCESS EXCLUSIVE locks on hot tables, then runs `VACUUM ANALYZE` (not VACUUM FULL) so Postgres can reuse the dead tuple space.

**Disk effect:** VACUUM alone marks dead space as reusable for new rows but does NOT return it to the OS (that requires VACUUM FULL, which locks exclusively—never from this worker). For immediate OS-level reclaim, Jason still needs to schedule a maintenance window for VACUUM FULL or a Render disk upgrade if usage inside 90 days already exceeds 15 GB.

**Never touches:** `CreditBlock`, `LedgerEntry`, `TagSpend`, `Hold`, `Org`, `User`, `Membership`, or anything in `domain/money`. The `PURGEABLE_TABLES` constant is the closed allow-list.

## Usage

```bash
# Dry run: see what would be deleted
treg-worker retention purge --dry-run

# Execute with defaults (90 days, batch 5000, VACUUM enabled)
treg-worker retention purge

# Custom retention window
treg-worker retention purge --days 60

# Skip VACUUM (for very large purges where you'll VACUUM later)
treg-worker retention purge --no-vacuum
```

**One-off prod invocation after merge:**
1. Shell into the Render web service or create a one-off job
2. Run `treg-worker retention purge --dry-run` to confirm expected delete count
3. Run `treg-worker retention purge` to execute

For a scheduled purge, add a Render cron with:
- `startCommand: treg-worker retention purge`
- Only DB URL + Fernet key required (no platform keys)
- Weekly cadence is sufficient

## How it was tested

```bash
uv run --frozen python -m pytest tests/test_retention.py -v  # 13 passed
uv run --frozen python -m pytest -q                          # 2470 passed, 4 skipped
```

Tests verify:
- Rows older than cutoff are deleted
- Rows within retention window are kept
- Batch size controls chunk deletion
- Dry run deletes nothing but reports count
- Money tables (CreditBlock, LedgerEntry, TagSpend) are never touched

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
  - `docs/context/architecture/data-model.md`: added "Retention purge" section
  - `docs/context/ops/deploy.md`: added worker command documentation
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbf66926-375a-446c-affe-532fbb8bebe1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbf66926-375a-446c-affe-532fbb8bebe1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

