### PR TITLE
feat(archive): profit-shaped pruner — strip bytes that cannot earn

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -250,3 +250,17 @@ bytes; `size_bytes` and `content_hash` describe RAW bytes always, keeping dedup 
 semantics unmoved. Rows from before migration 0014 stay raw and readable forever. The founder's
 keys-vs-values idea was examined and declined: compression removes repeated JSON keys anyway, and
 rebuilding JSON from stored values risks the byte-verbatim promise the hashes depend on.
+
+## The pruner (2026-09-03)
+
+Profit-shaped shelf clearing: a served hit is revenue with no vendor cost, so a body's right to
+disk is its earning potential. `prune_once` strips BYTES only — every version row keeps its hash,
+size and timestamp, the newest version of every key stays whole (serving and change-detection
+need it), and the strip set is decided before carrier protection so a surviving dedup reference
+never loses its carrier. Rank of removal: never-servable keys (TTL_NEVER) keep exactly one body,
+age no defense; then old (`archive_prune_min_age_days`, 7) versions beyond the newest
+`archive_prune_keep_versions` (2) on keys undemanded for 14 days. Archive-policy endpoints are
+exempt — their history is the future data product. Runs from the lifespan beside the refresh
+worker whenever the archive records, `archive_prune_batch` (500) bodies per pass per
+`archive_prune_interval_s` (3600); batch 0 disables. Rollup counters (bodies_kept, kept_bytes)
+move atomically with each strip.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -194,7 +194,7 @@ def content_hash(body: bytes) -> str:
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 _log = logging.getLogger("treg.archive")
 _pending: set[asyncio.Task] = set()
@@ -427,6 +427,107 @@ async def _store(
                 await s.rollback()
     except Exception:  # noqa: BLE001 — recording must never surface anywhere
         _log.warning("archive recording dropped for %s", endpoint_id, exc_info=True)
+
+
+
+# ---------------------------------------------------------------------------------------------
+# The pruner — profit-shaped shelf clearing. A served hit is revenue with no vendor cost, so a
+# body's right to disk is its earning potential. It strips BYTES only: every version row stays
+# (hash, size, timestamp — the history and the statistics are untouched), the newest version of
+# every key stays whole (serving and change-detection need it), and a dedup carrier is never
+# stripped while a kept version still points at it.
+#
+# Rank of removal, first to go:
+#   1. Old versions of keys the learner marked never-servable (TTL_NEVER) — they can never sell.
+#   2. Old versions beyond the newest `archive_prune_keep_versions` on keys nobody has demanded
+#      recently, oldest first, once they pass `archive_prune_min_age_days`.
+# Archive-policy endpoints are exempt: their history is the future data product.
+
+_PRUNE_DEMAND_GRACE_DAYS = 14  # a key demanded in this window keeps its full version budget
+
+
+def prune_enabled() -> bool:
+    return recording() and get_settings().archive_prune_batch > 0
+
+
+async def prune_worker() -> None:
+    """Run forever from lifespan; same discipline as refresh_worker."""
+    while True:
+        try:
+            done = await prune_once()
+            if done:
+                _log.info("archive prune: %d body(ies) stripped", done)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _log.warning("archive prune pass failed", exc_info=True)
+        await asyncio.sleep(get_settings().archive_prune_interval_s)
+
+
+async def prune_once() -> int:
+    """One bounded pass. Returns how many bodies were stripped."""
+    if not prune_enabled():
+        return 0
+    from sqlalchemy import select, update as sa_update
+
+    from .infra.db import session_maker
+    from .models import ArchiveEndpointStat, ArchiveKey, ArchiveSnapshot
+
+    s_cfg = get_settings()
+    batch = s_cfg.archive_prune_batch
+    keep_n = max(1, s_cfg.archive_prune_keep_versions)
+    min_age = _utcnow() - timedelta(days=s_cfg.archive_prune_min_age_days)
+    demand_floor = _utcnow() - timedelta(days=_PRUNE_DEMAND_GRACE_DAYS)
+    stripped = 0
+
+    async with session_maker() as s:
+        # Candidate keys, worst earners first: never-servable, then long-undemanded.
+        keys = (await s.execute(
+            select(ArchiveKey)
+            .where(ArchiveKey.policy != CACHE_ARCHIVE)
+            .where((ArchiveKey.ttl_s == TTL_NEVER)
+                   | (ArchiveKey.last_requested_at.is_(None))
+                   | (ArchiveKey.last_requested_at < demand_floor))
+            .order_by((ArchiveKey.ttl_s == TTL_NEVER).desc(), ArchiveKey.last_requested_at)
+            .limit(2000))).scalars().all()
+
+        for key in keys:
+            if stripped >= batch:
+                break
+            versions = (await s.execute(
+                select(ArchiveSnapshot).where(ArchiveSnapshot.key_id == key.id)
+                .order_by(ArchiveSnapshot.version.desc()))).scalars().all()
+            if not versions:
+                continue
+            budget = 1 if key.ttl_s == TTL_NEVER else keep_n
+            # Decide the strip set FIRST, then protect the carriers of everything that survives —
+            # a surviving version may reference a body on an older row (dedup), and stripping the
+            # carrier would silently orphan it.
+            candidates = [v for v in versions[budget:]
+                          if v.body is not None
+                          and (key.ttl_s == TTL_NEVER or v.fetched_at <= min_age)]
+            surviving = [v for v in versions if v not in candidates]
+            protected = ({v.id for v in surviving}
+                         | {v.body_of for v in surviving if v.body_of is not None})
+            freed_bytes = 0
+            freed_n = 0
+            for v in candidates:
+                if v.id in protected:
+                    continue
+                v.body, v.enc = None, None
+                freed_n += 1
+                freed_bytes += v.size_bytes
+                s.add(v)
+                stripped += 1
+                if stripped >= batch:
+                    break
+            if freed_n:
+                await s.execute(sa_update(ArchiveEndpointStat)
+                                .where(ArchiveEndpointStat.endpoint_id == key.endpoint_id)
+                                .values(bodies_kept=ArchiveEndpointStat.bodies_kept - freed_n,
+                                        kept_bytes=ArchiveEndpointStat.kept_bytes - freed_bytes))
+        await s.commit()
+    return stripped
 
 
 # ---------------------------------------------------------------------------------------------

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -434,6 +434,13 @@ def _lifespan(role: AppRole):
             if ROLE_BACKGROUND_TASKS[role] and archive.worker_enabled()
             else None
         )
