### PR TITLE
feat(ads): add Google Ads gtag for conversion tracking (AW-18392771132)

### DIFF
--- a/docs/context/architecture/ads-conversions.md
+++ b/docs/context/architecture/ads-conversions.md
@@ -5,6 +5,7 @@ sources:
   - src/treg/adsconv.py
   - src/treg/application/signup.py
   - src/treg/web/adtrack.js
+  - src/treg/web/gtag.js
 related:
   - architecture/money.md
   - architecture/multi-tenancy.md
@@ -30,14 +31,16 @@ read-side Ads catalog calls (`oauth_providers.GOOGLE_ADS`), a separate credentia
 
 ## The chain: capture → store → fire → upload
 
-1. **Capture** (`web/adtrack.js`, a first-party script, no Google tag). It reads `gclid`/`gbraid`/
+1. **Capture** (`web/adtrack.js`, a first-party script). It reads `gclid`/`gbraid`/
    `wbraid` off the URL — `gbraid`/`wbraid` are what Google substitutes on iOS traffic, and omitting
    them silently drops a large share of mobile conversions — and writes them into a `treg_ad` cookie
    (90 days, the length of Google's click-through attribution window; `SameSite=Lax` so it survives
-   the cross-site top-level navigation an ad click is). No third-party request is made from the
-   browser at any point. The cookie records the mutually-exclusive field name as well as its value
-   (`gclid|…`, `gbraid|…`, or `wbraid|…`); the old `CLICK_ID|landing` shape remains readable as a
-   legacy GCLID.
+   the cross-site top-level navigation an ad click is). The cookie records the mutually-exclusive
+   field name as well as its value (`gclid|…`, `gbraid|…`, or `wbraid|…`); the old `CLICK_ID|landing`
+   shape remains readable as a legacy GCLID. Marketing pages (landing, use-case pages, resources,
+   tutorial, catalog) also load `web/gtag.js`, which sends pageviews to Google Ads for attribution
+   modeling — this is the only browser-side Google request. The signed-in dashboard does not load
+   gtag.js.
 2. **Store** (`application.signup._ad_attribution_from`, read at both signup doors: `register_user` (`POST /users`)
    and `create_org` (`POST /orgs`), since a browser visitor who clicked an ad can land on either).
    The cookie is decoded and persisted onto the new `Org`: `ad_gclid` (the historical column name,

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -108,6 +108,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/privacy', ('GET',), 'privacy_page'),
     ('/connectors/claude', ('GET',), 'claude_connector_page'),
     ('/adtrack.js', ('GET',), 'adtrack_js'),
+    ('/gtag.js', ('GET',), 'gtag_js'),
     ('/resources', ('GET',), 'resources_page'),
     ('/grokbot', ('GET',), 'grokbot_page'),
     ('/fable', ('GET',), 'fable_page'),

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -223,6 +223,7 @@ def _page(title: str, description: str, path: str, body: str, ld: list[dict],
   </div>
 </footer>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>""", headers={"Cache-Control": "public, max-age=600"})
 
@@ -3006,6 +3007,21 @@ async def adtrack_js():
         raise HTTPException(status_code=404, detail="adtrack.js not bundled")
     # no-cache, same reasoning as tutorial.js: served as a bare `<script src="/adtrack.js">` with no
     # version query, so without this header a browser would keep an ad-window-stale copy after a fix.
+    return FileResponse(f, media_type="application/javascript", headers=headers)
+
+
+@app.get("/gtag.js", include_in_schema=False)
+async def gtag_js():
+    """Google Ads conversion tracking via gtag.js. Loads the base tag (AW-18392771132) on every
+    page; the signup conversion (AW-18392771132/0usqCIeQrO0cELzUrcJE) fires from the dashboard
+    on first team creation for a new user. Like adtrack.js, returns empty for unconfigured or
+    self-hosted deployments that don't want external Google requests."""
+    headers = {"Cache-Control": "no-cache"}
+    if not adsconv.enabled():
+        return Response(content="", media_type="application/javascript", headers=headers)
+    f = _WEB_DIR / "gtag.js"
+    if not f.exists():
+        raise HTTPException(status_code=404, detail="gtag.js not bundled")
     return FileResponse(f, media_type="application/javascript", headers=headers)
 
 

--- a/src/treg/web/fable-gtm.html
+++ b/src/treg/web/fable-gtm.html
@@ -787,5 +787,6 @@
 })();
 </script>
 <script src="sitetrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/grokbot.html
