### PR TITLE
perf(db): index callrecord by (endpoint_id, created_at) and (org_id, created_at)

### DIFF
--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -16,6 +16,7 @@ sources:
   - src/treg/alembic/versions/0017_async_task_record.py
   - src/treg/alembic/versions/0018_async_resource_ownership.py
   - src/treg/alembic/versions/0019_async_poll_failures.py
+  - src/treg/alembic/versions/0020_callrecord_created_at_indexes.py
   - src/treg/alembic/versions/0011_callrecord_archive_link.py
   - src/treg/alembic/versions/0015_idempotentcall_membership_cascade.py
   - src/treg/maintenance.py
@@ -138,6 +139,18 @@ uses this metadata, never the encrypted token's shape.
   Its `kind` is `call`, `local_run`, or `async_poll` for an authorized free platform status read.
   Poll rows remain available by call reference and in admin diagnostics, but `/calls` excludes
   them before pagination. No migration or historical reclassification is required.
+
+  **Its indexes are the platform's throughput.** It is the largest table (2.94M rows / 1.68 GB on
+  prod 2026-09-06) and every question asked of it is "… since <time>", so a `created_at` that no
+  index carried meant the planner chose an index for the other column and filtered the date in
+  memory - reading an endpoint's or an org's WHOLE history to answer a 30-day one. Revision 0020
+  adds `(endpoint_id, created_at)` for the catalog observation refresh (`domain/catalog/stats.py`,
+  which had read 1.60 BILLION tuples across 570k scans) and `(org_id, created_at)` for the
+  per-member daily counts (`routers/orgs.py`, 295M across 70k); 0016 already pairs
+  `(endpoint_id, id)` for the newest-N feed and 0012 a partial index on `cached`. The cost of
+  getting this wrong is not a slow page: all three connection pools share one Postgres, so a scan
+  here queues every other query and the API pool empties into `503 treg_saturated` - see
+  [deploy](../ops/deploy.md) § Three pools. The table has no retention sweep yet, so it only grows.
 
   `refused_by` distinguishes a treg refusal (`auth`, `policy`, `balance`, `cap`, `resolution`,
   `request`, and other mechanism-specific values) from an upstream answer, where it is null.

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -108,8 +108,19 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
   typo must neither stop the server booting nor pass silently and leave the operator believing they
   resized something. The range check is not pedantry — SQLAlchemy reads `pool_size=0` and
   `max_overflow=-1` as **unlimited**, and `pool_size=0` sets `_max_overflow=-1` too, so `-1` typed
-  to mean "no overflow" would uncap connections against the ~100 ceiling: the 2026-08-15 outage,
-  entered through the knob added to prevent outages.
+  to mean "no overflow" would uncap connections against the ~100 ceiling (`max_connections` on the
+  1c-2g plan reads **103**): the 2026-08-15 outage, entered through the knob added to prevent
+  outages.
+
+  **The live value outlives the code, so read it before trusting `POOL_SPECS`.** The reference
+  deployment ran `admin.pool_size=2,background.pool_size=4` from before the 2026-09-04 bulkhead
+  work until 2026-09-05 — pinning both minor pools BELOW the defaults that work had just raised
+  (`admin` to 3, `background` to the derived 13), including the exact `admin=2` whose post-mortem
+  is two bullets up. A `background` of 4 against 7 consumers needing 13 does not 503; it silently
+  drops audit rows. The knob being a dashboard edit rather than a deploy is what makes it useful
+  mid-incident and what lets it survive the fix. Today it reads
+  `api.pool_size=10,admin.pool_size=2,background.pool_size=4`; the two stale entries are still
+  there deliberately, so that the `api` change could be observed on its own.
 - **No statement timeout yet.** The pools bound how many connections a class of work can hold, not
   how long a query may run; `alembic/env.py` still has the only timeouts in the app. Adding per-pool
   `statement_timeout` is deliberately a SEPARATE change: it is a behavior change on every query,
@@ -120,10 +131,22 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
 - **Other Postgres pool hygiene:** `pool_pre_ping=True`, `pool_recycle=300`, and `pool_timeout=5` on
   every pool. A request that gets no slot in 5 s is answered `503 {"treg_saturated": true}` with
   `Retry-After: 2` (`bootstrap_handlers._pool_saturated`) instead of SQLAlchemy's default 30 s wait