+        # The pruner (profit-shaped shelf clearing — see archive.prune_once): runs wherever the
+        # archive records, bounded per pass; archive_prune_batch=0 disables it.
+        prune_task = (
+            asyncio.create_task(archive.prune_worker())
+            if ROLE_BACKGROUND_TASKS[role] and archive.prune_enabled()
+            else None
+        )
         endpoint_observations = app.state.endpoint_observation_reader
         routed_call.configure_endpoint_observation_reader(endpoint_observations)
         mcp_reader_bound = role != "control" and _mcp is not None
@@ -455,6 +462,8 @@ def _lifespan(role: AppRole):
                     ads_task.cancel()
                 if archive_task is not None:
                     archive_task.cancel()
+                if prune_task is not None:
+                    prune_task.cancel()
                 if mcp_reader_bound:
                     _mcp.clear_endpoint_observation_reader(endpoint_observations)
                 routed_call.clear_endpoint_observation_reader(endpoint_observations)

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -286,6 +286,12 @@ class Settings(BaseSettings):
     # no caller attached, so the cap is the brake — 0 disables refreshing without touching serving.
     archive_refresh_interval_s: int = 300
     archive_refresh_daily_cap: int = 50
+    # The pruner (profit-shaped: a stored body is inventory, and inventory that cannot sell goes
+    # first). Runs whenever the archive records (shadow or serve); 0 batch disables it.
+    archive_prune_interval_s: int = 3600       # one pass per hour
+    archive_prune_batch: int = 500             # bodies stripped per pass, the load bound
+    archive_prune_keep_versions: int = 2       # newest N bodies kept on servable keys
+    archive_prune_min_age_days: int = 7        # servable bodies younger than this are never touched
 
     # Additive Claude directory MCP. Default OFF so deploying code cannot publish a new connector
     # surface before its production Inspector and custom-connector gates have passed.

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -880,3 +880,75 @@ async def test_compressed_change_detection_still_compares_raw(clients: AsyncClie
     await archive.drain()
     keys, _ = await _rows()
     assert keys[0].change_seen == 1 and keys[0].stable_seen == 0
+
+
+# ---------------------------------------------------------------------------------------------
+# The pruner (profit-shaped): strip bytes that cannot earn, never rows, never the newest body
+
+async def _age_versions(days: int):
+    from datetime import timedelta
+    async with session_maker() as s:
+        for v in (await s.execute(select(ArchiveSnapshot))).scalars().all():
+            v.fetched_at = v.fetched_at - timedelta(days=days)
+            s.add(v)
+        for k in (await s.execute(select(ArchiveKey))).scalars().all():
+            if k.last_requested_at is not None:
+                k.last_requested_at = k.last_requested_at - timedelta(days=days)
+            s.add(k)
+        await s.commit()
+
+
+async def test_pruner_strips_old_undemanded_bodies_keeps_rows(clients: AsyncClient, shadow, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    for n in range(4):                                   # 4 distinct answers → 4 stored bodies
+        monkeypatch.setattr(call_service, "relay",
+                            _fake_relay(200, b'{"v": %d, "pad": "%s"}' % (n, b"x" * 300)))
+        await clients.get(f"/call/{EP}?aweme_id=7")
+        await archive.drain()
+    await _age_versions(days=30)                         # old AND undemanded
+    assert await archive.prune_once() == 2               # newest 2 bodies kept, 2 stripped
+    keys, snaps = await _rows()
+    assert len(snaps) == 4                               # rows never deleted
+    bodies = [s for s in snaps if s.body is not None]
+    assert len(bodies) == 2
+    assert max(s.version for s in bodies) == 4           # the newest survives whole
+    from treg.models import ArchiveEndpointStat
+    async with session_maker() as s:
+        st = (await s.execute(select(ArchiveEndpointStat)
+                              .where(ArchiveEndpointStat.endpoint_id == EP))).scalars().one()
+        assert st.bodies_kept == 2                       # totals moved with the strip
+    assert await archive.prune_once() == 0               # idempotent — nothing left to strip
+
+
+async def test_pruner_never_cache_keeps_only_newest(clients: AsyncClient, shadow, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    for n in range(3):
+        monkeypatch.setattr(call_service, "relay",
+                            _fake_relay(200, b'{"v": %d, "pad": "%s"}' % (n, b"y" * 300)))
+        await clients.get(f"/call/{EP}?aweme_id=7")
+        await archive.drain()
+    async with session_maker() as s:                     # the learner's verdict, set directly
+        k = (await s.execute(select(ArchiveKey))).scalars().one()
+        k.ttl_s = archive.TTL_NEVER
+        s.add(k); await s.commit()
+    assert await archive.prune_once() == 2               # young age is no defense for never-cache
+    _, snaps = await _rows()
+    assert sum(1 for x in snaps if x.body is not None) == 1
+    assert next(x.version for x in snaps if x.body is not None) == 3
+
+
+async def test_pruner_spares_demanded_and_carriers(clients: AsyncClient, shadow, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"stable": "%s"}' % (b"z" * 300)))
+    for _ in range(4):                                   # identical → v1 carries, v2-4 reference
+        await clients.get(f"/call/{EP}?aweme_id=7")
+        await archive.drain()
+    await _age_versions(days=30)
+    async with session_maker() as s:                     # but the key was demanded YESTERDAY
+        from datetime import timedelta
+        k = (await s.execute(select(ArchiveKey))).scalars().one()
+        k.last_requested_at = archive._utcnow() - timedelta(days=1)
+        s.add(k); await s.commit()
+    assert await archive.prune_once() == 0               # demanded recently: full budget kept
+    _, snaps = await _rows()
+    assert snaps[0].body is not None                     # v1 the carrier untouched


### PR DESCRIPTION
Bodies are inventory: never-servable keys (learner's TTL_NEVER) keep one body only; undemanded keys keep the newest 2, older-than-7-day versions stripped; demanded keys, dedup carriers, newest versions and archive-policy endpoints untouched. Rows and statistics never deleted; rollup counters move atomically. Hourly bounded passes (500/pass, 0 disables) beside the refresh worker. 3 new tests; suite 2278.