+++ b/src/treg/web/grokbot.html
@@ -1570,5 +1570,6 @@
   });
 })();
 </script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/gtag.js
+++ b/src/treg/web/gtag.js
@@ -1,8 +1,10 @@
-// Google Ads conversion tracking via gtag.js. Loaded on every public and authenticated page.
-// The base tag sends pageviews; tregSignupConversion() fires the one-time signup event.
+// Google Ads base tag via gtag.js. Loaded on marketing pages only (landing, use-case pages,
+// resources, tutorial, etc.) — NOT the signed-in dashboard. The base tag sends pageviews to
+// Google Ads for ad-click attribution. Signup conversions are tracked server-side via adsconv.py,
+// not here, to avoid double-counting.
 //
 // Conversion ID: AW-18392771132
-// Conversion action: treg Signup (web) (7745505287), 30-day click window (configured in Google Ads)
+// See docs/context/architecture/ads-conversions.md for the full tracking architecture.
 (function () {
   try {
     // Load the gtag.js script async (does not block page load)
@@ -17,20 +19,5 @@
     window.gtag = gtag;
     gtag('js', new Date());
     gtag('config', 'AW-18392771132');
-
-    // Fire the signup conversion. Called by the dashboard on first team creation for a new user.
-    // Uses localStorage to ensure it fires only once per browser, even if the signup flow retries.
-    window.tregSignupConversion = function () {
-      try {
-        var key = 'treg_signup_conv_fired';
-        if (localStorage.getItem(key)) return;
-        gtag('event', 'conversion', {
-          'send_to': 'AW-18392771132/0usqCIeQrO0cELzUrcJE',
-          'value': 1.0,
-          'currency': 'AUD'
-        });
-        localStorage.setItem(key, '1');
-      } catch (e) { /* never break the page for a marketing event */ }
-    };
   } catch (e) { /* never break the page for a marketing script */ }
 })();

--- a/src/treg/web/gtag.js
+++ b/src/treg/web/gtag.js
@@ -1,0 +1,36 @@
+// Google Ads conversion tracking via gtag.js. Loaded on every public and authenticated page.
+// The base tag sends pageviews; tregSignupConversion() fires the one-time signup event.
+//
+// Conversion ID: AW-18392771132
+// Conversion action: treg Signup (web) (7745505287), 30-day click window (configured in Google Ads)
+(function () {
+  try {
+    // Load the gtag.js script async (does not block page load)
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=AW-18392771132';
+    document.head.appendChild(s);
+
+    // Initialize the data layer and gtag function
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', 'AW-18392771132');
+
+    // Fire the signup conversion. Called by the dashboard on first team creation for a new user.
+    // Uses localStorage to ensure it fires only once per browser, even if the signup flow retries.
+    window.tregSignupConversion = function () {
+      try {
+        var key = 'treg_signup_conv_fired';
+        if (localStorage.getItem(key)) return;
+        gtag('event', 'conversion', {
+          'send_to': 'AW-18392771132/0usqCIeQrO0cELzUrcJE',
+          'value': 1.0,
+          'currency': 'AUD'
+        });
+        localStorage.setItem(key, '1');
+      } catch (e) { /* never break the page for a marketing event */ }
+    };
+  } catch (e) { /* never break the page for a marketing script */ }
+})();

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -44,7 +44,6 @@ addEventListener('load', function(){
 <script src="/tutorial.js"></script>
 <script src="/dashboard-tour/tour.js"></script>
 <script src="/adtrack.js"></script>
-<script src="/gtag.js"></script>
 <style>
   [v-cloak]{display:none}  /* hide the raw template until Vue mounts — else a hard refresh flashes the un-compiled markup while the script downloads. Vue drops the attribute on mount, which is also how the loader guard above detects that it never did. */
   /* ===== Ledger: warm paper + clay, mono-forward. Dark default. ===== */
@@ -5141,7 +5140,6 @@ createApp({
         this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){}  // don't re-prompt
         await this.loadAll(); this.switchOrg({slug:o.org});
         this.analyticsIdentify(); this.intercomUpdate(); this.track('onboarding_team_created',{team:o.org});
-        if(window.tregSignupConversion) window.tregSignupConversion();  // Google Ads conversion — fires once per browser (gtag.js dedupes via localStorage)
         this.welcome.step=1; }  // stay in the modal: pick your agent → get the setup line
       catch(e){ this.welcome.err='Could not create the team: '+(e.detail||e.status); }
       finally{ this.welcome.busy=false; } },

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -44,6 +44,7 @@ addEventListener('load', function(){
 <script src="/tutorial.js"></script>
 <script src="/dashboard-tour/tour.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 <style>
   [v-cloak]{display:none}  /* hide the raw template until Vue mounts — else a hard refresh flashes the un-compiled markup while the script downloads. Vue drops the attribute on mount, which is also how the loader guard above detects that it never did. */
   /* ===== Ledger: warm paper + clay, mono-forward. Dark default. ===== */
@@ -5140,6 +5141,7 @@ createApp({
         this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){}  // don't re-prompt
         await this.loadAll(); this.switchOrg({slug:o.org});
         this.analyticsIdentify(); this.intercomUpdate(); this.track('onboarding_team_created',{team:o.org});
+        if(window.tregSignupConversion) window.tregSignupConversion();  // Google Ads conversion — fires once per browser (gtag.js dedupes via localStorage)
         this.welcome.step=1; }  // stay in the modal: pick your agent → get the setup line
       catch(e){ this.welcome.err='Could not create the team: '+(e.detail||e.status); }
       finally{ this.welcome.busy=false; } },

--- a/src/treg/web/landing.html
+++ b/src/treg/web/landing.html
@@ -556,6 +556,7 @@ footer{margin-top:150px;border-top:1px solid var(--line);position:relative;overf
 }
 </script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </head>
 <body>
 

--- a/src/treg/web/people-search.html
+++ b/src/treg/web/people-search.html
@@ -1317,5 +1317,6 @@
   } catch (e) { /* analytics must never break the page */ }
 })();
 </script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/privacy.html
