### PR TITLE
fix(db): make 0020 survive autovacuum contention and its own debris

### DIFF
--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -471,6 +471,27 @@ the ALTER, both instances starved, and the shared Postgres stayed wedged until a
   Postgres only). A contended
   deploy therefore FAILS CLEANLY — prod keeps serving the old code — and the right response is to
   redeploy at a quieter moment, not to raise the timeout.
+  **The one sanctioned exception is `CREATE INDEX CONCURRENTLY`, and only in its own revision.**
+  The 5 s floor exists because an `ALTER` takes `ACCESS EXCLUSIVE`: it queues behind live traffic
+  and every new query then queues behind IT — the 2026-08-15 wedge. A concurrent index build is not
+  in that class. Its `SHARE UPDATE EXCLUSIVE` conflicts with neither `SELECT` nor
+  `INSERT`/`UPDATE`/`DELETE`; it blocks no reads or writes while it builds, and a statement WAITING
+  for it holds nothing and blocks nobody. What it does contend with is **autovacuum**, which takes
+  the same lock and runs constantly on a large, write-heavy table — 0020 died on
+  `LockNotAvailableError` in 5 s against exactly that, on the first try, at 00:37 UTC. Such a
+  revision raises both timeouts inside its `autocommit_block` and restores `env.py`'s values before
+  the block ends; it must not raise them for anything else in the same revision.
+  **A killed concurrent build leaves an INVALID index** — present in `pg_class`, unusable by the
+  planner, and never repaired — so a rebuilt-by-hand `IF NOT EXISTS` silently skips it and the scan
+  it was meant to remove stays, with nothing failing. 0020's first attempt left exactly that. Such a
+  revision therefore checks `pg_index.indisvalid` per index: valid ⇒ skip, invalid ⇒ drop
+  concurrently and rebuild, absent ⇒ build.
+  **Merging a revision breaks the crons before the web deploy applies it.** The three cron services
+  auto-deploy from `main` while the web service does not, so between the merge and the pre-deploy
+  they run new code against the old schema and `verify_db` refuses them (`Database schema revision
+  N is behind this build`). It is bounded and self-correcting, and it cannot be rolled back by
+  pinning a cron to the old commit — Render refuses `deploys create --commit` on a cron job. Deploy
+  the web service IMMEDIATELY after merging a revision, or revert the merge.
 - The pools are per instance and a rolling deploy runs two: keep the SUM of `pool_size +
   max_overflow` across every entry in `POOL_SPECS` such that DOUBLE it stays under the database
   plan's connection ceiling. A guard test pins this and counts all three deliberately — splitting

--- a/src/treg/alembic/versions/0020_callrecord_created_at_indexes.py
+++ b/src/treg/alembic/versions/0020_callrecord_created_at_indexes.py
@@ -22,12 +22,22 @@ This is the fix for the API-pool saturation, not a pool size: the three pools bu
 not the single database's CPU, so a scan of this table makes every ordinary 3 ms request query queue
 behind it until `pool_timeout` fires and callers get `503 treg_saturated`.
 
-Built CONCURRENTLY on Postgres, exactly as 0016 did on the same table: the preDeploy step runs while
-the old build still serves traffic, and a concurrent build never blocks writes to the hot audit
-table. `IF NOT EXISTS` is not used deliberately — a build killed mid-flight leaves an INVALID index
-that `IF NOT EXISTS` would then silently skip, leaving the scan in place with nothing failing. A
-second run failing loudly on "already exists" is the outcome that gets looked at; drop the invalid
-index and re-run. SQLite (tests, local) builds plainly — no concurrent mode, no traffic to block.
+**Why this one raises `lock_timeout`, and why that is not the 2026-08-15 rule being broken.** The
+first attempt died on `LockNotAvailableError: canceling statement due to lock timeout` in 5 s — not
+against traffic, which cannot block it, but almost certainly against autovacuum, which runs
+constantly on a table this size and takes the SAME `SHARE UPDATE EXCLUSIVE` lock. The 5 s floor in
+`alembic/env.py` exists because an **ALTER** takes `ACCESS EXCLUSIVE`: it queues behind live traffic
+and then every new query queues behind IT, which is exactly how the 2026-08-15 outage wedged the
+database. `CREATE INDEX CONCURRENTLY` is not in that class — its lock conflicts with neither
+`SELECT` nor `INSERT`/`UPDATE`/`DELETE`, it blocks no reads or writes while it builds, and a
+statement WAITING for it holds nothing and blocks nobody. Waiting longer here costs a slower
+pre-deploy and nothing else. The timeouts are restored to `env.py`'s values before the block ends.
+
+**Idempotent per index, because a concurrent build can leave debris.** A CIC that is killed
+mid-flight leaves an INVALID index — present, so a naive `IF NOT EXISTS` would skip it forever and
+leave the scan in place with nothing failing. Each index is therefore inspected first: valid ⇒ skip
+(a re-run, or a build done out of band), invalid ⇒ drop it concurrently and rebuild, absent ⇒ build.
+A failed attempt costs only the indexes it had not reached.
 
 The expand-safety linter counts the autocommit escape (get_bind/get_context) as non-additive, so
 this revision declares a rollback floor pro forma, as 0016 did: the operations themselves are purely
