### PR TITLE
feat(archive): recorder-maintained running totals for the panel report

### DIFF
--- a/ARCTERM-MUSIC-FIX.md
+++ b/ARCTERM-MUSIC-FIX.md
@@ -1,0 +1,107 @@
+# ArcTerm Session Music — required fix and republish
+
+Handoff from the Jazz session (Mac Studio, 2026-08-30). Two bugs were found in the
+generative.fm player harness. **6 of the 8 published music packs are broken for every
+ArcTerm user**: they play the first notes, then go silent forever.
+
+## Bug 1 — the missing random helper (the important one)
+
+The pieces from `pieces-alex-bainter` call a global the website normally provides:
+
+```js
+window.generativeMusic.rng()
+```
+
+Our pack harness (`tools/composer/ref-pieces/test-player/src/app.js`) never defines it.
+The first time a piece asks for a random number, the callback throws, its scheduling
+chain dies, and the music stops after the intro notes.
+
+Affected shipped packs (count of `generativeMusic` uses in each piece):
+aisatsana (1), meditation (3), above-the-rain (5), drones-2 (7), little-bells (5),
+pinwheels (1). Not affected: skyline (0), eno-machine (0).
+
+### Fix
+
+Add this at the very top of `tools/composer/ref-pieces/test-player/src/app.js`
+(before any import):
+
+```js
+// The generative.fm site injects this global; pieces depend on it.
+// Optional seed makes a performance repeatable (site-identical algorithm, MIT).
+(function () {
+  const q = new URLSearchParams(location.search);
+  const s = q.get('seed');
+  function xmur3(str) {
+    let h = 1779033703 ^ str.length;
+    for (let i = 0; i < str.length; i++) {
+      h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+      h = (h << 13) | (h >>> 19);
+    }
+    return () => {
+      h = Math.imul(h ^ (h >>> 16), 2246822507);
+      h = Math.imul(h ^ (h >>> 13), 3266489909);
+      return (h ^= h >>> 16) >>> 0;
+    };
+  }
+  function sfc32(a, b, c, d) {
+    return () => {
+      a |= 0; b |= 0; c |= 0; d |= 0;
+      let t = (((a + b) | 0) + d) | 0;
+      d = (d + 1) | 0;
+      a = b ^ (b >>> 9);
+      b = (c + (c << 3)) | 0;
+      c = (c << 21) | (c >>> 11);
+      c = (c + t) | 0;
+      return (t >>> 0) / 4294967296;
+    };
+  }
+  let rng = Math.random;
+  if (s) { const g = xmur3(s); rng = sfc32(g(), g(), g(), g()); }
+  window.generativeMusic = window.generativeMusic || { rng, seed: s || null };
+})();
+```
+
+## Bug 2 — scheduling starts before play (check whether app.js has it)
+
+In the gallery harness (`src/index.js`) the piece's `schedule()` was called right after
+activation, before any play command. Result: a few notes sound at once, the chain never
+continues (the transport is not started), and the play button state lies.
+
+The fix applied to `src/index.js`: `schedule()` runs only inside the play action,
+followed by `Tone.Transport.start()`. Stop calls `Transport.stop()`, `Transport.cancel()`,
+then the dispose function, and clears it.
+
+**Check `src/app.js`**: if its `__arc.play` path calls `schedule()` at activation time
+instead of on the play command, apply the same change. If `app.js` already schedules
+only on play, leave it.
+
+## Where the corrected reference lives
+
+The Jazz copy on the Mac Studio has both fixes working and verified by 80+ seconds of
+continuous playback (agua-ravine):
+
+- `~/devs/jazz/composer/ref-pieces/test-player/src/index.js` (gallery shim, fixed)
+- `~/devs/jazz/composer/ref-pieces/test-player/dist-pieces/*/index.html` (seeded shim injected)
+
+The ArcTerm repo copy on the MacBook (`arcterm-private/tools/composer/`) does NOT have
+these fixes yet.
+
+## What to do, in order
+
+1. Apply Bug 1's shim to `tools/composer/ref-pieces/test-player/src/app.js`.
+2. Check and, if needed, fix Bug 2 in `app.js`.
+3. Rebuild all packs: `python3 tools/composer/build-music-packs.py`.
+   Bump `version` to `3` for every entry in the `PIECES` dict first —
+   the app re-downloads a pack only when the version number rises.
+4. Copy `music-dist/*` into the gh-pages `music/` folder and push.
+5. Verify: in ArcTerm, delete a broken pack (e.g. aisatsana), re-download it,
+   and let it play for at least 3 minutes. Before the fix it dies within ~30 seconds;
+   after the fix it must keep developing.
+6. Also verify one unaffected pack (skyline) still behaves the same as before.
+
+## Optional, later
+
+- The seeded rng means a pack can ship a fixed, hand-picked performance
+  (`?seed=name` on the player URL). Not used yet; the bridge could pass it.
+- With the fix in place, the whole 57-piece catalog is a candidate for publishing,
+  not only the current 8. Decide separately; sizes are the constraint (GitHub Pages ~1GB).

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -226,3 +226,15 @@ answers honestly that nothing was kept. Every metric, chip, bar, tag and version
 the numbers mean, so the explanations are part of the product, not decoration. The report gained
 additive fields for the panel: per-endpoint `hits` and `kept_bytes`, and totals `hits_today`,
 `refreshes_today`, `worker_on`, `refresh_daily_cap`.
