### PR TITLE
fix(archive): panel report at production scale — partial index + 30s server cache

### DIFF
--- a/src/treg/alembic/versions/0012_callrecord_cached_index.py
+++ b/src/treg/alembic/versions/0012_callrecord_cached_index.py
@@ -1,0 +1,29 @@
+"""partial index over callrecord.cached — the archive report's two counts stop scanning
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-09-03
+
+The archive panel's report counts cached=true rows twice per refresh over the biggest table in
+the database; without an index that is two full scans per poll (measured 78s total report time on
+prod at 425k archive keys). Partial — only the cached=true sliver is indexed, so the index stays
+tiny and writes to the hot audit table pay almost nothing.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012"
+down_revision: str | Sequence[str] | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_callrecord_cached_true", "callrecord", ["cached"],
+                    postgresql_where=sa.text("cached"), sqlite_where=sa.text("cached"))
+
+
+def downgrade() -> None:
+    op.drop_index("ix_callrecord_cached_true", table_name="callrecord")

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, Index, UniqueConstraint
+from sqlalchemy import JSON, Column, Index, UniqueConstraint, text
 from sqlmodel import Field, SQLModel
 
 # Role ordering for gates (owner > admin > member > viewer).
@@ -222,6 +222,12 @@ class CallRecord(SQLModel, table=True):
     """Audit: who called which tool, in which org, when, with what result. Written off the
     request path (fire-and-forget) so it never adds latency to a proxied call.
     """
+
+    # Partial index: the archive report counts cached=true rows (twice per refresh) over the
+    # biggest table in the database — without this it is two full scans per panel poll (measured
+    # 78s on prod at 425k archive keys, 2026-09-03). Partial because hits are a sliver of rows.
+    __table_args__ = (Index("ix_callrecord_cached_true", "cached",
+                            postgresql_where=text("cached"), sqlite_where=text("cached")),)
 
     id: int | None = Field(default=None, primary_key=True)
     org_id: int | None = Field(default=None, foreign_key="org.id", index=True)

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -331,6 +331,10 @@ async def admin_reconcile_repeats(
             **await reconcile.repeat_rate(db, since, top=top)}
 
 
+_ARCHIVE_REPORT_TTL_S = 30
+_archive_report_cache: dict = {}
+
+
 @app.get("/admin/archive")
 async def admin_archive(
     top: int = 50,
@@ -342,6 +346,13 @@ async def admin_archive(
     raw signal for how fast an endpoint's answers move. `kept_bytes` only grows where a judged
     licence allows storing (docs/context/architecture/archive.md)."""
     from .. import archive as archive_mod
+
+    # One expensive aggregation every 30s, not one per poll: the panel refreshes every 5s and
+    # several viewers stack — at 425k keys the pile-up alone froze the page (2026-09-03).
+    import time as _time
+    hit = _archive_report_cache.get(top)
+    if hit and _time.monotonic() - hit[0] < _ARCHIVE_REPORT_TTL_S:
+        return hit[1]
 
     keys = func.count(ArchiveKey.id)
     stable = func.coalesce(func.sum(ArchiveKey.stable_seen), 0)
@@ -391,13 +402,15 @@ async def admin_archive(
             "hits": hits_by_ep.get(endpoint_id, 0),
             "kept_bytes": kept_by_ep.get(endpoint_id, 0),
         })
-    return {"mode": archive_mod.mode(),
+    report = {"mode": archive_mod.mode(),
             "worker_on": archive_mod.worker_enabled(),
             "refresh_daily_cap": get_settings().archive_refresh_daily_cap,
             "keys": int(total_keys), "snapshots": int(all_snaps),
             "bodies_kept": int(snap_totals[0]), "kept_bytes": int(snap_totals[1]),
             "hits_today": int(hits_today), "refreshes_today": int(refreshes_today),
             "endpoints": rows}
+    _archive_report_cache[top] = (_time.monotonic(), report)
+    return report
 
 
 @app.get("/admin/archive/keys")
@@ -545,6 +558,7 @@ async def admin_referrals(
             "paid_micro": r.referrer_reward_micro + r.referred_reward_micro,
         } for r in rows],
     }
+
 
 async def _is_last_active_superadmin(db: AsyncSession, target: User) -> bool:
     """True if `target` is currently the ONLY active (unsuspended) super-admin, so demoting /

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,6 +290,10 @@ async def clients():
     # forgives it) — the serial CI job hung exactly here, 5-minute faulthandler timeouts on
     # whichever archive test ran next (2026-08-28, twice).
     await archive.drain()
+    # The archive report's 30s server-side cache would outlive this reset and serve the previous
+    # test's numbers — clear it with the schema.
+    from treg.routers import admin as admin_routes
+    admin_routes._archive_report_cache.clear()
     await reset_db()
     await app.state.endpoint_observation_reader.reset()
     app.state.hook_hits = []  # webhook POSTs the upstream received (for alerting assertions)


### PR DESCRIPTION
The dashboard froze: the report took 78s at 425k keys because it full-scans callrecord for cached=true twice per poll, and the panel polls every 5s so queries stacked. Partial index over the cached=true sliver (migration 0012) plus a 30-second in-process report cache shared by all viewers. Suite 2255 green.