### PR TITLE
fix(capacity): concurrent signals are one strike; Cloudflare 1xxx JSON is an edge block

### DIFF
--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -330,7 +330,8 @@ does not choose for the caller (charter): it names the options. The audit row is
 The call path's breaker (`domain.capacity.marks`) opens slowly and closes fast. After a tier-4
 answer ≥ 400, `settle._note_capacity_signal` runs `domain.capacity.signatures.classify` on the
 vendor's status/headers/body. A `balance` or `quota` signature is a **strike**; the second strike
-within 10 min, with no 2xx in between, **locks** - the provider for a balance signature, only the
+within 10 min, at least 15 s after the first (a burst of concurrent calls hitting the same empty
+instant is one strike), with no 2xx in between, **locks** - the provider for a balance signature, only the
 endpoint for a quota one (allowances are per operation). While locked, `resolve` admits one real
 call per process per minute as a **probe** (`MarketplaceCall.probe_lock_id`, `probe` on the
 `tool_called` event); its 2xx clears exactly that lock (`settle._note_capacity_recovery`, conditional
@@ -340,7 +341,7 @@ the sweep never writes this namespace. Both writes run on their own short sessio
 settle closed the hold, never during flight, and are the dataplane writes this feature adds
 (`capacity_exhausted_mark` in `tests/test_call_architecture.py`). A burst 429 (`retry-after ≤ 60 s`)
 or an unknown one only logs; step D′ smooths those. An `edge_block` (the vendor's CDN answered, not
-the vendor) strikes nothing: one caller's request shape must not take the provider away from every
+the vendor: `cf-mitigated`, its HTML block page, or its 1xxx problem-JSON) strikes nothing: one caller's request shape must not take the provider away from every
 other team. The kind rides the `tool_called` event as `capacity_signal`. Tiers 1/2 resolve earlier
 and never consult the view: an org's own key running dry is the org's own answer, relayed
 unchanged. The vendor's 402 on THIS call is also relayed unchanged - the protection is for the

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -77,7 +77,7 @@ consulted or affected by anything here.
   (`capacity:lock:*`): the meter it reads may not be the allowance that ran out.
 - **`marks.py`** - the call-path breaker, its own namespace `capacity:lock:<key>`; key = provider
   for a balance signature, endpoint id for a quota one. Strike, lock on the second strike within
-  10 min with no 2xx between, admit one probe per process per minute, clear on the probe's 2xx
+  10 min and at least 15 s later with no 2xx between, admit one probe per process per minute, clear on the probe's 2xx
   (conditional on the lock id). A guessed hold lasts 1 h, a vendor-stated reset at most 6 h.
   See `architecture/proxy-model.md`.
 - **`view.py`** - `LatestStateView`: the in-process copy of both namespaces, reloaded from

--- a/src/treg/domain/capacity/marks.py
+++ b/src/treg/domain/capacity/marks.py
@@ -9,8 +9,9 @@ settle, never while an upstream request is in flight, and never raises: a lost w
 more relayed 402, not the call. Listed in `tests/test_call_architecture.py` as
 `capacity_exhausted_mark`.
 
-Open conservatively: a signature is a strike; the second strike within `STRIKE_WINDOW`, with no
-2xx in between, locks. Close eagerly: while locked, `probe_due` admits one real call per process
+Open conservatively: a signature is a strike; the second strike within `STRIKE_WINDOW`, at least
+`STRIKE_MIN_GAP` after the first (concurrent calls that hit the same instant are one strike), with
+no 2xx in between, locks. Close eagerly: while locked, `probe_due` admits one real call per process
 per `PROBE_EVERY_S`; that call's 2xx clears the lock (conditionally on the lock id it was admitted
 under, so a late probe cannot erase a newer lock). Nothing else clears it except `until`: a guessed
 hold lasts `DEFAULT_LOCK`, a vendor-stated reset at most `MAX_LOCK`.
@@ -31,6 +32,7 @@ from ...timeutil import utcnow_naive
 LOCK_NS = "capacity:lock"
 LOCK_TTL_S = 24 * 3600
 STRIKE_WINDOW = timedelta(minutes=10)