+
+## The running totals (2026-09-03)
+
+The panel's report reads `ArchiveEndpointStat` — one row per endpoint (keys, stable, changed,
+snapshots, bodies_kept, kept_bytes, newest_fetch), maintained by the recorder in the SAME
+transaction as each snapshot, using atomic column arithmetic only (the credit-block drift is why
+read-modify-write is banned near counters). The old per-load aggregates cost 9.9s + 8.0s + 14.8s
+at 434k keys on prod; the rollup read is milliseconds at any scale. Migration 0013 backfills the
+table once from the live archive and adds a partial index over refresh-origin snapshots for the
+"refreshes today" count; a 30s in-process report cache remains as the belt against poll stacking
+(cleared per test beside the drains). A dropped recording drops its counter bumps with it — the
+rollup rides the recording's own commit, so the two cannot drift.

--- a/src/treg/alembic/versions/0013_archive_endpoint_stats.py
+++ b/src/treg/alembic/versions/0013_archive_endpoint_stats.py
@@ -1,0 +1,74 @@
+"""archiveendpointstat — the report's running totals, backfilled from the live archive
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-09-03
+
+The panel's report walked 434k keys + 505k snapshots on every cold load (measured 9.9s + 8.0s +
+14.8s per query on prod). From this revision the recorder maintains one totals row per endpoint
+in the same transaction as each snapshot, and the report reads ~50 tiny rows. The backfill runs
+the old aggregates ONCE, here, where a preDeploy step may take its time — those two execute()
+statements are the rollback floor: a build older than this revision does not know the totals
+table and cannot re-derive rows recorded after it, so do not downgrade past here on a live
+database (the table would simply be dropped and rebuilt stale by a re-upgrade). A partial index over
+refresh snapshots keeps the report's "refreshes today" count off the big table too.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013"
+down_revision: str | Sequence[str] | None = "0012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+contract = True  # backfill executes — see the rollback floor note above
+
+
+def upgrade() -> None:
+    op.create_table(
+        "archiveendpointstat",
+        sa.Column("endpoint_id", sa.String(), primary_key=True),
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
+        sa.Column("policy", sa.String(), nullable=False, server_default="forbidden"),
+        sa.Column("keys", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("stable", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("changed", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("snapshots", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("bodies_kept", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("kept_bytes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("newest_fetch", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_archivesnapshot_refresh_fetched", "archivesnapshot", ["fetched_at"],
+                    postgresql_where=sa.text("origin = 'refresh'"),
+                    sqlite_where=sa.text("origin = 'refresh'"))
+    # Backfill: the exact aggregates the report used to compute per load, run once. Key-side
+    # counters first, then the snapshot-side counters merged in.
+    op.execute("""
+        INSERT INTO archiveendpointstat
+            (endpoint_id, provider, policy, keys, stable, changed,
+             snapshots, bodies_kept, kept_bytes, newest_fetch)
+        SELECT k.endpoint_id, max(k.provider), max(k.policy), count(k.id),
+               coalesce(sum(k.stable_seen), 0), coalesce(sum(k.change_seen), 0),
+               0, 0, 0, max(k.fetched_at)
+        FROM archivekey k GROUP BY k.endpoint_id
+    """)
+    op.execute("""
+        UPDATE archiveendpointstat SET
+            snapshots   = agg.snaps,
+            bodies_kept = agg.kept,
+            kept_bytes  = agg.bytes
+        FROM (
+            SELECT k.endpoint_id AS endpoint_id, count(s.id) AS snaps,
+                   count(s.body) AS kept,
+                   coalesce(sum(CASE WHEN s.body IS NOT NULL THEN s.size_bytes END), 0) AS bytes
+            FROM archivekey k JOIN archivesnapshot s ON s.key_id = k.id
+            GROUP BY k.endpoint_id
+        ) AS agg
+        WHERE archiveendpointstat.endpoint_id = agg.endpoint_id
+    """)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_archivesnapshot_refresh_fetched", table_name="archivesnapshot")
+    op.drop_table("archiveendpointstat")

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -254,6 +254,42 @@ async def drain() -> None:
                              _STORE_TIMEOUT_S)
 
 
+
+async def _bump_stats(s, *, endpoint_id: str, provider: str, pol: str, new_key: bool,
+                      stable_d: int, changed_d: int, kept: bool, size: int, now) -> None:
+    """Move the endpoint's running totals (ArchiveEndpointStat) inside the caller's transaction.
+    Atomic column arithmetic only (col = col + n) — never read-modify-write: the credit-block
+    drift showed what parallel writers do to in-memory subtraction. A missing row is inserted
+    and the racing loser retries as an update."""
+    from sqlalchemy import update as sa_update
+    from sqlalchemy.exc import IntegrityError
+
+    from .models import ArchiveEndpointStat
+
+    values = {
+        "provider": provider, "policy": pol, "newest_fetch": now,
+        "keys": ArchiveEndpointStat.keys + (1 if new_key else 0),
+        "stable": ArchiveEndpointStat.stable + stable_d,
+        "changed": ArchiveEndpointStat.changed + changed_d,
+        "snapshots": ArchiveEndpointStat.snapshots + 1,
+        "bodies_kept": ArchiveEndpointStat.bodies_kept + (1 if kept else 0),
+        "kept_bytes": ArchiveEndpointStat.kept_bytes + (size if kept else 0),
+    }
+    res = await s.execute(sa_update(ArchiveEndpointStat)
+                          .where(ArchiveEndpointStat.endpoint_id == endpoint_id).values(**values))
+    if res.rowcount == 0:
+        try:
+            async with s.begin_nested():
+                s.add(ArchiveEndpointStat(
+                    endpoint_id=endpoint_id, provider=provider, policy=pol,
+                    keys=1 if new_key else 0, stable=stable_d, changed=changed_d,
+                    snapshots=1, bodies_kept=1 if kept else 0,
+                    kept_bytes=size if kept else 0, newest_fetch=now))
+        except IntegrityError:  # a concurrent recording inserted the row first — count on it
+            await s.execute(sa_update(ArchiveEndpointStat)
+                            .where(ArchiveEndpointStat.endpoint_id == endpoint_id).values(**values))
+
+
 async def _store(
     *,
     method: str,
@@ -322,6 +358,8 @@ async def _store(
             newest = (await s.execute(
                 select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
                 .order_by(ArchiveSnapshot.version.desc()).limit(1))).scalars().first()
+            new_key = newest is None            # first version ⇒ this recording created the key
+            seen_before = (key.stable_seen, key.change_seen)
 
             snap = ArchiveSnapshot(
                 key_id=key.id, version=1 if newest is None else newest.version + 1,
@@ -353,6 +391,10 @@ async def _store(
                 key.last_requested_at = now
             s.add(key)
             s.add(snap)
+            await _bump_stats(
+                s, endpoint_id=endpoint_id, provider=provider, pol=pol, new_key=new_key,
+                stable_d=key.stable_seen - seen_before[0], changed_d=key.change_seen - seen_before[1],
+                kept=snap.body is not None, size=len(body), now=now)
             try:
                 await s.commit()
             except IntegrityError:  # version race with a concurrent recording — drop this sample
@@ -520,6 +562,8 @@ async def lookup(
             newest = (await s.execute(
                 select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
                 .order_by(ArchiveSnapshot.version.desc()).limit(1))).scalars().first()
+            new_key = newest is None            # first version ⇒ this recording created the key
+            seen_before = (key.stable_seen, key.change_seen)
             if newest is None or not (200 <= newest.status_code < 300):
                 return None
             age_s = int((_utcnow() - newest.fetched_at).total_seconds())

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, Index, UniqueConstraint, text
+from sqlalchemy import BigInteger, JSON, Column, Index, UniqueConstraint, text
 from sqlmodel import Field, SQLModel
 
 # Role ordering for gates (owner > admin > member > viewer).
@@ -1250,6 +1250,9 @@ class ArchiveSnapshot(SQLModel, table=True):
     __table_args__ = (
         UniqueConstraint("key_id", "version", name="uq_archive_snapshot_version"),
         Index("ix_archive_snapshot_content", "content_hash"),
+        # Partial index for the report's "refreshes today" count — only refresh-origin rows.
+        Index("ix_archivesnapshot_refresh_fetched", "fetched_at",
+              postgresql_where=text("origin = 'refresh'"), sqlite_where=text("origin = 'refresh'")),
     )
 
     id: int | None = Field(default=None, primary_key=True)
@@ -1264,3 +1267,23 @@ class ArchiveSnapshot(SQLModel, table=True):
     fetched_at: datetime = Field(default_factory=_now, index=True)
     # Who triggered the fetch: "caller" (a real request) | "refresh" (worker) | "sample" (learner).
     origin: str = Field(default="caller")
+
+
+
+class ArchiveEndpointStat(SQLModel, table=True):
+    """The archive report's running totals, one row per endpoint — maintained by the recorder in
+    the SAME transaction as each snapshot, so the panel reads 50 tiny rows instead of walking
+    434k keys + 505k snapshots (measured 9.9s + 8.0s + 14.8s per report on prod, 2026-09-03).
+    Counters move only via atomic column arithmetic (col = col + n): the credit-block drift
+    taught us what read-modify-write does under parallel settles."""
+
+    endpoint_id: str = Field(primary_key=True)
+    provider: str = Field(default="")
+    policy: str = Field(default="forbidden")       # the policy last observed for this endpoint
+    keys: int = Field(default=0)                   # distinct questions ever seen
+    stable: int = Field(default=0)                 # refetches whose stripped answer matched
+    changed: int = Field(default=0)                # refetches whose stripped answer differed
+    snapshots: int = Field(default=0)              # versions stored (bodies + dedup references)
+    bodies_kept: int = Field(default=0)            # versions whose bytes were kept
+    kept_bytes: int = Field(default=0, sa_column=Column(BigInteger, nullable=False, server_default="0"))  # already past int32 on prod
+    newest_fetch: datetime | None = Field(default=None)

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -18,7 +18,7 @@ from .. import reconcile
 from ..config import get_settings
 from ..infra.db import get_session, session_maker
 from ..domain import money
-from ..models import ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, LedgerEntry, Membership, Org, Referral, Secret, Tool, User
+from ..models import ArchiveEndpointStat, ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, LedgerEntry, Membership, Org, Referral, Secret, Tool, User
 from ..timeutil import as_naive as _as_naive
 from ..timeutil import utcnow_naive as _utcnow_naive
 from ..domain.identity.access import require_superadmin
@@ -340,38 +340,29 @@ async def admin_archive(
     top: int = 50,
     _: str = Depends(require_superadmin), db: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Phase 0's read-out: what the recorder has observed, per endpoint — the evidence for the
-    per-provider cache judgments (PR 3) and later for the timers. `refetches` counts repeat
-    observations of an existing key (stable + changed); `change_ratio` is changed/refetches, the
-    raw signal for how fast an endpoint's answers move. `kept_bytes` only grows where a judged
-    licence allows storing (docs/context/architecture/archive.md)."""
+    """Phase 0's read-out, served from the recorder-maintained running totals
+    (ArchiveEndpointStat): ~50 tiny rows instead of walking every key and snapshot — the old
+    aggregates cost 9.9s + 8.0s + 14.8s per cold load at 434k keys on prod (2026-09-03).
+    `refetches` = stable + changed; `change_ratio` = changed/refetches. The 30s in-process cache
+    stays as the belt against poll stacking."""
     from .. import archive as archive_mod
 
