### PR TITLE
perf(audit): one batching writer per process, two archive writers

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -289,8 +289,9 @@ move atomically with each strip.
 
 ## Recorder throttle (2026-09-03)
 
-At most `_MAX_CONCURRENT_WRITES` (4) recordings touch the database at once — audit's exact
-loop-bound-semaphore pattern. Before it, a burst could put up to 512 concurrent short sessions in
+At most `_MAX_CONCURRENT_WRITES` (2) recordings touch the database at once — audit's exact
+loop-bound-semaphore pattern (four until 2026-09-07; every slot is paid per uvicorn worker and
+again per rolling-deploy instance, and a recording is one INSERT of a body already in memory). Before it, a burst could put up to 512 concurrent short sessions in
 front of the API's 15-slot pool (SToneX's pool-pressure report); those writes now land on the
 BACKGROUND pool instead (`ops/deploy.md` § Three pools), so the semaphore is the inner bound rather
 than the only one — a third module reaching for the wrong maker no longer needs its author to have

--- a/docs/context/architecture/data-model.md
+++ b/docs/context/architecture/data-model.md
@@ -401,7 +401,7 @@ key, including first sightings that never recurred to carry their own count out.
 the shared queue is genuinely backing up (`_FAULT_QUEUE_SHARE` of `_MAX_PENDING`) - the congestion the
 throttle was ever meant to prevent, rather than a wall-clock rate that fired against an empty queue.
 
