### PR TITLE
fix(ratestore): kv_put of a missing key is an upsert, so racing writers do not raise

### DIFF
--- a/src/treg/ratestore.py
+++ b/src/treg/ratestore.py
@@ -22,6 +22,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .models import Ephemeral
@@ -57,13 +58,27 @@ async def kv_put(db: AsyncSession, ns: str, k: str, v: dict, ttl_s: float | None
     the code's lifetime)."""
     row = await db.get(Ephemeral, (ns, k))
     if row is None:
+        # An INSERT that another process may be racing: two uvicorn workers striking the same
+        # provider write the same `capacity:lock` key within the same millisecond, and the loser
+        # of a plain INSERT died on `ephemeral_pkey` (prod, 2026-09-06). ON CONFLICT makes the
+        # last writer win, which is what a key/value put means.
         exp = _utcnow_naive() + timedelta(seconds=ttl_s or 0)
-        db.add(Ephemeral(ns=ns, k=k, v=v, expires_at=exp))
+        await db.execute(_upsert(db.get_bind().dialect.name, ns=ns, k=k, v=v, expires_at=exp))
         return
     row.v = v  # reassign (not in-place) so SQLAlchemy marks the JSON column dirty
     if ttl_s is not None:
         row.expires_at = _utcnow_naive() + timedelta(seconds=ttl_s)
     db.add(row)
+
+
+def _upsert(dialect: str, **values):
+    """`INSERT ... ON CONFLICT (ns, k) DO UPDATE` for the dialect at hand - both backends spell it
+    the same way, but SQLAlchemy exposes it per dialect."""
+    insert = postgresql.insert if dialect == "postgresql" else sqlite.insert
+    stmt = insert(Ephemeral).values(**values)
+    return stmt.on_conflict_do_update(
+        index_elements=[Ephemeral.ns, Ephemeral.k],
+        set_={"v": stmt.excluded.v, "expires_at": stmt.excluded.expires_at})
 
 
 async def kv_pop(db: AsyncSession, ns: str, k: str) -> dict | None:

--- a/tests/test_ratestore.py
+++ b/tests/test_ratestore.py
@@ -7,6 +7,8 @@ SEPARATE session — if the state were still a per-process dict, the second sess
 
 from __future__ import annotations
 
+from sqlalchemy.dialects import postgresql, sqlite
+
 from treg import ratestore
 from treg.infra.db import reset_db, session_maker
 from treg.models import Ephemeral
@@ -94,3 +96,27 @@ async def test_sweep_drops_expired_rows_only():
         await db.commit()
         assert await db.get(Ephemeral, ("sandbox_hit", "dead")) is None
         assert await db.get(Ephemeral, ("sandbox_hit", "live")) is not None
+
+
+async def test_kv_put_of_a_missing_key_is_an_upsert_on_both_backends():
+    """Two processes striking the same provider write the same lock key in the same millisecond; the
+    loser of a plain INSERT died on `ephemeral_pkey` (prod, 2026-09-06). The statement must carry
+    ON CONFLICT on both dialects so the last writer wins instead of raising."""
+    from datetime import datetime
+    for dialect in ("postgresql", "sqlite"):
+        stmt = ratestore._upsert(dialect, ns="capacity:lock", k="p", v={"a": 1},
+                                 expires_at=datetime(2026, 1, 1))
+        sql = str(stmt.compile(dialect=(postgresql.dialect() if dialect == "postgresql" else sqlite.dialect())))
+        assert "ON CONFLICT (ns, k) DO UPDATE" in sql, sql
+
+
+async def test_kv_put_overwrites_a_row_written_by_another_session():
+    async with session_maker() as other:
+        await ratestore.kv_put(other, "ns", "k", {"n": 1}, ttl_s=600)
+        await other.commit()
+    async with session_maker() as db:
+        # This session has never loaded (ns, k); its `get` sees the committed row and updates it.
+        await ratestore.kv_put(db, "ns", "k", {"n": 2}, ttl_s=600)
+        await db.commit()
+    async with session_maker() as db:
+        assert (await ratestore.kv_get(db, "ns", "k")) == {"n": 2}


### PR DESCRIPTION
Seen on prod 2026-09-06 during the DataForSEO balance strike burst - three tracebacks in one second:

```
capacity lock dataforseo not written
asyncpg.exceptions.UniqueViolationError: duplicate key value violates unique constraint "ephemeral_pkey"
DETAIL:  Key (ns, k)=(capacity:lock, dataforseo) already exists.
```

Two uvicorn workers (the web service runs two - #360) strike the same provider in the same millisecond; `kv_put` did `get` → `add`, so the loser of the INSERT raised. The lock was written by the winner, so nothing was functionally wrong, but a put is last-writer-wins by definition.

The missing-row path is now `INSERT ... ON CONFLICT (ns, k) DO UPDATE` via the dialect's insert (Postgres and SQLite both support it). The loaded-row path is unchanged. Tests pin the ON CONFLICT clause on both dialects and the cross-session overwrite.