### PR TITLE
fix(web): the provider page hands the observation reader, not the session, to the stats lookup

### DIFF
--- a/src/treg/application/auth.py
+++ b/src/treg/application/auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -871,9 +873,13 @@ async def _refresh_grant(*, refresh_token: str, client_id: str, resource: str) -
             # cost of being wrong is one sign-in; the cost of the other mistake is somebody's balance.
             killed = await _revoke_refresh_family(row.family_id, "reuse detected", db)
             await db.commit()
+            # `CallRecord` has no column for the family or the kill count; audit drops unknown
+            # telemetry keys with a warning on every occurrence, so they go to the log instead.
+            logging.getLogger("treg.auth").warning(
+                "refresh token reuse: family %s revoked (%s grants)", row.family_id, killed)
             audit.record_call(org_id=row.org_id, user_email="", tool_name="oauth.refresh_reuse",
                               method="POST", path="/oauth/token", status_code=400, client="",
-                              telemetry={"family": row.family_id, "revoked": killed})
+                              refused_by="auth")
             raise OAuthServerError(
                 "invalid_grant",
                 "this refresh token was already used — the grant has been revoked, sign in again",

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -1972,7 +1972,9 @@ details.tl li.more a{color:var(--link);text-decoration:none}
 
 
 @app.get("/tools/{service}", include_in_schema=False)
-async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
+async def tools_provider(service: str, db: AsyncSession = Depends(get_session),
+                         observations: endpoint_stats.EndpointObservationReader = Depends(
+                             _endpoint_observation_reader)):
     """One provider's public page, in the use-case pages' skin (usecase.css): hero on the two
     measured terms — "{provider} api pricing" (what Search Console shows people typing) and
     "{provider} mcp" — the agent->treg->provider flow, setup (agent one-liner first), a prompt
@@ -2032,7 +2034,7 @@ async def tools_provider(service: str, db: AsyncSession = Depends(get_session)):
     badge = "YOUR ACCOUNT" if is_oauth else "NO SIGNUP"
     # The measured line: what treg.to has actually observed calling this provider. It is the one
     # thing a vendor's own pricing page cannot print, and it goes above the fold for that reason.
-    obs = await _observed_or_empty(db, [e["id"] for e in eps])
+    obs = await _observed_or_empty(observations, [e["id"] for e in eps])
     o_samples = sum(int(o.get("samples") or 0) for o in obs.values())
     # The provider-wide rate weights each endpoint's published rate by the calls that DECIDED it
     # (2xx + 5xx). `samples` still counts callers' 4xx, so weighting by it would let one team's

--- a/tests/test_provider_pages.py
+++ b/tests/test_provider_pages.py
@@ -82,3 +82,14 @@ async def test_sitemap_and_catalog_link_every_provider_page(clients: AsyncClient
         assert f"/tools/{s}<" in sm, s
         assert f'href="/tools/{s}"' in cat, s
     assert "/pricing<" in sm
+
+
+async def test_provider_page_reads_the_observation_reader_not_the_session(clients, caplog):
+    """`/tools/{service}` once handed `_observed_or_empty` the request's AsyncSession instead of the
+    app's observation reader; the measured line silently came up empty and every page view logged
+    an AttributeError traceback (prod, 2026-09-06)."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="treg.catalog"):
+        r = await clients.get("/tools/dataforseo")
+    assert r.status_code == 200
+    assert "endpoint stats unavailable" not in caplog.text


### PR DESCRIPTION
Two log-noise bugs seen on prod today after the pool work, both real.

**1. `/tools/{service}` lost its measured line.** `tools_provider` passed the request's `AsyncSession` to `_observed_or_empty`, which calls `reader.get_many(...)`:

```
endpoint stats unavailable
  File ".../treg/routers/catalog.py", line 168, in _observed_or_empty
    return await reader.get_many(endpoint_ids)
AttributeError: 'AsyncSession' object has no attribute 'get_many'
```

The catch-all swallowed it, so the page rendered with an empty measured line and a traceback per view. The handler now takes the `_endpoint_observation_reader` dependency like its siblings. Regression test asserts the page renders without the warning.

**2. Refresh-token-reuse audit passed unknown telemetry keys.** `family` / `revoked` are not `CallRecord` columns; `audit._known_fields` dropped them with a `"is a migration missing?"` warning every time. They go to the log now; the row carries `refused_by="auth"`.

Suite-relevant tests pass; ruff findings in `web.py` are pre-existing.