### PR TITLE
fix(analytics): a call rescued by overflow is one ok event, not a refusal

### DIFF
--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -267,7 +267,14 @@ produced the status (`treg_refused` / `gateway_failed` / `vendor_error` / `ok`),
 refusals never sum into a vendor's line; `refused_by`, `call_ref` (the join key to `callrecord`),
 `cached`, `smoothed`, `hit`, `response_bytes`, `capacity_signal` (the signature table's kind, catalog
 calls only) and the caller's `user_agent` / `ua_family`, which is what the vendor's edge saw because
-relay forwards it verbatim. Methods allowed: GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
+relay forwards it verbatim. **One event per request, and it says what the caller got:** when overflow
+rescues a call, the parent's event is held back (`_audit(..., defer_analytics=True)`) until the child
+cycle's verdict, and the event that goes out is the child's - the served status, `outcome=ok`,
+`tier=platform-overflow`, `served_via=overflow:<aggregator>`, the aggregator's price - never a
+`refused_by=capacity` 503 or the vendor's 4xx for a request that was answered (one night's dashboard
+counted 2,012 rescued calls among 4,455 "refusals"). Both attempts keep their DB rows on the same
+`call_ref`. When overflow does not rescue, the parent's event goes out as it was. Methods allowed:
+GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS.
 
 **Resolution + error hardening:** the URL-passthrough prefix match respects a **path-segment boundary**
 (`norm == base` or `base + "/"`), so `.../v1` no longer matches `.../v10/...` and inject the wrong

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -545,11 +545,30 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
     audit_org_id, audit_email, audit_tool = caller.org_id, caller.email, tool.name
     audit_slug = caller.org.slug  # PostHog group key — must match the browser's posthog.group('team', slug)
 
+    def _capture(props: dict) -> None:
+        analytics.capture(audit_email, "tool_called", props, groups={"team": audit_slug})
+
+    def _overflow_event(props: dict, outcome, charged: int) -> dict:
+        """What a caller rescued by overflow actually experienced: the child's answer at the
+        aggregator's price, tier platform-overflow. The direct attempt keeps its own DB row (the
+        child has one too, on the same call_ref); the dashboard sees ONE event per request, and
+        not a refusal for a request that was answered (2,012 of one night's 4,455 "refusals" were)."""
+        status = outcome.response.status
+        return props | {"status_code": status, "outcome": _outcome(status, None, answered=True),
+                        "refused_by": None, "tier": "platform-overflow",
+                        "served_via": f"overflow:{outcome.aggregator}", "charged_micro": charged,
+                        "observed_micro": outcome.observed_micro if outcome.observed_micro is not None else charged,
+                        "response_bytes": len(outcome.body)}
+
     def _audit(status_code: int, *, observed_micro: int | None = None, charged_micro: int | None = None,
                duration_ms: int | None = None, response_bytes: int | None = None,
                refused_by: str | None = None, hit: bool | None = None,
                error_request: str | None = None, error_response: str | None = None,
-               capacity_signal: str | None = None, answered: bool = True) -> None:
+               capacity_signal: str | None = None, answered: bool = True,
+               defer_analytics: bool = False) -> dict | None:
+        """Records the audit row now. The PostHog mirror goes out now too, unless
+        `defer_analytics`: then the props come back for the caller to `_capture` once it knows
+        whether overflow turned this attempt into an answer."""
         # Audit the attempt too — failures are results worth recording. A marketplace call additionally
         # carries its telemetry (which endpoint, which credential tier, what it cost): still
         # fire-and-forget, because the money itself already landed synchronously in the ledger.
@@ -602,7 +621,10 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                       "capacity_signal": capacity_signal, "probe": mk.probe_lock_id is not None}
         else:
             props["provider"] = urlsplit(upstream_url).hostname or ""
-        analytics.capture(audit_email, "tool_called", props, groups={"team": audit_slug})
+        if defer_analytics:
+            return props
+        _capture(props)
+        return None
 
     # Landing-page sandbox: never touch the network — EXCEPT the one live wire. A call to the
     # exact seeded stripe tool (fingerprint-matched; see sandbox.is_live_tool) relays to the real
@@ -682,8 +704,9 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
         # attempt, no parent hold — straight to the child cycle (plan §4 ladder, tier 4b). The DB
         # phase ends here; the child places its own hold and the aggregator answers with none open.
         await db.commit()