-  and an anonymous 500. The API's 15 slots are plenty because a `/call/` holds no connection during
-  its upstream round trip — `call_tool` commits before `relay()`; holding one there deadlocked 15
-  concurrent calls for 30 s on 2026-08-24 (see
-  [proxy-model](../architecture/proxy-model.md) § Connection discipline).
+  and an anonymous 500. A `/call/` holds no connection during its upstream round trip —
+  `call_tool` commits before `relay()` (`require_member` commits before it returns the `Caller`, so
+  the request-scoped session is idle by then); holding one there deadlocked 15 concurrent calls for
+  30 s on 2026-08-24 (see [proxy-model](../architecture/proxy-model.md) § Connection discipline).
+- **The bulkhead isolates CONNECTIONS, not the database's CPU** — and that is why "the API's 15
+  slots are plenty" was wrong for a year. Three pools stop `admin` and `background` work from
+  taking `api`'s slots; they do nothing about the fact that all three share ONE Postgres with one
+  vCPU. A query that scans `callrecord` makes every ordinary 3 ms request query queue behind it,
+  so `api` checkouts stretch from milliseconds to seconds and 15 slots empty. Measured 2026-09-05:
+  db_pool faults ran all day (peak 714 in the 14:00 hour) while non-`/call/` routes sat at p50 3 ms
+  and only ~22 requests were in flight — an order of magnitude below what the pool arithmetic says
+  it should take, because the pool was never the constraint. The scans were: 2.94M-row / 1.68 GB
+  `callrecord` taking 80,932 sequential scans for 27 BILLION tuples, plus 1.60 BILLION tuples read
+  through `ix_callrecord_endpoint_id_id` because no index carried `created_at` (revision 0020
+  adds the pairs). **Reach for a pool size only after ruling out a scan;** raising it buys headroom
+  and hides the cause.
 - **SQLite aliases all three to one engine.** It has no pool to protect and file-level write locks
   it cannot share, so three engines against one file would only manufacture "database is locked".
   Tests therefore pin the ROUTING (which maker each module reaches for), not the isolation.

--- a/src/treg/alembic/versions/0020_callrecord_created_at_indexes.py
+++ b/src/treg/alembic/versions/0020_callrecord_created_at_indexes.py
@@ -1,0 +1,65 @@
+"""composite (endpoint_id, created_at) and (org_id, created_at) on callrecord — time windows stop
+reading whole histories
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-09-06
+
+Every question asked of `callrecord` is "… since <time>", and no index carried `created_at`. The
+planner therefore chose an index for the OTHER column and filtered the date in memory, reading an
+endpoint's or an org's entire history to answer a 30-day question. Measured on prod 2026-09-06 at
+2.94M rows / 1.68 GB:
+
+    ix_callrecord_endpoint_id_id   570,130 scans   1,603,968,175 tuples read
+    ix_callrecord_org_id            70,003 scans     295,077,614 tuples read
+    callrecord (sequential)          80,932 scans  27,063,404,479 tuples read
+
+The first is the catalog observation refresh (`domain/catalog/stats.py`, WINDOW_DAYS = 30), the
+second the per-member daily counts (`routers/orgs.py`). Both become tight range scans with these
+pairs.
+
+This is the fix for the API-pool saturation, not a pool size: the three pools bulkhead CONNECTIONS,
+not the single database's CPU, so a scan of this table makes every ordinary 3 ms request query queue
+behind it until `pool_timeout` fires and callers get `503 treg_saturated`.
+
+Built CONCURRENTLY on Postgres, exactly as 0016 did on the same table: the preDeploy step runs while
+the old build still serves traffic, and a concurrent build never blocks writes to the hot audit
+table. `IF NOT EXISTS` is not used deliberately — a build killed mid-flight leaves an INVALID index
+that `IF NOT EXISTS` would then silently skip, leaving the scan in place with nothing failing. A
+second run failing loudly on "already exists" is the outcome that gets looked at; drop the invalid
+index and re-run. SQLite (tests, local) builds plainly — no concurrent mode, no traffic to block.
+
+The expand-safety linter counts the autocommit escape (get_bind/get_context) as non-additive, so
+this revision declares a rollback floor pro forma, as 0016 did: the operations themselves are purely
+additive — two indexes — and downgrading past it merely drops them.
+"""
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0020"
+down_revision: str | Sequence[str] | None = "0019"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+contract = True  # pro forma — see the rollback floor note; the operations are additive indexes
+
+_INDEXES = (
+    ("ix_callrecord_endpoint_id_created_at", ["endpoint_id", "created_at"]),
+    ("ix_callrecord_org_id_created_at", ["org_id", "created_at"]),
+)
+
+
+def upgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        # CONCURRENTLY cannot run inside a transaction; alembic opens one by default.
+        with op.get_context().autocommit_block():
+            for name, columns in _INDEXES:
+                op.create_index(name, "callrecord", columns, postgresql_concurrently=True)
+    else:
+        for name, columns in _INDEXES:
+            op.create_index(name, "callrecord", columns)
+
+
+def downgrade() -> None:
+    for name, _ in _INDEXES:
+        op.drop_index(name, table_name="callrecord")

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -232,7 +232,23 @@ class CallRecord(SQLModel, table=True):
                       # Without the pair, the planner walked the WHOLE table backward via the
                       # primary key, testing endpoint_id row by row — measured 7.5s per click on
                       # prod (2026-09-03). With it, the same question is a 30-row index read.
