### PR TITLE
feat(ops): gauge each connection pool's per-minute peak so sizing is measured

### DIFF
--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -124,6 +124,27 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
   on 2026-09-06: against a database that is waiting on DISK (below), five more slots meant five
   more readers of the same cold pages, and the worst hour on record (2,136 pool faults at 11:00,
   on a third of the previous day's traffic) followed.
+- **The pools are measured, not argued about: `db_pool_gauge`.** `bootstrap.pool_gauge` samples
+  `infra/db.pool_snapshot()` once a second and emits one PostHog event a minute per instance:
+  `<pool>_peak` (most connections that pool had checked out in the minute), `<pool>_capacity`
+  (`pool_size + max_overflow`) and `<pool>_headroom`. Telemetry, not a database consumer, so it is
+  not in `ROLE_BACKGROUND_TASKS` and runs in every role. Read it like this: a pool whose peak sits
+  at capacity is one whose waiters are timing out (`api`: `503 treg_saturated`; `background`: an
+  audit or archive row dropped after `pool_timeout`); a pool whose peak never nears capacity is
+  holding connections nothing uses. **Resize from the gauge, never from the arithmetic** - the
+  arithmetic got both minor pools wrong once each (above), and the 2026-09-05 `api` raise made the
+  saturation it meant to fix worse. The protocol: one pool at a time, one override at a time, each
+  setting across at least one full daily peak (the 01:00-04:00 UTC batch window), judged by the same
+  hour on consecutive days on three numbers - db_pool faults, `/call/` 503 rate, and the gap between
+  `tool_called` events and `callrecord` rows (dropped audit). A change that raises the 503 rate at
+  equal traffic is reverted, not tuned around.
+
+    ```
+    SELECT toStartOfHour(timestamp) h, max(toFloat(properties.background_peak)) bg_peak,
+           any(properties.background_capacity) bg_cap, max(toFloat(properties.api_peak)) api_peak
+    FROM events WHERE event = 'db_pool_gauge' AND timestamp > now() - INTERVAL 2 DAY
+    GROUP BY h ORDER BY h DESC
+    ```
 - **No statement timeout yet.** The pools bound how many connections a class of work can hold, not
   how long a query may run; `alembic/env.py` still has the only timeouts in the app. Adding per-pool
   `statement_timeout` is deliberately a SEPARATE change: it is a behavior change on every query,

--- a/src/treg/analytics.py
+++ b/src/treg/analytics.py
@@ -54,7 +54,8 @@ _FLUSH_INTERVAL_S = 2.0    # max staleness before a flush
 
 _flusher: asyncio.Task | None = None
 
-_SERVER_DISTINCT_ID = "treg-server"
+SERVER_DISTINCT_ID = "treg-server"
+_SERVER_DISTINCT_ID = SERVER_DISTINCT_ID  # older name, kept for callers
 _FAULT_VALUE_MAX = 500
 _FAULT_WINDOW_S = 10.0     # one event per (fault type, site) per window; the rest are counted
 _FAULT_MAX_KEYS = 500      # bound the ledger — it is what caps the cost, so it must be finite

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from copy import copy
@@ -413,6 +415,44 @@ def _route_manifest(routes: Sequence[BaseRoute]) -> list[str]:
     return result
 
 
+_POOL_GAUGE_SAMPLE_S = 1.0
+_POOL_GAUGE_EMIT_S = 60.0
+
+
+async def pool_gauge(*, sample_s: float = _POOL_GAUGE_SAMPLE_S,
+                     emit_s: float = _POOL_GAUGE_EMIT_S) -> None:
+    """Every minute, one `db_pool_gauge` event: the peak connections each pool had checked out in
+    that minute, next to its capacity. The reading behind `TREG_DB_POOL_OVERRIDES`: a pool whose
+    peak sits at capacity is one whose waiters are timing out (api: `503 treg_saturated`;
+    background: an audit or archive row dropped after `pool_timeout`), and a pool whose peak never
+    nears it is holding connections nothing uses. Sampling is a counter read, no I/O; a bad pass
+    never kills the loop. Telemetry, not a database consumer - so it is not in
+    `ROLE_BACKGROUND_TASKS` and runs in every role."""
+    from .infra.db import fold_pool_peaks, pool_snapshot
+    peaks: dict[str, int] = {}
+    samples = 0
+    opened = time.monotonic()
+    while True:
+        try:
+            fold_pool_peaks(peaks, pool_snapshot())
+            samples += 1
+            if time.monotonic() - opened >= emit_s:
+                snapshot = pool_snapshot()
+                props: dict = {"samples": samples, "window_s": round(time.monotonic() - opened)}
+                for name, row in snapshot.items():
+                    props[f"{name}_peak"] = peaks.get(name, 0)
+                    props[f"{name}_capacity"] = row["capacity"]
+                    props[f"{name}_headroom"] = row["capacity"] - peaks.get(name, 0)
+                if snapshot:
+                    analytics.capture(analytics.SERVER_DISTINCT_ID, "db_pool_gauge", props)
+                peaks, samples, opened = {}, 0, time.monotonic()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - a gauge must never take the service down
+            logging.getLogger("treg").exception("db pool gauge pass failed")
+        await asyncio.sleep(sample_s)
+
+
 def _lifespan(role: AppRole):
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -428,6 +468,7 @@ def _lifespan(role: AppRole):
             if ROLE_BACKGROUND_TASKS[role] and adsconv.enabled()
             else None
         )
