### PR TITLE
Add AlertKick provider: uptime & server monitoring (15 endpoints, new uptime platform)

### DIFF
--- a/src/treg/catalog/alertkick.yaml
+++ b/src/treg/catalog/alertkick.yaml
@@ -1,0 +1,339 @@
+provider: alertkick
+source:
+  docs: https://alertkick.com/docs/api/
+  openapi: https://alertkick.com/openapi.yaml
+  curated: '2026-09-03'
+# AlertKick is an uptime + server monitoring service: uptime monitors (HTTP/API/DNS/TCP/domain/
+# mail), cron-job heartbeats, alerting with on-call escalation, and agent-based server monitoring.
+# The API itself is NOT metered — every call below is free — and the account's PLAN caps how many
+# monitors/heartbeats/hosts can EXIST (Free: 10 monitors & heartbeats; paid plans raise the caps,
+# see pricing_url). Creating past a cap answers 402, never a charge.
+#
+# TENANCY — the one thing to know before calling: every workspace lives on its own host
+# (https://{workspace}.alertkick.com/api/v1) and an API key only works against the workspace that
+# minted it. A well-formed key on the wrong workspace host answers 401 (observed live
+# 2026-09-03). The registry entry's base_url is the `app` workspace host; a user on another
+# workspace must point calls at their own host until per-account base URLs are supported.
+# Keys: Settings → API Keys in the workspace UI, shown once at creation, sent as X-API-Key.
+#
+# UUIDs in test_requests are CHAINED, ACCOUNT-BOUND IDs: monitors/heartbeats/alerts live inside
+# the calling workspace, so a re-verify must first harvest ids from the list endpoints (or from
+# the create entries below) rather than trusting a 404 on someone else's id.
+limits: "no API metering; plan quotas cap monitors/heartbeats/hosts — a full quota answers 402"
+pricing_url: https://alertkick.com/pricing/  # Free £0 (10 monitors & heartbeats); Professional £39/mo; Business £149/mo (GBP)
+
+endpoints:
+  - id: alertkick.uptime.monitors.list
+    domain: monitors
+    capability: uptime.monitors.list
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /monitors/all
+    name: "List your uptime monitors"
+    summary: "List the workspace's uptime monitors with current up/down status and recent response times"
+    input:
+      queryParams:
+        offset: {type: integer, required: false, example: 0}
+        limit: {type: integer, required: false, note: "default 50", example: 50}
+    test_request:
+      queryParams: {limit: 5}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/listmonitors/
+
+  - id: alertkick.uptime.monitors.get
+    domain: monitors
+    capability: uptime.monitors.get
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /monitors/{uuid}
+    name: "Get one uptime monitor"
+    summary: "Get one monitor's full config, check history and poller locations"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, note: "from the list or create endpoints", example: "dacdvk0fhf9s73ehbet0"}
+    test_request:
+      pathParams: {uuid: "dacdvk0fhf9s73ehbet0"}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/getmonitor/
+
+  - id: alertkick.uptime.monitors.create
+    domain: monitors
+    capability: uptime.monitors.create
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: POST
+    path: /monitors/create
+    name: "Create an uptime monitor"
+    summary: "Create an uptime monitor for a URL, API, DNS record, TCP port, domain expiry or mailbox"
+    input:
+      body:
+        display_name: {type: string, required: true, example: "Marketing site"}
+        monitor_type: {type: string, required: true, note: "http | api | dns | tcp | domain | mail", example: "http"}
+        url: {type: string, required: true, example: "https://example.com"}
+        http_method: {type: string, required: true, note: "REQUIRED for http/api monitors — GET, POST, PUT, PATCH, DELETE, HEAD or OPTIONS (verified live: omitting it is a 400)", example: "GET"}
+        check_interval_seconds: {type: integer, required: true, note: "must be > 0; Free plan floor is 300, paid plans allow 60", example: 300}
+        timeout_seconds: {type: integer, required: true, note: "must be > 0 (verified live: omitting it is a 400)", example: 30}
+        expected_status_code: {type: integer, required: true, note: "must be > 0 for http/api monitors (verified live: omitting it is a 400)", example: 200}
+        expected_response_contains: {type: string, required: false}
+        tcp_port: {type: integer, required: false, note: "tcp monitors"}
+        dns_record_type: {type: string, required: false, note: "dns monitors — A, AAAA, CNAME, MX, TXT…", example: "A"}
+        expected_dns_host: {type: string, required: false}
+        ssl_cert_monitoring: {type: boolean, required: false, example: true}
+        ssl_cert_expiry_alert_days: {type: integer, required: false, example: 14}
+        domain_expiry_alert_days: {type: integer, required: false, note: "domain monitors", example: 30}
+        response_time_alert_ms: {type: integer, required: false}
+        failure_threshold: {type: integer, required: false, note: "consecutive failures before an alert", example: 3}
+        locations: {type: array, required: false, note: "poller location keys from the locations endpoint; omit for the default"}
+      bodyType: json
+      note: "creates a REAL monitor that counts against the workspace's plan quota — a full quota answers 402. The response carries the new monitor's uuid; delete or pause it from the dashboard (or the update/delete API) when it was only a test"
+    test_request:
+      body: {display_name: "treg verification monitor", monitor_type: "http", url: "https://example.com", http_method: "GET", check_interval_seconds: 300, timeout_seconds: 30, expected_status_code: 200}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free but quota-bound — see the endpoint note"}
+    docs_url: https://alertkick.com/docs/api/operations/createmonitor/
+
+  - id: alertkick.uptime.monitors.pause
+    domain: monitors
+    capability: uptime.monitors.pause
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: POST
+    path: /monitors/{uuid}/pause
+    name: "Pause an uptime monitor"
+    summary: "Pause a monitor's checks without deleting its history"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, example: "dacdvk0fhf9s73ehbet0"}
+      bodyType: json
+      note: "empty JSON body"
+    test_request:
+      pathParams: {uuid: "dacdvk0fhf9s73ehbet0"}
+      body: {}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/pausemonitor/
+
+  - id: alertkick.uptime.monitors.resume
+    domain: monitors
+    capability: uptime.monitors.resume
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: POST
+    path: /monitors/{uuid}/resume
+    name: "Resume a paused uptime monitor"
+    summary: "Resume checks on a paused monitor"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, example: "dacdvk0fhf9s73ehbet0"}
+      bodyType: json
+      note: "empty JSON body"
+    test_request:
+      pathParams: {uuid: "dacdvk0fhf9s73ehbet0"}
+      body: {}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/resumemonitor/
+
+  - id: alertkick.uptime.heartbeats.list
+    domain: heartbeats
+    capability: uptime.heartbeats.list
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /heartbeats/all
+    name: "List your cron heartbeats"
+    summary: "List the workspace's cron-job heartbeats with their health and last-ping times"
+    input:
+      queryParams:
+        offset: {type: integer, required: false, example: 0}
+        limit: {type: integer, required: false, example: 50}
+    test_request:
+      queryParams: {limit: 5}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/listheartbeats/
+
+  - id: alertkick.uptime.heartbeats.get
+    domain: heartbeats
+    capability: uptime.heartbeats.get
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /heartbeats/{uuid}
+    name: "Get one heartbeat"
+    summary: "Get one heartbeat's config, health and its scoped ping key"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, note: "from the list endpoint or the auto-ping response"}
+    test_request:
+      pathParams: {uuid: "dacdurofhf9s73ehbesg"}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/getheartbeat/
+
+  - id: alertkick.uptime.heartbeats.ping
+    domain: heartbeats
+    capability: uptime.heartbeats.ping
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: GET
+    path: /hb/auto/{slug}
+    name: "Create-or-ping a heartbeat by slug"
+    summary: "Idempotently create a heartbeat on first call and record a ping on every call — one URL a cron job can curl"
+    input:
+      pathParams:
+        slug: {type: string, required: true, note: "stable job name; creation happens on the first call for a new slug", example: "nightly-backup"}
+      queryParams:
+        interval: {type: integer, required: false, note: "expected seconds between pings — creation-time only", example: 86400}
+        grace: {type: integer, required: false, note: "late allowance in seconds — creation-time only", example: 3600}
+        name: {type: string, required: false, note: "display name — creation-time only"}
+      note: "201 on first-call creation, 200 on subsequent pings. Creation counts against the plan's heartbeat quota (402 when full). POST works identically for callers that can't GET"
+    test_request:
+      pathParams: {slug: "treg-verify"}
+      queryParams: {interval: 86400, grace: 3600}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free but the first call for a new slug is quota-bound"}
+    docs_url: https://alertkick.com/docs/api/operations/autopingheartbeat/
+
+  - id: alertkick.uptime.alerts.list
+    domain: alerts
+    capability: uptime.alerts.list
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /alerts
+    name: "List monitoring alerts"
+    summary: "List the workspace's monitoring alerts, filtered by status"
+    input:
+      queryParams:
+        status: {type: string, required: false, note: "triggered | acknowledged | resolved", example: "triggered"}
+        offset: {type: integer, required: false, example: 0}
+        limit: {type: integer, required: false, example: 50}
+    test_request:
+      queryParams: {limit: 5}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/listalerts/
+
+  - id: alertkick.uptime.alerts.get
+    domain: alerts
+    capability: uptime.alerts.get
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /alerts/{uuid}
+    name: "Get one alert"
+    summary: "Get one alert with its source, severity and timeline"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, note: "from the list endpoint"}
+    test_request:
+      pathParams: {uuid: "dacdgi3r895c73chbt2g"}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/getalert/
+
+  - id: alertkick.uptime.alerts.acknowledge
+    domain: alerts
+    capability: uptime.alerts.acknowledge
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: POST
+    path: /alerts/acknowledge
+    name: "Acknowledge alerts"
+    summary: "Acknowledge open alerts so the on-call escalation stops"
+    input:
+      body:
+        UUIDs: {type: array, required: true, note: "alert uuids — note the capitalised field name", example: ["dacdgi3r895c73chbt2g"]}
+      bodyType: json
+      note: "mutates real alert state in the calling workspace — only replay against an alert that should be acknowledged"
+    test_request:
+      body: {UUIDs: ["dacdgi3r895c73chbt2g"]}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/acknowledgealerts/
+
+  - id: alertkick.uptime.alerts.resolve
+    domain: alerts
+    capability: uptime.alerts.resolve
+    platform: uptime
+    scope: own_account
+    kind: action
+    method: POST
+    path: /alerts/resolve
+    name: "Resolve alerts"
+    summary: "Mark alerts resolved once the underlying problem is fixed"
+    input:
+      body:
+        UUIDs: {type: array, required: true, note: "alert uuids — note the capitalised field name", example: ["dacdgi3r895c73chbt2g"]}
+      bodyType: json
+      note: "mutates real alert state in the calling workspace — only replay against an alert that should be resolved"
+    test_request:
+      body: {UUIDs: ["dacdgi3r895c73chbt2g"]}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/resolvealerts/
+
+  - id: alertkick.uptime.servers.list
+    domain: servers
+    capability: uptime.servers.list
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /hosts
+    name: "List monitored servers"
+    summary: "List servers monitored by an installed AlertKick agent, with online state"
+    input:
+      queryParams:
+        offset: {type: integer, required: false, example: 0}
+        limit: {type: integer, required: false, example: 50}
+    test_request:
+      queryParams: {limit: 5}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/listhosts/
+
+  - id: alertkick.uptime.servers.get
+    domain: servers
+    capability: uptime.servers.get
+    platform: uptime
+    scope: own_account
+    method: GET
+    path: /hosts/{uuid}
+    name: "Get one monitored server"
+    summary: "Get one monitored server's details, agent state and last-seen time"
+    input:
+      pathParams:
+        uuid: {type: string, required: true, note: "from the list endpoint"}
+    test_request:
+      pathParams: {uuid: "da88t6jp62tc73dd6h7g"}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/operations/gethost/
+
+  - id: alertkick.uptime.locations.list
+    domain: monitors
+    capability: uptime.locations.list
+    platform: uptime
+    scope: own_account
+    kind: utility
+    method: GET
+    path: /poller-locations/all
+    name: "List polling locations"
+    summary: "List the polling locations a monitor's checks can run from — the keys the create endpoint's locations field takes"
+    input: {}
+    test_request: {}
+    cost: {type: free, value: 0, currency: USD, unit: call}
+    docs_url: https://alertkick.com/docs/api/
+
+proposed_capabilities:
+  uptime.monitors.list: "List your uptime monitors with current status"
+  uptime.monitors.get: "Get one uptime monitor's config and recent checks"
+  uptime.monitors.create: "Create an uptime monitor for a URL, host or domain"
+  uptime.monitors.pause: "Pause an uptime monitor's checks"
+  uptime.monitors.resume: "Resume a paused uptime monitor"
+  uptime.heartbeats.list: "List your cron-job heartbeats with health"
+  uptime.heartbeats.get: "Get one heartbeat's config and last ping"
+  uptime.heartbeats.ping: "Create or ping a heartbeat for a scheduled job"
+  uptime.alerts.list: "List monitoring alerts, filtered by status"
+  uptime.alerts.get: "Get one alert with its timeline"
+  uptime.alerts.acknowledge: "Acknowledge open monitoring alerts"
+  uptime.alerts.resolve: "Resolve monitoring alerts"
+  uptime.servers.list: "List servers monitored by an installed agent"
+  uptime.servers.get: "Get one monitored server's details"
+  uptime.locations.list: "List polling locations monitors can check from"

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -49,6 +49,7 @@ platforms:
 
   # --- Developer: code hosting & developer platforms -------------------------------------------
   github: {label: "GitHub", category: "Developer", summary: "Public repos, users, contributions and trending pages from GitHub."}