-                      Index("ix_callrecord_endpoint_id_id", "endpoint_id", "id"),)
+                      Index("ix_callrecord_endpoint_id_id", "endpoint_id", "id"),
+                      # EVERY question asked of this table is "… since <time>", and until now no
+                      # index carried `created_at`, so the planner picked an index for the other
+                      # column and filtered the date in memory — reading the endpoint's or the
+                      # org's WHOLE history to answer a 30-day question. Measured on prod
+                      # 2026-09-06 at 2.94M rows / 1.68 GB: `ix_callrecord_endpoint_id_id` had
+                      # read 1.60 BILLION tuples across 570k scans (the catalog observation
+                      # refresh, `domain/catalog/stats.py`, WINDOW_DAYS=30), `ix_callrecord_org_id`
+                      # 295M across 70k (the per-member daily counts in `routers/orgs.py`), and
+                      # the table had taken 80,932 sequential scans for 27 BILLION tuples.
+                      #
+                      # That load is why the API pool saturates: the three pools bulkhead
+                      # CONNECTIONS, not the one database's CPU, so a scan of this table makes
+                      # every 3 ms request query queue behind it until `pool_timeout` fires and
+                      # callers get `503 treg_saturated`. Sizing the pool cannot fix a scan.
+                      Index("ix_callrecord_endpoint_id_created_at", "endpoint_id", "created_at"),
+                      Index("ix_callrecord_org_id_created_at", "org_id", "created_at"),)
 
     id: int | None = Field(default=None, primary_key=True)
     org_id: int | None = Field(default=None, foreign_key="org.id", index=True)


### PR DESCRIPTION
## What

Two composite indexes on `callrecord`, built `CONCURRENTLY` on Postgres (revision `0020`, same pattern as `0016` on this table):

- `(endpoint_id, created_at)`
- `(org_id, created_at)`

## Why

Every question asked of `callrecord` is "… since \<time\>", and no index carried `created_at`. The planner therefore chose an index for the *other* column and filtered the date in memory, reading an endpoint's or an org's entire history to answer a 30-day question.

Measured on prod 2026-09-06 at 2.94M rows / 1.68 GB:

| what | scans | tuples read |
|---|---|---|
| `ix_callrecord_endpoint_id_id` | 570,130 | **1,603,968,175** |
| `ix_callrecord_org_id` | 70,003 | 295,077,614 |
| `callrecord` sequential | 80,932 | **27,063,404,479** |

The first is the catalog observation refresh (`domain/catalog/stats.py`, `WINDOW_DAYS = 30`), the second the per-member daily counts (`routers/orgs.py`). Both become tight range scans with these pairs.

## This is the API-pool fix

db_pool saturation has run since 2026-09-03 (peak 714 fault occurrences in the 14:00 hour on 09-05, 100% of them `QueuePool limit of size 5 overflow 10` — the `api` pool; zero from `admin` or `background`). It emptied at only ~22 in-flight requests while non-`/call/` routes sat at p50 3 ms — an order of magnitude below what the pool arithmetic allows.

The reason is that **the three pools bulkhead connections, not the single database's CPU**. A scan of this table queues every ordinary query behind it, so `api` checkouts stretch from milliseconds to seconds and 15 slots empty into `503 treg_saturated`. Raising the pool (done separately, `api.pool_size` 5 → 10 via `TREG_DB_POOL_OVERRIDES`) buys headroom; this removes the cause.

## Deploy note

`CREATE INDEX CONCURRENTLY` runs under `env.py`'s `statement_timeout = 120s`. `0016` built a comparable index on this same table successfully on 2026-09-03. `IF NOT EXISTS` is deliberately *not* used: a build killed mid-flight leaves an INVALID index that `IF NOT EXISTS` would silently skip, leaving the scan in place with nothing failing. If the migration fails, drop the invalid index and re-run.

`contract = True` is pro forma, as in `0016` — the expand-safety linter counts the autocommit escape as non-additive; the operations are two additive indexes.

## Fragments updated

- `architecture/data-model.md` — the indexes and why they are the platform's throughput
- `ops/deploy.md` — corrects "the API's 15 slots are plenty", records that the bulkhead does not isolate DB CPU, and records that the live `TREG_DB_POOL_OVERRIDES` had been pinning `admin`/`background` *below* the defaults the 09-04 bulkhead work raised

## Tests

`2704 passed, 5 skipped`; `lint-imports` 13/13; the alembic model-drift guard passes.