+        gauge_task = asyncio.create_task(pool_gauge()) if analytics.enabled() else None
         # The archive's refresh worker (docs/context/architecture/archive.md): serve mode only,
         # and a zero daily cap disables it without touching serving. Same discipline as the ads
         # task — in-process, cancelled on shutdown, a bad pass never kills the loop.
@@ -460,6 +501,8 @@ def _lifespan(role: AppRole):
                     yield
         finally:
             try:
+                if gauge_task is not None:
+                    gauge_task.cancel()
                 if ads_task is not None:
                     ads_task.cancel()
                 if archive_task is not None:

--- a/src/treg/infra/db.py
+++ b/src/treg/infra/db.py
@@ -128,6 +128,37 @@ if _is_sqlite:
     _admin_engine = _background_engine = _engine
 
 _engines = (_engine, _admin_engine, _background_engine)
+_POOL_NAMES = ("api", "admin", "background")
+
+
+def pool_snapshot() -> dict[str, dict[str, int]]:
+    """What each pool holds RIGHT NOW: connections checked out, of how many it may hand out.
+
+    The sizing question `POOL_SPECS` answers by arithmetic ("13 is the sum of the semaphores") can
+    only be settled by measurement; this is the measurement. `checked_out` counts slots in use
+    (persistent and overflow alike), `capacity` is `pool_size + max_overflow`. SQLite has no pool
+    worth reading and reports nothing. A pure read of SQLAlchemy's counters - no lock, no I/O.
+    """
+    if _is_sqlite:
+        return {}
+    out: dict[str, dict[str, int]] = {}
+    for name, engine in zip(_POOL_NAMES, _engines):
+        pool = engine.sync_engine.pool
+        checked_out = getattr(pool, "checkedout", None)
+        if checked_out is None:
+            continue
+        spec = POOL_SPECS[name]
+        out[name] = {"checked_out": int(checked_out()),
+                     "capacity": spec["pool_size"] + spec["max_overflow"]}
+    return out
+
+
+def fold_pool_peaks(peaks: dict[str, int], snapshot: dict[str, dict[str, int]]) -> dict[str, int]:
+    """Keep the per-pool maximum of `checked_out` seen across samples (the gauge's whole job)."""
+    for name, row in snapshot.items():
+        if row["checked_out"] > peaks.get(name, 0):
+            peaks[name] = row["checked_out"]
+    return peaks
 
 # The API pool: every request handler, through `get_session` or directly.
 session_maker = async_sessionmaker(_engine, class_=AsyncSession, expire_on_commit=False)