-    # One expensive aggregation every 30s, not one per poll: the panel refreshes every 5s and
-    # several viewers stack — at 425k keys the pile-up alone froze the page (2026-09-03).
     import time as _time
     hit = _archive_report_cache.get(top)
     if hit and _time.monotonic() - hit[0] < _ARCHIVE_REPORT_TTL_S:
         return hit[1]
 
-    keys = func.count(ArchiveKey.id)
-    stable = func.coalesce(func.sum(ArchiveKey.stable_seen), 0)
-    changed = func.coalesce(func.sum(ArchiveKey.change_seen), 0)
-    per_ep = (await db.execute(
-        select(ArchiveKey.endpoint_id, ArchiveKey.provider, ArchiveKey.policy,
-               keys, stable, changed, func.max(ArchiveKey.fetched_at))
-        .group_by(ArchiveKey.endpoint_id, ArchiveKey.provider, ArchiveKey.policy)
-        .order_by((stable + changed).desc(), keys.desc()).limit(max(1, min(top, 500))))).all()
+    stats = (await db.execute(
+        select(ArchiveEndpointStat)
+        .order_by((ArchiveEndpointStat.stable + ArchiveEndpointStat.changed).desc(),
+                  ArchiveEndpointStat.keys.desc())
+        .limit(max(1, min(top, 500))))).scalars().all()
+    totals = (await db.execute(
+        select(func.coalesce(func.sum(ArchiveEndpointStat.keys), 0),
+               func.coalesce(func.sum(ArchiveEndpointStat.snapshots), 0),
+               func.coalesce(func.sum(ArchiveEndpointStat.bodies_kept), 0),
+               func.coalesce(func.sum(ArchiveEndpointStat.kept_bytes), 0)))).one()
 
