### PR TITLE
Add Realie property-data API to the catalog

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -230,6 +230,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/catalog.css` | interface/seo.md |
 | `src/treg/web/claude-connector.html` | architecture/mcp-oauth.md |
 | `src/treg/web/connect-demo.html` | architecture/mcp-oauth.md |
+| `src/treg/web/fable-gtm.html` | interface/seo.md |
 | `src/treg/web/grokbot.html` | interface/seo.md |
 | `src/treg/web/index.html` | architecture/instagram-oauth.md, interface/dashboard.md, interface/landing-sandbox.md, interface/onboarding.md, interface/seo.md |
 | `src/treg/web/install.sh` | interface/landing-sandbox.md |
@@ -304,7 +305,7 @@ Regenerate via `scripts/build-map.py`.
 | `interface/env-import.md` | `providers.py`, `skills.py` |
 | `interface/landing-sandbox.md` | `sandbox.py`, `sandbox_identity.py`, `pubfeed.py`, `sandbox.py`, `__init__.py`, `sandbox.py`, `api.py`, `onboard.py`, `web.py`, `index.html`, `install.sh` |
 | `interface/onboarding.md` | `auth.py`, `__init__.py`, `demo.py`, `cli.py`, `auth.py`, `onboard.py`, `index.html` |
-| `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `usecase.css`, `index.html`, `landing.html`, `people-search.html`, `grokbot.html`, `llms.txt`, `indexnow_submit.py`, `support.html`, `og-card.html` |
+| `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `usecase.css`, `index.html`, `landing.html`, `people-search.html`, `grokbot.html`, `fable-gtm.html`, `llms.txt`, `indexnow_submit.py`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
 | `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py`, `test_capacity_collectors.py` |

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1357,6 +1357,9 @@ long strings clipped, ~10 KB cap) by the verifier, then human-reviewed for PII b
 | moz | web | Basic (AccessID:SecretKey base64), POST JSON API | SEO: web.backlinks.*, web.url.metrics |
 | tikhub | tiktok (+instagram, youtube, x) | Bearer key | Social: tiktok.* |
 | justoneapi | tiktok (+instagram, xiaohongshu, weibo) | `?token=` query param | Social: tiktok.* |
+| realie (2026-09-02) | property (Enrichment) | Bearer key; BYOK-only — monthly token plans, tokens-per-call unpublished | proposed: property.search, property.address.lookup, property.parcel.lookup, property.location.search, property.comparables.search |
 
 The SEO pair and the social pair each implement the same capabilities on purpose — they are the
-first real test that the capability taxonomy supports cross-provider comparison.
+first real test that the capability taxonomy supports cross-provider comparison. Realie is the
+first nationwide U.S. property-records listing; its costs stay `value: null` until a meter
+observation or rate card makes USD-per-call computable (no platform-key slot until then).

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -113,9 +113,17 @@ rejects on HTTP status by default.
   give `catalog_verify.py` a second pass for the routes that timed out instead of widening its timeout.
 - **Django trailing slash.** influencers.club's slash-less paths 301 with the body dropped; the Akta
   fix (slash IN `probe_path`) applies to every catalog `path` too.
+- **Vercel/Next trailing slash 308.** Realie (2026-09-02) answers HTTP 308 without the slash and
+  drops the Authorization header on the redirect — put the trailing slash in `probe_path` and every
+  catalog `path` so the connect probe sees the clean 401 `{"error":"Unauthorized: Invalid API key"}`.
+- **Unpublished tokens-per-call → BYOK-only.** Realie's plans publish monthly token allowances and
+  overage USD/token, but not how many tokens a call burns (CLI reports `apiCalls` vs `apiTokens`
+  separately; no rate-card endpoint). Cost blocks stay `value: null` / `confidence: unknown` and
+  the platform-key slot is deferred until a computable USD rate can be stated.
 - **A cross-platform provider needs its own platform slug.** influencers.club enriches a handle on any
   of 11 networks through a `platform` body field, so no single social slug is honest; it got a
-  `creators` platform on the Enrichment shelf (2026-08-21). Platforms cannot be proposed from a
+  `creators` platform on the Enrichment shelf (2026-08-21). Realie (2026-09-02) got a `property`
+  platform on the same shelf for nationwide U.S. parcel records. Platforms cannot be proposed from a
   provider file — add the slug to `capabilities.yaml` and propose only the capabilities.
 
 ## Selection heuristics (what makes a provider worth adding)

--- a/docs/context/interface/catalog-review-proposal.md
+++ b/docs/context/interface/catalog-review-proposal.md
@@ -74,6 +74,9 @@ no ad platform mis-shelved, nothing accidentally defaulted to `Other` except the
 `account` shelf (correct). **No unambiguous, non-controversial miscategorization was found,
 so nothing was force-moved.**
 
+*(Later addition, 2026-09-02: `property` was added under Enrichment for Realie's nationwide
+U.S. parcel/ownership records — distinct from `beike`'s Chinese resale-listing surface.)*
+
 Three placements are *debatable* but are judgment calls, not safe fixes — escalated to the
 founder rather than applied:
 

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -107,6 +107,7 @@ platforms:
   companies: {label: "Company data", category: "Enrichment", featured: 1, summary: "Enrich and search companies — firmographics, funding, tech stack, employees."}
   people: {label: "People & contact data", category: "Enrichment", featured: 2, summary: "Enrich people and find or verify work contact details — role, company, email, phone."}
   creators: {label: "Creators & influencers", category: "Enrichment", featured: 3, summary: "Find and enrich creators across Instagram, YouTube, TikTok, Twitch, X and OnlyFans — profile, audience, contact email, posts and lookalikes."}
+  property: {label: "U.S. property records", category: "Enrichment", summary: "Nationwide U.S. parcel, ownership, mortgage, tax and zoning records by address, parcel ID or location."}
 
   ebay: {label: "eBay", category: "E-commerce", summary: "Product listings and search results from eBay."}
   walmart: {label: "Walmart", category: "E-commerce", summary: "Product listings and search results from Walmart."}

--- a/src/treg/catalog/realie.yaml
+++ b/src/treg/catalog/realie.yaml
@@ -1,0 +1,215 @@
+provider: realie
+source:
+  docs: https://docs.realie.ai/api-reference/v3/overview
+  openapi: https://docs.realie.ai/api-reference/v3/openapi.json
+  curated: 2026-09-02
+# UNVERIFIED — no REALIE_API_KEY in the listing environment; every path and parameter below is
+# ingested from Realie's published v3 OpenAPI (2026-09-02). Do not stamp verified: or commit
+# example responses until a live credential observes a real target and a meter delta.
+#
+# AUTH. Homepage curl and this registry use Authorization: Bearer {secret}. OpenAPI declares an
+# apiKey in the Authorization header. A garbage Bearer token against the address probe returns
+# HTTP 401 with body {"error":"Unauthorized: Invalid API key"} (observed 2026-09-02). Paths
+# without a trailing slash answer 308 — keep the slash on every catalogued route and on probe_path.
+#
+# BILLING. Shared monthly token allowance across Platform + API (Free $0/25 tokens/$0.15 overage;
+# Tier 1 $50/1,250/$0.05; Tier 2 $150/6,000/$0.025; Tier 3 $350/30,000/$0.012). Same endpoints on
+# every plan. Max 100 parcels per request; 1,200 requests/minute. There is no rate-card endpoint,
+# and tokens-per-call is unpublished (CLI reports apiCalls vs apiTokens separately), so every cost
+# block carries value: null / confidence: unknown. No platform-key slot (config.py / render.yaml /
+# fx.yaml) until a computable USD-per-call can be stated — BYOK-only for now.
+#
+# SURFACE MAP (v3 OpenAPI, 5 paths — all catalogued):
+#   GET /public/property/search/          catalogued
+#   GET /public/property/address/         catalogued (also the registry probe)
+#   GET /public/property/parcelId/        catalogued (no inventable APN — harvest from sibling)
+#   GET /public/property/location/        catalogued
+#   GET /public/premium/comparables/      catalogued
+# Excluded: owner search (not in v3 OpenAPI), CLI, MCP, bulk/enterprise sales, deprecated offset as
+# its own endpoint, v2-legacy duplicate pages.
+
+limits: "1200 requests/minute; max 100 parcels per request; monthly token allowance per plan"
+pricing_url: https://docs.realie.ai/api-reference/pricing  # Free 25 tokens/$0.15 overage; T1 1250/$0.05; T2 6000/$0.025; T3 30000/$0.012. Tokens-per-call unpublished.
+
+proposed_capabilities:
+  property.search: "Search U.S. property records by state and optional address, city, county, ZIP or filters"
+  property.address.lookup: "Look up a U.S. property record by street address and state"
+  property.parcel.lookup: "Look up a U.S. property record by parcel ID, county and state"
+  property.location.search: "Search U.S. property records near a latitude/longitude"
+  property.comparables.search: "Find comparable property sales near a latitude/longitude"
+
+endpoints:
+  - id: realie.property.search
+    domain: property
+    capability: property.search
+    platform: property
+    scope: any_account
+    method: GET
+    path: /public/property/search/
+    name: "Search U.S. properties by state and filters"
+    summary: "Search and paginate through properties across states, counties, or cities"
+    input:
+      queryParams:
+        state: {type: string, required: true, note: "two-letter state code", example: "TX"}
+        zipCode: {type: string, required: false, note: "ZIP code"}
+        county: {type: string, required: false, note: "county name"}
+        city: {type: string, required: false, note: "city name"}
+        transferedSince: {type: string, required: false, note: "days to look back for transfers, e.g. \"30\""}
+        useCode: {type: integer, required: false, note: "numerical use code, e.g. 1002"}
+        address: {type: string, required: false, note: "street address line 1 only — do not include city, state, or ZIP", example: "504 LAVACA ST"}
+        unitNumberStripped: {type: string, required: false, note: "unit number without type prefix (\"2B\" not \"APT 2B\")"}
+        includeUnassignedAddress: {type: boolean, required: false, note: "include parcels without an assigned address; default false"}
+        limit: {type: integer, required: false, note: "results per page, default 10, max 100 — keep at 1 for cheap tests", example: 1}
+        cursor: {type: string, required: false, note: "opaque pagination token; pass \"start\" then metadata.nextCursor. Prefer over offset for deep walks"}
+        offset: {type: integer, required: false, note: "DEPRECATED — does not scale; responses may carry Deprecation: true"}
+        residential: {type: boolean, required: false, note: "true = residential only; false = non-residential only"}
+      note: "state is required. For lowest latency include state + county + address. Trailing slash required."
+    test_request:
+      queryParams: {state: "TX", address: "504 LAVACA ST", limit: 1}
+    cost:
+      type: per_call
+      value: null
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.realie.ai/api-reference/pricing
+      checked: '2026-09-02'
+      confidence: unknown
+      note: "Spends Realie tokens from the monthly allowance; tokens-per-call is unpublished, so no USD-per-call can be stated. Same endpoints on every plan."
+    docs_url: https://docs.realie.ai/api-reference/v3/property/property-search
+
+  - id: realie.property.address.lookup
+    domain: property
+    capability: property.address.lookup
+    platform: property
+    scope: any_account
+    method: GET
+    path: /public/property/address/
+    name: "Look up a U.S. property by street address"
+    summary: "Address Lookup"
+    input:
+      queryParams:
+        state: {type: string, required: true, note: "two-letter state code", example: "TX"}
+        address: {type: string, required: true, note: "street address line 1 only — do not include city, state, or ZIP", example: "504 LAVACA ST"}
+        unitNumberStripped: {type: string, required: false, note: "unit number without type prefix"}
+        county: {type: string, required: false, note: "required when city is provided"}
+        city: {type: string, required: false, note: "if set, county is required"}
+      note: "Faster than property search for a single known address. Also the registry's connect probe. Trailing slash required."
+    test_request:
+      queryParams: {address: "504 LAVACA ST", state: "TX"}
+    cost:
+      type: per_call
+      value: null
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.realie.ai/api-reference/pricing
+      checked: '2026-09-02'
+      confidence: unknown
+      note: "Spends Realie tokens from the monthly allowance; tokens-per-call is unpublished, so no USD-per-call can be stated."
+    docs_url: https://docs.realie.ai/api-reference/v3/property/address-lookup
+
+  - id: realie.property.parcel.lookup
+    domain: property
+    capability: property.parcel.lookup
+    platform: property
+    scope: any_account
+    method: GET
+    path: /public/property/parcelId/
+    name: "Look up a U.S. property by parcel ID"
+    summary: "Parcel ID Lookup"
+    input:
+      queryParams:
+        state: {type: string, required: true, note: "two-letter state code", example: "TX"}
+        county: {type: string, required: true, note: "county where the parcel is located"}
+        parcelId: {type: string, required: true, note: "exact assessor parcel number / APN — harvest from a sibling live response; never invent one"}
+      note: "No test_request yet: without a live key there is no honest APN to send. On verification, harvest parcelId (and county) from address or search, then call this route."
+    cost:
+      type: per_call
+      value: null
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.realie.ai/api-reference/pricing
+      checked: '2026-09-02'
+      confidence: unknown
+      note: "Spends Realie tokens from the monthly allowance; tokens-per-call is unpublished, so no USD-per-call can be stated."
+    docs_url: https://docs.realie.ai/api-reference/v3/property/parcel-id-lookup
+
+  - id: realie.property.location.search
+    domain: property
+    capability: property.location.search
+    platform: property
+    scope: any_account
+    method: GET
+    path: /public/property/location/
+    name: "Search U.S. properties near a lat/lng"
+    summary: "Search by latitude/longitude with an optional radius in miles"
+    input:
+      queryParams:
+        longitude: {type: number, required: true, note: "center longitude", example: -97.7404}
+        latitude: {type: number, required: true, note: "center latitude", example: 30.2747}
+        radius: {type: number, required: false, note: "miles from center; max 2", example: 0.25}
+        limit: {type: integer, required: false, note: "results to return, default 10, max 100", example: 1}
+        offset: {type: integer, required: false, note: "records to skip; default 0"}
+        residential: {type: boolean, required: false, note: "true = residential only; false = non-residential only"}
+        includeUnassignedAddress: {type: boolean, required: false, note: "include nearby parcels without an assigned address; default excludes them"}
+      note: "By default nearby searches exclude parcels without assigned addresses. Trailing slash required."
+    test_request:
+      queryParams: {latitude: 30.2747, longitude: -97.7404, radius: 0.25, limit: 1}
+    cost:
+      type: per_call
+      value: null
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.realie.ai/api-reference/pricing
+      checked: '2026-09-02'
+      confidence: unknown
+      note: "Spends Realie tokens from the monthly allowance; tokens-per-call is unpublished, so no USD-per-call can be stated."
+    docs_url: https://docs.realie.ai/api-reference/v3/property/location-search
+
+  - id: realie.property.comparables.search
+    domain: property
+    capability: property.comparables.search
+    platform: property
+    scope: any_account
+    method: GET
+    path: /public/premium/comparables/
+    name: "Find comparable property sales near a lat/lng"
+    summary: "Search for comparable properties based on location and optional property characteristics"
+    input:
+      queryParams:
+        latitude: {type: number, required: true, note: "target property latitude", example: 30.2747}
+        longitude: {type: number, required: true, note: "target property longitude", example: -97.7404}
+        radius: {type: number, required: false, note: "search radius in miles; default 1"}
+        timeFrame: {type: integer, required: false, note: "months to look back for comparable sales; default 18"}
+        maxResults: {type: integer, required: false, note: "max results, default 25, max 50 — keep at 1 for cheap tests", example: 1}
+        sqftMin: {type: integer, required: false}
+        sqftMax: {type: integer, required: false}
+        bedsMin: {type: integer, required: false}
+        bedsMax: {type: integer, required: false}
+        bathsMin: {type: number, required: false}
+        bathsMax: {type: number, required: false}
+        propertyType: {type: string, required: false, note: "one of any | condo | house"}
+        priceMin: {type: integer, required: false}
+        priceMax: {type: integer, required: false}
+      note: "Premium comparables route; same auth and token meter as the property routes. Trailing slash required."
+    test_request:
+      queryParams: {latitude: 30.2747, longitude: -97.7404, maxResults: 1}
+    cost:
+      type: per_call
+      value: null
+      currency: USD
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://docs.realie.ai/api-reference/pricing
+      checked: '2026-09-02'
+      confidence: unknown
+      note: "Spends Realie tokens from the monthly allowance; tokens-per-call is unpublished, so no USD-per-call can be stated. Whether premium routes burn more tokens than property routes is also unpublished."
+    docs_url: https://docs.realie.ai/api-reference/v3/premium/premium-comparables-search

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1190,6 +1190,42 @@ HUNTER = OAuthProvider(
     probe_path="/account",  # free — consumes no search/verification/enrichment credits
 )
 
+REALIE = OAuthProvider(
+    service="realie",
+    display_name="Realie",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Realie API key",
+    # Homepage curl and connect probes use Authorization: Bearer {secret}. OpenAPI declares an
+    # apiKey in the Authorization header; a garbage Bearer token is rejected with HTTP 401.
+    # Defaults (Authorization / Bearer {secret}) match — leave them explicit for the listing PR.
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://app.realie.ai/developer",
+    setup_action_label="Get your Realie API key",
+    setup_steps=(
+        "Sign up at https://app.realie.ai/developer.",
+        "Add a payment method at https://app.realie.ai/billing/ (temporary $0.50 card hold).",
+        "Copy your key from Usage → API access at https://app.realie.ai/dashboard/.",
+    ),
+    setup_note=(
+        "Property lookups spend the plan's monthly token allowance; tokens-per-call is unpublished. "
+        "Slash-less paths 308 — keep the trailing slash on every route."
+    ),
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary=(
+        "Look up nationwide U.S. property records by address, parcel ID, location, or search "
+        "filters (parcel, ownership, mortgage, tax, zoning)."
+    ),
+    base_url="https://app.realie.ai/api",
+    docs_url="https://docs.realie.ai/api-reference/v3/overview",
+    # Trailing slash required — without it the host answers 308 and the connect probe never sees 401.
+    probe_path="/public/property/address/?address=504%20LAVACA%20ST&state=TX",
+)
+
 TIKHUB = OAuthProvider(
     service="tikhub",
     display_name="TikHub",
@@ -2537,7 +2573,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
+        APOLLO, PDL, AKTA, HUNTER, REALIE, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT, EXA,

--- a/src/treg/web/logos/realie.svg
+++ b/src/treg/web/logos/realie.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="realie">
+  <!-- Placeholder lettermark. Replace with the official realie brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#1B4D3E"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">R</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
+    for svc in ("apollo", "pdl", "akta", "hunter", "realie", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
                 "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -47,7 +47,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "apollo", "pdl", "akta", "hunter", "realie", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
         "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",


### PR DESCRIPTION
Contact: support@realie.ai

## Summary

Adds **Realie** (nationwide U.S. property-data API) to the treg catalog as an Enrichment key provider, modeled on Hunter. All five v3 OpenAPI REST routes are curated. Costs are honest `value: null` / `confidence: unknown` because tokens-per-call is unpublished — **BYOK-only** (no `platform_key_*` / `render.yaml` / `fx.yaml` slot until a computable USD rate can be stated).

Happy to send a test credential privately for maintainer live verification / `verified:` stamps.

## Auth & probe (wire, 2026-09-02)

- **Auth:** `Authorization: Bearer {secret}` (homepage curl). OpenAPI: apiKey in `Authorization` header.
- **Probe:** `GET /public/property/address/?address=504%20LAVACA%20ST&state=TX` (trailing slash required — without it the host answers **308**).
- **Direct garbage Bearer** → HTTP **401**, body `{"error":"Unauthorized: Invalid API key"}`.
- **Via treg** `POST /connections/token` with provider `realie` + garbage key → **422** `Realie rejected that token (Unauthorized: Invalid API key)`.

## Full-surface map (v3 OpenAPI — 5 paths, all catalogued)

| Path | Status | Notes |
|---|---|---|
| `GET /public/property/search/` | catalogued | cheap test: `state=TX&address=504 LAVACA ST&limit=1` |
| `GET /public/property/address/` | catalogued | cheap test: address+state; also registry probe |
| `GET /public/property/parcelId/` | catalogued | no inventable APN — harvest from sibling on live verify; no `test_request` yet |
| `GET /public/property/location/` | catalogued | Texas Capitol lat/lng, `limit=1`, small radius |
| `GET /public/premium/comparables/` | catalogued | same coords, `maxResults=1` |
| Owner search | excluded | not in v3 OpenAPI |
| CLI / MCP | excluded | not HTTP catalog surface |
| Bulk / enterprise sales | excluded | sales channel |
| Deprecated `offset` as its own endpoint | excluded | query param only |
| v2-legacy duplicate pages | excluded | same routes, flat shape |

## Pricing / OpenAPI

- Docs: https://docs.realie.ai/api-reference/v3/overview
- OpenAPI: https://docs.realie.ai/api-reference/v3/openapi.json
- Pricing: https://www.realie.ai/pricing · https://docs.realie.ai/api-reference/pricing
- Plans (monthly token allowance, same endpoints all plans): Free $0 / 25 tokens / $0.15 overage; T1 $50 / 1,250 / $0.05; T2 $150 / 6,000 / $0.025; T3 $350 / 30,000 / $0.012
- Limits: 100 parcels/request; 1,200 rpm
- No rate-card endpoint; tokens-per-call unpublished (CLI shows `apiCalls` vs `apiTokens` separately)

## Platform-key decision

**Deferred / BYOK-only.** Without a published or observed tokens-per-call figure there is no honest USD-per-call for `fx.yaml` / `platform_eligible`. Wiring `config.py` + `render.yaml` + `fx.yaml` would invent a rate.

## Verification evidence ledger (2026-09-02)

No `REALIE_API_KEY` in this environment — endpoints were **not** live-called with a valid key. No `verified:` stamps; no example responses committed.

| endpoint | http | test target | credits/tokens observed | catalog price | matches? | evidence |
|---|---|---|---|---|---|---|
| realie.property.search | — | TX / 504 LAVACA ST / limit=1 | not run (no key) | `value: null` unknown | ⚠️ unobserved | docs pricing page only |
| realie.property.address.lookup | — | 504 LAVACA ST, TX | not run (no key) | `value: null` unknown | ⚠️ unobserved | docs pricing page only |
| realie.property.parcel.lookup | — | harvest APN from sibling | not run (no key) | `value: null` unknown | ⚠️ unobserved | no APN invented; no `test_request` |
| realie.property.location.search | — | 30.2747,-97.7404 limit=1 | not run (no key) | `value: null` unknown | ⚠️ unobserved | docs pricing page only |
| realie.property.comparables.search | — | same coords maxResults=1 | not run (no key) | `value: null` unknown | ⚠️ unobserved | docs pricing page only |

**Bogus-key probe (quoted):** direct upstream `401` `{"error":"Unauthorized: Invalid API key"}`; treg connect `422` `Realie rejected that token (Unauthorized: Invalid API key)`.

**Checks:** `catalog_validate.py` → OK (0 errors); `pytest -q` → 2457 passed, 4 skipped.

## Files

- `src/treg/oauth_providers.py` — `REALIE` registry entry + REGISTRY
- `src/treg/catalog/realie.yaml` — 5 endpoints + proposed capabilities
- `src/treg/catalog/capabilities.yaml` — `property` platform (Enrichment)
- `src/treg/web/logos/realie.svg` — lettermark R
- `tests/test_oauth_providers_m3.py`, `tests/test_key_providers.py`
- docs fragments: `expanding-a-category.md`, `catalog.md`, `catalog-review-proposal.md`

Fragments updated: `docs/context/guides/expanding-a-category.md`, `docs/context/architecture/catalog.md`, `docs/context/interface/catalog-review-proposal.md`.
