### PR TITLE
feat(activity): show a call's stored request and response

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -28,6 +28,7 @@ Regenerate via `scripts/build-map.py`.
 | `plugins/treg/.cursor-plugin/plugin.json` | interface/skill.md |
 | `pyproject.toml` | architecture/import-boundaries.md, ops/deploy.md |
 | `render.yaml` | ops/deploy.md |
+| `scripts/backfill_call_archive_links.py` | architecture/archive.md |
 | `scripts/build_plugin.py` | interface/skill.md |
 | `scripts/catalog_drift.py` | architecture/catalog.md |
 | `scripts/catalog_ingest.py` | architecture/catalog.md, architecture/instagram-oauth.md |
@@ -52,6 +53,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/alembic/versions/0008_org_platform_overflow_disabled.py` | architecture/data-model.md, ops/capacity.md |
 | `src/treg/alembic/versions/0009_callrecord_hit.py` | architecture/data-model.md |
 | `src/treg/alembic/versions/0010_oauth_authorization_method.py` | architecture/instagram-oauth.md |
+| `src/treg/alembic/versions/0011_callrecord_archive_link.py` | architecture/archive.md, architecture/data-model.md |
 | `src/treg/analytics.py` | architecture/data-model.md |
 | `src/treg/api.py` | architecture/archive.md, architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
 | `src/treg/application/__init__.py` | architecture/import-boundaries.md |
@@ -67,7 +69,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/call/reserve.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/resolve.py` | architecture/import-boundaries.md, architecture/instagram-oauth.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/route.py` | architecture/catalog.md, architecture/import-boundaries.md |
-| `src/treg/application/call/service.py` | architecture/import-boundaries.md, architecture/instagram-oauth.md, architecture/proxy-model.md, interface/api.md |
+| `src/treg/application/call/service.py` | architecture/archive.md, architecture/import-boundaries.md, architecture/instagram-oauth.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/settle.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/types.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/connect.py` | architecture/auth-secrets.md, architecture/composition.md, guides/expanding-a-category.md, interface/api.md |
@@ -281,11 +283,11 @@ Regenerate via `scripts/build-map.py`.
 | Fragment | Sources |
 |---|---|
 | `architecture/ads-conversions.md` | `adsconv.py`, `signup.py`, `adtrack.js` |
-| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `api.py`, `bootstrap.py`, `admin.py` |
+| `architecture/archive.md` | `archive.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0011_callrecord_archive_link.py`, `service.py`, `backfill_call_archive_links.py`, `api.py`, `bootstrap.py`, `admin.py` |
 | `architecture/auth-secrets.md` | `injectors.py`, `ssrf.py`, `crypto.py`, `oauth.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `oauth_exchange.py`, `oauth_refresh.py`, `oauth_providers.py`, `health.py`, `connect.py`, `connections.py`, `resources.py`, `__init__.py`, `bindings.py`, `bundles.py`, `test_oauth_refresh.py` |
 | `architecture/catalog.md` | `contracts.yaml`, `adapters.yaml`, `findymail.search.business-profile.json`, `__init__.py`, `contracts.py`, `paths.py`, `plan.py`, `synthetic.py`, `route.py`, `test_routing.py`, `catalog-drift.yml`, `catalog_drift.py`, `catalog_ingest.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `google-tag-manager.yaml`, `google-tag-manager.extended.yaml`, `instagram.yaml`, `instagram.extended.yaml`, `justoneapi.extended.yaml`, `tikhub.extended.yaml`, `__init__.py`, `store.py`, `stats.py`, `catalog_observations.py`, `catalog.py` |
 | `architecture/composition.md` | `bootstrap.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `connect.py`, `mcp_oauth.py`, `session.py`, `admin.py`, `auth.py`, `billing.py`, `call.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `web.py`, `dump_surface.py`, `test_app_roles.py` |
-| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
+| `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0011_callrecord_archive_link.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -6,6 +6,9 @@ sources:
   - src/treg/alembic/versions/0002_archive_tables.py
   - src/treg/alembic/versions/0003_callrecord_cached.py
   - src/treg/alembic/versions/0004_archivekey_request_shape.py
+  - src/treg/alembic/versions/0011_callrecord_archive_link.py
+  - src/treg/application/call/service.py
+  - scripts/backfill_call_archive_links.py
   - src/treg/api.py
   - src/treg/bootstrap.py
   - src/treg/routers/admin.py
@@ -26,7 +29,28 @@ time-series — backlink profiles over time, price history), not waste.
 **Build state: COMPLETE (PR 6 of 6 — the panel shipped after the original five).** All five slices exist behind `TREG_ARCHIVE_MODE`:
 skeleton, recorder, catalog `cache` field + report, serve path, and the learner + refresh worker.
 What does NOT exist: any billing difference for a cached hit (deferred founder decision), and the
-phase-3 aggregator surfaces (history endpoints) — do not document either as existing.
+phase-3 aggregator surfaces (history endpoints) — do not document either as existing. What DOES
+exist since 2026-09-03 is the per-call read below: a team can see the answer ITS OWN call got.
+
+## The call→archive link (2026-09-03)
+
+`record()` returns `(key_hash, content_hash)` — computed synchronously and handed to `_store`
+so the hash is taken once — and `lookup()` adds `key_hash`, `content_hash` and `version` to its
+dict. The call service (`application/call/service.py`) keeps them in `archive_key_hash` /
+`archive_content_hash` and the `_audit` closure writes them onto the `CallRecord` (migration
+0011: two nullable columns, no index — the read starts from the org-scoped row by id and both
+targets are already indexed). `archive.resolve_result(session, key_hash, content_hash)` walks
+row → key → newest snapshot with that content hash → `body_of` carrier, and returns the request
+shape (`req_*`, pre-injection) plus the answer; a hash-only version reports `stored: false`.
+`GET /calls/{id}/result` (api.py) exposes it to members of the row's org, with a `note` on every
+"nothing on file" branch; `/calls` rows carry `has_result`. The archive stays platform-scoped —
+what makes the read safe is that the row belongs to the team and names the exact bytes that
+team already received. Failure evidence (`error_*`) is untouched and still admin-only.
+
+Rows older than the migration have no link and cannot get an exact one (the key needs the query
+and body the audit row never kept); `scripts/backfill_call_archive_links.py` links them best-
+effort — same endpoint, same byte size, fetch within ±10 s, unambiguous in both directions —
+dry run by default, `--apply` to write, `--render` for the prod allowlist dance.
 
 ## The learner (PR 5)
 

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -13,6 +13,7 @@ sources:
   - src/treg/alembic/versions/0007_overflow_spend.py
   - src/treg/alembic/versions/0008_org_platform_overflow_disabled.py
   - src/treg/alembic/versions/0009_callrecord_hit.py
+  - src/treg/alembic/versions/0011_callrecord_archive_link.py
   - src/treg/maintenance.py
   - src/treg/web/sitetrack.js
   - src/treg/models.py
@@ -138,6 +139,11 @@ SQLModel tables in `src/treg/models.py`. Kept minimal on purpose. Org multi-tena
   the reserve refusal, where `detail` names **which** cap was hit, since every 429 collapses to
   `refused_by='cap'` and that one value spans member, tag, org, platform and trial limits.
   Never written for a success; `/calls` defers and omits both fields, keeping them admin-only.
+  Separate from that evidence, `archive_key_hash` + `archive_content_hash` (migration 0011, the
+  last two columns, nullable, no index) name the archived answer a metered platform 2xx call
+  received — `ArchiveKey.key_hash` and `ArchiveSnapshot.content_hash` — set by the call service
+  from what `archive.record()`/`archive.lookup()` return; the join behind the team-facing
+  `GET /calls/{id}/result` (see [archive](archive.md)). NULL on every other row.
   Redaction is exact-match-first for every injected credential: platform settings and decrypted org
   Secrets. OAuth/secret-file JSON masks the raw blob, injected field, `Bearer` form, and string values
   under the sensitive-key allowlist (including the binding's `secret_field`), while diagnosis fields

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -580,6 +580,15 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   "we said no"). It does **not** carry `error_request`/`error_response`, and defers them so they are
   not even fetched: the captured evidence is admin-only in v1, and putting it on a team's own feed
   has to be a deliberate edit in two places rather than a column appearing by accident.
+  Each row also carries `has_result` — true when the archive holds this call's answer — and
+  `get_call_result` (`GET /calls/{id}/result`, member, org-scoped by the row's `org_id`) returns
+  it: the vendor-facing request shape BEFORE credential injection (`ArchiveKey.req_*`) and the
+  stored answer (`ArchiveSnapshot`: status, media type, size, fetch time, `body_text`), resolved
+  through the row's `archive_key_hash` + `archive_content_hash` by `archive.resolve_result`. Only
+  a metered platform 2xx call ever has one; every other row answers `stored: false` with a `note`
+  naming the case (own-key/own-tool never stored · failed · recording off · expired · hash-only
+  because the licence or size cap kept the hash and not the bytes). The failure-evidence columns
+  are still never read here (see [archive](../architecture/archive.md)).
 - **OAuth connect + the provider marketplace:** `oauth_start` (`POST /oauth/start`) creates a
   `PendingOAuth` and returns `consent_url` + `state` + `redirect_uri` + registry-owned
   `connect_guidance`; `oauth_callback`
@@ -806,6 +815,7 @@ if returning the hold itself fails, the money comes back when the hold is reaped
 | Route | Does |
 |---|---|
 | `GET /calls?days=&before_id=&limit=` | this team's calls, windowed and pageable. Analytics — **not** an invoice source |
+| `GET /calls/{id}/result` | what one call asked and what came back — the archive's copy; metered platform 2xx only, `stored: false` + `note` otherwise |
 | `GET /calls/{call_ref}` | one call by its `X-Treg-Call-Id`, plus the ledger entries for it |
 | `GET /orgs/{id}/usage/by-tag?key=&days=` | per-value spend for one tag key. **Money from the ledger**; admin+ |
 | `GET/PUT/DELETE /orgs/{id}/budgets[/{dim}/{val}]` | per-tag limits and blocking; admin+ |

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -316,6 +316,9 @@ Server side (`domain.identity.access`): `require_identity` (who, from token OR s
 - **Activity** — one time-sorted feed (`activityRows`) merging `GET /calls` (proxy calls) + `GET /runs`
   (CLI executions). Local runs now arrive via `/runs` (tagged `where`), so the calls feed **excludes**
   `local_run` rows to avoid double-counting, and each run row shows a **local/server** chip.
+  The feed shows **successes only by default** (`actOkOnly`, `activityShown` filters on `ok`);
+  a "Show all (N)" / "Successes only" button toggles failed and refused rows in, and the empty
+  state offers the same switch when every recent call failed.
   A call row is clickable (`openCall` → `callView`, a right-side drawer in the `epTry` pattern)
   and loads `GET /calls/{id}/result`: the request line (method + vendor URL before injection),
   the response (status · media type · size · fetch time, JSON pretty-printed by `pretty`, a Copy

--- a/docs/context/interface/dashboard.md
+++ b/docs/context/interface/dashboard.md
@@ -316,6 +316,13 @@ Server side (`domain.identity.access`): `require_identity` (who, from token OR s
 - **Activity** — one time-sorted feed (`activityRows`) merging `GET /calls` (proxy calls) + `GET /runs`
   (CLI executions). Local runs now arrive via `/runs` (tagged `where`), so the calls feed **excludes**
   `local_run` rows to avoid double-counting, and each run row shows a **local/server** chip.
+  A call row is clickable (`openCall` → `callView`, a right-side drawer in the `epTry` pattern)
+  and loads `GET /calls/{id}/result`: the request line (method + vendor URL before injection),
+  the response (status · media type · size · fetch time, JSON pretty-printed by `pretty`, a Copy
+  button via `toClipboard`, rendered text capped at 256 KB with a "show full" link), or the
+  endpoint's `note` when nothing is on file. Rows whose `has_result` is true show a small
+  "result ›" affordance next to the status badge; own-key, own-tool and failed calls open the
+  same drawer and read the note. Only metered platform 2xx calls ever have a stored answer.
 - **Admin** — nav auto-appears iff the caller is `is_superadmin` (read from `/auth/me` on boot — **not**
   by probing `/admin/stats`, which would 403 + log a console error on every load for normal users); `loadAdmin` fetches `stats` + `orgs` + `users` only when you open the panel. Shows `stats` + `orgs` + `users`, each
   with **mutations** (`_adm` helper): `admGrant`/`admSuspendUser`/`admDeleteUser`,

--- a/scripts/backfill_call_archive_links.py
+++ b/scripts/backfill_call_archive_links.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Link calls made BEFORE migration 0011 to the archived answers they received — best effort.
+
+New calls carry `callrecord.archive_key_hash` / `archive_content_hash` themselves (the audit row
+gets them from `archive.record()`), which is what `GET /calls/{id}/result` reads. Older rows cannot
+be linked exactly: the archive key is computed from the full query string and body, and the audit
+row never kept either. What both sides DO share is the endpoint, the byte size of the answer
+(`callrecord.response_bytes` == `archivesnapshot.size_bytes`) and a fetch time within seconds of
+each other, so this script matches on those and links a pair only when it is unambiguous in BOTH
+directions: one snapshot ↔ one call. Anything else is counted and left alone — a wrong link would
+show a team someone else's answer, and "no result on file" is the honest fallback.
+
+Only metered platform 2xx rows that are not already linked are candidates (the archive never holds
+anything else). Served hits are skipped: prod recorded in `shadow`, so none exist.
+
+    python scripts/backfill_call_archive_links.py                # dry run: counts only
+    python scripts/backfill_call_archive_links.py --apply        # write the links
+    python scripts/backfill_call_archive_links.py --window 10    # ± seconds (default 10)
+
+Connects with `TREG_DATABASE_URL` / `--dsn` (a postgres:// DSN). With `--render`, reuses
+`scripts/usage_report.py`'s open-allowlist / connect / close-allowlist dance for the prod database
+(needs RENDER_API_KEY in the environment or the repo's .env).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# One statement finds every unambiguous pair. `snap_n` is how many calls a snapshot could be, and
+# `call_n` how many snapshots a call could be — a link is written only where both are exactly 1.
+MATCH_SQL = """
+with cand as (
+  select s.id as snapshot_id, k.key_hash, s.content_hash, c.id as call_id,
+         count(*) over (partition by s.id) as snap_n,
+         count(*) over (partition by c.id) as call_n
+  from archivesnapshot s
+  join archivekey k on k.id = s.key_id
+  join callrecord c
+    on c.endpoint_id = k.endpoint_id
+   and c.credential_tier = 'platform'
+   and c.status_code between 200 and 299
+   and c.cached = false
+   and c.archive_key_hash is null
+   and c.response_bytes = s.size_bytes
+   and c.created_at between s.fetched_at - make_interval(secs => $1)
+                        and s.fetched_at + make_interval(secs => $1)
+  where s.origin = 'caller'
+)
+select snapshot_id, key_hash, content_hash, call_id, snap_n, call_n from cand
+"""
+
+COUNT_SQL = """
+select
+  (select count(*) from archivesnapshot where origin = 'caller') as snapshots,
+  (select count(*) from callrecord
+     where credential_tier = 'platform' and status_code between 200 and 299
+       and cached = false and archive_key_hash is null) as unlinked_calls
+"""
+
+UPDATE_SQL = "update callrecord set archive_key_hash = $1, archive_content_hash = $2 where id = $3 and archive_key_hash is null"
+
+
+async def run(conn, *, window_s: int, apply: bool) -> dict:
+    totals = dict(await conn.fetchrow(COUNT_SQL))
+    rows = await conn.fetch(MATCH_SQL, float(window_s))
+    exact = [r for r in rows if r["snap_n"] == 1 and r["call_n"] == 1]
+    ambiguous = {r["call_id"] for r in rows if r["snap_n"] > 1 or r["call_n"] > 1}
+    report = {**totals, "window_s": window_s, "matched": len(exact), "ambiguous_calls": len(ambiguous),
+              "unmatched_calls": totals["unlinked_calls"] - len(exact) - len(ambiguous),
+              "applied": 0}
+    if apply and exact:
+        async with conn.transaction():
+            for r in exact:
+                tag = await conn.execute(UPDATE_SQL, r["key_hash"], r["content_hash"], r["call_id"])
+                report["applied"] += int(tag.split()[-1])
+    return report
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--apply", action="store_true", help="write the links (default: dry run)")
+    ap.add_argument("--window", type=int, default=10, help="± seconds between call and fetch (default 10)")
+    ap.add_argument("--dsn", default=os.environ.get("TREG_DATABASE_URL", ""), help="postgres DSN")
+    ap.add_argument("--render", action="store_true", help="open the prod allowlist via the Render API, like usage_report.py")
+    args = ap.parse_args()
+
+    import asyncpg
+
+    if args.render:
+        sys.path.insert(0, str(REPO / "scripts"))
+        import usage_report as ur  # the allowlist dance lives there; do not duplicate it
+
+        ip = ur.my_ip()
+        print(f"opening prod allowlist for {ip}/32 ...", file=sys.stderr)
+        ur.render_api("PATCH", f"/postgres/{ur.DB_ID}",
+                      {"ipAllowList": [{"cidrBlock": f"{ip}/32", "description": "backfill_call_archive_links.py"}]})
+        try:
+            dsn = ur.render_api("GET", f"/postgres/{ur.DB_ID}/connection-info")["externalConnectionString"]
+            await asyncio.sleep(3)
+            conn = await asyncpg.connect(dsn, ssl="require", timeout=45)
+            try:
+                report = await run(conn, window_s=args.window, apply=args.apply)
+            finally:
+                await conn.close()
+        finally:
+            ur.render_api("PATCH", f"/postgres/{ur.DB_ID}", {"ipAllowList": []})
+            print("prod allowlist closed", file=sys.stderr)
+    else:
+        if not args.dsn:
+            print("no DSN: pass --dsn, set TREG_DATABASE_URL, or use --render", file=sys.stderr)
+            return 2
+        dsn = args.dsn.replace("postgresql+asyncpg://", "postgresql://")
+        conn = await asyncpg.connect(dsn, timeout=45)
+        try:
+            report = await run(conn, window_s=args.window, apply=args.apply)
+        finally:
+            await conn.close()
+
+    mode = "APPLIED" if args.apply else "DRY RUN"
+    print(f"[{mode}] snapshots={report['snapshots']} unlinked_platform_2xx_calls={report['unlinked_calls']} "
+          f"window=±{report['window_s']}s → matched={report['matched']} "
+          f"ambiguous={report['ambiguous_calls']} unmatched={report['unmatched_calls']} "
+          f"written={report['applied']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/treg/alembic/versions/0011_callrecord_archive_link.py
+++ b/src/treg/alembic/versions/0011_callrecord_archive_link.py
@@ -1,0 +1,31 @@
+"""callrecord.archive_key_hash / archive_content_hash — the call→archive link
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-09-03
+
+Two nullable text columns, no default, no index: an instant metadata-only ALTER on Postgres even
+on the hot audit table. They name the archived answer a metered platform call received, so the
+team-facing `/calls/{id}/result` can show it; nothing else reads them.
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0011"
+down_revision: str | Sequence[str] | None = "0010"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("callrecord", sa.Column("archive_key_hash", sa.String(), nullable=True))
+    op.add_column("callrecord", sa.Column("archive_content_hash", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("callrecord") as batch:
+        batch.drop_column("archive_content_hash")
+        batch.drop_column("archive_key_hash")

--- a/src/treg/api.py
+++ b/src/treg/api.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import defer
 from sqlmodel import select
 
-from . import audit, crypto, localrun, ratestore, runner, sandbox as demo_sandbox
+from . import archive, audit, crypto, localrun, ratestore, runner, sandbox as demo_sandbox
 from .caller_metadata import _client_of
 from .config import get_settings
 from .domain.catalog import store as catalog_store
@@ -661,6 +661,10 @@ async def list_calls(
             # The archive answered instead of the vendor; the money columns are still identical to
             # a live call on purpose (docs/context/architecture/archive.md).
             "cached": c.cached,
+            # The archive holds this call's answer: `GET /calls/{id}/result` can show it. False
+            # for own-key/own-tool calls (never stored), failures, and calls made while recording
+            # was off.
+            "has_result": c.archive_key_hash is not None,
             "cost_estimated_micro": c.cost_estimated_micro,
             "cost_observed_micro": c.cost_observed_micro,
             "cost_charged_micro": c.cost_charged_micro,
@@ -680,6 +684,50 @@ async def list_calls(
         }
         for c in rows
     ]
+
+
+@app.get("/calls/{call_id:int}/result")
+async def get_call_result(
+    call_id: int, caller: Caller = Depends(require_member), db: AsyncSession = Depends(get_session)
+) -> dict:
+    """What one of this team's calls asked and what came back — the archive's copy.
+
+    Only a METERED PLATFORM 2xx call has one: those answers are recorded by the archive (see
+    docs/context/architecture/archive.md), and the audit row keeps the identities of the exact
+    bytes the caller received. Own-key and own-tool calls are relayed without being stored, a
+    failed call never is, and the redacted failure evidence stays admin-only — `stored` is false
+    with a `note` saying which. The request shape is the vendor-facing one BEFORE credential
+    injection, so no secret can appear in it.
+    """
+    row = (await db.execute(
+        select(CallRecord)
+        .options(defer(CallRecord.error_request), defer(CallRecord.error_response))
+        .where(CallRecord.org_id == caller.org_id, CallRecord.id == call_id))).scalars().first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="no call with that id")
+    out = {"id": row.id, "call_ref": row.call_ref, "endpoint_id": row.endpoint_id,
+           "provider": row.provider, "credential_tier": row.credential_tier,
+           "method": row.method, "path": row.path, "status_code": row.status_code,
+           "cached": row.cached, "created_at": row.created_at.isoformat() if row.created_at else None,
+           "stored": False, "note": None, "request": None, "response": None}
+    if not row.archive_key_hash or not row.archive_content_hash:
+        if row.credential_tier != "platform":
+            out["note"] = ("not stored: calls on your own key or your own tools are relayed "
+                           "without being kept")
+        elif not (200 <= row.status_code < 300):
+            out["note"] = "not stored: the call failed, so there is no answer on file"
+        else:
+            out["note"] = "not stored: recording was off when this call was made"
+        return out
+    found = await archive.resolve_result(db, row.archive_key_hash, row.archive_content_hash)
+    if found is None:
+        out["note"] = "expired: this answer is no longer on file"
+        return out
+    out |= found
+    if not found["stored"]:
+        out["note"] = ("hash-only: the provider's licence or the size cap did not allow keeping "
+                       "the bytes")
+    return out
 
 
 @app.get("/calls/{call_ref}")

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -379,6 +379,10 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
 
     drop_params: set[str] = set()
     served_hit = False  # a cached hit — set where the archive answers instead of the vendor
+    # The archive identities of this call's answer (question key + exact bytes), set where the
+    # archive records or serves; kept on the audit row so `/calls/{id}/result` can find it.
+    archive_key_hash: str | None = None
+    archive_content_hash: str | None = None
     smoothed: list[str] = []  # what burst smoothing did (`wait=<ms>`, `retry=1`) - set on the relay path
     mk: MarketplaceCall | None = None
     own_tool_miss: dict | None = None
@@ -571,6 +575,9 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                 "params_hash": mk.params_hash,
                 # found / not found, when this endpoint's routing adapter could read the body
                 **({"hit": hit} if hit is not None else {}),
+                # The stored answer's identities — the join to the archive for `/calls/{id}/result`.
+                **({"archive_key_hash": archive_key_hash,
+                    "archive_content_hash": archive_content_hash} if archive_key_hash else {}),
             }
         # Sanctioned reversal of PR #139: failed own-key and own-tool calls now retain the same
         # redacted, admin-only, 14-day evidence as marketplace failures. Successes remain empty and
@@ -816,6 +823,7 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             if served is not None:
                 body = served["body"]
                 served_hit = True
+                archive_key_hash, archive_content_hash = served["key_hash"], served["content_hash"]
                 response = _served_response(served, body)
             else:
                 response = await relay(
@@ -848,7 +856,7 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                 if archive.recording() and 200 <= response.status < 300:
                     _ct = next((v.decode("latin-1") for k, v in response.raw_headers
                                 if k.lower() == b"content-type"), "")
-                    archive.record(
+                    archive_key_hash, archive_content_hash = archive.record(
                         method=request.method, endpoint_id=mk.endpoint_id, provider=mk.provider,
                         url=archive.key_url(upstream_url,
                                             list(request.query_params.multi_items()),

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -210,21 +210,31 @@ def record(
     media_type: str,
     body: bytes,
     origin: str = "caller",
-) -> None:
+) -> tuple[str, str]:
     """Schedule one observation of a metered platform answer. Returns immediately; the write runs
     off-request on its own session. Call sites gate on `recording()` and 2xx — this function
-    trusts them and never raises."""
+    trusts them and never raises.
+
+    Returns `(key_hash, content_hash)` — the identities of the question and of this exact
+    answer. They are what the audit row keeps so a call can later be joined back to its stored
+    bytes (`/calls/{id}/result`). Computed here rather than in `_store` so they are computed
+    ONCE (the store reuses them) and are true whether or not the write lands: a shed recording
+    still names the answer the caller received."""
+    kh = cache_key(method, endpoint_id, url, caller_body, headers)
+    ch = content_hash(body)
     if len(_pending) >= _MAX_PENDING:  # shed load; the stream self-heals on the next call
-        return
+        return kh, ch
     task = asyncio.create_task(asyncio.wait_for(_store(
         method=method, endpoint_id=endpoint_id, provider=provider, url=url,
         caller_body=caller_body, headers=headers, status_code=status_code,
-        media_type=media_type, body=body, origin=origin), timeout=_STORE_TIMEOUT_S))
+        media_type=media_type, body=body, origin=origin, key_hash=kh, body_hash=ch),
+        timeout=_STORE_TIMEOUT_S))
     _pending.add(task)
     # NOT redundant with drain()'s own removal: on a running server drain() never fires, and this
     # callback is the only exit from `_pending` — without it the set fills to _MAX_PENDING and
     # record() sheds every recording from then on.
     task.add_done_callback(_pending.discard)
+    return kh, ch
 
 
 async def drain() -> None:
@@ -256,6 +266,8 @@ async def _store(
     media_type: str,
     body: bytes,
     origin: str = "caller",
+    key_hash: str | None = None,
+    body_hash: str | None = None,
 ) -> None:
     """One recording: upsert the key, append a version, keep the change statistics honest.
 
@@ -276,8 +288,10 @@ async def _store(
 
         entry = catalog_store.load().by_id.get(endpoint_id)
         pol = policy(entry)
-        kh = cache_key(method, endpoint_id, url, caller_body, headers)
-        ch = content_hash(body)
+        # `record()` hands both hashes in, computed once on the call path; the fallback keeps
+        # `_store` callable on its own (tests).
+        kh = key_hash or cache_key(method, endpoint_id, url, caller_body, headers)
+        ch = body_hash or content_hash(body)
         cap = get_settings().archive_max_body_bytes
         keep_bytes = pol in _STORABLE and len(body) <= cap
         now = _utcnow()
@@ -345,6 +359,55 @@ async def _store(
                 await s.rollback()
     except Exception:  # noqa: BLE001 — recording must never surface anywhere
         _log.warning("archive recording dropped for %s", endpoint_id, exc_info=True)
+
+
+# ---------------------------------------------------------------------------------------------
+# Reading one call's stored answer back (the team-facing `/calls/{id}/result`)
+
+def _decode(body: bytes | None) -> str | None:
+    if body is None:
+        return None
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+async def resolve_result(session, key_hash: str, content_hash: str) -> dict[str, Any] | None:
+    """The request shape and the stored answer a call row points at, or None when the key or
+    that exact answer is no longer on file.
+
+    `content_hash` names the exact bytes the caller received (dedup means several versions can
+    share them — the newest matching version is the one reported). Follows a `body_of` reference
+    to the row carrying the bytes; a hash-only version returns `stored=False` with the bytes
+    honestly absent. Never raises on decode: a non-UTF-8 body reports `body_text=None`."""
+    from sqlalchemy import select
+
+    from .models import ArchiveKey, ArchiveSnapshot
+
+    key = (await session.execute(
+        select(ArchiveKey).where(ArchiveKey.key_hash == key_hash))).scalars().one_or_none()
+    if key is None:
+        return None
+    snap = (await session.execute(
+        select(ArchiveSnapshot)
+        .where(ArchiveSnapshot.key_id == key.id, ArchiveSnapshot.content_hash == content_hash)
+        .order_by(ArchiveSnapshot.version.desc()).limit(1))).scalars().first()
+    if snap is None:
+        return None
+    body = snap.body
+    if body is None and snap.body_of is not None:
+        carrier = await session.get(ArchiveSnapshot, snap.body_of)
+        body = carrier.body if carrier is not None else None
+    return {
+        "stored": body is not None,
+        "request": {"method": key.req_method or "", "url": key.req_url or "",
+                    "body_text": _decode(key.req_body)},
+        "response": {"status_code": snap.status_code, "media_type": snap.media_type,
+                     "size_bytes": snap.size_bytes, "fetched_at": snap.fetched_at.isoformat(),
+                     "origin": snap.origin, "version": snap.version,
+                     "body_text": _decode(body)},
+    }
 
 
 # ---------------------------------------------------------------------------------------------
@@ -471,7 +534,9 @@ async def lookup(
         _touch(kh)
         return {"body": body, "media_type": newest.media_type,
                 "status_code": newest.status_code, "fetched_at": newest.fetched_at,
-                "age_s": age_s}
+                "age_s": age_s,
+                # Identities of the served answer, for the audit row's call→archive link.
+                "key_hash": kh, "content_hash": newest.content_hash, "version": newest.version}
     except Exception:  # noqa: BLE001 — a lookup fault must degrade to a live call, never a 500
         _log.warning("archive lookup failed for %s — serving live", endpoint_id, exc_info=True)
         return None

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -217,6 +217,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/bundles/{bundle_id}', ('PATCH',), 'update_bundle'),
     ('/bundles/{bundle_id}', ('DELETE',), 'delete_bundle'),
     ('/calls', ('GET',), 'list_calls'),
+    ('/calls/{call_id:int}/result', ('GET',), 'get_call_result'),
     ('/calls/{call_ref}', ('GET',), 'get_call'),
     ('/runs', ('GET',), 'list_runs'),
     ('/oauth/providers', ('GET',), 'oauth_providers_list'),

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -300,8 +300,15 @@ class CallRecord(SQLModel, table=True):
     # Did the provider FIND something? Decided at settle from the response body by the endpoint's
     # routing adapter (`catalog/adapters.yaml` `miss`), never stored as content — only the verdict.
     # NULL = no adapter could tell (or the call failed). Feeds `stats.observed` `hit_rate`, the
-    # P(hit) of the router's expected-cost-per-hit ranking. Last column on purpose (alembic appends).
+    # P(hit) of the router's expected-cost-per-hit ranking.
     hit: bool | None = Field(default=None)
+    # The archive identities of the answer this call received — `ArchiveKey.key_hash` (the
+    # question) and `ArchiveSnapshot.content_hash` (the exact bytes) — set only when the archive
+    # recorded or served it, i.e. metered platform 2xx calls while recording is on. The join
+    # behind the team-facing `/calls/{id}/result`. Not indexed on purpose: the read starts from
+    # this row by id and both targets carry their own index. Last columns (alembic appends).
+    archive_key_hash: str | None = Field(default=None)
+    archive_content_hash: str | None = Field(default=None)
 
 
 class RunRecord(SQLModel, table=True):

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -429,6 +429,7 @@ addEventListener('load', function(){
   .soon-note:hover::after{opacity:1}
   .chip.demo{border-color:var(--accent);color:var(--accent)}
   .modal .hd{display:flex;justify-content:space-between;align-items:center;padding:15px 18px;border-bottom:1px solid var(--line)}
+  tr.act-row{cursor:pointer} tr.act-row:hover td{background:var(--panel2)} .act-view{font-size:11px;color:var(--accent);margin-left:6px;white-space:nowrap}
   .drawer{position:fixed;top:0;right:0;height:100vh;width:min(520px,96vw);background:var(--panel);border-left:1px solid var(--line);z-index:50;box-shadow:-12px 0 44px rgba(20,16,10,.34);display:flex;flex-direction:column}
   pre{margin:0;padding:14px;background:var(--bg);border:1px solid var(--line);border-radius:10px;font-family:var(--mono);font-size:12.5px;overflow:auto;white-space:pre-wrap;word-break:break-word;max-height:50vh}
   pre.code{white-space:pre;overflow-x:auto;word-break:normal;overflow-wrap:normal;line-height:1.55}
@@ -2751,7 +2752,7 @@ a:hover{text-decoration-color:var(--muted)}
           <template v-if="actTab==='feed'">
           <p class="sub">Every proxy call and server CLI run in this org.</p>
           <table><tr><th>When</th><th>Who</th><th v-if="anyTagged">Tagged</th><th>Tool</th><th>Action</th><th>Status</th><th style="text-align:right">Cost</th></tr>
-            <tr v-for="a in activityRows" :key="a.kind+'-'+a.id"><td class="muted">{{when(a.created_at)}}</td><td>{{short(a.user_email)}}<span v-if="a.client && a.client!=='cli'" class="chip" style="margin-left:6px" :title="'reported by the runtime — attribution, not authentication'">via {{a.client}}</span></td><td v-if="anyTagged"><template v-if="a.tags"><span v-for="(v,k) in a.tags" :key="k" class="chip" style="margin-right:4px" :title="'X-Treg-Meta '+k+'='+v">{{k}}={{v}}</span></template><span v-else class="muted">—</span></td><td>{{a.tool}}</td><td><span v-if="a.kind==='run'" class="chip" style="margin-right:6px" :title="a.where==='local'?'ran on this member\'s machine':'ran on the registry server'">{{a.where||'run'}}</span>{{a.action}}</td><td><span class="badge" :class="a.ok?'ok':'invalid'">{{a.status}}</span></td><td style="text-align:right;white-space:nowrap" class="muted" :title="a.tier==='platform'?'charged to team balance':(a.cost!=null?'estimated — billed to your own provider key':'')">{{a.cost!=null?money(a.cost):'—'}}</td></tr></table>
+            <tr v-for="a in activityRows" :key="a.kind+'-'+a.id" :class="{'act-row':a.kind==='call'}" @click="a.kind==='call'&&openCall(a)" :title="a.kind==='call'?(a.has_result?'Show request and response':'Show call details'):''"><td class="muted">{{when(a.created_at)}}</td><td>{{short(a.user_email)}}<span v-if="a.client && a.client!=='cli'" class="chip" style="margin-left:6px" :title="'reported by the runtime — attribution, not authentication'">via {{a.client}}</span></td><td v-if="anyTagged"><template v-if="a.tags"><span v-for="(v,k) in a.tags" :key="k" class="chip" style="margin-right:4px" :title="'X-Treg-Meta '+k+'='+v">{{k}}={{v}}</span></template><span v-else class="muted">—</span></td><td>{{a.tool}}</td><td><span v-if="a.kind==='run'" class="chip" style="margin-right:6px" :title="a.where==='local'?'ran on this member\'s machine':'ran on the registry server'">{{a.where||'run'}}</span>{{a.action}}</td><td><span class="badge" :class="a.ok?'ok':'invalid'">{{a.status}}</span><span v-if="a.has_result" class="act-view">result ›</span></td><td style="text-align:right;white-space:nowrap" class="muted" :title="a.tier==='platform'?'charged to team balance':(a.cost!=null?'estimated — billed to your own provider key':'')">{{a.cost!=null?money(a.cost):'—'}}</td></tr></table>
           <p v-if="!loading && !activityRows.length" class="sub">No activity yet.</p>
           </template>
 
@@ -3840,6 +3841,43 @@ product, including per-customer usage tracking and billing.</pre>
     <!-- Try a MARKETPLACE endpoint right here. Same relay as any call — served by the org's own
          key when one exists, else treg's key billed to the team balance — and logged in Activity
          exactly like a CLI call. -->
+    <!-- Activity → one call. The archive's copy of what was asked and what came back (metered
+         platform calls only — own-key and own-tool calls are relayed without being stored). -->
+    <div class="scrim" role="dialog" aria-modal="true" v-if="callView" @click.self="callView=null" style="place-items:stretch;justify-items:end">
+      <div class="drawer" style="width:min(680px,96vw)"><div class="hd" style="padding:15px 18px;border-bottom:1px solid var(--line)"><b>{{callView.endpoint_id||callView.tool||'Call'}}</b><button class="btn sm" @click="callView=null" aria-label="Close">✕</button></div>
+        <div class="bd" style="padding:16px 18px;overflow:auto">
+          <div class="kv">
+            <div><b>When</b>{{when(callView.created_at)}}</div>
+            <div><b>Status</b><span class="badge" :class="callView.status_code<400?'ok':'invalid'">{{callView.status_code}}</span></div>
+            <div v-if="callView.provider"><b>Provider</b>{{callView.provider}}</div>
+            <div v-if="callView.credential_tier"><b>Served on</b>{{callView.credential_tier==='platform'?'treg key':'your key'}}</div>
+            <div v-if="callView.cached"><b>Answer</b><span class="chip" title="served from the archive instead of the vendor">cached</span></div>
+            <div v-if="callView.call_ref"><b>Call id</b><span class="mono" style="font-size:11px">{{callView.call_ref}}</span></div>
+          </div>
+          <p v-if="callView.loading" class="sub">Loading…</p>
+          <p v-else-if="callView.error" class="sub" style="color:var(--red)">{{callView.error}}</p>
+          <template v-else>
+            <p v-if="callView.note" class="sub" style="margin:4px 0 12px">{{callView.note}}</p>
+            <template v-if="callView.request">
+              <h3 style="margin:10px 0 6px;font-size:13px">Request</h3>
+              <p class="explain" style="margin:0 0 6px"><span class="mono">{{callView.request.method}} {{callView.request.url}}</span></p>
+              <pre v-if="callView.request.body_text" style="max-height:24vh">{{pretty(callView.request.body_text)}}</pre>
+            </template>
+            <template v-if="callView.response">
+              <h3 style="margin:14px 0 6px;font-size:13px;display:flex;align-items:center;gap:8px">Response
+                <span class="muted" style="font-weight:400;font-size:11px">{{callView.response.status_code}} · {{callView.response.media_type||'—'}} · {{fmtBytes(callView.response.size_bytes)}} · fetched {{when(callView.response.fetched_at)}}</span>
+                <button v-if="callView.response.body_text" class="btn sm" style="margin-left:auto" @click="copyCallBody()">{{callCopied||'Copy'}}</button>
+              </h3>
+              <template v-if="callView.response.body_text">
+                <pre style="max-height:60vh">{{callBodyShown}}</pre>
+                <p v-if="callBodyTruncated" class="sub" style="margin:6px 0 0"><a href="#" @click.prevent="callViewFull=true">Show full response ({{fmtBytes(callView.response.body_text.length)}})</a></p>
+              </template>
+              <p v-else-if="callView.stored" class="sub">The stored answer is not text — copy is unavailable for binary bodies.</p>
+            </template>
+          </template>
+        </div>
+      </div>
+    </div>
     <div class="scrim" role="dialog" aria-modal="true" v-if="epTry" @click.self="epTry=null" style="place-items:stretch;justify-items:end">
       <div class="drawer"><div class="hd" style="padding:15px 18px;border-bottom:1px solid var(--line)"><b>Try “{{epTry.id}}”</b><button class="btn sm" @click="epTry=null" aria-label="Close">✕</button></div>
         <div class="bd" style="padding:16px 18px;overflow:auto">
@@ -4060,6 +4098,7 @@ createApp({
       cfgMenu:false,  // detail-page ⚙ Configure tool-picker (skills with >1 tool)
       tryMenu:false,  // detail-page ▶ Try it tool-picker (skills with >1 tool)
       // marketplace endpoint Try-it drawer
+      callView:null, callViewFull:false, callCopied:'',  // Activity → one call's request/response drawer
       epTry:null, epTryTab:'agent', epTryAccess:null, epTryAccessByMethod:{}, epTryAuthMethod:'', epTryParams:[], epTryBody:'', epTryResp:'', epTryStatus:null,
       epTryMs:null, epTryCost:null, epTryBusy:false,
       catalogClis:null,  // bin → catalog default deny patterns (lazy, from /providers.json)
@@ -4324,9 +4363,16 @@ createApp({
       // Cost precedence: what was CHARGED (settle amount; 0 on a release — the estimate alone would
       // over-report a refunded call as spend), else observed, else the estimate (old rows / own-key).
       const calls=(this.calls||[]).filter(c=>c.kind!=='local_run').map(c=>({kind:'call', id:c.id, created_at:c.created_at, user_email:c.user_email, client:c.client, tool:c.tool_name, action:c.method, status:c.status_code, ok:c.status_code<400,
-        cost:(c.cost_charged_micro!=null?c.cost_charged_micro:(c.cost_observed_micro!=null?c.cost_observed_micro:c.cost_estimated_micro)), tier:c.credential_tier, tags:c.tags}));
+        cost:(c.cost_charged_micro!=null?c.cost_charged_micro:(c.cost_observed_micro!=null?c.cost_observed_micro:c.cost_estimated_micro)), tier:c.credential_tier, tags:c.tags,
+        has_result:!!c.has_result, endpoint_id:c.endpoint_id, call_ref:c.call_ref, path:c.path, cached:c.cached}));
       const runs=(this.runs||[]).map(r=>({kind:'run', where:r.where, id:r.id, created_at:r.created_at, user_email:r.user_email, client:r.client, tool:r.tool, action:(r.argv||[]).join(' ').slice(0,48)||'-', status:(r.where==='local'?'local run':'exit '+r.exit_code), ok:(r.where==='local'?true:r.exit_code===0)}));
       return calls.concat(runs).sort((a,b)=>a.created_at<b.created_at?1:-1);
+    },
+    callBodyTruncated(){ const t=this.callView&&this.callView.response&&this.callView.response.body_text; return !!t && !this.callViewFull && t.length>262144; },
+    callBodyShown(){  // pretty-print JSON when it parses; cap the rendered text at 256 KB unless asked for all of it
+      const t=this.callView&&this.callView.response&&this.callView.response.body_text; if(!t) return '';
+      if(this.callBodyTruncated) return t.slice(0,262144)+'\n… (truncated)';
+      return this.pretty(t);
     },
     anyTagged(){  // hide the column entirely for teams that never send X-Treg-Meta
       return (this.calls||[]).some(c=>c.tags && Object.keys(c.tags).length);
@@ -6236,6 +6282,15 @@ createApp({
         if(this.view==='secrets') this.loadSecrets();  // …and the Secrets view (was showing the previous org's)
       }catch(e){ this.err='Failed to load: '+(e.detail||e.status); }
       finally{ this.loading=false; } },
+    async openCall(a){  // Activity row → the drawer; details load from /calls/{id}/result
+      this.callViewFull=false; this.callCopied='';
+      this.callView={id:a.id, tool:a.tool, endpoint_id:a.endpoint_id, call_ref:a.call_ref, created_at:a.created_at, status_code:a.status, credential_tier:a.tier, cached:a.cached, loading:true};
+      try{ const d=await this.api('/calls/'+a.id+'/result'); this.callView={...this.callView, ...d, loading:false}; }
+      catch(e){ this.callView={...this.callView, loading:false, error:'Could not load this call.'}; }
+    },
+    pretty(text){ try{ return JSON.stringify(JSON.parse(text), null, 2); }catch(e){ return text; } },
+    fmtBytes(n){ if(n==null) return '—'; if(n<1024) return n+' B'; if(n<1048576) return (n/1024).toFixed(1)+' KB'; return (n/1048576).toFixed(2)+' MB'; },
+    async copyCallBody(){ const t=this.callView&&this.callView.response&&this.callView.response.body_text; if(!t) return; if(await this.toClipboard(t)){ this.callCopied='Copied'; setTimeout(()=>{ this.callCopied=''; },1400); } },
     async loadCalls(){ try{ const [calls,runs]=await Promise.all([this.api('/calls?limit=100'), this.api('/runs?limit=100').catch(()=>[])]); this.calls=calls; this.runs=runs; }catch(e){ this.err='Failed to load activity.'; } },
     async loadAdmin(){ this.confirmAdmUser=null; this.confirmAdmOrg=null;
       try{ this.adminStats=await this.api('/admin/stats'); this.adminOrgs=await this.api('/admin/orgs'); this.adminUsers=await this.api('/admin/users'); }

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -4373,12 +4373,9 @@ createApp({
       return calls.concat(runs).sort((a,b)=>a.created_at<b.created_at?1:-1);
     },
     activityShown(){ return this.actOkOnly ? this.activityRows.filter(a=>a.ok) : this.activityRows; },
-    callBodyTruncated(){ const t=this.callView&&this.callView.response&&this.callView.response.body_text; return !!t && !this.callViewFull && t.length>262144; },
-    callBodyShown(){  // pretty-print JSON when it parses; cap the rendered text at 256 KB unless asked for all of it
-      const t=this.callView&&this.callView.response&&this.callView.response.body_text; if(!t) return '';
-      if(this.callBodyTruncated) return t.slice(0,262144)+'\n… (truncated)';
-      return this.pretty(t);
-    },
+    callBodyPretty(){ const t=this.callView&&this.callView.response&&this.callView.response.body_text; return t?this.pretty(t):''; },  // JSON pretty-printed when it parses (a 2 MB parse is ~20 ms)
+    callBodyTruncated(){ return !this.callViewFull && this.callBodyPretty.length>262144; },  // cap the RENDERED text at 256 KB unless asked for all of it
+    callBodyShown(){ const t=this.callBodyPretty; return this.callBodyTruncated ? t.slice(0,262144)+'\n… (truncated)' : t; },
     anyTagged(){  // hide the column entirely for teams that never send X-Treg-Meta
       return (this.calls||[]).some(c=>c.tags && Object.keys(c.tags).length);
     },

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2750,10 +2750,14 @@ a:hover{text-decoration-color:var(--muted)}
           </div>
 
           <template v-if="actTab==='feed'">
-          <p class="sub">Every proxy call and server CLI run in this org.</p>
+          <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+            <p class="sub" style="margin:0;flex:1">{{actOkOnly?'Successful calls and runs in this org.':'Every proxy call and server CLI run in this org.'}}</p>
+            <button v-if="activityRows.length" class="btn sm" @click="actOkOnly=!actOkOnly" :title="actOkOnly?'Include failed and refused calls':'Hide failed and refused calls'">{{actOkOnly?'Show all ('+activityRows.length+')':'Successes only'}}</button>
+          </div>
           <table><tr><th>When</th><th>Who</th><th v-if="anyTagged">Tagged</th><th>Tool</th><th>Action</th><th>Status</th><th style="text-align:right">Cost</th></tr>
-            <tr v-for="a in activityRows" :key="a.kind+'-'+a.id" :class="{'act-row':a.kind==='call'}" @click="a.kind==='call'&&openCall(a)" :title="a.kind==='call'?(a.has_result?'Show request and response':'Show call details'):''"><td class="muted">{{when(a.created_at)}}</td><td>{{short(a.user_email)}}<span v-if="a.client && a.client!=='cli'" class="chip" style="margin-left:6px" :title="'reported by the runtime — attribution, not authentication'">via {{a.client}}</span></td><td v-if="anyTagged"><template v-if="a.tags"><span v-for="(v,k) in a.tags" :key="k" class="chip" style="margin-right:4px" :title="'X-Treg-Meta '+k+'='+v">{{k}}={{v}}</span></template><span v-else class="muted">—</span></td><td>{{a.tool}}</td><td><span v-if="a.kind==='run'" class="chip" style="margin-right:6px" :title="a.where==='local'?'ran on this member\'s machine':'ran on the registry server'">{{a.where||'run'}}</span>{{a.action}}</td><td><span class="badge" :class="a.ok?'ok':'invalid'">{{a.status}}</span><span v-if="a.has_result" class="act-view">result ›</span></td><td style="text-align:right;white-space:nowrap" class="muted" :title="a.tier==='platform'?'charged to team balance':(a.cost!=null?'estimated — billed to your own provider key':'')">{{a.cost!=null?money(a.cost):'—'}}</td></tr></table>
+            <tr v-for="a in activityShown" :key="a.kind+'-'+a.id" :class="{'act-row':a.kind==='call'}" @click="a.kind==='call'&&openCall(a)" :title="a.kind==='call'?(a.has_result?'Show request and response':'Show call details'):''"><td class="muted">{{when(a.created_at)}}</td><td>{{short(a.user_email)}}<span v-if="a.client && a.client!=='cli'" class="chip" style="margin-left:6px" :title="'reported by the runtime — attribution, not authentication'">via {{a.client}}</span></td><td v-if="anyTagged"><template v-if="a.tags"><span v-for="(v,k) in a.tags" :key="k" class="chip" style="margin-right:4px" :title="'X-Treg-Meta '+k+'='+v">{{k}}={{v}}</span></template><span v-else class="muted">—</span></td><td>{{a.tool}}</td><td><span v-if="a.kind==='run'" class="chip" style="margin-right:6px" :title="a.where==='local'?'ran on this member\'s machine':'ran on the registry server'">{{a.where||'run'}}</span>{{a.action}}</td><td><span class="badge" :class="a.ok?'ok':'invalid'">{{a.status}}</span><span v-if="a.has_result" class="act-view">result ›</span></td><td style="text-align:right;white-space:nowrap" class="muted" :title="a.tier==='platform'?'charged to team balance':(a.cost!=null?'estimated — billed to your own provider key':'')">{{a.cost!=null?money(a.cost):'—'}}</td></tr></table>
           <p v-if="!loading && !activityRows.length" class="sub">No activity yet.</p>
+          <p v-else-if="!loading && !activityShown.length" class="sub">No successful calls yet — <a href="#" @click.prevent="actOkOnly=false">show all {{activityRows.length}}</a>.</p>
           </template>
 
           <template v-if="canAdmin && actTab==='usage'">
@@ -4099,6 +4103,7 @@ createApp({
       tryMenu:false,  // detail-page ▶ Try it tool-picker (skills with >1 tool)
       // marketplace endpoint Try-it drawer
       callView:null, callViewFull:false, callCopied:'',  // Activity → one call's request/response drawer
+      actOkOnly:true,  // Activity feed: successes only by default; the toggle shows failed/refused too
       epTry:null, epTryTab:'agent', epTryAccess:null, epTryAccessByMethod:{}, epTryAuthMethod:'', epTryParams:[], epTryBody:'', epTryResp:'', epTryStatus:null,
       epTryMs:null, epTryCost:null, epTryBusy:false,
       catalogClis:null,  // bin → catalog default deny patterns (lazy, from /providers.json)
@@ -4368,6 +4373,7 @@ createApp({
       const runs=(this.runs||[]).map(r=>({kind:'run', where:r.where, id:r.id, created_at:r.created_at, user_email:r.user_email, client:r.client, tool:r.tool, action:(r.argv||[]).join(' ').slice(0,48)||'-', status:(r.where==='local'?'local run':'exit '+r.exit_code), ok:(r.where==='local'?true:r.exit_code===0)}));
       return calls.concat(runs).sort((a,b)=>a.created_at<b.created_at?1:-1);
     },
+    activityShown(){ return this.actOkOnly ? this.activityRows.filter(a=>a.ok) : this.activityRows; },
     callBodyTruncated(){ const t=this.callView&&this.callView.response&&this.callView.response.body_text; return !!t && !this.callViewFull && t.length>262144; },
     callBodyShown(){  // pretty-print JSON when it parses; cap the rendered text at 256 KB unless asked for all of it
       const t=this.callView&&this.callView.response&&this.callView.response.body_text; if(!t) return '';

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -429,6 +429,7 @@ addEventListener('load', function(){
   .soon-note:hover::after{opacity:1}
   .chip.demo{border-color:var(--accent);color:var(--accent)}
   .modal .hd{display:flex;justify-content:space-between;align-items:center;padding:15px 18px;border-bottom:1px solid var(--line)}
+  .tabs .act-toggle{margin-left:auto;align-self:center;margin-bottom:6px;padding:4px 11px;font-family:inherit;font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:999px} .tabs .act-toggle:hover{border-color:var(--accent);color:var(--accent)}
   tr.act-row{cursor:pointer} tr.act-row:hover td{background:var(--panel2)} .act-view{font-size:11px;color:var(--accent);margin-left:6px;white-space:nowrap}
   .drawer{position:fixed;top:0;right:0;height:100vh;width:min(520px,96vw);background:var(--panel);border-left:1px solid var(--line);z-index:50;box-shadow:-12px 0 44px rgba(20,16,10,.34);display:flex;flex-direction:column}
   pre{margin:0;padding:14px;background:var(--bg);border:1px solid var(--line);border-radius:10px;font-family:var(--mono);font-size:12.5px;overflow:auto;white-space:pre-wrap;word-break:break-word;max-height:50vh}
@@ -2747,13 +2748,11 @@ a:hover{text-decoration-color:var(--muted)}
           <div class="tabs" style="margin:10px 0 4px">
             <button :class="{active:actTab==='feed'}" @click="actTab='feed'">Activity</button>
             <button v-if="canAdmin" :class="{active:actTab==='usage'}" @click="actTab='usage'; loadUsage()">Usage</button>
+            <button v-if="actTab==='feed' && activityRows.length" class="act-toggle" @click="actOkOnly=!actOkOnly" :title="actOkOnly?'Include failed and refused calls':'Hide failed and refused calls'">{{actOkOnly?'Show all ('+activityRows.length+')':'Successes only'}}</button>
           </div>
 
           <template v-if="actTab==='feed'">
-          <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-            <p class="sub" style="margin:0;flex:1">{{actOkOnly?'Successful calls and runs in this org.':'Every proxy call and server CLI run in this org.'}}</p>
-            <button v-if="activityRows.length" class="btn sm" @click="actOkOnly=!actOkOnly" :title="actOkOnly?'Include failed and refused calls':'Hide failed and refused calls'">{{actOkOnly?'Show all ('+activityRows.length+')':'Successes only'}}</button>
-          </div>
+          <p class="sub">{{actOkOnly?'Successful calls and runs in this org.':'Every proxy call and server CLI run in this org.'}}</p>
           <table><tr><th>When</th><th>Who</th><th v-if="anyTagged">Tagged</th><th>Tool</th><th>Action</th><th>Status</th><th style="text-align:right">Cost</th></tr>
             <tr v-for="a in activityShown" :key="a.kind+'-'+a.id" :class="{'act-row':a.kind==='call'}" @click="a.kind==='call'&&openCall(a)" :title="a.kind==='call'?(a.has_result?'Show request and response':'Show call details'):''"><td class="muted">{{when(a.created_at)}}</td><td>{{short(a.user_email)}}<span v-if="a.client && a.client!=='cli'" class="chip" style="margin-left:6px" :title="'reported by the runtime — attribution, not authentication'">via {{a.client}}</span></td><td v-if="anyTagged"><template v-if="a.tags"><span v-for="(v,k) in a.tags" :key="k" class="chip" style="margin-right:4px" :title="'X-Treg-Meta '+k+'='+v">{{k}}={{v}}</span></template><span v-else class="muted">—</span></td><td>{{a.tool}}</td><td><span v-if="a.kind==='run'" class="chip" style="margin-right:6px" :title="a.where==='local'?'ran on this member\'s machine':'ran on the registry server'">{{a.where||'run'}}</span>{{a.action}}</td><td><span class="badge" :class="a.ok?'ok':'invalid'">{{a.status}}</span><span v-if="a.has_result" class="act-view">result ›</span></td><td style="text-align:right;white-space:nowrap" class="muted" :title="a.tier==='platform'?'charged to team balance':(a.cost!=null?'estimated — billed to your own provider key':'')">{{a.cost!=null?money(a.cost):'—'}}</td></tr></table>
           <p v-if="!loading && !activityRows.length" class="sub">No activity yet.</p>

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -431,6 +431,7 @@ addEventListener('load', function(){
   .modal .hd{display:flex;justify-content:space-between;align-items:center;padding:15px 18px;border-bottom:1px solid var(--line)}
   .tabs .act-toggle{margin-left:auto;align-self:center;margin-bottom:6px;padding:4px 11px;font-family:inherit;font-size:12px;color:var(--ink);background:var(--panel);border:1px solid var(--line);border-radius:999px} .tabs .act-toggle:hover{border-color:var(--accent);color:var(--accent)}
   tr.act-row{cursor:pointer} tr.act-row:hover td{background:var(--panel2)} .act-view{font-size:11px;color:var(--accent);margin-left:6px;white-space:nowrap}
+  .drawer .hd{display:flex;justify-content:space-between;align-items:center;gap:12px} .drawer .hd b{min-width:0;overflow-wrap:anywhere}
   .drawer{position:fixed;top:0;right:0;height:100vh;width:min(520px,96vw);background:var(--panel);border-left:1px solid var(--line);z-index:50;box-shadow:-12px 0 44px rgba(20,16,10,.34);display:flex;flex-direction:column}
   pre{margin:0;padding:14px;background:var(--bg);border:1px solid var(--line);border-radius:10px;font-family:var(--mono);font-size:12.5px;overflow:auto;white-space:pre-wrap;word-break:break-word;max-height:50vh}
   pre.code{white-space:pre;overflow-x:auto;word-break:normal;overflow-wrap:normal;line-height:1.55}

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -4880,6 +4880,78 @@
         "summary": "List Calls"
       }
     },
+    "/calls/{call_id}/result": {
+      "get": {
+        "description": "What one of this team's calls asked and what came back — the archive's copy.\n\nOnly a METERED PLATFORM 2xx call has one: those answers are recorded by the archive (see\ndocs/context/architecture/archive.md), and the audit row keeps the identities of the exact\nbytes the caller received. Own-key and own-tool calls are relayed without being stored, a\nfailed call never is, and the redacted failure evidence stays admin-only — `stored` is false\nwith a `note` saying which. The request shape is the vendor-facing one BEFORE credential\ninjection, so no secret can appear in it.",
+        "operationId": "get_call_result_calls__call_id__result_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "call_id",
+            "required": true,
+            "schema": {
+              "title": "Call Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-token",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Token",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-treg-org",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Treg-Org",
+              "type": "string"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "treg_session",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Treg Session",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Call Result Calls  Call Id  Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Call Result"
+      }
+    },
     "/calls/{call_ref}": {
       "get": {
         "description": "One call by the `X-Treg-Call-Id` it returned — the join key for a builder's own records.\n\nAlso reports the LEDGER's view of the same reference, because that is the durable one: the audit\nrow is fire-and-forget and may have been shed, while the money entries were written synchronously.\nA 404 here therefore means \"no audit row\", not \"this call never happened\" — check `ledger` in the\nbody before concluding anything about money.",

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -1611,6 +1611,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "get_call_result",
+    "path": "/calls/{call_id:int}/result"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "get_call",
     "path": "/calls/{call_ref}"
   },

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -686,3 +686,129 @@ async def test_admin_archive_body_viewer(clients: AsyncClient, serve, monkeypatc
         assert r.status_code == 404
     finally:
         get_settings.cache_clear()
+
+
+# ---- the call→archive link: `has_result` on /calls and GET /calls/{id}/result -------------------
+# The team-facing read of a stored answer. Only metered platform 2xx calls have one (the archive's
+# gate 3); every other row answers `stored: false` with a note saying which case it is.
+
+async def _make_org_and_token(name: str, email: str) -> str:
+    from treg import crypto
+    from treg.models import Membership, Org, User
+    async with session_maker() as db:
+        org = Org(name=name, slug=name)
+        db.add(org)
+        await db.flush()
+        user = User(email=email)
+        db.add(user)
+        await db.flush()
+        token = crypto.new_token()
+        db.add(Membership(user_id=user.id, org_id=org.id, role="admin",
+                          token_hash=crypto.hash_token(token)))
+        await db.commit()
+    return token
+
+
+async def test_a_recorded_call_links_to_its_stored_answer(clients: AsyncClient, shadow):
+    r1 = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r1.status_code == 200, r1.text
+    await archive.drain()
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert row["has_result"] is True
+    got = await clients.get(f"/calls/{row['id']}/result")
+    assert got.status_code == 200, got.text
+    d = got.json()
+    assert d["stored"] is True and d["note"] is None and d["cached"] is False
+    assert d["endpoint_id"] == EP
+    assert d["response"]["body_text"] == r1.text            # the exact bytes the caller got
+    assert d["response"]["status_code"] == 200 and d["response"]["origin"] == "caller"
+    assert d["request"]["method"] == "GET"
+    assert "aweme_id=7" in d["request"]["url"] and "count=5" in d["request"]["url"]
+    assert "PLATFORM-TIKHUB-KEY" not in d["request"]["url"]  # pre-injection shape, no secret
+
+
+async def test_a_served_hit_links_to_the_same_answer(clients: AsyncClient, serve):
+    r1 = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    await archive.drain()
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert r2.headers["X-Treg-Cache"] == "hit"
+    await audit.drain()
+    rows = (await clients.get("/calls")).json()
+    hit, live = rows[0], rows[1]
+    assert hit["cached"] is True and hit["has_result"] is True
+    a = (await clients.get(f"/calls/{hit['id']}/result")).json()
+    b = (await clients.get(f"/calls/{live['id']}/result")).json()
+    assert a["stored"] and b["stored"] and a["cached"] is True
+    assert a["response"]["body_text"] == b["response"]["body_text"] == r1.text
+    assert a["response"]["version"] == b["response"]["version"]   # a hit is not a new version
+
+
+async def test_an_own_tool_call_has_no_stored_result(clients: AsyncClient, shadow):
+    await clients.post("/tools", json={"name": "echo", "base_url": "http://upstream",
+                                       "auth": {"kind": "bearer", "secret_name": "echo"}})
+    await clients.post("/secrets", json={"name": "echo", "value": "S"})
+    r = await clients.get("/call/echo/anything")
+    assert r.status_code == 200, r.text
+    await archive.drain()
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert row["has_result"] is False
+    d = (await clients.get(f"/calls/{row['id']}/result")).json()
+    assert d["stored"] is False and d["request"] is None and d["response"] is None
+    assert d["note"].startswith("not stored: calls on your own key")
+
+
+async def test_a_platform_call_made_while_recording_was_off(clients: AsyncClient, platform_on,
+                                                            monkeypatch):
+    monkeypatch.setattr(get_settings(), "archive_mode", "off")
+    assert (await clients.get(f"/call/{EP}?aweme_id=7&count=5")).status_code == 200
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert row["has_result"] is False
+    d = (await clients.get(f"/calls/{row['id']}/result")).json()
+    assert d["stored"] is False and d["note"] == "not stored: recording was off when this call was made"
+
+
+async def test_a_hash_only_answer_says_so(clients: AsyncClient, shadow, monkeypatch):
+    # A judged `forbidden` licence: counted, hashed, bytes never kept.
+    monkeypatch.setitem(catalog_store.load().by_id[EP], "cache", "forbidden")
+    assert (await clients.get(f"/call/{EP}?aweme_id=7&count=5")).status_code == 200
+    await archive.drain()
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert row["has_result"] is True                  # the link exists; the bytes do not
+    d = (await clients.get(f"/calls/{row['id']}/result")).json()
+    assert d["stored"] is False and d["note"].startswith("hash-only")
+    assert d["response"]["body_text"] is None and d["response"]["size_bytes"] > 0
+    assert d["request"]["method"] == "GET"            # the question is still on file
+
+
+async def test_a_result_is_scoped_to_the_team(clients: AsyncClient, shadow):
+    assert (await clients.get(f"/call/{EP}?aweme_id=7&count=5")).status_code == 200
+    await archive.drain()
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    assert (await clients.get(f"/calls/{row['id']}/result")).status_code == 200
+    outsider = await _make_org_and_token("other-team", "outsider@example.com")
+    denied = await clients.get(f"/calls/{row['id']}/result", headers={"X-Treg-Token": outsider})
+    assert denied.status_code == 404
+
+
+async def test_the_result_never_carries_failure_evidence(clients: AsyncClient, shadow):
+    # The redacted error columns stay admin-only: a failed call answers with a note, nothing more.
+    from treg.models import CallRecord
+    assert (await clients.get(f"/call/{EP}?aweme_id=7&count=5")).status_code == 200
+    await archive.drain()
+    await audit.drain()
+    row = (await clients.get("/calls")).json()[0]
+    async with session_maker() as s:
+        rec = await s.get(CallRecord, row["id"])
+        rec.status_code, rec.archive_key_hash, rec.archive_content_hash = 502, None, None
+        rec.error_response = "SECRET-EVIDENCE"
+        s.add(rec)
+        await s.commit()
+    got = await clients.get(f"/calls/{row['id']}/result")
+    assert got.status_code == 200
+    assert "SECRET-EVIDENCE" not in got.text
+    assert got.json()["note"] == "not stored: the call failed, so there is no answer on file"


### PR DESCRIPTION
## What

Users can now see what a catalog call asked and what came back, from the Activity page.

- **Call → archive link.** Each metered platform 2xx call stores the archive identities of its answer on the audit row (`callrecord.archive_key_hash` / `archive_content_hash`, migration 0011: two nullable columns, no index, instant ALTER). `archive.record()` returns `(key_hash, content_hash)` and `lookup()` reports them; the call service writes both via `_audit`.
- **`GET /calls/{id}/result`** (member, org-scoped) returns the pre-injection request shape (`ArchiveKey.req_*`) and the stored answer (`ArchiveSnapshot`) via the new `archive.resolve_result`. Every "nothing on file" case answers `stored: false` with a `note`: own-key/own-tool never stored · failed · recording off · expired · hash-only. `/calls` rows carry `has_result`.
- **Dashboard.** Activity rows open a right-side drawer: request line, response pretty-printed (rendered text capped at 256 KB with "Show full"), Copy. The feed shows **successes only by default** with a "Show all (N)" toggle in the tabs bar. Drawer headers now right-align their close button (fixes the Use/Try drawers too).
- **Backfill.** `scripts/backfill_call_archive_links.py` links pre-migration rows best-effort (same endpoint + byte size + fetch within ±10 s, unambiguous in both directions). Dry run by default, `--apply` to write, `--render` for the prod allowlist dance.

## What it deliberately does not do

- Own-key / own-tool bodies are never stored (the archive's privacy line is unchanged).
- `error_request` / `error_response` stay admin-only; the result endpoint never reads them (test pins it).
- No change to cached-hit billing and no `serve` flip — prod stays `shadow`, which already records everything this needs.

## Verification

- 7 new tests in `tests/test_archive.py`: recorded call links + body round-trips; served hit resolves to the same version; own-tool → note; recording off → note; forbidden licence → hash-only note; cross-org 404; failure evidence never leaks.
- Full suite: 2460 passed. The 5 failures are pre-existing `.env` leaks (archive mode, PostHog, overflow, Intercom) and fail identically on clean `main`.
- Browser, on a fresh local DB in `shadow`: real coingecko, hunter.people.enrich ($0.0049) and scrapecreators.instagram.user.profile (333 KB, $0.0019) calls; drawer opens in ~0.1 s, "show full" renders 333 KB in ~0.4 s, no console errors. Failed and own-tool rows show their notes.
- Not verified: the backfill script's SQL against a real Postgres (none available locally) — run it in dry-run mode first.

## After deploy

```
python scripts/backfill_call_archive_links.py --render          # counts only
python scripts/backfill_call_archive_links.py --render --apply
```

Docs: `interface/api.md`, `interface/dashboard.md`, `architecture/archive.md`, `architecture/data-model.md`, context MAP; route + OpenAPI snapshots regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dpWfn7BoXd4k24ZrBWwhZ