+++ b/src/treg/web/privacy.html
@@ -39,7 +39,7 @@
       <li><b>We collect almost nothing about you.</b> An email address to sign in, the teams you're in, and a log of which tools were called. That's the account.</li>
       <li><b>Your credentials are encrypted and never returned.</b> No stored secret value is ever sent back to a client, shown in the dashboard, or read by us.</li>
       <li><b>We don't store what flows through the proxy.</b> A call's request and response bodies pass through and are gone. We keep the method, path, status code, and timestamp — not the content.</li>
-      <li><b>No trackers.</b> No analytics scripts, no advertising pixels, no third-party cookies. Two first-party cookies, both ours: one keeps you signed in, one (only if you arrived from a Google Ads click) tells us the ad worked.</li>
+      <li><b>Minimal tracking.</b> Two first-party cookies, both ours: one keeps you signed in, one (only if you arrived from a Google Ads click) tells us the ad worked. On marketing pages (the landing page and use-case pages, not the signed-in dashboard), we load Google's gtag.js so that signups from ad clicks are counted back to Google Ads — this sets Google's <code>_gcl_*</code> cookies and sends pageviews to Google. There is no analytics on the dashboard itself.</li>
       <li><b>No training, no selling.</b> Your credentials, skills, and connected-account data are never sold and never used to train models.</li>
     </ul>
   </div>
@@ -118,8 +118,9 @@
     <li>We never <b>sell</b> personal data, credentials, or anything reached through them.</li>
     <li>We never use your credentials, connected-account data, or skill content to <b>train machine
       learning models</b> — ours or anyone else's.</li>
-    <li>We never run <b>advertising, analytics, or tracking scripts</b> on our pages. There is no
-      Google Analytics, no pixel, no session-replay, no third-party cookie.</li>
+    <li>We do not run <b>analytics or session-replay scripts</b> on the signed-in dashboard. Marketing
+      pages (landing, use-case pages) load Google's gtag.js for ad-conversion measurement only — there
+      is no Google Analytics property, no pixel, and no session replay anywhere.</li>
     <li>We never use your stored credentials for anything other than the call you or a permitted
       teammate initiated, plus automated health checks and token refreshes.</li>
   </ul>

--- a/src/treg/web/resources.html
+++ b/src/treg/web/resources.html
@@ -65,5 +65,6 @@
 
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/tutorial.html
+++ b/src/treg/web/tutorial.html
@@ -218,5 +218,6 @@
   go(0);
 })();
 </script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-ads.html