-**Losing data is ERROR, not WARNING.** `audit._write`, `audit._schedule`'s back-pressure shed, and
+**Losing data is ERROR, not WARNING.** `audit._write_batch`, `audit._enqueue`'s back-pressure shed, and
 `archive`'s `_store`/`_touch_write` drops all log at ERROR, because `FaultCaptureHandler` starts at ERROR:
 below it the loss reaches container stdout and nothing else, so it can neither be alerted on nor found
 without already suspecting it. Degradations that cost nothing (an archive lookup falling back to a live

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -72,7 +72,7 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
   |---|---|---|---|
   | `api` | `session_maker` | 5 + 10 | every request handler, via `get_session` or directly |
   | `admin` | `admin_session_maker` | 3 + **0** | `/admin/*` only, via `get_admin_session` |
-  | `background` | `background_session_maker` | 13 + **0** | audit, archive writes, ads worker, the observation reader, the error-evidence sweep |
+  | `background` | `background_session_maker` | 8 + **0** | audit (one batching writer), archive writes (two), ads worker, the observation reader, the error-evidence sweep |
 
   Each class of work can exhaust only its own slots. Before this there was ONE pool of 15, and on
   2026-09-03 a single admin browser tab polling `/admin/archive/panel` (every 5 s, no in-flight
@@ -93,15 +93,18 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
 
   | specs | per process | per instance | deploy peak | 103? |
   |---|---|---|---|---|
-  | code defaults 15 + 3 + 13 | 31 | 62 | **124** | over |
+  | code defaults 15 + 3 + 13 (until 2026-09-07) | 31 | 62 | **124** | over |
+  | code defaults 15 + 3 + 8 (since 2026-09-07) | 26 | 52 | 104 | over by one |
   | dashboard override 15 + 2 + 4 | 21 | 42 | 84 | fits |
 
   That is the post-mortem of the 2026-09-04 defaults: `background = 13` did not overload the
   database, it opened 124 connections at every deploy and restart until the override cut it to 84.
   Every earlier passage in this file that multiplied by two instances only was counting half the
   connections. Any resize must clear the deploy-peak column first; within it there are 2 spare
-  per process today (23 → 92), and the way to more is fewer consumers per process (batched audit
-  writes, smaller archive semaphores), `WEB_CONCURRENCY=1`, a larger database plan, or a pooler -
+  per process today (23 → 92). Batching the audit writer (4 → 1) and halving the archive semaphore
+  (4 → 2) on 2026-09-07 cut the derived `background` from 13 to 8, so a pool of 6 now serves every
+  consumer but two archive writers at once and still fits (15 + 2 + 6 = 23 → 92); the way to more
+  is `WEB_CONCURRENCY=1`, a larger database plan, or a pooler -
   not a bigger number in the override.
 
   Two sizing rules, both learned by getting them wrong first:
@@ -138,8 +141,8 @@ bound to a closed maintenance loop. Calling `maintenance.upgrade()` directly doe
   deployment ran `admin.pool_size=2,background.pool_size=4` from before the 2026-09-04 bulkhead
   work until 2026-09-05 — pinning both minor pools BELOW the defaults that work had just raised
   (`admin` to 3, `background` to the derived 13), including the exact `admin=2` whose post-mortem
-  is two bullets up. A `background` of 4 against 7 consumers needing 13 does not 503; it silently
-  drops audit rows. The knob being a dashboard edit rather than a deploy is what makes it useful
+  is two bullets up. A `background` of 4 against 7 consumers needing 13 (8 since 2026-09-07) does
+  not 503; it silently drops audit rows. The knob being a dashboard edit rather than a deploy is what makes it useful
   mid-incident and what lets it survive the fix. Today it reads
   `admin.pool_size=2,background.pool_size=4` - and those two entries are no longer "stale": with
   two uvicorn workers (§ above) they are what keeps a rolling deploy at 84 connections instead of
@@ -381,13 +384,15 @@ UTC (SQLite is lax and hid this; it only bites on Postgres — the deploy target
 and in the serial Postgres CI migration set. `env.py` bounds Postgres lock and statement wait time so
 a contended migration fails before it queues the serving database behind DDL.
 
-**Audit back-pressure (`audit.py`).** Audit rows are written off the request path (fire-and-forget), and
-each write opens a DB connection — from the **background** pool since 2026-09-03, so a burst here can no
-longer starve real requests, only other background work. Two limits still apply inside it: a loop-bound
-semaphore caps concurrent audit writes at `_MAX_CONCURRENT_WRITES` (queueing in-process rather than
-holding a pooled connection, and keeping `drain()` deterministic on SQLite, where all three makers share
-one engine), and under an extreme burst the writer **sheds** load — it drops any audit row past
-`_MAX_PENDING` rather than let the pending set grow without bound. Audit must never OOM or wedge the
+**Audit back-pressure (`audit.py`).** Audit rows are written off the request path (fire-and-forget):
+`record_call` appends to an in-process queue and ONE writer task per process drains it `_BATCH` rows
+per INSERT on a **background**-pool connection (since 2026-09-07; before that four writers each took
+one row per session, which cost four slots per process for millisecond inserts). A burst can therefore
+never starve real requests, only other background work. Two limits still apply: a loop-bound semaphore
+holds the writer to `_MAX_CONCURRENT_WRITES` (1), which keeps `drain()` deterministic on SQLite, where
+all three makers share one engine, and under an extreme burst `_enqueue` **sheds** load — it drops any
+audit row past `_MAX_PENDING` queued rows rather than let the queue grow without bound. A batch the
+database refuses is retried row by row, so one bad row costs one row. Audit must never OOM or wedge the
 server. Shedding is the *only* loss that should ever happen: `record_call` splats its telemetry dict
 into `CallRecord(**fields)`, so a key with no matching column used to raise inside `_write`, where the
 except swallowed it, and the whole row disappeared — a telemetry field deployed one commit ahead of its

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -206,8 +206,10 @@ _MAX_PENDING = 512
 # At most this many recordings TOUCH THE DATABASE at once (audit's discipline, and its exact
 # loop-bound pattern). Without it a traffic burst put up to 512 concurrent short sessions in
 # front of the API's 15-slot pool — SToneX's pool-pressure report, 2026-09-03. Queued recordings
-# wait INSIDE their task; the caller's response left long ago either way.
-_MAX_CONCURRENT_WRITES = 4
+# wait INSIDE their task; the caller's response left long ago either way. Two, not four: every
+# slot here is paid twice (two uvicorn workers) and again at every deploy against the database's
+# 103-connection ceiling, and a recording is one INSERT of a body that is already in memory.
+_MAX_CONCURRENT_WRITES = 2
 
 _sem: asyncio.Semaphore | None = None
 _sem_loop = None

--- a/src/treg/audit.py
+++ b/src/treg/audit.py
@@ -1,29 +1,38 @@
 """Audit writes — deferred and fire-and-forget (rule #2: never block the proxied response).
 
-`record_call` schedules an insert on its own session and returns immediately; the response
-streams without waiting. A strong reference to each task is held until it finishes (otherwise
-the event loop may GC a bare create_task). Failures are swallowed: an audit hiccup must never
-break a real call. `drain()` flushes pending writes on shutdown / in tests.
+`record_call` queues a row and returns immediately; the response streams without waiting. One
+writer task per process drains the queue in batches on one connection (a strong reference to it
+is held until it finishes, otherwise the event loop may GC a bare create_task). Failures are
+swallowed: an audit hiccup must never break a real call. `drain()` flushes pending writes on
+shutdown / in tests.
 
-Back-pressure (why this matters): each write opens a DB connection, from the BACKGROUND pool
-(db.py), so a burst here can starve other background work but never real calls. The semaphore stays
-as the inner, cheaper bound — it queues in-process instead of holding a pooled connection, and it is
-what keeps `drain()` deterministic on sqlite, where all three makers share one engine. Under an
-extreme burst we DROP audit rows past `_MAX_PENDING` rather than grow without bound — audit is
-best-effort; never OOM or wedge the server for it.
+Back-pressure (why this matters): the writer's connection comes from the BACKGROUND pool (db.py),
+so a burst here can starve other background work but never real calls. Rows queue in-process, not
+as pooled connections: one writer per process takes them off the queue `_BATCH` at a time and lands
+each batch in one INSERT round trip, which is what keeps `drain()` deterministic on sqlite, where
+all three makers share one engine. Under an extreme burst we DROP audit rows past `_MAX_PENDING`
+rather than grow without bound — audit is best-effort; never OOM or wedge the server for it.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections import deque
 
 from .infra.db import background_session_maker
 from .models import CallRecord, RunRecord, SearchMiss
 
 _pending: set[asyncio.Task] = set()
-_MAX_CONCURRENT_WRITES = 4   # cap on audit writes holding a DB connection at once (protect the request pool)
+# ONE writer per process, and it writes in batches. Audit rows are single-row inserts that cost
+# milliseconds each, so four concurrent writers bought nothing but four `background` slots - and
+# every slot is paid twice (two uvicorn workers) and again at every deploy against the database's
+# 103-connection ceiling (ops/deploy.md). One writer draining a queue in batches of `_BATCH` rows
+# lands the same rows in fewer round trips and holds one connection.
+_MAX_CONCURRENT_WRITES = 1
 _MAX_PENDING = 5000          # shed load past this: drop the audit row rather than grow unbounded
+_BATCH = 200                 # rows per INSERT round trip; a failed batch retries row by row
+_queue: deque[tuple[type, dict]] = deque()
 
 _sem: asyncio.Semaphore | None = None
 _sem_loop = None
@@ -48,7 +57,7 @@ def record_call(
     stay NULL. It is still fire-and-forget: the money landed in the ledger synchronously, so losing a
     row here costs analytics, not accounting. `refused_by` marks a call TREG refused before anything
     went upstream (see models.CallRecord) — NULL whenever the provider actually answered."""
-    _schedule(_write(CallRecord,
+    _enqueue(CallRecord, dict(
         org_id=org_id, user_email=user_email, tool_name=tool_name,
         method=method, path=path, status_code=status_code, client=client, refused_by=refused_by,
         **_known_fields(CallRecord, telemetry),
@@ -78,14 +87,14 @@ def record_search_miss(*, query: str, source: str) -> None:
     """A catalog search that matched nothing — logged so the misses can steer ingest (see
     models.SearchMiss). Same contract as every write here: fire-and-forget, and a dropped row
     under load costs a data point, never a search response."""
-    _schedule(_write(SearchMiss, query=query[:300], source=source))
+    _enqueue(SearchMiss, dict(query=query[:300], source=source))
 
 
 def record_run(
     *, org_id: int | None = None, user_email: str, bundle_name: str, argv: list, exit_code: int,
     duration_ms: int, client: str = ""
 ) -> None:
-    _schedule(_write(RunRecord,
+    _enqueue(RunRecord, dict(
         org_id=org_id, user_email=user_email, bundle_name=bundle_name,
         argv=argv, exit_code=exit_code, duration_ms=duration_ms, client=client,
     ))
@@ -95,39 +104,74 @@ _shed = 0  # audit rows dropped by back-pressure this process; only ever grows
 
 
 def _schedule(coro) -> None:
-    if len(_pending) >= _MAX_PENDING:  # shed load — audit is best-effort, never OOM the server
-        coro.close()
-        # Say so. Shedding bypasses `_write` entirely, so the warning there never fires for it, and
-        # a shed row is invisible: the audit table simply has less in it. For a table whose job is
-        # to record what happened, "quiet" and "quietly broken" must not look identical — and the
-        # failure-evidence columns ride this same path, so a burst silently loses exactly the errors
-        # someone would go looking for. Logged on the first drop and then every 1,000th, so a long
-        # incident cannot itself flood the log.
-        global _shed
-        _shed += 1
-        if _shed == 1 or _shed % 1000 == 0:
-            logging.getLogger("treg.audit").error(
-                "audit back-pressure: %d row(s) dropped this process (pending at %d)",
-                _shed, _MAX_PENDING)
-        return
+    """Run the writer as a tracked task. Shedding happens in `_enqueue`, on the queue: a shed row is
+    invisible - the audit table simply has less in it - so for a table whose job is to record what
+    happened, "quiet" and "quietly broken" must not look identical. The failure-evidence columns
+    ride this same path, so a burst would otherwise silently lose exactly the errors someone would
+    go looking for. Logged on the first drop and then every 1,000th."""
     task = asyncio.create_task(coro)
     _pending.add(task)
-    task.add_done_callback(_pending.discard)
+    task.add_done_callback(_writer_done)
 
 
-async def _write(model, **fields) -> None:
-    async with _get_sem():  # cap concurrent DB connections held by audit — never starve the request pool
-        try:
-            async with background_session_maker() as session:
-                session.add(model(**fields))
-                await session.commit()
-        except Exception:  # noqa: BLE001 — audit must never surface into a call's result
-            # Swallowed on purpose, but neither silent nor local: the row is lost — that is the
-            # contract — and ERROR is what puts that loss in front of someone. At WARNING it stayed
-            # in the container's stdout, below the fault handler's threshold, so the only way to
-            # learn that audit was dropping rows was to already suspect it and go grep.
+def _writer_done(task: asyncio.Task) -> None:
+    """A row enqueued between the writer's last empty-queue check and this callback saw `_pending`
+    still occupied and did not start a writer; start one for it here or it waits for the next call."""
+    _pending.discard(task)
+    if _queue and not _pending:
+        _schedule(_flush())
+
+
+def _enqueue(model, fields: dict) -> None:
+    """Queue one row and make sure a writer is running. The shed check is on the QUEUE, which is
+    where rows wait now; `_pending` holds at most the one writer task."""
+    if len(_queue) >= _MAX_PENDING:
+        _shed_one()
+        return
+    _queue.append((model, fields))
+    if not _pending:
+        _schedule(_flush())
+
+
+def _shed_one() -> None:
+    global _shed
+    _shed += 1
+    if _shed == 1 or _shed % 1000 == 0:
+        logging.getLogger("treg.audit").error(
+            "audit back-pressure: %d row(s) dropped this process (pending at %d)",
+            _shed, _MAX_PENDING)
+
+
+async def _flush() -> None:
+    """Drain the queue in batches until it is empty, then exit. One connection for the whole run.
+
+    A batch that fails is retried row by row, so one row the database refuses (a value out of
+    range, a constraint) costs that row and not the 199 around it - the failure evidence of a
+    burst is exactly what such a burst must not take down with it.
+    """
+    async with _get_sem():
+        while _queue:
+            batch = [_queue.popleft() for _ in range(min(_BATCH, len(_queue)))]
+            if not await _write_batch(batch):
+                for row in batch:
+                    await _write_batch([row])
+
+
+async def _write_batch(rows: list[tuple[type, dict]]) -> bool:
+    try:
+        async with background_session_maker() as session:
+            session.add_all([model(**fields) for model, fields in rows])
+            await session.commit()
+        return True
+    except Exception:  # noqa: BLE001 — audit must never surface into a call's result
+        # Swallowed on purpose, but neither silent nor local: the row is lost — that is the
+        # contract — and ERROR is what puts that loss in front of someone. At WARNING it stayed
+        # in the container's stdout, below the fault handler's threshold, so the only way to
+        # learn that audit was dropping rows was to already suspect it and go grep.
+        if len(rows) == 1:
             logging.getLogger("treg.audit").error(
-                "audit write dropped for %s", model.__name__, exc_info=True)
+                "audit write dropped for %s", rows[0][0].__name__, exc_info=True)
+        return False
 
 
 async def drain() -> None:
@@ -139,7 +183,16 @@ async def drain() -> None:
     # suspends, so a loop keyed only on the callback spins synchronously forever while that callback
     # (and every timer on the loop) starves. Latent since the first import; a CI Postgres runner hit
     # the window deterministically and wedged whole 15-minute jobs on it.
-    while _pending:
+    #
+    # Whatever is still queued once no writer is running is flushed HERE, inline, not through
+    # `_schedule`: a drain that depends on scheduling a task to make progress spins forever the
+    # moment scheduling is stubbed out (a test kills the pipeline exactly that way).
+    while True:
         tasks = list(_pending)
-        await asyncio.gather(*tasks, return_exceptions=True)
-        _pending.difference_update(tasks)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            _pending.difference_update(tasks)
+            continue
+        if not _queue:
+            return
+        await _flush()

--- a/src/treg/infra/db.py
+++ b/src/treg/infra/db.py
@@ -39,8 +39,9 @@ _is_sqlite = "sqlite" in _db_url
 # whole pool when this was 2 — see `_purge_expired_error_evidence`, now on `background` and
 # single-flighted so concurrent readers cannot multiply it.
 #
-# Sizes are PER INSTANCE and a rolling deploy runs two, so the SUM is what must stay under the
-# database plan's ~100 ceiling — see ops/deploy.md, and the guard test.
+# Sizes are PER PROCESS, the web service runs two uvicorn workers, and a rolling deploy runs two
+# instances, so `per_process × 2 × 2` is what must stay under the database plan's 103 ceiling —
+# see `connection_budget` below and ops/deploy.md.
 #
 # These numbers can only be validated in production: too small and real traffic gets 503s, too large
 # and the bulkhead is decorative, and no test can tell you which. `TREG_DB_POOL_OVERRIDES` makes a
@@ -49,8 +50,8 @@ _is_sqlite = "sqlite" in _db_url
 # Everything that can hold a `background` slot at the same moment. Keep this in step with reality:
 # it is what sizes the pool, and a consumer missing from it is a row silently dropped under load.
 BACKGROUND_CONSUMERS: dict[str, int] = {
-    "audit._write": 4,            # bounded by audit._MAX_CONCURRENT_WRITES
-    "archive._store/_touch": 4,   # bounded by archive._MAX_CONCURRENT_WRITES (one shared semaphore)
+    "audit._flush": 1,            # one batching writer per process (audit._MAX_CONCURRENT_WRITES)
+    "archive._store/_touch": 2,   # bounded by archive._MAX_CONCURRENT_WRITES (one shared semaphore)
     "adsconv.worker": 1,          # holds its slot across two Google round trips — see follow-ups
     "archive.prune_worker": 1,    # holds one across a whole sweep
     "archive.refresh_worker": 1,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -58,3 +58,106 @@ def test_drain_livelock_regression_fails_instead_of_wedging(name):
     result = subprocess.run(
         [sys.executable, "-c", program], timeout=30, capture_output=True, text=True)
     assert result.returncode == 0, result.stderr[-500:]
+
+
+# ---- the batching writer (2026-09-07) ----------------------------------------------------------
+# One writer per process, `_BATCH` rows per INSERT. What the pool budget bought must not cost rows:
+# every row enqueued lands, a row the database refuses costs only itself, and shedding is the one
+# loss - on the queue, where rows wait now.
+
+from treg.infra.db import reset_db, session_maker  # noqa: E402
+from treg.models import SearchMiss  # noqa: E402
+
+
+async def _misses() -> list[str]:
+    from sqlalchemy import select
+    async with session_maker() as db:
+        return sorted((await db.execute(select(SearchMiss.query))).scalars().all())
+
+
+@pytest.fixture
+async def clean_audit():
+    await reset_db()
+    await audit.drain()
+    audit._queue.clear()
+    yield
+    await audit.drain()
+
+
+async def test_a_burst_lands_in_batches_on_one_writer(clean_audit, monkeypatch):
+    """More rows than one batch, enqueued at once: every one lands, and never more than one writer
+    task existed to do it (the whole point - one `background` slot per process, not four)."""
+    monkeypatch.setattr(audit, "_BATCH", 7)
+    peak = 0
+    real = audit._schedule
+
+    def counting(coro):
+        nonlocal peak
+        real(coro)
+        peak = max(peak, len(audit._pending))
+    monkeypatch.setattr(audit, "_schedule", counting)
+
+    for i in range(50):
+        audit.record_search_miss(query=f"q{i:02d}", source="test")
+    await audit.drain()
+    assert await _misses() == [f"q{i:02d}" for i in range(50)]
+    assert peak == 1
+
+
+async def test_a_refused_row_costs_only_itself(clean_audit, monkeypatch):
+    """A batch with one row the database rejects (NULL into a NOT NULL column) is retried row by
+    row, so the 199 rows around it still land - the failure evidence of a burst must survive the
+    burst."""
+    monkeypatch.setattr(audit, "_BATCH", 10)
+    for i in range(5):
+        audit.record_search_miss(query=f"ok{i}", source="test")
+    audit._enqueue(SearchMiss, dict(query=None, source="test"))   # the bad row, mid-batch
+    for i in range(5, 9):
+        audit.record_search_miss(query=f"ok{i}", source="test")
+    await audit.drain()
+    assert await _misses() == [f"ok{i}" for i in range(9)]
+
+
+async def test_rows_past_the_queue_bound_are_shed_not_queued(clean_audit, monkeypatch):
+    monkeypatch.setattr(audit, "_MAX_PENDING", 3)
+    monkeypatch.setattr(audit, "_schedule", lambda coro: coro.close())   # nothing drains meanwhile
+    before = audit._shed
+    for i in range(5):
+        audit.record_search_miss(query=f"s{i}", source="test")
+    assert len(audit._queue) == 3
+    assert audit._shed - before == 2
+    audit._queue.clear()
+
+
+async def test_a_row_enqueued_as_the_writer_exits_still_lands(clean_audit, monkeypatch):
+    """The gap between the writer's last empty-queue check and its done-callback: a row enqueued
+    there sees `_pending` occupied and starts nothing. The callback must start a writer for it, or
+    the row waits for the next call - forever, on a quiet server.
+
+    The writer is made to finish inside its first step (a batch writer that never suspends), so a
+    `call_soon` queued right behind that step runs after the task completed and BEFORE its done
+    callbacks - exactly the gap.
+    """
+    landed: list[str] = []
+
+    async def instant(rows):
+        landed.extend(fields["query"] for _, fields in rows)
+        return True
+    monkeypatch.setattr(audit, "_write_batch", instant)
+
+    audit.record_search_miss(query="first", source="test")
+    (writer,) = audit._pending
+    seen: dict = {}
+
+    def late():
+        audit.record_search_miss(query="late", source="test")
+        seen["pending"] = set(audit._pending)
+        seen["queued"] = len(audit._queue)
+    asyncio.get_running_loop().call_soon(late)
+
+    await writer   # resumes after the writer's done callbacks, `late` having run before them
+    assert seen == {"pending": {writer}, "queued": 1}, "the late row did not hit the gap"
+    # No drain: the done callback alone must have started a writer for the late row.
+    assert audit._pending and writer not in audit._pending
+    await asyncio.gather(*audit._pending)
+    assert landed == ["first", "late"]

--- a/tests/test_db_pool_isolation.py
+++ b/tests/test_db_pool_isolation.py
@@ -118,7 +118,7 @@ def test_the_background_pool_fits_every_consumer_not_just_the_throttled_ones():
     from treg import archive, audit
 
     consumers = infra_db.BACKGROUND_CONSUMERS
-    assert consumers["audit._write"] == audit._MAX_CONCURRENT_WRITES
+    assert consumers["audit._flush"] == audit._MAX_CONCURRENT_WRITES
     assert consumers["archive._store/_touch"] == archive._MAX_CONCURRENT_WRITES
     assert infra_db.POOL_SPECS["background"]["pool_size"] >= sum(consumers.values())
 

--- a/tests/test_tag_billing.py
+++ b/tests/test_tag_billing.py
@@ -677,10 +677,11 @@ async def test_a_pin_cannot_smuggle_what_the_header_cannot(clients: AsyncClient)
 
 # ---- the invariants an invoice actually rests on -------------------------------------------------
 async def test_usage_survives_a_dead_audit_pipeline(clients: AsyncClient, platform_on, monkeypatch):
-    """THE test that proves an invoice never depends on a lossy table. `audit._schedule` sheds rows
-    past its queue bound and swallows every exception — precisely under the load a successful builder
-    generates. With the audit pipeline entirely dead, the money must still be complete."""
-    monkeypatch.setattr(audit, "_schedule", lambda coro: coro.close())
+    """THE test that proves an invoice never depends on a lossy table. `audit._enqueue` sheds rows
+    past its queue bound and the writer swallows every exception — precisely under the load a
+    successful builder generates. With the audit pipeline entirely dead, the money must still be
+    complete."""
+    monkeypatch.setattr(audit, "_enqueue", lambda model, fields: None)
     org_id = await _org_id(clients)
     for who in ("cust_A", "cust_B"):
         r = await clients.get(f"/call/{EP}?aweme_id=7", headers={"X-Treg-Meta": f"customer={who}"})


### PR DESCRIPTION
## Why

The `background` pool is pinned at its override of 4 on every gauge sample, and every slot is paid per uvicorn worker (2) and again per rolling-deploy instance against the database's 103-connection ceiling. Its largest line was four audit writers, each holding a connection for one millisecond single-row insert at a time.

## What

- `audit.py`: `record_*` append to an in-process deque; one writer task per process drains it 200 rows per INSERT. A batch the database refuses is retried row by row, so a bad row costs one row. Shedding keeps `_MAX_PENDING`, now on the queue. `_pending` and `drain()` keep their contract; drain flushes a leftover queue inline so a stubbed scheduler cannot make it spin, and a row enqueued between the writer's last empty check and its done callback is picked up by that callback.
- `archive.py`: `_MAX_CONCURRENT_WRITES` 4 -> 2.
- `infra/db.py`: `BACKGROUND_CONSUMERS` audit 4 -> 1, archive 4 -> 2, sum 13 -> 8.
- Tests: batches land on one writer, a refused row costs only itself, shedding is on the queue, the callback gap (fails without the fix, verified), tag-billing's dead-pipeline test now kills `_enqueue`.

## Deploy

The production override stays at `background.pool_size=4` for this deploy. If `db_pool_gauge` still shows `background_peak` pinned at capacity, the next step is raising it to 6 (15 + 2 + 6 = 23 per process, 92 at deploy peak, under 103).

Fragments: `ops/deploy.md`, `architecture/archive.md`, `architecture/data-model.md`.