-        _audit(503, charged_micro=0, refused_by="capacity",
-               error_response="treg: own account exhausted — served via overflow" )
+        pending = _audit(503, charged_micro=0, refused_by="capacity",
+                         error_response="treg: own account exhausted — served via overflow",
+                         defer_analytics=True)
         try:
             outcome = await overflow_cycle.maybe_overflow(
                 mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=402,
@@ -691,9 +714,11 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                 query_items=request.query_params.multi_items(), caller_body=caller_body,
                 client=upstream_client, audit_client=_client_name(request), force_trigger="exhausted")
         except asyncio.CancelledError:
+            _capture(pending)
             await _finish_cancelled_call(request, mk, call_ref)
             raise
         if outcome is None or not outcome.served or outcome.response is None:
+            _capture(pending)  # a refusal after all
             request.state.call_cost_micro = 0
             from .resolve import _provider_capacity_unavailable
             raise (outcome.failure if outcome is not None and outcome.failure is not None
@@ -701,6 +726,7 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                        _catalog_endpoint_for(mk.endpoint_id) or {"id": mk.endpoint_id},
                        mk.provider, capacity_view.exhausted_until(mk.provider, mk.endpoint_id)))
         response, body, charged = outcome.response, outcome.body, outcome.charged_micro
+        _capture(_overflow_event(pending, outcome, charged))
         if idem_key:
             try:
                 await _store_idempotent(idem_key, caller, status_code=response.status, body=body,
@@ -979,14 +1005,16 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                     tool, caller_body, _renderings)
                 err_response = _error_response_evidence(
                     response.raw_headers, body, _renderings)
-        _audit(response.status, observed_micro=observed, charged_micro=charged,
-               duration_ms=duration_ms, response_bytes=len(body), hit=_hit_verdict(mk, response.status, body),
-               capacity_signal=capacity_signal, error_request=err_request, error_response=err_response)
+        may_overflow = response.status >= 400 and mk.tier == "platform"
+        pending = _audit(response.status, observed_micro=observed, charged_micro=charged,
+                         duration_ms=duration_ms, response_bytes=len(body), hit=_hit_verdict(mk, response.status, body),
+                         capacity_signal=capacity_signal, error_request=err_request, error_response=err_response,
+                         defer_analytics=may_overflow)
         served_via = ""
-        if response.status >= 400 and mk.tier == "platform":
+        if may_overflow:
             # Overflow (plan §4.3): the primary attempt is settled ($0) and audited above; a child
             # cycle may now serve the SAME endpoint through an aggregator. Off by default; shadow
-            # mode returns the vendor's answer regardless.
+            # mode returns the vendor's answer regardless. The event waits for the verdict.
             try:
                 outcome = await overflow_cycle.maybe_overflow(
                     mk=mk, caller=caller, meta=meta, call_ref=call_ref, status=response.status,
@@ -994,18 +1022,24 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
                     query_items=request.query_params.multi_items(), caller_body=caller_body,
                     client=upstream_client, audit_client=_client_name(request))
             except asyncio.CancelledError:
+                _capture(pending)
                 await _finish_cancelled_call(request, mk, call_ref, response)
                 raise
             except CallFailure as exc:  # the child's own 402 (insufficient balance for the child hold)
+                _capture(pending)
                 request.state.call_cost_micro = 0
                 raise
             if outcome is not None and outcome.failure is not None:
+                _capture(pending)
                 request.state.call_cost_micro = 0
                 raise outcome.failure
             if outcome is not None and outcome.served and outcome.response is not None:
                 await response.close()
                 response, body, charged = outcome.response, outcome.body, outcome.charged_micro
                 served_via = f"overflow:{outcome.aggregator}"
+                _capture(_overflow_event(pending, outcome, charged))
+            else:
+                _capture(pending)  # the vendor's own answer stands
         if idem_key:
             # Here, and not earlier: this is the first point where BOTH the response and what it
             # actually cost are known, and a replay has to hand back the real charge rather than the

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -456,3 +456,69 @@ def test_cli_org_overflow_parses(monkeypatch):
         pytest.skip("no exposed parser builder")
     args = parser.parse_args(["org", "overflow", "off"])
     assert args.state == "off" and args.fn is not None