+  uptime: {label: "Uptime & Server Monitoring", category: "Developer", summary: "Uptime monitors, cron heartbeats, alerts and monitored servers in your own monitoring account."}
 
   # --- Chinese social & video (merged into Social; non-China platforms lead by popularity) ---
   douyin: {label: "Douyin (TikTok China)", category: "Social", summary: "Profiles, videos, comments, search, billboards and live data — the deepest platform here."}

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1190,6 +1190,40 @@ HUNTER = OAuthProvider(
     probe_path="/account",  # free — consumes no search/verification/enrichment credits
 )
 
+ALERTKICK = OAuthProvider(
+    service="alertkick",
+    display_name="AlertKick",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="ak_…",
+    # AlertKick authenticates API calls with an X-API-Key header only — never a query param, never
+    # the URL path. A bad key answers 401 {"code":"401","error":"Unauthorized Access",
+    # "message":"Invalid API-Key"} (observed live 2026-09-03).
+    token_header="X-API-Key",
+    token_format="{secret}",
+    setup_url="https://app.alertkick.com/settings",
+    setup_action_label="Get your AlertKick API key",
+    setup_steps=(
+        "Sign in to your AlertKick workspace and open Settings → API Keys.",
+        "Create a key and copy it — it is shown once.",
+    ),
+    # Keys are WORKSPACE-BOUND: each workspace lives on its own host
+    # (https://{workspace}.alertkick.com) and a key only works on the host that minted it — the
+    # wrong host answers 401 (observed live 2026-09-03). base_url below is the
+    # `app` workspace host; users on another workspace must swap the host until per-account
+    # base URLs are supported.
+    setup_note="API calls are free on every plan; plan quotas cap how many monitors, heartbeats "
+               "and hosts can exist. Keys are workspace-bound — see the catalog notes.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Developer",
+    summary="Create and read uptime monitors, cron heartbeats, alerts and monitored servers in your own AlertKick workspace.",
+    base_url="https://app.alertkick.com/api/v1",
+    docs_url="https://alertkick.com/docs/api/",
+    probe_path="/monitors/all?limit=1",  # free, in the public OpenAPI spec, clean 401 on a bad key
+)
+
 TIKHUB = OAuthProvider(
     service="tikhub",
     display_name="TikHub",
@@ -2537,7 +2571,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
+        APOLLO, PDL, AKTA, HUNTER, ALERTKICK, CRUNCHBASE, TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT, EXA,
@@ -2557,7 +2591,7 @@ DEFAULT_CAPABILITY = "read"
 
 # Shelf order in the marketplace. Anything carrying a category not named here sorts last, so a
 # provider added without one is visible rather than lost between the shelves.
-CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Market data", "Community", "Other")
+CATEGORY_ORDER = ("SEO", "Advertising", "Social media", "Enrichment", "Market data", "Community", "Developer", "Other")
 
 
 def get(service: str) -> OAuthProvider | None:

--- a/src/treg/web/logos/alertkick.svg
+++ b/src/treg/web/logos/alertkick.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="alertkick">
+  <!-- Placeholder lettermark. Replace with the official AlertKick brand SVG. -->
+  <rect width="24" height="24" rx="5" fill="#111144"/>
+  <text x="12" y="12" fill="#fff" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="13" font-weight="700" text-anchor="middle" dominant-baseline="central">A</text>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush",
+    for svc in ("apollo", "pdl", "akta", "hunter", "alertkick", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
                 "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -47,7 +47,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "apollo", "pdl", "akta", "hunter", "alertkick", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
         "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",


### PR DESCRIPTION
## New provider: AlertKick — uptime & server monitoring (first monitoring vendor)

AlertKick (https://alertkick.com) is an uptime + server monitoring SaaS: uptime monitors
(HTTP/API/DNS/TCP/domain-expiry/mail), cron-job heartbeats, alerting with on-call escalation, and
agent-based server monitoring. This PR lists its REST API — 15 endpoints under a new `uptime`
platform (Developer category), which the catalog does not cover today.

I am the vendor (founder). **Contact: partnerships@alertkick.com**

### What's in the diff
- `src/treg/catalog/alertkick.yaml` — 15 endpoints (monitors, heartbeats, alerts, servers, locations), all `scope: own_account`
- `src/treg/oauth_providers.py` — `ALERTKICK` key provider (X-API-Key header), + `"Developer"` added to `CATEGORY_ORDER` (no Developer shelf existed; happy to re-shelve if you prefer)
- `src/treg/catalog/capabilities.yaml` — new `uptime` platform line only; the 15 capability ids arrive via `proposed_capabilities` in the provider file per the header convention
- `src/treg/web/logos/alertkick.svg` — neutral lettermark (brand navy #111144, "A")
- both provider-list tests extended with `alertkick`

### Billing model
API calls are not metered on any plan — every catalogued endpoint is `cost: free` (canonical free spelling). Plans cap how many monitors/heartbeats/hosts can *exist*; creating past a cap answers **402**, never a charge. Pricing page (public): https://alertkick.com/pricing/ — Free £0 (10 monitors & heartbeats), Professional £39/mo, Business £149/mo. No machine-readable rate card (nothing to rate). Because nothing is metered, the "reconcile costs against the meter" step reduces to: no balance exists, no charge was observed on any call below.

### Self-verification ledger (all live against production, 2026-09-03, vendor credentials)
| endpoint | status | latency | claimed | metered |
|---|---|---|---|---|
| `GET /monitors/all?limit=5` | 200 | 275ms | free (claimed) | free (no charge observed) |
| `GET /monitors/dacdvk0fhf9s73ehbet0` | 200 | 203ms | free (claimed) | free (no charge observed) |
| `POST /monitors/create` | 201 | 248ms | free (claimed) | free (no charge observed) |
| `POST /monitors/dacdvk0fhf9s73ehbet0/pause` | 200 | 224ms | free (claimed) | free (no charge observed) |
| `POST /monitors/dacdvk0fhf9s73ehbet0/resume` | 200 | 221ms | free (claimed) | free (no charge observed) |
| `GET /heartbeats/all?limit=5` | 200 | 192ms | free (claimed) | free (no charge observed) |
| `GET /heartbeats/dacdurofhf9s73ehbesg` | 200 | 198ms | free (claimed) | free (no charge observed) |
| `GET /hb/auto/treg-verify?interval=86400&grace=3600` | 201 | 214ms | free (claimed) | free (no charge observed) | [expect 201 first call]
| `GET /hb/auto/treg-verify` | 200 | 200ms | free (claimed) | free (no charge observed) | [expect 200 ping]
| `GET /alerts?limit=5` | 200 | 228ms | free (claimed) | free (no charge observed) |
| `GET /alerts?status=resolved&limit=3` | 200 | 235ms | free (claimed) | free (no charge observed) |
| `GET /alerts/dacdgi3r895c73chbt2g` | 200 | 190ms | free (claimed) | free (no charge observed) |
| `POST /alerts/acknowledge` | 200 | 201ms | free (claimed) | free (no charge observed) | [deliberate no-op: already-resolved]
| `POST /alerts/resolve` | 200 | 197ms | free (claimed) | free (no charge observed) | [deliberate no-op: already-resolved]
| `GET /hosts?limit=2` | 200 | 301ms | free (claimed) | free (no charge observed) |
| `GET /hosts/da88t6jp62tc73dd6h7g` | 200 | 236ms | free (claimed) | free (no charge observed) |
| `GET /poller-locations/all` | 200 | 206ms | free (claimed) | free (no charge observed) |
| `DELETE /monitors/dacdvk0fhf9s73ehbet0` | 200 | 209ms | free (claimed) | free (no charge observed) | [cleanup - not catalogued]
| `POST /heartbeats/delete` | 200 | 179ms | free (claimed) | free (no charge observed) | [cleanup - not catalogued]

Notes:
- `monitors.create` → **201** with the new uuid; the created "treg verification monitor" and the `treg-verify` heartbeat were deleted afterwards (delete endpoints exist but are not catalogued — see surface map).
- `alerts.acknowledge`/`resolve` were replayed against an **already-resolved** alert as a deliberate, transparent no-op (200) — acknowledging a live triggered alert would silence a real on-call page; the endpoint notes in the YAML say exactly that.
- heartbeat `hb/auto/{slug}` answered **201 on first call (creation), 200 on the repeat ping**, as documented.
- Chained ids in `test_request`s are real ids from this run and are **account-bound** (the YAML header explains re-verify must harvest fresh ids from the list endpoints).

### Probe behavior (live, 2026-09-03)
`GET /monitors/all?limit=1` with a garbage key:
HTTP **401**, `Content-Type: application/json`, body:
```json
{"code":"401","error":"Unauthorized Access","message":"Invalid API-Key"}
```
With a valid key: 200 and a JSON page envelope. The probe endpoint is free and in the published OpenAPI spec.

### Auth transport
`X-API-Key` **header only** — never a query param, never the URL path. Keys are self-serve (Settings → API Keys in the workspace UI; free tier signs up with no card). **One caveat stated plainly:** keys are workspace-bound and each workspace lives on its own host (`https://{workspace}.alertkick.com/api/v1`). The registry entry pins the `app` workspace host, and the provider setup notes + YAML header call out that other workspaces must swap the host — if there's a supported pattern for per-account base URLs I'd gladly adopt it.

### OpenAPI spec
Stable public URL: https://alertkick.com/openapi.yaml (24 operations; rendered reference at https://alertkick.com/docs/api/).

### Full-surface map
**Catalogued (15):** monitors list/get/create/pause/resume, heartbeats list/get/auto-ping, alerts list/get/acknowledge/resolve, hosts list/get, poller-locations list.
**In the public OpenAPI spec but excluded:** monitor update/delete, heartbeat create/delete/enable/disable, `hb/ping/{uuid}` (separate `X-Heartbeat-Key` credential) — destructive/duplicative variants kept out of an agent's default reach; happy to add any on request.
**Supported but not in the spec (excluded as undocumented):** incidents, change management, security events, host containers/metrics, agent-install command, billing usage.
**Server-side but internal (excluded):** escalation policies, rosters/on-call, maintenance windows, status pages, compliance, AI-assistant, importer, websocket, superadmin, agent/poller ingest, and the inbound webhook intake family (Service-Key auth; the one place a key may ride a query param — none of it is catalogued here).

### Validation
- `python scripts/catalog_validate.py` → OK, 0 errors 0 warnings (84 provider files, 3018 endpoints)
- `python -m pytest -q` on this branch → **2462 passed, 3 failed, 4 skipped** (32m43s). The 3 failures are all `tests/test_shell.py` PTY-interaction tests and fail **identically on a clean `origin/main` checkout** in this environment — pre-existing/environmental, untouched by this diff. The extended provider-list tests pass with `alertkick` added.
- No credential value appears anywhere in the diff.
- Rebased/branched from today's `main` (6dd7714).

Test credentials for maintainer verification: happy to provision a dedicated workspace + API key — email the contact above.