### PR TITLE
fix(analytics): roll faults up instead of rate-limiting them, and report a lost row at ERROR

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -136,8 +136,10 @@ later for the timers; it complements `/admin/reconcile/repeats`, which prices wh
 Hooked in `call_tool` immediately after `_buffer_response` — the one line where "metered platform
 call, body already in memory" is a fact, which IS eligibility gate 3. Metered 2xx only; the
 `X-Treg-Cache`-style serve headers do not exist yet. `archive.record()` is fire-and-forget with
-audit's discipline: bounded pending set (512), failures swallowed with a log line, `drain()` on
-shutdown (bootstrap) and in tests. A recorder crash cannot fail a call (tested). `drain()` removes
+audit's discipline: bounded pending set (512), failures swallowed but logged at **ERROR** (a lost
+recording has to clear `FaultCaptureHandler`'s threshold to be reportable at all; degradations that
+cost nothing, like a lookup falling back to a live call, stay at WARNING), `drain()` on
+shutdown (bootstrap, **before** `analytics.drain()` so a loss during it still gets reported) and in tests. A recorder crash cannot fail a call (tested). `drain()` removes
 the tasks it gathered itself rather than waiting on their done callbacks — audit's exact drain
 discipline; the busy-spin both avoid (the 2026-08 serial-Postgres CI hang) is explained and pinned
 for both modules in `tests/test_audit.py`.

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -346,7 +346,11 @@ are counted, and `_emit_fault_summaries` releases the count **on the flusher's t
 `drain()`** — never on the back of the next occurrence, which is how a storm that stopped (or a restart
 mid-incident) used to take its count with it. Every event carries `fault_occurrences`, the number it
 stands for, so `sum(fault_occurrences)` is the true total; PostHog's issue list counts events and is a
-lower bound. Cost is bounded by key **cardinality** (`_FAULT_MAX_KEYS`, LRU-evicted), not volume, which is
+lower bound. A window's payload is **fixed at construction**: PostHog fingerprints on exception type +
+value, so a summary carrying a later occurrence's message would land in a different issue from the event
+it summarises and split the sum — under-reporting for anyone filtering by issue, which is the normal way
+to read Error Tracking. The cost is that a window reports its first message, not its latest, and the
+key's other messages are counted under it. Cost is bounded by key **cardinality** (`_FAULT_MAX_KEYS`, LRU-evicted), not volume, which is
 why no global budget exists: the process-wide bucket this replaced let one loud key silence every other
 key, including first sightings that never recurred to carry their own count out. Faults are shed only when
 the shared queue is genuinely backing up (`_FAULT_QUEUE_SHARE` of `_MAX_PENDING`) — the congestion the

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -322,7 +322,9 @@ connection. Emitters:
 `call_tool`'s `_audit` funnel (`tool_called`, with the catalog `provider` as vendor or the upstream host
 for own tools; the field list is in [proxy-model](proxy-model.md)), `bootstrap_handlers._pool_saturated`
 (`call_intake_failed`), `billing_topup` (`topup_started`), and `billing._credit` (`topup_completed`,
-gated on `fresh`). Drained in the lifespan `finally` after `audit.drain()`. The engine adds Postgres pool
+gated on `fresh`). Drained in the lifespan `finally` **last** — after `audit.drain()` and
+`archive.drain()`, because it is the sink those two report their losses into and draining it first
+strands those events behind a cancelled flusher. The engine adds Postgres pool
 hygiene (`pool_pre_ping`/`pool_recycle`/sizing) for non-SQLite URLs, and `verify_db` refuses to start with
 no `TREG_SECRET_KEY` on a real DB (an ephemeral key would lose every stored secret on restart).
 
@@ -333,12 +335,28 @@ value are replaced with `?[redacted]` **before truncation**, so query-injected c
 frames, locals, request bodies, and user identity are never included. `FaultCaptureHandler` mirrors ERROR+
 records while analytics is enabled; it ignores the
 `treg.analytics` logger tree, marks records to prevent duplicate root/Uvicorn delivery, and uses a