+
+
+# --- the dashboard sees what the caller got -----------------------------------------------------
+
+async def _exhausted(provider: str = "tikhub") -> None:
+    from datetime import timedelta
+    now = utcnow_naive()
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, provider, LatestState(
+            provider, 0.0, "USD", now, "exact", exhausted_until=now + timedelta(hours=1), health="exhausted").to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+
+
+async def test_a_call_rescued_by_overflow_is_one_ok_event_not_a_refusal(clients: AsyncClient, overflow_on, monkeypatch, posthog_events):
+    """Skip-direct: the resolver knew the account was dry and went straight to the aggregator. The
+    caller got a 200; the dashboard used to see a 503 refused_by=capacity and nothing else."""
+    await _route(price_micro=3_000)
+    await _exhausted()
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], []))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200 and r.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    (e,) = await posthog_events()
+    p = e["properties"]
+    assert p["status_code"] == 200 and p["outcome"] == "ok" and p["refused_by"] is None
+    assert p["tier"] == "platform-overflow" and p["served_via"] == "overflow:orthogonal"
+    assert p["charged_micro"] == 3_000 and p["call_ref"] == r.headers["X-Treg-Call-Id"]
+    await audit.drain()
+    rows = [x for x in (await clients.get("/calls")).json() if x["tool_name"] == EP]
+    assert {x.get("credential_tier") for x in rows} == {"platform", "platform-overflow"}, "both DB rows stay"
+
+
+async def test_a_call_overflow_could_not_rescue_is_still_one_refusal_event(clients: AsyncClient, overflow_on, monkeypatch, posthog_events):
+    await _route(price_micro=3_000)
+    await _exhausted()
+    monkeypatch.setattr(O, "_send", _orthogonal([(402, {"success": False, "error": "insufficient balance"})], []))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503
+    (e,) = await posthog_events()
+    p = e["properties"]
+    assert p["status_code"] == 503 and p["outcome"] == "treg_refused" and p["refused_by"] == "capacity"
+    assert "served_via" not in p
+
+
+async def test_a_vendor_402_rescued_by_overflow_is_one_ok_event(clients: AsyncClient, overflow_on, monkeypatch, posthog_events):
+    """The post-failure path: the vendor answered 402, the child served. One event, the child's."""
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], []))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 200
+    (e,) = await posthog_events()
+    p = e["properties"]
+    assert p["status_code"] == 200 and p["outcome"] == "ok" and p["tier"] == "platform-overflow"
+    assert p["served_via"] == "overflow:orthogonal" and p["capacity_signal"] == "balance", "the strike is still on the event"
+
+
+async def test_a_vendor_402_overflow_did_not_rescue_keeps_the_vendor_error_event(clients: AsyncClient, overflow_on, monkeypatch, posthog_events):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"nope"}'))
+    monkeypatch.setattr(O, "_send", _orthogonal([(400, {"success": False, "error": "x", "_orthogonal": {"error": "orthogonal_endpoint_contract", "message": "missing"}})], []))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402
+    (e,) = await posthog_events()
+    p = e["properties"]
+    assert p["status_code"] == 402 and p["outcome"] == "vendor_error" and p["tier"] == "platform" and "served_via" not in p


### PR DESCRIPTION
## Why

Every call overflow rescued looked, on the dashboard, exactly like a failure. The skip-direct rung recorded a `503 refused_by=capacity` `tool_called` event **before** contacting the aggregator; the post-failure rung recorded the vendor's 4xx before the child cycle; the child wrote only its DB audit row, no PostHog event. One night's dashboard counted 4,455 "refusals", at least 2,012 of which were requests the caller got an answer to, and the failure rate was inflated accordingly.

## What

`service.py` only (~30 lines):

- `_audit(..., defer_analytics=True)` records the DB row now but hands the PostHog props back instead of capturing them.
- Both overflow rungs capture after the verdict: **served** → the child's event (the served status, `outcome=ok`, `tier=platform-overflow`, `served_via=overflow:<aggregator>`, the aggregator's price, `capacity_signal` kept); **not served** → the parent's event unchanged, on every path including the raises.
- One event per request; DB rows untouched (both attempts keep theirs on the same `call_ref`, visible in `/calls`).

Four tests pin the four combinations (skip-direct × served/not, vendor-4xx × served/not). `docs/context/architecture/proxy-model.md` documents the one-event rule.

## Verification

- `uv run --frozen python -m pytest -q`: 2478 passed
- `drift.sh origin/main..HEAD`: reviewed

Independent of #301 (no shared files).