+STRIKE_MIN_GAP = timedelta(seconds=15)
 DEFAULT_LOCK = timedelta(hours=1)
 MAX_LOCK = timedelta(hours=6)
 PROBE_EVERY_S = 60.0
@@ -81,6 +83,8 @@ async def strike(provider: str, *, endpoint_id: str | None, kind: str,
             prev = Lock.from_json(raw) if raw else None
             if prev is not None and prev.is_active(now):
                 return prev
+            if prev is not None and not immediate and now - prev.first_signal_at < STRIKE_MIN_GAP:
+                return prev  # the same burst as the first strike
             fresh = prev is None or now - prev.first_signal_at > STRIKE_WINDOW
             strikes = 1 if fresh else prev.strikes + 1
             first_at = now if fresh else prev.first_signal_at

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -81,14 +81,21 @@ def _retry_after(headers, now: datetime) -> int | None:
     return None
 
 
-def _edge_block(status: int, headers) -> bool:
-    """Headers only, never the User-Agent: Cloudflare's `cf-mitigated` marker, or its HTML block page
-    where the vendor's app would have answered JSON."""
+_CF_1XXX = re.compile(r"cloudflare-1xxx-errors|error 10\d\d: access denied")
+
+
+def _edge_block(status: int, headers, text_l: str) -> bool:
+    """Never the User-Agent: Cloudflare's `cf-mitigated` marker, its HTML block page where the
+    vendor's app would have answered JSON, or its 1xxx problem-JSON (error 1010 is the browser
+    signature block)."""
     if status in (403, 503) and _header(headers, "cf-mitigated") is not None:
         return True
-    return (status == 403
-            and "cloudflare" in (_header(headers, "server") or "").lower()
-            and "text/html" in (_header(headers, "content-type") or "").lower())
+    if status != 403:
+        return False
+    if ("cloudflare" in (_header(headers, "server") or "").lower()
+            and "text/html" in (_header(headers, "content-type") or "").lower()):
+        return True
+    return _CF_1XXX.search(text_l) is not None
 
 
 def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
@@ -98,7 +105,7 @@ def classify(provider: str, status: int, headers=None, body: bytes | str = b"",
     text = body.decode("utf-8", "replace") if isinstance(body, bytes) else (body or "")
     text_l = text.lower()
     provider = (provider or "").lower()
-    if _edge_block(status, headers):  # before the table: a block page carries no vendor body to match
+    if _edge_block(status, headers, text_l):  # before the table: a block page carries no vendor body to match
         return Signal("edge_block", None, None, detail=text[:120])
     for prov, st, pattern, kind in _TABLE:
         if st != status or prov not in ("*", provider):

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -198,6 +198,11 @@ def test_a_cdn_block_page_is_an_edge_block_not_an_account_signal():
                       b'{"code":"noCreditsRemaining"}').kind == "balance"
     # An HTML 503 without the marker is the vendor down, not a block.
     assert S.classify("anyone", 503, {"server": "cloudflare", "content-type": "text/html"}, b"<html>") is None
+    # The CDN's problem-JSON block (error 1010, "browser's signature"): no marker header, not HTML.
+    cf_json = (b'{"type":"https://developers.cloudflare.com/support/troubleshooting/http-status-codes/'
+               b'cloudflare-1xxx-errors/error-1010/","title":"Error 1010: Access denied","status":403}')
+    sig = S.classify("anyone", 403, {"content-type": "application/problem+json"}, cf_json)
+    assert sig.kind == "edge_block" and not S.is_exhausting(sig)
 
 
 # ---- aggregator envelopes round-trip their fixtures --------------------------------------------

--- a/tests/test_capacity_protect.py
+++ b/tests/test_capacity_protect.py
@@ -63,6 +63,7 @@ def _relay(status: int, body: bytes, headers=()):
 
 
 async def _lock_by_two_signals(clients: AsyncClient, monkeypatch, relay=None) -> Lock:
+    monkeypatch.setattr(capacity_marks, "STRIKE_MIN_GAP", timedelta(0))  # two calls, seconds apart
     monkeypatch.setattr(call_service, "relay", relay or _fake_relay(402, OUT))
     assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code in (402, 429)
     assert not (await _lock("tikhub") or await _lock(EP)).is_active(), "one strike never locks"
@@ -156,6 +157,7 @@ async def test_a_probe_that_fails_again_keeps_the_lock(clients: AsyncClient, pla
 
 
 async def test_a_vendor_500_or_caller_400_neither_strikes_nor_clears(clients: AsyncClient, platform_on, monkeypatch):
+    monkeypatch.setattr(capacity_marks, "STRIKE_MIN_GAP", timedelta(0))
     monkeypatch.setattr(call_service, "relay", _fake_relay(402, OUT))
     assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 402
     for status, body in ((500, b"down"), (400, b'{"detail":"bad aweme_id"}'), (429, b'{"detail":"slow down"}')):
@@ -176,9 +178,20 @@ async def test_quota_429_locks_the_endpoint_only_until_the_reset(clients: AsyncC
     assert capacity_view.is_exhausted("tikhub", EP) and not capacity_view.is_exhausted("tikhub")
 
 
+async def test_a_burst_of_concurrent_signals_is_one_strike(clients: AsyncClient, platform_on):
+    t0 = utcnow_naive()
+    kw = dict(endpoint_id=EP, kind="balance", resets_at=None)
+    for offset in (0, 1, 3, 8):  # parallel callers hitting the same empty instant
+        lock = await capacity_marks.strike("tikhub", now=t0 + timedelta(seconds=offset), **kw)
+        assert lock.strikes == 1 and not lock.is_active(t0 + timedelta(seconds=offset))
+    lock = await capacity_marks.strike("tikhub", now=t0 + timedelta(seconds=20), **kw)
+    assert lock.strikes == 2 and lock.is_active(t0 + timedelta(seconds=20)), "a second, later burst locks"
+
+
 async def test_a_lock_never_outlives_the_ceiling_whatever_the_vendor_said(clients: AsyncClient, platform_on):
     far = utcnow_naive() + timedelta(days=10)
-    await capacity_marks.strike("tikhub", endpoint_id=EP, kind="quota", resets_at=far)
+    await capacity_marks.strike("tikhub", endpoint_id=EP, kind="quota", resets_at=far,
+                                now=utcnow_naive() - timedelta(seconds=30))
     lock = await capacity_marks.strike("tikhub", endpoint_id=EP, kind="quota", resets_at=far)
     assert lock.is_active() and lock.until - utcnow_naive() <= MAX_LOCK
 
@@ -225,7 +238,8 @@ async def test_a_probe_never_takes_an_archived_answer(clients: AsyncClient, plat
 
 
 async def test_clear_is_conditional_on_the_lock_id(clients: AsyncClient, platform_on):
-    await capacity_marks.strike("tikhub", endpoint_id=EP, kind="balance", resets_at=None)
+    await capacity_marks.strike("tikhub", endpoint_id=EP, kind="balance", resets_at=None,
+                                now=utcnow_naive() - timedelta(seconds=30))
     lock = await capacity_marks.strike("tikhub", endpoint_id=EP, kind="balance", resets_at=None)
     assert lock.is_active()
     assert not await capacity_marks.clear("tikhub", lock_id="stale-probe")


### PR DESCRIPTION
## Why

Two things the first production hours of the breaker (#300) showed:

- A vendor with auto top-up whose balance hovers near zero answers several quota 429s **in the same second** when parallel callers hit the empty instant. That satisfied "two strikes with no 2xx between" instantly, so the endpoint locked for a minute every few minutes (each lock: 50 to 90 refusals at current traffic) even though every probe succeeded.
- Cloudflare blocked one caller's client signature with its **problem-JSON** answer (error 1010): no `cf-mitigated` header, not HTML, so the edge_block classifier missed it and thousands of 403s counted against treg's own failure rate.

## What

- `STRIKE_MIN_GAP = 15 s`: a second signal earlier than that after the first is the same burst and leaves the row at one strike. A genuinely exhausted account keeps answering for minutes, so it still locks on the next burst.
- `_edge_block` also matches Cloudflare's 1xxx problem-JSON in the body (`cloudflare-1xxx-errors` or `error 10xx: access denied`). Still never the User-Agent.

## Tests

Burst-of-four-then-later-strike unit test; classifier case for the problem-JSON block; existing two-call tests pin the gap to 0 where two back-to-back calls are the point. Full suite: 2463 passed.