-thread-local re-entry guard plus a never-raise `emit`. `_allow_fault` applies token buckets of 10/minute
-per `(fault type, logger/site)` and 60/minute process-wide; throttled events are dropped before the shared
-queue and the next allowed event for that key carries `throttled_dropped`. The lifespan installs the
+thread-local re-entry guard plus a never-raise `emit`. The lifespan installs the
 handler on root and directly on `uvicorn.error` (Uvicorn's default parent does not propagate to root),
 then removes it after shutdown drain. `bootstrap_handlers._pool_saturated` calls `capture_fault` directly
 because its typed 503 is handled before Uvicorn would log it.
+
+**Repeats roll up; they are not rate-limited.** `_note_fault` opens one `_FaultWindow` per
+`(fault type, logger/site)` for `_FAULT_WINDOW_S`: the first occurrence is reported immediately, the rest
+are counted, and `_emit_fault_summaries` releases the count **on the flusher's timer and again in
+`drain()`** — never on the back of the next occurrence, which is how a storm that stopped (or a restart
+mid-incident) used to take its count with it. Every event carries `fault_occurrences`, the number it
+stands for, so `sum(fault_occurrences)` is the true total; PostHog's issue list counts events and is a
+lower bound. Cost is bounded by key **cardinality** (`_FAULT_MAX_KEYS`, LRU-evicted), not volume, which is
+why no global budget exists: the process-wide bucket this replaced let one loud key silence every other
+key, including first sightings that never recurred to carry their own count out. Faults are shed only when
+the shared queue is genuinely backing up (`_FAULT_QUEUE_SHARE` of `_MAX_PENDING`) — the congestion the
+throttle was ever meant to prevent, rather than a wall-clock rate that fired against an empty queue.
+
+**Losing data is ERROR, not WARNING.** `audit._write`, `audit._schedule`'s back-pressure shed, and
+`archive`'s `_store`/`_touch_write` drops all log at ERROR, because `FaultCaptureHandler` starts at ERROR:
+below it the loss reaches container stdout and nothing else, so it can neither be alerted on nor found
+without already suspecting it. Degradations that cost nothing (an archive lookup falling back to a live
+call, a retried pass) stay at WARNING — the line is whether data was actually lost.
 
 > **Tenancy:** every resource noun carries `org_id`; access is scoped to the caller's org. Details:
 > [multi-tenancy](multi-tenancy.md).

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -302,8 +302,10 @@ server. Shedding is the *only* loss that should ever happen: `record_call` splat
 into `CallRecord(**fields)`, so a key with no matching column used to raise inside `_write`, where the
 except swallowed it, and the whole row disappeared — a telemetry field deployed one commit ahead of its
 migration would have silently emptied the table. `_known_fields` now drops unknown keys (logging which
-ones), and `_write`'s swallow logs a warning with the traceback. **A quiet audit table is now a bug you
-can see in the logs**, not one you find out about weeks later.
+ones), and `_write`'s swallow logs the traceback at **ERROR** — as does the back-pressure shed. The level
+is the whole point: `FaultCaptureHandler` starts at ERROR, so at WARNING a lost row reached container
+stdout and nothing else, and the only way to learn audit was dropping was to already suspect it and go
+grep. **A quiet audit table is now a bug you can alert on**, not one you find out about weeks later.
 
 The proxy is thin and IO-bound (a relay, low CPU/memory), so cheap machines scale it.
 

--- a/src/treg/analytics.py
+++ b/src/treg/analytics.py
@@ -67,6 +67,13 @@ class _FaultWindow:
     `pending` is what happened after the window's one reported event. It leaves on a timer
     (`_emit_fault_summaries`), not on the back of the next occurrence — a storm that stops, or a
     process that restarts mid-incident, would otherwise take the count with it.