-    snap_totals = (await db.execute(
-        select(func.count(ArchiveSnapshot.id),
-               func.coalesce(func.sum(ArchiveSnapshot.size_bytes), 0))
-        .where(ArchiveSnapshot.body.is_not(None)))).one()
-    all_snaps = (await db.execute(select(func.count(ArchiveSnapshot.id)))).scalar_one()
-    total_keys = (await db.execute(select(func.count(ArchiveKey.id)))).scalar_one()
-
-    # Served-hit counts per endpoint, and today's totals — the panel's headline numbers. All
-    # additive: nothing the report already promised changes shape.
     hit_rows = (await db.execute(
         select(CallRecord.endpoint_id, func.count(CallRecord.id))
         .where(CallRecord.cached.is_(True)).group_by(CallRecord.endpoint_id))).all()
@@ -384,29 +375,24 @@ async def admin_archive(
         select(func.count(ArchiveSnapshot.id))
         .where(ArchiveSnapshot.origin == "refresh",
                ArchiveSnapshot.fetched_at >= today))).scalar_one()
-    kept_rows = (await db.execute(
-        select(ArchiveKey.endpoint_id, func.coalesce(func.sum(ArchiveSnapshot.size_bytes), 0))
-        .join(ArchiveSnapshot, ArchiveSnapshot.key_id == ArchiveKey.id)
-        .where(ArchiveSnapshot.body.is_not(None)).group_by(ArchiveKey.endpoint_id))).all()
-    kept_by_ep = {ep: int(n) for ep, n in kept_rows}
 
     rows = []