+++ b/src/treg/web/usecase-ads.html
@@ -281,5 +281,6 @@ search by advertiser domain and get back creatives, spend estimates and targetin
 </script>
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-company.html
+++ b/src/treg/web/usecase-company.html
@@ -285,5 +285,6 @@ Codex included, can use the <code>treg</code> CLI or plain HTTP.</p>
 </script>
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-enrichment.html
+++ b/src/treg/web/usecase-enrichment.html
@@ -260,5 +260,6 @@ for the setup line.</p>
 </script>
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-seo.html
+++ b/src/treg/web/usecase-seo.html
@@ -300,5 +300,6 @@ Codex included, can use the <code>treg</code> CLI or plain HTTP.</p>
 </script>
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/src/treg/web/usecase-social.html
+++ b/src/treg/web/usecase-social.html
@@ -273,5 +273,6 @@ paste the setup line from <code>/llms.txt</code> into Grok and it can use the tr
 </script>
 <script src="/sitetrack.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 </body>
 </html>

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -637,6 +637,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "gtag_js",
+    "path": "/gtag.js"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "sitetrack_js",
     "path": "/sitetrack.js"
   },

--- a/tests/test_adsconv.py
+++ b/tests/test_adsconv.py
@@ -266,6 +266,13 @@ async def test_adtrack_script_is_empty_when_disabled(clients, ads_disabled):
     assert r.text == ""
 
 
+async def test_gtag_script_is_empty_when_disabled(clients, ads_disabled):
+    """gtag.js returns empty when ads tracking is disabled, same as adtrack.js."""
+    r = await clients.get("/gtag.js")
+    assert r.status_code == 200
+    assert r.text == ""
+
+
 async def test_signup_queues_a_conversion_when_attributed(clients, ads_enabled):
     r = await clients.post("/users", json={"email": "conv@example.com"},
                               cookies={"treg_ad": "CLICK_SIGNUP|p1"})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Adds Google Ads gtag (AW-18392771132) to **marketing pages only** (landing, use-case pages, resources, tutorial, catalog). The base tag sends pageviews to Google Ads for attribution modeling. Signup conversions are handled server-side via `adsconv.py` (existing), not client-side, to avoid double-counting.

**Key design decision**: The gtag does NOT load on the signed-in dashboard (`index.html`), per the privacy policy which now accurately states that tracking is limited to marketing pages.

## Implementation

**New file**: `src/treg/web/gtag.js`
- Loads the Google gtag.js script async (does not block page load)
- Configures `gtag('config', 'AW-18392771132')` for pageview tracking
- No client-side conversion firing — server-side (`adsconv.py` action 7723667014) handles signup conversions

**Marketing pages with gtag.js**:
- `landing.html` — marketing front door
- `usecase-seo.html`, `usecase-social.html`, `usecase-enrichment.html`, `usecase-company.html`, `usecase-ads.html` — use case pages
- `resources.html` — resources page
- `tutorial.html` — docs/tutorial
- `people-search.html`, `fable-gtm.html`, `grokbot.html` — feature landing pages
- Server-rendered catalog pages via `_page()` in `web.py`

**NOT on dashboard**: `index.html` does not load gtag.js

**Route**: `/gtag.js` in `web.py`
- Returns empty script for unconfigured/self-hosted deployments (same as `/adtrack.js`)
- Registered in `bootstrap.py` for role routing

## Addressing review feedback

1. **Privacy policy updated** (`privacy.html` lines 42 and 121-122) — now accurately states that marketing pages load gtag.js for conversion measurement, while the dashboard has no analytics

2. **No double-counting** — removed client-side conversion call; server-side `adsconv.py` already fires to action 7723667014 (marked SECONDARY in Google Ads per existing docs)

3. **Docs fragment updated** (`docs/context/architecture/ads-conversions.md`) — added gtag.js to sources, noted that marketing pages make browser-side Google requests, clarified dashboard exclusion

4. **Test added** — `test_gtag_script_is_empty_when_disabled` verifies the route returns empty when ads tracking is disabled

## How it was tested

- `uv run pytest -q tests/test_adsconv.py` — all 43 tests pass (including new gtag test)
- `uv run pytest -q` — 2497 passed, 4 skipped

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (`test_gtag_script_is_empty_when_disabled`)
- [x] Updated the relevant `docs/context/` fragment (`ads-conversions.md`)
- [x] No secrets in the diff (conversion IDs are public; keys are in environment variables)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84e56364-3b86-4e9f-800e-ab44ebc16ae5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84e56364-3b86-4e9f-800e-ab44ebc16ae5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