+
+    `fault` is fixed at construction and never updated. PostHog fingerprints on exception type +
+    VALUE, so a summary carrying a later occurrence's message lands in a different issue from the
+    event it is summarising, and `sum(fault_occurrences)` silently splits — under-reporting for
+    anyone filtering by issue, which is how you actually read Error Tracking. The cost is that a
+    window reports its first message rather than its latest; that is what fingerprint stability
+    buys, and occurrences of the key's other messages are counted under it.
     """
 
     __slots__ = ("opened", "pending", "fault")
@@ -148,14 +155,18 @@ def _note_fault(key: tuple[str, str], fault: tuple[str, str, str, str | None],
                 # Evict the oldest window that is NOT holding a count. Evicting one that is would
                 # discard occurrences nobody has reported — the exact loss this rewrite removes.
                 # If every key holds one, the ledger runs over until the next sweep clears them.
-                stale = next((k for k, w in _fault_windows.items() if not w.pending), None)
+                # `k != key` because the window just opened is the only clean one in that case, and
+                # evicting it means this key is never in the ledger, so every occurrence opens and
+                # loses a window and reports individually — no rollup at all, precisely during the
+                # broad storm the cap exists for.
+                stale = next((k for k, w in _fault_windows.items()
+                              if not w.pending and k != key), None)
                 if stale is None:
                     break
                 del _fault_windows[stale]
             if not congested:
                 return True
         _fault_windows.move_to_end(key)
-        window.fault = fault
         window.pending += 1
         return False
 

--- a/src/treg/analytics.py
+++ b/src/treg/analytics.py
@@ -22,13 +22,21 @@ Server faults share this intentionally lossy pipe. A root logging handler mirror
 records into PostHog's Error Tracking `$exception` event; Uvicorn's error logger gets the
 same handler because its default configuration stops propagation before root. Fault payloads
 contain only exception type + a short message — never frames, locals, request bodies, or a
-user identity. Per-key and global token buckets keep a fault storm from evicting ordinary
-analytics. Losing a fault costs an alert, never the availability of the server reporting it.
+user identity. Losing a fault costs an alert, never the availability of the server reporting it.
+
+Repeats are ROLLED UP, not rate-limited: one event per `(fault type, site)` per
+`_FAULT_WINDOW_S`, and every event carries `fault_occurrences`, so `sum(fault_occurrences)`
+is the true count even though PostHog's issue list counts events. A rate limit would trade
+that number away — this bounds cost by key CARDINALITY instead, which the code bounds, so
+volume stops mattering and no key can silence another. Faults yield to product analytics only
+when the shared queue is actually backing up (`_FAULT_QUEUE_SHARE`), which is the congestion
+this pipe was ever at risk from.
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 from datetime import datetime, timezone
 import logging
 import re
@@ -48,28 +56,29 @@ _flusher: asyncio.Task | None = None
 
 _SERVER_DISTINCT_ID = "treg-server"
 _FAULT_VALUE_MAX = 500
-_FAULT_PER_KEY_CAPACITY = 10.0
-_FAULT_PER_KEY_REFILL_S = 60.0 / _FAULT_PER_KEY_CAPACITY
-_FAULT_GLOBAL_CAPACITY = 60.0
-_FAULT_GLOBAL_REFILL_S = 60.0 / _FAULT_GLOBAL_CAPACITY
+_FAULT_WINDOW_S = 10.0     # one event per (fault type, site) per window; the rest are counted
+_FAULT_MAX_KEYS = 500      # bound the ledger — it is what caps the cost, so it must be finite
+_FAULT_QUEUE_SHARE = 0.5   # faults may fill at most this much of the shared queue
 
 
-class _TokenBucket:
-    def __init__(self, capacity: float, now: float):
-        self.capacity = capacity
-        self.tokens = capacity
-        self.updated = now
-        self.dropped = 0
+class _FaultWindow:
+    """One `(fault type, site)` key's current rollup window.
 
-    def refill(self, now: float, refill_s: float) -> None:
-        elapsed = max(0.0, now - self.updated)
-        self.tokens = min(self.capacity, self.tokens + elapsed / refill_s)
-        self.updated = now
+    `pending` is what happened after the window's one reported event. It leaves on a timer
+    (`_emit_fault_summaries`), not on the back of the next occurrence — a storm that stops, or a
+    process that restarts mid-incident, would otherwise take the count with it.
+    """
+
+    __slots__ = ("opened", "pending", "fault")
+
+    def __init__(self, now: float, fault: tuple[str, str, str, str | None]):
+        self.opened = now
+        self.pending = 0
+        self.fault = fault
 
 
 _fault_lock = threading.Lock()
-_fault_buckets: dict[tuple[str, str], _TokenBucket] = {}
-_fault_global = _TokenBucket(_FAULT_GLOBAL_CAPACITY, time.monotonic())
+_fault_windows: OrderedDict[tuple[str, str], _FaultWindow] = OrderedDict()
 _fault_capture_active = threading.local()
 
 _handler_lock = threading.Lock()
@@ -107,22 +116,66 @@ def capture(distinct_id: str, event: str, properties: dict | None = None,
         pass
 
 
-def _allow_fault(key: tuple[str, str]) -> int | None:
-    """Return this key's accumulated drop count, or None when this event is throttled."""
+def _fault_properties(fault: tuple[str, str, str, str | None], occurrences: int) -> dict:
+    """The `$exception` payload. `occurrences` is how many faults THIS event stands for, so
+    summing it across events recovers the true count that the issue list cannot show."""
+    fault_type, value, component, logger = fault
+    properties: dict = {
+        "$exception_list": [{
+            "type": fault_type,
+            "value": value,
+            "mechanism": {"handled": False},
+        }],
+        "component": component,
+        "fault_type": fault_type,
+        "fault_occurrences": occurrences,
+    }
+    if logger:
+        properties["logger"] = logger
+    return properties
+
+
+def _note_fault(key: tuple[str, str], fault: tuple[str, str, str, str | None],
+                *, congested: bool) -> bool:
+    """Record one occurrence. True = report it now, False = it is counted and rides a summary."""
     now = time.monotonic()
     with _fault_lock:
-        bucket = _fault_buckets.get(key)
-        if bucket is None:
-            bucket = _fault_buckets[key] = _TokenBucket(_FAULT_PER_KEY_CAPACITY, now)
-        bucket.refill(now, _FAULT_PER_KEY_REFILL_S)
-        _fault_global.refill(now, _FAULT_GLOBAL_REFILL_S)
-        if bucket.tokens < 1.0 or _fault_global.tokens < 1.0:
-            bucket.dropped += 1
-            return None
-        bucket.tokens -= 1.0
-        _fault_global.tokens -= 1.0
-        dropped, bucket.dropped = bucket.dropped, 0
-        return dropped
+        window = _fault_windows.get(key)
+        if window is None or now - window.opened >= _FAULT_WINDOW_S:
+            window = _fault_windows[key] = _FaultWindow(now, fault)
+            _fault_windows.move_to_end(key)
+            while len(_fault_windows) > _FAULT_MAX_KEYS:
+                # Evict the oldest window that is NOT holding a count. Evicting one that is would
+                # discard occurrences nobody has reported — the exact loss this rewrite removes.
+                # If every key holds one, the ledger runs over until the next sweep clears them.
+                stale = next((k for k, w in _fault_windows.items() if not w.pending), None)
+                if stale is None:
+                    break
+                del _fault_windows[stale]
+            if not congested:
+                return True
+        _fault_windows.move_to_end(key)
+        window.fault = fault
+        window.pending += 1
+        return False
+
+
+def _fault_summaries_pending() -> bool:
+    with _fault_lock:
+        return any(window.pending for window in _fault_windows.values())
+
+
+def _emit_fault_summaries(*, force: bool = False) -> None:
+    """Queue one event per window whose time is up, carrying everything it counted."""
+    now = time.monotonic()
+    due = []
+    with _fault_lock:
+        for window in _fault_windows.values():
+            if window.pending and (force or now - window.opened >= _FAULT_WINDOW_S):
+                due.append((window.fault, window.pending))
+                window.pending, window.opened = 0, now
+    for fault, occurrences in due:
+        capture(_SERVER_DISTINCT_ID, "$exception", _fault_properties(fault, occurrences))
 
 
 def capture_fault(exc: BaseException | None = None, *, component: str,
@@ -141,23 +194,12 @@ def capture_fault(exc: BaseException | None = None, *, component: str,
         # Query injection puts credentials in URLs, and exception strings (notably httpx's)
         # can include the full request URL. Redact before truncation so no partial key survives.
         resolved_value = re.sub(r"\?\S*", "?[redacted]", resolved_value)
-        dropped = _allow_fault((resolved_type, logger or component))
-        if dropped is None:
+        fault = (resolved_type, resolved_value[:_FAULT_VALUE_MAX], component, logger)
+        if not _note_fault((resolved_type, logger or component), fault,
+                           congested=len(_queue) >= _MAX_PENDING * _FAULT_QUEUE_SHARE):
+            _ensure_flusher()  # nothing was queued, so nothing else would start the sweeper
             return
-        properties: dict = {
-            "$exception_list": [{
-                "type": resolved_type,
-                "value": resolved_value[:_FAULT_VALUE_MAX],
-                "mechanism": {"handled": False},
-            }],
-            "component": component,
-            "fault_type": resolved_type,
-        }
-        if logger:
-            properties["logger"] = logger
-        if dropped:
-            properties["throttled_dropped"] = dropped
-        capture(_SERVER_DISTINCT_ID, "$exception", properties)
+        capture(_SERVER_DISTINCT_ID, "$exception", _fault_properties(fault, 1))
     except Exception:  # noqa: BLE001 — reporting a fault must never become another fault
         pass
     finally:
@@ -238,8 +280,9 @@ def _ensure_flusher() -> None:
 
 
 async def _flush_loop() -> None:
-    while _queue:
+    while _queue or _fault_summaries_pending():
         await asyncio.sleep(_FLUSH_INTERVAL_S)
+        _emit_fault_summaries()
         while _queue:
             batch, _queue[:_BATCH_MAX] = _queue[:_BATCH_MAX], []
             try:
@@ -259,8 +302,13 @@ async def _post(batch: list[dict]) -> None:
 
 
 async def drain() -> None:
-    """Best-effort flush of whatever is queued (shutdown / tests). One attempt per batch."""
+    """Best-effort flush of whatever is queued (shutdown / tests). One attempt per batch.
+
+    Sweeps the fault windows first, unconditionally: a restart mid-incident is exactly when the
+    counts nobody has reported yet are worth the most, and after this there is no later.
+    """
     global _flusher
+    _emit_fault_summaries(force=True)
     if _flusher is not None and not _flusher.done():
         _flusher.cancel()
         try:

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -196,6 +196,9 @@ import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
+# Losing a recording is ERROR, not WARNING: the fault handler starts at ERROR, so anything below it
+# reaches stdout and nowhere else. Degradations that cost nothing (a lookup miss serving live, a
+# retried pass) stay at WARNING — the line is whether data was actually lost.
 _log = logging.getLogger("treg.archive")
 _pending: set[asyncio.Task] = set()
 _MAX_PENDING = 512
@@ -293,8 +296,8 @@ async def drain() -> None:
         _pending.difference_update(tasks)
         for r in results:
             if isinstance(r, asyncio.TimeoutError | TimeoutError):
-                _log.warning("archive recording dropped: database did not answer in %ss",
-                             _STORE_TIMEOUT_S)
+                _log.error("archive recording dropped: database did not answer in %ss",
+                           _STORE_TIMEOUT_S)
 
 
 
@@ -365,7 +368,7 @@ async def _store(
                 media_type=media_type, body=body, origin=origin,
                 key_hash=key_hash, body_hash=body_hash)
     except Exception:  # noqa: BLE001 — recording must never surface anywhere
-        _log.warning("archive recording dropped for %s", endpoint_id, exc_info=True)
+        _log.error("archive recording dropped for %s", endpoint_id, exc_info=True)
 
 
 async def _store_locked(
@@ -783,7 +786,7 @@ async def _touch_write(key_hash: str) -> None:
                             .values(last_requested_at=_utcnow()))
             await s.commit()
     except Exception:  # noqa: BLE001
-        _log.warning("archive touch dropped", exc_info=True)
+        _log.error("archive touch dropped", exc_info=True)
 
 
 # ---------------------------------------------------------------------------------------------

--- a/src/treg/audit.py
+++ b/src/treg/audit.py
@@ -106,7 +106,7 @@ def _schedule(coro) -> None:
         global _shed
         _shed += 1
         if _shed == 1 or _shed % 1000 == 0:
-            logging.getLogger("treg.audit").warning(
+            logging.getLogger("treg.audit").error(
                 "audit back-pressure: %d row(s) dropped this process (pending at %d)",
                 _shed, _MAX_PENDING)
         return
@@ -122,10 +122,11 @@ async def _write(model, **fields) -> None:
                 session.add(model(**fields))
                 await session.commit()
         except Exception:  # noqa: BLE001 — audit must never surface into a call's result
-            # Swallowed on purpose, but no longer SILENT: this used to be a bare `pass`, so a bad
-            # write was indistinguishable from a call that never happened. The row is still lost —
-            # that is the contract — but now something says so.
-            logging.getLogger("treg.audit").warning(
+            # Swallowed on purpose, but neither silent nor local: the row is lost — that is the
+            # contract — and ERROR is what puts that loss in front of someone. At WARNING it stayed
+            # in the container's stdout, below the fault handler's threshold, so the only way to
+            # learn that audit was dropping rows was to already suspect it and go grep.
+            logging.getLogger("treg.audit").error(
                 "audit write dropped for %s", model.__name__, exc_info=True)
 
 

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -469,9 +469,12 @@ def _lifespan(role: AppRole):
                     _mcp.clear_endpoint_observation_reader(endpoint_observations)
                 routed_call.clear_endpoint_observation_reader(endpoint_observations)
                 await endpoint_observations.aclose()
+                # analytics LAST: it is the sink the other two report their losses into, and a
+                # drop during their drain is the one most worth hearing about. Draining it first
+                # left those events queued behind a cancelled flusher.
                 await audit.drain()
-                await analytics.drain()
                 await archive.drain()
+                await analytics.drain()
                 await app.state.http.aclose()
             finally:
                 analytics.remove_fault_handler(fault_handler)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -28,10 +28,9 @@ async def _clean():
         analytics.remove_fault_handler(analytics._installed_fault_handler)
     analytics._queue.clear()
     analytics._flusher = None
-    analytics._fault_buckets.clear()
-    analytics._fault_global = analytics._TokenBucket(
-        analytics._FAULT_GLOBAL_CAPACITY, analytics.time.monotonic())
+    analytics._fault_windows.clear()
     yield
+    analytics._fault_windows.clear()
     # Enabled tests inspect queued payloads but must never send them to a real PostHog host.
     analytics._queue.clear()
     await analytics.drain()
@@ -129,6 +128,7 @@ def test_fault_payload_is_secret_minimal_and_truncated(enabled):
         }],
         "component": "scheduler",
         "fault_type": "RuntimeError",
+        "fault_occurrences": 1,
         "$lib": "treg-server",
     }
     assert "frames" not in str(event).lower()
@@ -146,37 +146,93 @@ def test_fault_value_redacts_query_credentials_before_capture(enabled):
     assert "api_key=" not in value
 
 
-def test_per_key_throttle_counts_drops_on_next_allowed_event(enabled, monkeypatch):
+def _occurrences() -> int:
+    """What a `sum(fault_occurrences)` query in PostHog would return."""
+    return sum(e["properties"]["fault_occurrences"] for e in _exception_events())
+
+
+def test_a_storm_costs_one_event_per_window_but_reports_every_occurrence(enabled, monkeypatch):
+    """The point of the rollup: cost is bounded, the COUNT is not approximated. The old token
+    bucket emitted ~10/minute and pinned the dashboard at its own refill rate, so the graph of a
+    two-hour incident was a flat line at the limiter."""
     now = [100.0]
     monkeypatch.setattr(analytics.time, "monotonic", lambda: now[0])
-    monkeypatch.setattr(analytics, "_MAX_PENDING", 20)
-    analytics._fault_global = analytics._TokenBucket(analytics._FAULT_GLOBAL_CAPACITY, now[0])
 
     for _ in range(100):
         analytics.capture_fault(PoolTimeoutError("pool full"), component="db_pool")
-    assert len(_exception_events()) == 10
-    analytics.capture("person@example.com", "normal_analytics")
-    assert len(analytics._queue) == 11  # the storm cannot evict an ordinary event
+    assert len(_exception_events()) == 1  # one event stands for the window
 
-    now[0] += 6.0  # ten per minute = one replenished token every six seconds
-    analytics.capture_fault(PoolTimeoutError("pool full"), component="db_pool")
-    assert len(_exception_events()) == 11
-    assert _exception_events()[-1]["properties"]["throttled_dropped"] == 90
+    now[0] += analytics._FAULT_WINDOW_S
+    analytics._emit_fault_summaries()
+    assert len(_exception_events()) == 2
+    assert _occurrences() == 100  # ...and nothing was approximated away
 
 
-def test_global_throttle_limits_many_distinct_faults(enabled, monkeypatch):
+def test_a_loud_fault_cannot_silence_an_unrelated_one(enabled, monkeypatch):
+    """The bug the global bucket had: one key exhausting a shared budget dropped every OTHER key,
+    including a first sighting — the highest-information event there is, and the one least likely
+    to recur and carry its own count out later."""
     now = [100.0]
     monkeypatch.setattr(analytics.time, "monotonic", lambda: now[0])
-    analytics._fault_global = analytics._TokenBucket(analytics._FAULT_GLOBAL_CAPACITY, now[0])
 
-    for i in range(70):
-        analytics.capture_fault(RuntimeError(str(i)), component=f"site-{i}")
-    assert len(_exception_events()) == 60
+    for _ in range(500):
+        analytics.capture_fault(PoolTimeoutError("pool full"), component="db_pool")
+    analytics.capture_fault(RuntimeError("something new"), component="scheduler")
 
-    now[0] += 1.0
-    analytics.capture_fault(RuntimeError("60"), component="site-60")
-    assert len(_exception_events()) == 61
-    assert _exception_events()[-1]["properties"]["throttled_dropped"] == 1
+    assert [e["properties"]["fault_type"] for e in _exception_events()] == [
+        "TimeoutError", "RuntimeError"]
+
+
+def test_the_key_ledger_is_bounded(enabled, monkeypatch):
+    """Cardinality is what caps the cost now that volume does not, so it must be finite."""
+    monkeypatch.setattr(analytics, "_FAULT_MAX_KEYS", 5)
+    for i in range(50):
+        analytics.capture_fault(RuntimeError("x"), component=f"site-{i}")
+    assert len(analytics._fault_windows) == 5
+
+
+def test_eviction_never_discards_a_count_that_was_never_reported(enabled, monkeypatch):
+    """Bounding the ledger must not reintroduce the loss this rewrite exists to remove: a window
+    holding occurrences nobody has seen is not eligible for eviction, even over the cap."""
+    monkeypatch.setattr(analytics, "_FAULT_MAX_KEYS", 3)
+    for i in range(3):
+        for _ in range(4):  # first reports, next three land in `pending`
+            analytics.capture_fault(RuntimeError("x"), component=f"loud-{i}")
+    for i in range(20):
+        analytics.capture_fault(RuntimeError("x"), component=f"quiet-{i}")
+
+    holding = {k: w.pending for k, w in analytics._fault_windows.items() if w.pending}
+    assert sorted(k[1] for k in holding) == ["loud-0", "loud-1", "loud-2"]
+    assert set(holding.values()) == {3}
+
+
+async def test_a_shutdown_does_not_take_the_counts_with_it(enabled, posts, monkeypatch):
+    """A storm that stops, or a process that restarts mid-incident, used to lose its accumulated
+    count: the old code released it only on the back of the NEXT event for that key. Restarting is
+    what you do during an incident, so the counts died exactly when they were worth the most."""
+    now = [100.0]
+    monkeypatch.setattr(analytics.time, "monotonic", lambda: now[0])
+
+    for _ in range(30):
+        analytics.capture_fault(PoolTimeoutError("pool full"), component="db_pool")
+    analytics._queue.clear()  # the window's one reported event is already on its way
+
+    await analytics.drain()  # sweeps unconditionally: after this there is no later
+    sent = [e for batch in posts for e in batch if e["event"] == "$exception"]
+    assert [e["properties"]["fault_occurrences"] for e in sent] == [29]
+
+
+def test_faults_yield_to_analytics_only_when_the_queue_is_actually_backing_up(enabled, monkeypatch):
+    """The old rate limit shed at full speed against an empty queue — it fired on elapsed time,
+    while the resource it existed to protect was at ~1% of its bound."""
+    monkeypatch.setattr(analytics, "_MAX_PENDING", 10)
+    analytics.capture_fault(RuntimeError("first"), component="quiet")
+    assert len(_exception_events()) == 1  # queue empty: no reason to drop anything
+
+    for i in range(9):
+        analytics.capture("a@b.c", "tool_called", {"i": i})
+    analytics.capture_fault(RuntimeError("second"), component="congested")
+    assert len(_exception_events()) == 1  # past the share: counted, not queued
 
 
 def test_handler_recursion_guard_swallows_capture_failure(enabled, monkeypatch):
@@ -324,6 +380,20 @@ async def test_typed_refusals_auth_and_validation_are_not_faults(enabled):
     await _run_through_uvicorn(app, "/validated", b"count=not-an-int")
     analytics.remove_fault_handler(handler)
     assert _exception_events() == []
+
+
+def test_the_lifespan_drains_analytics_after_everything_that_reports_into_it():
+    """Order matters now that audit and archive report their losses at ERROR: analytics is their
+    sink, so draining it first leaves those events queued behind a cancelled flusher and they are
+    lost — silently, and exactly at shutdown, which is when a loss is most worth hearing about."""
+    import pathlib
+
+    from treg import bootstrap
+
+    source = pathlib.Path(bootstrap.__file__).read_text()
+    drains = ("audit.drain()", "archive.drain()", "analytics.drain()")
+    assert all(name in source for name in drains)
+    assert sorted(drains, key=source.index) == list(drains)
 
 
 async def test_typed_pool_saturation_is_explicitly_captured(enabled):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -206,6 +206,44 @@ def test_eviction_never_discards_a_count_that_was_never_reported(enabled, monkey
     assert set(holding.values()) == {3}
 
 
+def test_a_full_ledger_still_rolls_up_a_newly_seen_key(enabled, monkeypatch):
+    """A new window is the only one with an empty count when every other key is holding one, so an
+    eviction scan looking for `not pending` picks the key it just created. That key then never
+    stays in the ledger: each occurrence opens a window, loses it, and reports on its own. The
+    rollup would be off exactly during a broad storm, which is the case the cap exists for."""
+    monkeypatch.setattr(analytics, "_FAULT_MAX_KEYS", 3)
+    for i in range(3):
+        for _ in range(2):
+            analytics.capture_fault(RuntimeError("x"), component=f"loud-{i}")
+    assert all(w.pending for w in analytics._fault_windows.values())  # ledger full, all holding
+
+    analytics._queue.clear()
+    for _ in range(50):
+        analytics.capture_fault(RuntimeError("newcomer"), component="new-site")
+
+    assert len(_exception_events()) == 1     # one report, 49 rolled up — not 50 reports
+    assert _occurrences() == 1
+    assert ("RuntimeError", "new-site") in analytics._fault_windows
+
+
+def test_a_summary_shares_the_fingerprint_of_the_event_it_summarises(enabled, monkeypatch):
+    """PostHog fingerprints on type + value. A summary carrying a LATER occurrence's message lands
+    in a different issue from its own first report, so `sum(fault_occurrences)` splits and anyone
+    filtering by issue — the normal way to read Error Tracking — gets a number that is quietly low.
+    Constant messages hide this; any `str(exc)` carrying an id, path or URL does not."""
+    now = [100.0]
+    monkeypatch.setattr(analytics.time, "monotonic", lambda: now[0])
+
+    for message in ("first for /a", "second for /b", "third for /c"):
+        analytics.capture_fault(RuntimeError(message), component="relay")
+    now[0] += analytics._FAULT_WINDOW_S
+    analytics._emit_fault_summaries()
+
+    values = [e["properties"]["$exception_list"][0]["value"] for e in _exception_events()]
+    assert values == ["first for /a", "first for /a"]
+    assert _occurrences() == 3
+
+
 async def test_a_shutdown_does_not_take_the_counts_with_it(enabled, posts, monkeypatch):
     """A storm that stops, or a process that restarts mid-incident, used to lose its accumulated
     count: the old code released it only on the back of the NEXT event for that key. Restarting is


### PR DESCRIPTION
Two telemetry defects found while diagnosing the 2026-09-04 pool incident. Neither caused the
incident; both made it much harder to read than it needed to be.

## 1. The fault throttle was measuring itself

`_allow_fault` applied token buckets of 10/min per `(fault type, site)` and 60/min process-wide.
The visible result, from PostHog:

```
09-02 15:00  610      09-03 20:00  525
09-02 16:00  600      09-03 21:00  384
09-02 17:00  611      09-03 22:00  433
09-02 18:00  607      09-03 23:00  901
```

~600/hour for 20 straight hours. 600/hour is 10/minute, which is the bucket's refill rate.
**That curve plots the limiter, not the server.** The issue page said 7,544 occurrences for
something whose real count is unknown and much larger.

Three problems, in order of harm:

**The global bucket re-coupled every key.** A per-key bucket is right; a process-wide one on top
of it means one loud fault silences every other one. During the incident `TimeoutError` alone ate
the 60/min global budget, so a *new, rare* exception — its own 10 tokens untouched, and the
highest-information event there is — was dropped anyway. Worse than the loud one: it may never
recur, so its count never rides out on a later event. The throttle was tightest exactly when a
second, different failure was most likely and most informative.

**The count only escaped by hitching a ride.** `dropped, bucket.dropped = bucket.dropped, 0` released
the accumulated total on the *next event that passed for that key*. A storm that stops, or a process
restarted mid-incident, took it with it. Restarting is what you do during an incident.

**It sheds against the wrong signal.** The docstring says the buckets exist to keep a fault storm
from evicting ordinary analytics out of the shared 2,000-event queue. Measured during the incident:
~2.6 events/s arriving, flusher draining every 2s, **queue depth ~5**. The throttle dropped ~90% of
events to protect a queue at 0.3% of its bound. It fires on elapsed time; the resource it guards is
measured in depth.

### What replaces it

A rollup, not a rate limit. A rate limit trades information for a cost ceiling; a rollup gets the
ceiling without the trade.

- One `_FaultWindow` per `(type, site)` per `_FAULT_WINDOW_S`. First occurrence reported
  immediately, the rest counted.
- Every event carries `fault_occurrences` — how many faults it stands for. `sum(fault_occurrences)`
  is now exact; PostHog's issue count is a documented lower bound.
- `_emit_fault_summaries` releases counts **on the flusher's timer and again in `drain()`**, so
  neither a storm ending nor a restart loses them.
- Cost is bounded by key **cardinality** (`_FAULT_MAX_KEYS`, LRU), which the code bounds — so volume
  stops mattering and **the global budget is deleted**. The silencing bug goes with it rather than
  being patched around.
- Shedding keys on real queue depth (`_FAULT_QUEUE_SHARE`). An empty queue drops nothing.

Eviction skips any window still holding an unreported count — bounding the ledger must not
reintroduce the loss the rewrite removes.

## 2. A lost row logged below the reporting threshold

`audit._write` and `archive._store` / `_touch_write` swallow-and-log at WARNING.
`FaultCaptureHandler` is `level=ERROR`. **So background write loss was structurally invisible to
PostHog** — confirming whether it was happening today meant grepping Render logs by hand, which is
not something you can alert on.

Raised to ERROR: audit's write failure and back-pressure shed, archive's store failure, store
timeout, and touch failure. Degradations that cost nothing — an archive lookup falling back to a
live call, a retried pass — stay at WARNING. The line is whether data was actually lost.

These two halves fit together: raising the level means a DB outage now generates a fault event per
dropped row, which is exactly the volume the rollup absorbs into one event plus a count.

## 3. Lifespan drain order

`analytics.drain()` ran *before* `archive.drain()`. Analytics is the sink the other two report into,
so anything they lost during their own drain was queued behind an already-cancelled flusher and
never sent. Now drains last. Pinned by a test, since it is invisible until it matters.

## Verification

`2547 passed, 5 skipped` on the full suite.

New tests cover: a storm costing one event per window while reporting every occurrence; a loud fault
not silencing an unrelated one; the ledger staying bounded; eviction never discarding an unreported
count; shutdown not losing counts; shedding only under real queue pressure; and the drain order.

## Not in scope

The API pool saturation itself. Root cause there was that #324 raised per-instance pool capacity
from 15 to 31 against a 0.5-CPU Postgres, which slowed every query and made the API pool — unchanged
at 15 — saturate more. Already handled in production via `TREG_DB_POOL_OVERRIDES` plus a database
upgrade to `1c-2g`; `/orgs` p50 went 938ms to 15ms and 503s to zero. No code change was needed.