--- a/tests/test_db_pool_gauge.py
+++ b/tests/test_db_pool_gauge.py
@@ -1,0 +1,58 @@
+"""The pool gauge is the reading behind `TREG_DB_POOL_OVERRIDES`: per-minute peak checked-out
+connections per pool, next to capacity. Sizing by arithmetic got both minor pools wrong once each
+(ops/deploy.md § Three pools); this is what settles the number."""
+import asyncio
+
+import pytest
+
+from treg import analytics, bootstrap
+from treg.infra import db as infra_db
+
+
+def test_snapshot_reports_nothing_on_sqlite_and_a_pool_row_per_engine_otherwise():
+    snap = infra_db.pool_snapshot()
+    if infra_db._is_sqlite:
+        assert snap == {}
+        return
+    assert set(snap) == {"api", "admin", "background"}
+    for name, row in snap.items():
+        spec = infra_db.POOL_SPECS[name]
+        assert row["capacity"] == spec["pool_size"] + spec["max_overflow"]
+        assert 0 <= row["checked_out"] <= row["capacity"]
+
+
+def test_fold_keeps_the_per_pool_maximum():
+    peaks: dict[str, int] = {}
+    infra_db.fold_pool_peaks(peaks, {"api": {"checked_out": 3, "capacity": 15}})
+    infra_db.fold_pool_peaks(peaks, {"api": {"checked_out": 9, "capacity": 15},
+                                     "background": {"checked_out": 2, "capacity": 13}})
+    infra_db.fold_pool_peaks(peaks, {"api": {"checked_out": 1, "capacity": 15}})
+    assert peaks == {"api": 9, "background": 2}
+
+
+async def test_gauge_emits_one_event_per_window_with_peak_capacity_and_headroom(monkeypatch):
+    samples = iter([
+        {"api": {"checked_out": 4, "capacity": 15}, "background": {"checked_out": 1, "capacity": 13}},
+        {"api": {"checked_out": 11, "capacity": 15}, "background": {"checked_out": 13, "capacity": 13}},
+        {"api": {"checked_out": 2, "capacity": 15}, "background": {"checked_out": 0, "capacity": 13}},
+    ])
+    last = {"api": {"checked_out": 0, "capacity": 15}, "background": {"checked_out": 0, "capacity": 13}}
+    monkeypatch.setattr(infra_db, "pool_snapshot", lambda: next(samples, last))
+    captured: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(analytics, "capture", lambda d, e, p=None, **kw: captured.append((d, e, p)))
+    task = asyncio.create_task(bootstrap.pool_gauge(sample_s=0.01, emit_s=0.05))
+    try:
+        for _ in range(100):
+            await asyncio.sleep(0.01)
+            if captured:
+                break
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert captured, "no gauge event within the window"
+    distinct_id, event, props = captured[0]
+    assert (distinct_id, event) == (analytics.SERVER_DISTINCT_ID, "db_pool_gauge")
+    assert props["api_peak"] == 11 and props["api_capacity"] == 15 and props["api_headroom"] == 4
+    assert props["background_peak"] == 13 and props["background_headroom"] == 0
+    assert props["samples"] >= 3


### PR DESCRIPTION
## Why

Pool sizes have been set by arithmetic three times and been wrong three times: the first `background` cut summed two of seven consumers, `admin=2` consumed itself, and the 2026-09-05 `api` raise made a disk-bound saturation worse. The dashboard override still carries `admin=2, background=4` against code defaults of 3 and 13, and neither side of that argument has a measurement.

## What

`bootstrap.pool_gauge` samples `infra/db.pool_snapshot()` (SQLAlchemy's checked-out counter per engine - a counter read, no I/O) once a second and emits one `db_pool_gauge` PostHog event a minute per instance:

| property | meaning |
|---|---|
| `<pool>_peak` | most connections that pool had checked out in the minute |
| `<pool>_capacity` | `pool_size + max_overflow` as configured (overrides applied) |
| `<pool>_headroom` | capacity − peak |

A pool at capacity is one whose waiters time out (`api`: `503 treg_saturated`; `background`: a dropped audit/archive row after `pool_timeout`). A pool whose peak never nears capacity holds connections nothing uses.

Telemetry, not a database consumer: outside `ROLE_BACKGROUND_TASKS`, runs in every role, gated on analytics being enabled, cancelled first on shutdown. A bad pass logs and continues.

`ops/deploy.md` gets the reading rule and the protocol: one pool, one override at a time, each across a full daily peak, judged on db_pool faults, `/call/` 503 rate, and the `tool_called` − `callrecord` gap (dropped audit).

## Tests

`tests/test_db_pool_gauge.py`: snapshot shape (empty on SQLite, one row per engine with `checked_out ≤ capacity` otherwise), the peak fold, and the emitted event's peak/capacity/headroom through a fake sampler.