### PR TITLE
test(asynctasks): give the process-deadline case room for its own claim

### DIFF
--- a/tests/test_asynctasks.py
+++ b/tests/test_asynctasks.py
@@ -167,12 +167,17 @@ async def test_queued_worker_rows_are_not_claimed_before_a_poll_slot(
         await tick
 
 
-@pytest.mark.parametrize("deadline", ["POLL_TIMEOUT_S", "PROCESS_TIMEOUT_S"])
+# POLL_TIMEOUT_S wraps only the upstream poll, so it can be near-zero. PROCESS_TIMEOUT_S also
+# wraps the claim's own DB round trip: at 10 ms a loaded CI runner fires it BEFORE the claim,
+# which is correctly reported as backed_off with the row untouched - and then this test, which
+# wants the post-claim path, fails on `consecutive_failures == 1`. Give the claim room; the hung
+# poll is what the deadline must cut, and it never returns regardless.
+@pytest.mark.parametrize("deadline, seconds", [("POLL_TIMEOUT_S", 0.01), ("PROCESS_TIMEOUT_S", 0.5)])
 async def test_worker_bounds_whole_poll_and_keeps_hold_on_timeout(
-    clients: AsyncClient, monkeypatch, replicate_platform, deadline,
+    clients: AsyncClient, monkeypatch, replicate_platform, deadline, seconds,
 ):
     call_id = await _due_submission(clients, monkeypatch, {})
-    monkeypatch.setattr(task_app, deadline, 0.01)
+    monkeypatch.setattr(task_app, deadline, seconds)
     async def hangs(row, client):
         await asyncio.Event().wait()
     monkeypatch.setattr(task_app, "_poll", hangs)


### PR DESCRIPTION
Flake seen on #354's first CI run (34036769106, `test` job): `test_worker_bounds_whole_poll_and_keeps_hold_on_timeout[PROCESS_TIMEOUT_S]` failed with `consecutive_failures == 0`.

`PROCESS_TIMEOUT_S` wraps the claim's DB round trip as well as the poll. At 10 ms a loaded runner fires it **before** the claim; `settle_due` correctly reports that as `backed_off` with the row untouched, and the test - which wants the post-claim `poll_error` path - fails. The hung poll never returns, so 0.5 s still exercises the deadline. `POLL_TIMEOUT_S` keeps 0.01 because it wraps only the poll.

No production code touched.