@@ -35,6 +45,7 @@ additive — two indexes — and downgrading past it merely drops them.
 """
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 revision: str = "0020"
@@ -48,16 +59,39 @@ _INDEXES = (
     ("ix_callrecord_org_id_created_at", ["org_id", "created_at"]),
 )
 
+# Long enough to outlast an autovacuum pass on a 1.7 GB table; see the docstring for why waiting
+# on THIS lock is safe. `env.py`'s values are restored before the autocommit block ends.
+_LOCK_TIMEOUT = "180s"
+_STATEMENT_TIMEOUT = "600s"
+_ENV_LOCK_TIMEOUT = "5s"
+_ENV_STATEMENT_TIMEOUT = "120s"
+
+_VALIDITY = sa.text(
+    "SELECT i.indisvalid FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+    "WHERE c.relname = :name")
+
 
 def upgrade() -> None:
-    if op.get_bind().dialect.name == "postgresql":
-        # CONCURRENTLY cannot run inside a transaction; alembic opens one by default.
-        with op.get_context().autocommit_block():
-            for name, columns in _INDEXES:
-                op.create_index(name, "callrecord", columns, postgresql_concurrently=True)
-    else:
-        for name, columns in _INDEXES:
+    if op.get_bind().dialect.name != "postgresql":
+        for name, columns in _INDEXES:  # SQLite: no concurrent mode, no traffic to block
             op.create_index(name, "callrecord", columns)
+        return
+    # CONCURRENTLY cannot run inside a transaction; alembic opens one by default.
+    with op.get_context().autocommit_block():
+        bind = op.get_bind()
+        bind.execute(sa.text(f"SET lock_timeout = '{_LOCK_TIMEOUT}'"))
+        bind.execute(sa.text(f"SET statement_timeout = '{_STATEMENT_TIMEOUT}'"))
+        try:
+            for name, columns in _INDEXES:
+                valid = bind.execute(_VALIDITY, {"name": name}).scalar()
+                if valid is True:
+                    continue
+                if valid is False:  # debris from a killed build — unusable, and never repaired
+                    op.drop_index(name, table_name="callrecord", postgresql_concurrently=True)
+                op.create_index(name, "callrecord", columns, postgresql_concurrently=True)
+        finally:
+            bind.execute(sa.text(f"SET lock_timeout = '{_ENV_LOCK_TIMEOUT}'"))
+            bind.execute(sa.text(f"SET statement_timeout = '{_ENV_STATEMENT_TIMEOUT}'"))
 
 
 def downgrade() -> None:


### PR DESCRIPTION
Follow-up to #350, which failed in production pre-deploy.

## What happened

```
asyncpg.exceptions.LockNotAvailableError: canceling statement due to lock timeout
[SQL: CREATE INDEX CONCURRENTLY ix_callrecord_endpoint_id_created_at ON callrecord (endpoint_id, created_at)]
```

Not traffic — a concurrent build cannot be blocked by `SELECT`/`INSERT`. **autovacuum**, which takes the same `SHARE UPDATE EXCLUSIVE` lock and runs constantly on a 1.7 GB write-heavy table. Confirmed live: `AUTOVACUUM ON CALLRECORD RIGHT NOW: 1`.

It also left debris:

```
ix_callrecord_endpoint_id_created_at   indisvalid = False
ALEMBIC VERSION: 0019
```

CIC creates its catalog entry before it finishes acquiring the lock, so a plain retry would fail on "already exists", and an `IF NOT EXISTS` would skip an index the planner can never use — the scan stays, nothing fails.

## Fix

Both scoped to revision 0020:

1. `lock_timeout` 180s / `statement_timeout` 600s inside the `autocommit_block`, restored to `env.py`'s 5s/120s before it ends.
2. Per-index `pg_index.indisvalid` check: valid ⇒ skip, invalid ⇒ `DROP INDEX CONCURRENTLY` + rebuild, absent ⇒ build.

## Why raising the timeout is not the 2026-08-15 rule being broken

That floor exists because an `ALTER` takes `ACCESS EXCLUSIVE`: it queues behind live traffic and every new query queues behind it. `CREATE INDEX CONCURRENTLY` conflicts with neither `SELECT` nor `INSERT`/`UPDATE`/`DELETE`, blocks no reads or writes while it builds, and holds nothing while it waits. Waiting longer costs a slower pre-deploy and nothing else. `ops/deploy.md` records the exception and its bounds.

## Also recorded in ops/deploy.md

Merging a revision breaks the three cron services before the web pre-deploy applies it — they auto-deploy from `main`, the web service does not, so `verify_db` refuses them. It cannot be undone by pinning a cron to the previous commit: Render answers `cannot deploy cron job service ... by commit reference ID`. Deploy the web service immediately after merging a revision, or revert the merge.

## Tests

`2704 passed, 5 skipped`; alembic model-drift guard passes.