-    for endpoint_id, provider, pol, n_keys, n_stable, n_changed, newest in per_ep:
-        refetches = int(n_stable) + int(n_changed)
+    for st in stats:
+        refetches = st.stable + st.changed
         rows.append({
-            "endpoint_id": endpoint_id, "provider": provider, "policy": pol,
-            "keys": int(n_keys), "refetches": refetches,
-            "stable": int(n_stable), "changed": int(n_changed),
-            "change_ratio": round(int(n_changed) / refetches, 4) if refetches else None,
-            "newest_fetch": newest.isoformat() if newest else None,
-            "hits": hits_by_ep.get(endpoint_id, 0),
-            "kept_bytes": kept_by_ep.get(endpoint_id, 0),
+            "endpoint_id": st.endpoint_id, "provider": st.provider, "policy": st.policy,
+            "keys": st.keys, "refetches": refetches,
+            "stable": st.stable, "changed": st.changed,
+            "change_ratio": round(st.changed / refetches, 4) if refetches else None,
+            "newest_fetch": st.newest_fetch.isoformat() if st.newest_fetch else None,
+            "hits": hits_by_ep.get(st.endpoint_id, 0),
+            "kept_bytes": st.kept_bytes,
         })
     report = {"mode": archive_mod.mode(),
             "worker_on": archive_mod.worker_enabled(),
             "refresh_daily_cap": get_settings().archive_refresh_daily_cap,
-            "keys": int(total_keys), "snapshots": int(all_snaps),
-            "bodies_kept": int(snap_totals[0]), "kept_bytes": int(snap_totals[1]),
+            "keys": int(totals[0]), "snapshots": int(totals[1]),
+            "bodies_kept": int(totals[2]), "kept_bytes": int(totals[3]),
             "hits_today": int(hits_today), "refreshes_today": int(refreshes_today),
             "endpoints": rows}
     _archive_report_cache[top] = (_time.monotonic(), report)

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -1450,7 +1450,7 @@
   "paths": {
     "/admin/archive": {
       "get": {
-        "description": "Phase 0's read-out: what the recorder has observed, per endpoint — the evidence for the\nper-provider cache judgments (PR 3) and later for the timers. `refetches` counts repeat\nobservations of an existing key (stable + changed); `change_ratio` is changed/refetches, the\nraw signal for how fast an endpoint's answers move. `kept_bytes` only grows where a judged\nlicence allows storing (docs/context/architecture/archive.md).",
+        "description": "Phase 0's read-out, served from the recorder-maintained running totals\n(ArchiveEndpointStat): ~50 tiny rows instead of walking every key and snapshot — the old\naggregates cost 9.9s + 8.0s + 14.8s per cold load at 434k keys on prod (2026-09-03).\n`refetches` = stable + changed; `change_ratio` = changed/refetches. The 30s in-process cache\nstays as the belt against poll stacking.",
         "operationId": "admin_archive_admin_archive_get",
         "parameters": [
           {

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -812,3 +812,32 @@ async def test_the_result_never_carries_failure_evidence(clients: AsyncClient, s
     assert got.status_code == 200
     assert "SECRET-EVIDENCE" not in got.text
     assert got.json()["note"] == "not stored: the call failed, so there is no answer on file"
+
+
+async def test_endpoint_stats_match_direct_aggregation(clients: AsyncClient, shadow, monkeypatch):
+    """The rollup IS the report now, so it must equal what walking the tables would say — after
+    new keys, dedup references, a changed answer, and a policy-forbidden recording."""
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"n": 1}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    await clients.get(f"/call/{EP}?aweme_id=7")            # identical → dedup ref, stable+1
+    await archive.drain()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"n": 2}'))
+    await clients.get(f"/call/{EP}?aweme_id=7")            # changed+1
+    await clients.get(f"/call/{EP}?aweme_id=8")            # second key
+    await archive.drain()
+
+    from sqlalchemy import func as F
+    from treg.models import ArchiveEndpointStat
+    async with session_maker() as s:
+        st = (await s.execute(select(ArchiveEndpointStat)
+                              .where(ArchiveEndpointStat.endpoint_id == EP))).scalars().one()
+        keys, snaps = await _rows()
+        assert st.keys == len(keys) == 2
+        assert st.snapshots == len(snaps) == 4
+        assert st.stable == sum(k.stable_seen for k in keys) == 1
+        assert st.changed == sum(k.change_seen for k in keys) == 1
+        assert st.bodies_kept == sum(1 for x in snaps if x.body is not None)
+        assert st.kept_bytes == sum(x.size_bytes for x in snaps if x.body is not None)
+        assert st.newest_fetch is not None


### PR DESCRIPTION
Cold report loads cost 33s of database walks at current scale (measured on prod) and grow daily. One totals row per endpoint, bumped atomically in the recording's own transaction; report reads ~50 rows. Migration 0013 backfills once (contract=True, rollback floor) + partial index for the today-counter. Property test pins rollup == direct aggregation; Postgres 16 verified locally.