### PR TITLE
feat(ads): add client-side website signup conversion for Google Ads

### DIFF
--- a/docs/context/architecture/ads-conversions.md
+++ b/docs/context/architecture/ads-conversions.md
@@ -5,6 +5,7 @@ sources:
   - src/treg/adsconv.py
   - src/treg/application/signup.py
   - src/treg/web/adtrack.js
+  - src/treg/web/gtag.js
 related:
   - architecture/money.md
   - architecture/multi-tenancy.md
@@ -169,6 +170,22 @@ Created live on Google Ads account `5149790776` (type `UPLOAD_CLICKS`):
 signup measures curiosity, not commercial intent, so it should inform Google's targeting without
 being a bidding goal. `first_call` and `paid` are the two events the campaign should actually bid
 toward — an agent successfully calling a tool, and a team paying for more balance.
+
+## Client-side website conversion (separate)
+
+A **fourth action** (`7745505287`, "treg Signup (web)") fires client-side from `web/gtag.js`. This is
+a **website** conversion (type `WEBSITE`, not `UPLOAD_CLICKS`) that populates the Ads UI SIGNUP goal
+under website conversion tracking. It is NOT a duplicate of the server-side `signup` action above —
+they are different action IDs serving different purposes:
+
+- **Client-side** (`gtag.js`): gives Google a real-time browser-side signal the moment a new user
+  creates their first team (`welcomeCreate` in `index.html`). Uses localStorage dedupe
+  (`treg_signup_conv_fired`) so retries/reloads don't double-fire. Fires `send_to:
+  AW-18392771132/0usqCIeQrO0cELzUrcJE` with `value: 1.0, currency: 'AUD'`.
+- **Server-side** (`adsconv.py`): uploads durable attributed conversions to the UPLOAD_CLICKS actions
+  above, carrying the click id captured in `treg_ad`. Used for bidding optimization.
+
+Both are gated by `adsconv.enabled()` — `/gtag.js` returns an empty script when disabled.
 
 ## API version
 

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -108,6 +108,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/privacy', ('GET',), 'privacy_page'),
     ('/connectors/claude', ('GET',), 'claude_connector_page'),
     ('/adtrack.js', ('GET',), 'adtrack_js'),
+    ('/gtag.js', ('GET',), 'gtag_js'),
     ('/resources', ('GET',), 'resources_page'),
     ('/grokbot', ('GET',), 'grokbot_page'),
     ('/fable', ('GET',), 'fable_page'),

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -3009,6 +3009,25 @@ async def adtrack_js():
     return FileResponse(f, media_type="application/javascript", headers=headers)
 
 
+@app.get("/gtag.js", include_in_schema=False)
+async def gtag_js():
+    """Google Ads tag for CLIENT-SIDE website conversion tracking. Exposes `tregSignupConversion()`
+    for the dashboard to call on new-account signup success.
+
+    This is the **website** conversion (action 7745505287 "treg Signup (web)") that fires to the
+    Ads UI SIGNUP goal. It is NOT a duplicate of the server-side adsconv upload conversions, which
+    go to different action IDs (signup 7723667014, first_call 7723667017, paid 7723667020) via the
+    Data Manager API. Both coexist: client gives Google a real-time website signal; server uploads
+    durable attributed conversions for bidding."""
+    headers = {"Cache-Control": "no-cache"}
+    if not adsconv.enabled():
+        return Response(content="", media_type="application/javascript", headers=headers)
+    f = _WEB_DIR / "gtag.js"
+    if not f.exists():
+        raise HTTPException(status_code=404, detail="gtag.js not bundled")
+    return FileResponse(f, media_type="application/javascript", headers=headers)
+
+
 @app.get("/sitetrack.js", include_in_schema=False)
 async def sitetrack_js():
     """First-touch traffic-source capture (`treg_utm` cookie, always on — first-party, no PII) plus

--- a/src/treg/web/gtag.js
+++ b/src/treg/web/gtag.js
@@ -1,0 +1,53 @@
+// Google Ads tag — base config and client-side website signup conversion.
+//
+// Two tracking systems serve different purposes and fire to DIFFERENT action IDs:
+//
+//   1. CLIENT-SIDE (this file): fires `tregSignupConversion()` once per browser on signup success.
+//      This is the **website** conversion for Google Ads action "treg Signup (web)" (7745505287).
+//      It populates the Ads UI "SIGNUP" goal under website conversion tracking. The gtag snippet
+//      loads from Google and makes a third-party request; a `treg_signup_conv_fired` localStorage
+//      flag dedupes so retries or reloads don't double-fire.
+//
+//   2. SERVER-SIDE (adsconv.py): uploads UPLOAD_CLICKS conversions via the Data Manager API.
+//      These go to different action IDs (signup 7723667014, first_call 7723667017, paid 7723667020)
+//      and are attributed to the ad click that produced them (gclid/gbraid/wbraid captured in
+//      `treg_ad`). The server-side path is durable (outbox → retry → eventual upload) and carries
+//      value/currency for the `paid` action.
+//
+// Both systems coexist: the client event gives Google a real-time website signal for its SIGNUP
+// goal; the server upload feeds the bidding model with higher-quality attributed conversions.
+// Neither duplicates the other — they track different action IDs entirely.
+
+(function () {
+  // Inject Google's gtag.js loader. The script is async; gtag() calls queue until it loads.
+  try {
+    var GA_MEASUREMENT_ID = 'AW-18392771132';
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', GA_MEASUREMENT_ID);
+
+    var s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=' + GA_MEASUREMENT_ID;
+    document.head.appendChild(s);
+  } catch (e) { /* never break the page for analytics */ }
+
+  // Expose the signup conversion for the dashboard to call on new-account success.
+  // Fires ONCE per browser (localStorage dedupe) so retries/reloads don't double-count.
+  window.tregSignupConversion = function () {
+    try {
+      var KEY = 'treg_signup_conv_fired';
+      if (localStorage.getItem(KEY)) return;  // already fired in this browser
+      localStorage.setItem(KEY, '1');
+      if (typeof gtag !== 'function') return;  // gtag not loaded (should not happen)
+      gtag('event', 'conversion', {
+        'send_to': 'AW-18392771132/0usqCIeQrO0cELzUrcJE',
+        'value': 1.0,
+        'currency': 'AUD'
+      });
+    } catch (e) { /* never throw */ }
+  };
+})();

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -44,6 +44,7 @@ addEventListener('load', function(){
 <script src="/tutorial.js"></script>
 <script src="/dashboard-tour/tour.js"></script>
 <script src="/adtrack.js"></script>
+<script src="/gtag.js"></script>
 <style>
   [v-cloak]{display:none}  /* hide the raw template until Vue mounts — else a hard refresh flashes the un-compiled markup while the script downloads. Vue drops the attribute on mount, which is also how the loader guard above detects that it never did. */
   /* ===== Ledger: warm paper + clay, mono-forward. Dark default. ===== */
@@ -5140,6 +5141,7 @@ createApp({
         this.onboarded=true; try{ await this.api('/onboard/skip',{method:'POST'}); }catch(e){}  // don't re-prompt
         await this.loadAll(); this.switchOrg({slug:o.org});
         this.analyticsIdentify(); this.intercomUpdate(); this.track('onboarding_team_created',{team:o.org});
+        try{ if(window.tregSignupConversion) window.tregSignupConversion(); }catch(e){}  // client-side website conversion (Ads action 7745505287)
         this.welcome.step=1; }  // stay in the modal: pick your agent → get the setup line
       catch(e){ this.welcome.err='Could not create the team: '+(e.detail||e.status); }
       finally{ this.welcome.busy=false; } },

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -637,6 +637,15 @@
       "GET",
       "HEAD"
     ],
+    "name": "gtag_js",
+    "path": "/gtag.js"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
+      "GET",
+      "HEAD"
+    ],
     "name": "sitetrack_js",
     "path": "/sitetrack.js"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Adds Google Ads **client-side website conversion** tracking for signup success. This fires the website action "treg Signup (web)" (action ID **7745505287**, `send_to: AW-18392771132/0usqCIeQrO0cELzUrcJE`) to populate the Ads UI SIGNUP goal.

**This is NOT a duplicate of server-side conversion uploads.** The server-side `adsconv.py` uploads to different UPLOAD_CLICKS action IDs (signup 7723667014, first_call 7723667017, paid 7723667020) via the Data Manager API. Both coexist: client gives Google a real-time website signal; server uploads durable attributed conversions for bidding.

### Changes

- **`src/treg/web/gtag.js`** (new): Base Google Ads config (AW-18392771132) and `tregSignupConversion()` function
  - Uses localStorage dedupe (`treg_signup_conv_fired`) so retries/reloads don't double-fire
  - Fires: `value: 1.0, currency: 'AUD'`
  - Never throws
- **`src/treg/routers/web.py`**: `/gtag.js` route (empty when adsconv disabled, serves file when enabled)
- **`src/treg/bootstrap.py`**: Register expected route
- **`src/treg/web/index.html`**: 
  - Load `/gtag.js` in `<head>` section
  - Call `tregSignupConversion()` in `welcomeCreate()` after successful first team creation

### Hook location

The conversion fires in `welcomeCreate()` in `src/treg/web/index.html` — this is the signup success moment when a new user creates their first team.

## How it was tested

```bash
uv run --frozen python -m pytest -q
# 2496 passed, 4 skipped
```

## Checklist

- [x] `uv run pytest -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior) — snapshot updated
- [ ] Updated the relevant `docs/context/` fragment (if a subsystem changed) — N/A (docs/context/architecture/ads-conversions.md already documents the separation)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f43f7fd-84db-4e72-87e6-28bcd4f479ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f43f7fd-84db-4e72-87e6-28bcd4f479ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

