### PR TITLE
fix(archive): keys endpoint drops body loads; panel drops the 50-request fan-out

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -273,3 +273,12 @@ front of the API's 15-slot pool (SToneX's pool-pressure report). Queued recordin
 their fire-and-forget task, so the caller is unaffected; the 30s bound covers wait+write, so a
 stuck queue still sheds rather than wedges. Throttled, not shed: the burst test proves all 12
 concurrent recordings land while peak DB concurrency stays ≤4.
+
+## Keys-endpoint weight fix (2026-09-03, the pool-pressure repeat)
+
+`/admin/archive/keys` ran one whole-row query per key, dragging every stored BODY out of the
+database just to report whether one exists — and the panel fired it once per endpoint row
+(limit=100) to fill TTL cells: ~50 near-simultaneous heavy calls per page open. Now: the
+versions come from ONE columns-only query (`body IS NOT NULL` reads the header, never the
+bytes), and the panel fills a TTL cell only for the endpoint the operator clicks, from the
+inspector's own load. A dash in the TTL column means "click to learn".

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -415,11 +415,24 @@ async def admin_archive_keys(
         select(AK).where(AK.endpoint_id == endpoint_id)
         .order_by(AK.last_requested_at.desc().nulls_last(), AK.fetched_at.desc())
         .limit(limit))).scalars().all()
+    # ONE columns-only query for every key's recent versions — the previous shape ran a query
+    # per key AND selected whole rows, dragging every stored BODY out of the database just to
+    # report whether one exists (12 bodies × up to 100 keys × the panel's fan-out = the
+    # 2026-09-03 pool-pressure repeat). `body IS NOT NULL` reads the row header, never the bytes.
+    key_ids = [k.id for k in keys]
+    vrows = (await db.execute(
+        select(AS.key_id, AS.version, AS.origin, AS.size_bytes, AS.fetched_at,
+               AS.body_of, AS.body.is_not(None))
+        .where(AS.key_id.in_(key_ids))
+        .order_by(AS.key_id, AS.version.desc()).limit(12 * max(1, len(key_ids))))).all()
+    vers_by_key: dict[int, list] = {}
+    for kid, version, origin, size_bytes, fetched_at, body_of, has_body in vrows:
+        bucket = vers_by_key.setdefault(kid, [])
+        if len(bucket) < 12:
+            bucket.append((version, origin, size_bytes, fetched_at, body_of, has_body))
     out_keys = []
     for k in keys:
-        vers = (await db.execute(
-            select(AS).where(AS.key_id == k.id).order_by(AS.version.desc()).limit(12)
-        )).scalars().all()
+        vers = vers_by_key.get(k.id, [])
         out_keys.append({
             "key_hash": k.key_hash, "ttl_s": k.ttl_s, "policy": k.policy,
             "stable": k.stable_seen, "changed": k.change_seen,
@@ -429,10 +442,10 @@ async def admin_archive_keys(
             "volatile_paths": k.volatile_paths or [],
             "question": f"{k.req_method} {k.req_url}"[:200] if k.req_url else "",
             "versions": [{
-                "version": v.version, "origin": v.origin, "size_bytes": v.size_bytes,
-                "stored": "body" if v.body is not None else ("ref" if v.body_of else "hash"),
-                "fetched_at": v.fetched_at.isoformat(),
-            } for v in reversed(vers)],
+                "version": version, "origin": origin, "size_bytes": size_bytes,
+                "stored": "body" if has_body else ("ref" if body_of else "hash"),
+                "fetched_at": fetched_at.isoformat(),
+            } for version, origin, size_bytes, fetched_at, body_of, has_body in reversed(vers)],
         })
     events = (await db.execute(
         select(CallRecord).where(CallRecord.endpoint_id == endpoint_id)

--- a/src/treg/web/archive-panel.html
+++ b/src/treg/web/archive-panel.html
@@ -380,7 +380,17 @@
   async function select(ep) {
     selected = ep;
     document.querySelectorAll("#eptable tr[data-ep]").forEach(r => r.classList.toggle("sel", r.dataset.ep === ep));
-    try { renderKeys(await api("/admin/archive/keys?endpoint_id=" + encodeURIComponent(ep))); }
+    try {
+      const kd = await api("/admin/archive/keys?endpoint_id=" + encodeURIComponent(ep));
+      renderKeys(kd);
+      const cell = document.getElementById("ttl-" + ep);
+      if (cell) {
+        const ttls = kd.keys.map(x => x.ttl_s).filter(x => x > 0);
+        cell.textContent = ttls.length ? (ttls.length > 1 && Math.min(...ttls) !== Math.max(...ttls)
+          ? fmtS(Math.min(...ttls)) + " – " + fmtS(Math.max(...ttls)) : fmtS(ttls[0])) : "—";
+        cell.dataset.learned = "1";
+      }
+    }
     catch (e) { $("i-body").innerHTML = '<div class="empty">could not load keys: ' + e.message + '</div>'; }
   }
 
@@ -388,17 +398,12 @@
     try {
       const d = await api("/admin/archive");
       renderReport(d);
-      // fill learned-TTL cells from the keys endpoint lazily for judged endpoints only
+      // Learned-TTL cells fill ONLY for the endpoint you click (from the inspector's own load).
+      // The old behavior fired one keys request per row — 50 near-simultaneous heavy calls per
+      // page open, which crowded the production pool (2026-09-03). A dash means "click to learn".
       for (const e of d.endpoints) {
         const cell = document.getElementById("ttl-" + e.endpoint_id);
-        if (!cell) continue;
-        if (e.policy !== "transient" && e.policy !== "archive") { cell.textContent = "—"; continue; }
-        api("/admin/archive/keys?endpoint_id=" + encodeURIComponent(e.endpoint_id) + "&limit=100")
-          .then(kd => {
-            const ttls = kd.keys.map(x => x.ttl_s).filter(x => x > 0);
-            cell.textContent = ttls.length ? (ttls.length > 1 && Math.min(...ttls) !== Math.max(...ttls)
-              ? fmtS(Math.min(...ttls)) + " – " + fmtS(Math.max(...ttls)) : fmtS(ttls[0])) : "—";
-          }).catch(() => { cell.textContent = "—"; });
+        if (cell && !cell.dataset.learned) cell.textContent = "—";
       }
       if (selected) select(selected);
     } catch (e) {


### PR DESCRIPTION
The pool-pressure repeat traced to /admin/archive/keys: whole-row selects pulled every stored body out of the DB per call, and the panel fired one call per endpoint row on page open. One columns-only query now, and TTL cells fill on click only. Suite 2279.