### PR TITLE
feat(catalog): price + verify Replicate extended image models

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -15,7 +15,9 @@ sources:
   - .github/workflows/catalog-drift.yml
   - scripts/catalog_drift.py
   - scripts/catalog_ingest.py
+  - scripts/catalog_replicate_prices.py
   - scripts/catalog_validate.py
+  - scripts/catalog_verify_extended.py
   - src/treg/catalog/aliases.yaml
   - src/treg/catalog/fx.yaml
   - src/treg/catalog/aviato.yaml
@@ -199,6 +201,8 @@ scripts/
   catalog_verify_extended.py  # the same for the extended tier, in bulk, under a spend cap
   catalog_ingest.py           # bulk-generates the extended tier from provider specs
   catalog_cost_provenance.py  # backfills cost units + provenance; re-run after any re-ingest
+  catalog_replicate_prices.py # prices replicate.extended.yaml image rows from the model pages'
+                              # embedded billingConfig rate card; re-run after any re-ingest
 src/treg/routers/catalog.py    # open Catalog JSON routes, attached in legacy registration order
 ```
 
@@ -459,6 +463,23 @@ Replicate ingest joins the official text-to-image, text-to-video, and image-to-v
 each generated row takes its request fields from `latest_version.openapi_schema`. Its generated
 prices are explicitly unknown, while the curated core rows carry per-model page provenance. Both
 ingesters sort their inputs and produce byte-identical output when upstream data is unchanged.
+`scripts/catalog_replicate_prices.py` is the re-runnable pricing pass over those unknown rows: each
+official model's public page embeds the provider's own structured rate card (a `billingConfig` JSON
+blob, cross-checked 2026-09-06 against the human-transcribed core flux-schnell price), and the
+script rewrites a row's cost block with `documented` provenance when every price is per-unit on
+`image_output_count`. It emits the curated flux-schnell table + fallback-ceiling shape: string-
+equals criteria tiers become `when` rows (the card's tier vocabulary maps to input fields through
+the script's explicit `CRITERIA_FIELDS` table, per the X_RATES lesson), a bounded integer output
+count field (`OUTPUT_COUNT_FIELDS`) becomes an enumerated 1..max table or a per-row `times`, and
+seedream's `sequential_image_generation` + `max_images` pair becomes a gated `times` row. Anything
+it cannot read unambiguously - megapixel metering (an input image's megapixels defeat any bounded
+`times`, same reason OpenRouter's megapixel SKUs stay BYOK), `unspecified_billing_metric`, unknown
+criteria titles or count fields - is skipped and stays unknown/BYOK-only, because a misread price
+bills real money. Run it after any replicate re-ingest, like `catalog_cost_provenance.py`. Its
+`--test-requests` flag also writes a minimal prompt-only `test_request` onto priced rows as the
+first half of a `catalog_verify_extended.py` run (whose `cost_of` budgets a table row at its
+fallback ceiling); the validator rightly refuses an unverified `test_request`, so the two halves
+are run back-to-back and committed together.
 
 Utility capability names still describe the utility's actual job. OpenRouter model discovery uses
 the file-local proposed `video-gen.models.list`; OpenRouter and MiniMax content retrieval use the

--- a/scripts/catalog_replicate_prices.py
+++ b/scripts/catalog_replicate_prices.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Backfill documented prices onto replicate.extended.yaml from Replicate's own model pages.
+
+Run from the repo root:
+  uv run python scripts/catalog_replicate_prices.py --check            # fetch + report, write nothing
+  uv run python scripts/catalog_replicate_prices.py --only flux-dev    # price matching models
+  uv run python scripts/catalog_replicate_prices.py                    # price every qualifying model
+
+Why this is a script and not a hand edit: the extended tier is regenerated wholesale by
+scripts/catalog_ingest.py, which prices every generated replicate row `confidence: unknown`
+(the collections API carries no prices), so a hand-typed price is lost on the next re-ingest.
+This script is the re-runnable pricing pass: run it after any re-ingest, exactly like
+scripts/catalog_cost_provenance.py.
+
+Where the numbers come from: each official model's public page embeds the provider's own
+structured rate card as a `billingConfig` JSON blob (verified 2026-09-06 against the
+human-transcribed core price of flux-schnell: the page says "$3 per thousand output images",
+core says value 0.003 - identical). That is a provider-published figure, so the blocks it
+writes earn `confidence: documented` with the model page as `source_url`.
+
+A price this script cannot read UNAMBIGUOUSLY is not written at all - the row stays
+`confidence: unknown` and therefore BYOK-only, because a wrong price bills real money
+(docs/context/architecture/catalog.md, Cost). What qualifies:
+
+  * every price is per-unit on `image_output_count` (per-second hardware billing, megapixel
+    metering and `unspecified_billing_metric` are all skipped - an input image's megapixels
+    cannot be bounded by any `times` field, the same reason OpenRouter's megapixel SKUs
+    stay BYOK);
+  * tiers either have no criteria (one flat price) or every tier carries exactly one
+    string-equals criterion whose title resolves through CRITERIA_FIELDS to exactly one
+    declared input field (the rate card's vocabulary -> our field names is a transcription
+    judgement, so it is an explicit table here, per the X_RATES lesson);
+  * how many images one call may produce is either fixed, or bounded by one known integer
+    count field (OUTPUT_COUNT_FIELDS) with a declared max, or is seedream's
+    `sequential_image_generation` + `max_images` pair - emitted as a `times`-multiplied row.
+    Two count fields on one model, or an unknown count-shaped field, disqualify it.
+
+The emitted blocks reuse the curated flux-schnell shape (first-match table + explicit
+fallback ceiling) so reserve always holds the request maximum.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+EXTENDED = ROOT / "src" / "treg" / "catalog" / "replicate.extended.yaml"
+
+# Input fields that multiply how many billed output images one call produces, in every official
+# model observed so far. All are integer fields with a declared max. A model carrying two of
+# them, or a count-shaped field not listed here, is skipped instead of guessed at.
+OUTPUT_COUNT_FIELDS = ("num_outputs", "num_images", "number_of_images", "max_images")
+# ... except seedream's pair: `max_images` only multiplies when sequential generation is on.
+SEQUENTIAL_GATE = "sequential_image_generation"
+
+# Rate-card criteria title -> the input fields it may describe. The card speaks the provider's
+# vocabulary ("target resolution", "model variant"); which request field that IS on a given model
+# is a transcription judgement, so it lives in this explicit reviewable table. A title not listed
+# here, or resolving to zero or several declared fields, skips the model.
+CRITERIA_FIELDS = {
+    "target resolution": ("resolution", "size"),
+    "model variant": ("quality", "generation_mode", "variant"),
+}
+
+PRICE_TITLES = {"per output image": 1, "per thousand output images": 1000}
+MAX_ENUMERATED_OUTPUTS = 10  # above this a 1..N table stops being a readable rate card
+
+# The same neutral scene the curated core rows test with. Every input beyond the prompt keeps
+# its documented default, so the verified call is the model's default-priced, single-output form.
+TEST_PROMPT = "A small red kite above a calm beach."
+
+
+def fetch_billing(model_name: str) -> dict | None:
+    """The `billingConfig` blob embedded in the model's public page, or None."""
+    req = urllib.request.Request(f"https://replicate.com/{model_name}",
+                                 headers={"User-Agent": "treg-catalog-pricing/1.0"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        html = resp.read().decode("utf-8", "replace")
+    marker = html.find('"billingConfig"')
+    if marker < 0:
+        return None
+    start = html.find("{", marker + len('"billingConfig"'))
+    depth = 0
+    for pos in range(start, len(html)):
+        if html[pos] == "{":
+            depth += 1
+        elif html[pos] == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(html[start:pos + 1])
+    return None
+
+
+def _per_image_usd(price: dict) -> tuple[float, str] | str:
+    """USD per one output image and the quoted rate line, or a reason string."""
+    if price.get("type") != "per-unit" or price.get("metric") != "image_output_count":
+        return f"metric {price.get('metric')!r} type {price.get('type')!r}"
+    title = str(price.get("title") or "").strip()
+    per = PRICE_TITLES.get(title)
+    amount = re.fullmatch(r"\$(\d+(?:\.\d+)?)", str(price.get("price") or "").strip())
+    if per is None or amount is None:
+        return f"unparsed price {price.get('price')!r} {title!r}"
+    return float(amount.group(1)) / per, f"{price['price']} {title}"
+
+
+def parse_billing(billing: dict | None, properties: dict) -> tuple[list, str] | str:
+    """[(when-or-None, usd, quote)] plus a rate summary, or a reason string for skipping.
+
+    `when` is a ready {input field: value} mapping for criteria tiers, None for a flat price.
+    """
+    tiers = (billing or {}).get("current_tiers") or []
+    if not tiers:
+        return "no pricing tiers"
+    if len(tiers) == 1 and not tiers[0].get("criteria"):
+        prices = tiers[0].get("prices") or []
+        if len(prices) != 1:
+            return f"{len(prices)} price rows"
+        parsed = _per_image_usd(prices[0])
+        if isinstance(parsed, str):
+            return parsed
+        usd, quote = parsed
+        return [(None, usd, quote)], quote
+
+    rows, titles = [], set()
+    for tier in tiers:
+        criteria, prices = tier.get("criteria") or [], tier.get("prices") or []
+        if len(criteria) != 1 or len(prices) != 1:
+            return f"{len(criteria)} criteria x {len(prices)} prices in one tier"
+        criterion = criteria[0]
+        if criterion.get("type") != "equals" or not isinstance(criterion.get("value"), str):
+            return f"unsupported criterion {json.dumps(criterion)[:80]}"
+        title = str(criterion.get("title") or "").strip().lower()
+        candidates = [f for f in CRITERIA_FIELDS.get(title, ()) if f in properties]
+        if len(candidates) != 1:
+            return f"criteria title {title!r} resolves to {candidates or 'no field'}"
+        field = candidates[0]
+        spec = properties[field] or {}
+        if spec.get("required") is not True and "default" not in spec:
+            return f"criteria field {field!r} lacks a default"
+        parsed = _per_image_usd(prices[0])
+        if isinstance(parsed, str):
+            return parsed
+        usd, quote = parsed
+        titles.add(title)
+        rows.append(({f"body.input.{field}": criterion["value"]}, usd, quote))
+    if len(titles) != 1 or len({json.dumps(w, sort_keys=True) for w, _, _ in rows}) != len(rows):
+        return "criteria tiers overlap or mix titles"
+    summary = ", ".join(f"{list(w.values())[0]} {q}" for w, _, q in rows)
+    return rows, summary
+
+
+def output_multiplier(properties: dict) -> tuple[str, int] | None | str:
+    """(count field, max) that multiplies billed outputs, None when fixed, or a skip reason."""
+    counts = [f for f in OUTPUT_COUNT_FIELDS if f in properties]
+    if not counts:
+        if SEQUENTIAL_GATE in properties:
+            return f"{SEQUENTIAL_GATE!r} without a bounded max_images"
+        return None
+    if len(counts) > 1:
+        return f"two output count fields {counts}"
+    field = counts[0]
+    spec = properties[field] or {}
+    top = spec.get("max")
+    if spec.get("type") != "integer" or not isinstance(top, int) or not 1 <= top <= 15 \
+            or (spec.get("required") is not True and "default" not in spec):
+        return f"unbounded or non-integer {field!r}"
+    return field, top
+
+
+def priced_cost(endpoint: dict, billing: dict | None, checked: str) -> tuple[dict, str] | str:
+    """(billable cost block in the curated flux-schnell shape, rate summary), or a skip reason."""
+    properties = (((endpoint.get("input") or {}).get("body") or {}).get("input") or {}) \
+        .get("properties") or {}
+    parsed = parse_billing(billing, properties)
+    if isinstance(parsed, str):
+        return parsed
+    price_rows, summary = parsed
+    multiplier = output_multiplier(properties)
+    if isinstance(multiplier, str):
+        return multiplier
+
+    sequential = multiplier and multiplier[0] == "max_images" and SEQUENTIAL_GATE in properties
+    if sequential and (properties[SEQUENTIAL_GATE] or {}).get("default") != "disabled":
+        return f"{SEQUENTIAL_GATE!r} default is not 'disabled'"
+    table, ceiling = [], 0.0
+    for when, usd, _ in price_rows:
+        if sequential:
+            # One image unless sequential generation is switched on; then up to `max_images`.
+            gate = f"body.input.{SEQUENTIAL_GATE}"
+            table.append({"when": {**(when or {}), gate: "disabled"}, "value": round(usd, 9)})
+            table.append({"when": {**(when or {}), gate: "auto"}, "value": round(usd, 9),
+                          "times": "body.input.max_images"})
+            ceiling = max(ceiling, usd * multiplier[1])
+        elif multiplier and when is None:
+            field, top = multiplier
+            if top > MAX_ENUMERATED_OUTPUTS:
+                return f"{field!r} max {top} is too large to enumerate"
+            table.extend({"when": {f"body.input.{field}": n}, "value": round(usd * n, 9)}
+                         for n in range(1, top + 1))
+            ceiling = max(ceiling, usd * top)
+        elif multiplier:
+            field, top = multiplier
+            table.append({"when": when, "value": round(usd, 9), "times": f"body.input.{field}"})
+            ceiling = max(ceiling, usd * top)
+        elif when is None:
+            ceiling = max(ceiling, usd)
+        else:
+            table.append({"when": when, "value": round(usd, 9)})
+            ceiling = max(ceiling, usd)
+
+    cost: dict = {"type": "per_success"}
+    if table:
+        bound = f"{multiplier[1]} outputs at " if multiplier else ""
+        cost["table"] = table
+        cost["fallback"] = {"value": round(ceiling, 9),
+                            "note": f"{bound}the dearest published rate ({summary}) is the "
+                                    "explicit request maximum."}
+    else:
+        cost["value"] = round(ceiling, 9)
+    cost.update({"currency": "USD", "source": "docs",
+                 "source_url": f"https://replicate.com/{endpoint['name']}",
+                 "checked": checked, "confidence": "documented",
+                 "note": f"Replicate's model page lists {endpoint['name']} at {summary}."})
+    return cost, summary
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fetch and report; write nothing")
+    parser.add_argument("--only", nargs="*", default=None,
+                        help="substrings of model names/ids to price (default: all image-gen rows)")
+    parser.add_argument("--test-requests", action="store_true",
+                        help="also write a minimal prompt-only test_request onto priced rows; "
+                             "run scripts/catalog_verify_extended.py immediately after, because "
+                             "an unverified test_request fails catalog_validate.py")
+    args = parser.parse_args(argv)
+    checked = dt.date.today().isoformat()
+
+    text = EXTENDED.read_text()
+    doc = yaml.safe_load(text)
+    priced, skipped = [], []
+    for endpoint in doc["endpoints"]:
+        if endpoint.get("platform") != "image-gen":
+            continue
+        if args.only and not any(pat in endpoint["id"] or pat in endpoint["name"]
+                                 for pat in args.only):
+            continue
+        try:
+            billing = fetch_billing(endpoint["name"])
+        except Exception as exc:  # a fetch failure must never write a price
+            skipped.append((endpoint["id"], f"fetch failed: {exc}"))
+            continue
+        result = priced_cost(endpoint, billing, checked)
+        if isinstance(result, str):
+            skipped.append((endpoint["id"], result))
+            continue
+        cost, summary = result
+        priced.append((endpoint["id"], summary))
+        if not args.check:
+            endpoint["cost"] = cost
+            # Only written when the model's sole required input is the prompt; every other
+            # field keeps its documented default. Behind a flag because the validator rightly
+            # refuses a test_request with no verdict - write these only as the first half of a
+            # catalog_verify_extended run, and commit the two results together.
+            properties = endpoint["input"]["body"]["input"].get("properties") or {}
+            required = {k for k, v in properties.items() if (v or {}).get("required") is True}
+            if args.test_requests and "test_request" not in endpoint and required == {"prompt"}:
+                endpoint["test_request"] = {"body": {"input": {"prompt": TEST_PROMPT}}}
+
+    for eid, summary in priced:
+        print(f"priced    {eid}: {summary}")
+    for eid, reason in skipped:
+        print(f"skipped   {eid}: {reason}")
+    print(f"\n{len(priced)} priced, {len(skipped)} skipped (skipped rows stay BYOK-only)")
+
+    if priced and not args.check:
+        # The exact dump call catalog_ingest.py uses, so untouched rows do not reflow.
+        header, _, _ = text.partition("provider:")
+        EXTENDED.write_text(header + yaml.safe_dump(doc, sort_keys=False, allow_unicode=True,
+                                                    width=4096))
+        print(f"wrote {EXTENDED.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/catalog_replicate_prices.py
+++ b/scripts/catalog_replicate_prices.py
@@ -255,8 +255,10 @@ def main(argv: list[str]) -> int:
             continue
         try:
             billing = fetch_billing(endpoint["name"])
-        except Exception as exc:  # a fetch failure must never write a price
-            skipped.append((endpoint["id"], f"fetch failed: {exc}"))
+        except Exception:  # a fetch failure must never write a price
+            # Do not interpolate the exception: CodeQL treats HTTP-derived
+            # text as sensitive, and the page body can leak into urllib errors.
+            skipped.append((endpoint["id"], "fetch failed"))
             continue
         result = priced_cost(endpoint, billing, checked)
         if isinstance(result, str):
@@ -275,10 +277,13 @@ def main(argv: list[str]) -> int:
             if args.test_requests and "test_request" not in endpoint and required == {"prompt"}:
                 endpoint["test_request"] = {"body": {"input": {"prompt": TEST_PROMPT}}}
 
-    for eid, summary in priced:
-        print(f"priced    {eid}: {summary}")
-    for eid, reason in skipped:
-        print(f"skipped   {eid}: {reason}")
+    # Log only catalog ids (local YAML). Rate summaries and skip reasons are
+    # derived from the fetched model page, which CodeQL classifies as private;
+    # printing them trips py/clear-text-logging-sensitive-data on CI.
+    for eid, _summary in priced:
+        print(f"priced    {eid}")
+    for eid, _reason in skipped:
+        print(f"skipped   {eid}")
     print(f"\n{len(priced)} priced, {len(skipped)} skipped (skipped rows stay BYOK-only)")
 
     if priced and not args.check:

--- a/scripts/catalog_verify_extended.py
+++ b/scripts/catalog_verify_extended.py
@@ -151,6 +151,17 @@ def cost_of(ep: dict) -> float:
         listed = 0.0
     if listed:
         return listed
+    # A price TABLE has no top-level value - its validated ceiling lives in fallback.value
+    # (replicate's per-image tables, priced by catalog_replicate_prices.py). Reading it as $0
+    # would make --budget inert for exactly the rows that bill the most per call.
+    fallback = c.get("fallback")
+    if isinstance(fallback, dict):
+        try:
+            ceiling = float(fallback.get("value") or 0.0)
+        except (TypeError, ValueError):
+            ceiling = 0.0
+        if ceiling:
+            return ceiling
     observed = ep.get("observed_cost")
     return float(observed) if isinstance(observed, (int, float)) else 0.0
 

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-1-1-pro-ultra.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-1-1-pro-ultra.json
@@ -1,0 +1,21 @@
+{
+  "id": "2ybh45a89xrmr0d0f538qa36s0",
+  "model": "black-forest-labs/flux-1.1-pro-ultra",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.303Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/2ybh45a89xrmr0d0f538qa36s0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/2ybh45a89xrmr0d0f538qa36s0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-cqfubzfcfnmyreoan2zadh2seyzxfxhj4icohpa2jbjvh23yf6tq",
+    "web": "https://replicate.com/p/2ybh45a89xrmr0d0f538qa36s0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-dev-lora.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-dev-lora.json
@@ -1,0 +1,21 @@
+{
+  "id": "aa9m7zth91rmt0d0f5394k1wzc",
+  "model": "black-forest-labs/flux-dev-lora",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.6Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/aa9m7zth91rmt0d0f5394k1wzc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/aa9m7zth91rmt0d0f5394k1wzc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-v3y234hgcuodgp54cp57gtpmhykgnnxlk6sevbh53nbtbev37p3q",
+    "web": "https://replicate.com/p/aa9m7zth91rmt0d0f5394k1wzc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-dev.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-dev.json
@@ -1,0 +1,21 @@
+{
+  "id": "az5s6wjdr5rne0d0f53b2njte4",
+  "model": "black-forest-labs/flux-dev",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.697Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/az5s6wjdr5rne0d0f53b2njte4/cancel",
+    "get": "https://api.replicate.com/v1/predictions/az5s6wjdr5rne0d0f53b2njte4",
+    "stream": "https://stream.replicate.com/v1/files/iovw-iwjwd2y2dcbtahhnjisnunhnaykpyl765eilx3bwxkcfhffxgcba",
+    "web": "https://replicate.com/p/az5s6wjdr5rne0d0f53b2njte4"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-kontext-max.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-kontext-max.json
@@ -1,0 +1,21 @@
+{
+  "id": "8680xpj9z1rmt0d0f53b1bbkw8",
+  "model": "black-forest-labs/flux-kontext-max",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.728Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/8680xpj9z1rmt0d0f53b1bbkw8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/8680xpj9z1rmt0d0f53b1bbkw8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-zs2h7v75rzwisvq5mgsn4a54jp2pahxxc22np5g4bztojklcungq",
+    "web": "https://replicate.com/p/8680xpj9z1rmt0d0f53b1bbkw8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-kontext-pro.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-kontext-pro.json
@@ -1,0 +1,21 @@
+{
+  "id": "0bw1h8t345rmw0d0f539sphygr",
+  "model": "black-forest-labs/flux-kontext-pro",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.977Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/0bw1h8t345rmw0d0f539sphygr/cancel",
+    "get": "https://api.replicate.com/v1/predictions/0bw1h8t345rmw0d0f539sphygr",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-qq33flriuokpqanyh37djyhwlgzp5iz2s6mu2cdcsjl4cglbt6gq",
+    "web": "https://replicate.com/p/0bw1h8t345rmw0d0f539sphygr"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-pro.json
+++ b/src/treg/catalog/examples/replicate.x.black-forest-labs-flux-pro.json
@@ -1,0 +1,21 @@
+{
+  "id": "ms7kvxa869rmw0d0f539qps3f8",
+  "model": "black-forest-labs/flux-pro",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.274Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/ms7kvxa869rmw0d0f539qps3f8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/ms7kvxa869rmw0d0f539qps3f8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ae6wjk3h7lbplxw66zkpycogasw3rldq6nv2qgryouwftayazsuq",
+    "web": "https://replicate.com/p/ms7kvxa869rmw0d0f539qps3f8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bria-fibo.json
+++ b/src/treg/catalog/examples/replicate.x.bria-fibo.json
@@ -1,0 +1,21 @@
+{
+  "id": "sfrgzma4k1rmw0d0f538jc7p0m",
+  "model": "bria/fibo",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.352Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/sfrgzma4k1rmw0d0f538jc7p0m/cancel",
+    "get": "https://api.replicate.com/v1/predictions/sfrgzma4k1rmw0d0f538jc7p0m",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-uxccqi5sakgli6zsxnat6dk3ogg45hf4o33icaf2sxxebrnitfea",
+    "web": "https://replicate.com/p/sfrgzma4k1rmw0d0f538jc7p0m"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bria-image-3-2.json
+++ b/src/treg/catalog/examples/replicate.x.bria-image-3-2.json
@@ -1,0 +1,21 @@
+{
+  "id": "zb0q6za4y9rmt0d0f539pd6ktm",
+  "model": "bria/image-3.2",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.442Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/zb0q6za4y9rmt0d0f539pd6ktm/cancel",
+    "get": "https://api.replicate.com/v1/predictions/zb0q6za4y9rmt0d0f539pd6ktm",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-xp4rt4svadxbgquztdqltyiv4bj3glnkakrfw76455jbmnfuqtia",
+    "web": "https://replicate.com/p/zb0q6za4y9rmt0d0f539pd6ktm"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bytedance-seedream-3.json
+++ b/src/treg/catalog/examples/replicate.x.bytedance-seedream-3.json
@@ -1,0 +1,21 @@
+{
+  "id": "vy4avta1gnrmt0d0f53bqhmqt8",
+  "model": "bytedance/seedream-3",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.565Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/vy4avta1gnrmt0d0f53bqhmqt8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/vy4avta1gnrmt0d0f53bqhmqt8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ujy3kusypwrgsji4s4t2umwy5zpc4rgjto7ztr745pghgh7n2skq",
+    "web": "https://replicate.com/p/vy4avta1gnrmt0d0f53bqhmqt8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bytedance-seedream-4-5.json
+++ b/src/treg/catalog/examples/replicate.x.bytedance-seedream-4-5.json
@@ -1,0 +1,21 @@
+{
+  "id": "kpbe74c6vxrmt0d0f5grc45yar",
+  "model": "bytedance/seedream-4.5",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T01:00:29.791Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/kpbe74c6vxrmt0d0f5grc45yar/cancel",
+    "get": "https://api.replicate.com/v1/predictions/kpbe74c6vxrmt0d0f5grc45yar",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-7fsvzgr3quedfbrgnggmnhsvg4udsmweej7ys3avindykozdedlq",
+    "web": "https://replicate.com/p/kpbe74c6vxrmt0d0f5grc45yar"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bytedance-seedream-4.json
+++ b/src/treg/catalog/examples/replicate.x.bytedance-seedream-4.json
@@ -1,0 +1,21 @@
+{
+  "id": "dnvmkg2j95rmy0d0f539q8p46c",
+  "model": "bytedance/seedream-4",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.857Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/dnvmkg2j95rmy0d0f539q8p46c/cancel",
+    "get": "https://api.replicate.com/v1/predictions/dnvmkg2j95rmy0d0f539q8p46c",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-soasmd42qhwflr74ou4ittdep6k63ag4php6kbgvfpukvbx4yn6q",
+    "web": "https://replicate.com/p/dnvmkg2j95rmy0d0f539q8p46c"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.bytedance-seedream-5-lite.json
+++ b/src/treg/catalog/examples/replicate.x.bytedance-seedream-5-lite.json
@@ -1,0 +1,21 @@
+{
+  "id": "82dk1k2jq9rmt0d0f53abrg68g",
+  "model": "bytedance/seedream-5-lite",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.97Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/82dk1k2jq9rmt0d0f53abrg68g/cancel",
+    "get": "https://api.replicate.com/v1/predictions/82dk1k2jq9rmt0d0f53abrg68g",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-l5ek5ol6mphyybnuvhjuhcpceiihm72eqxjmvlnabehkvbd6qf4a",
+    "web": "https://replicate.com/p/82dk1k2jq9rmt0d0f53abrg68g"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-imagen-3-fast.json
+++ b/src/treg/catalog/examples/replicate.x.google-imagen-3-fast.json
@@ -1,0 +1,21 @@
+{
+  "id": "hckrk4hzrsrmr0d0f53b7va444",
+  "model": "google/imagen-3-fast",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.118Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/hckrk4hzrsrmr0d0f53b7va444/cancel",
+    "get": "https://api.replicate.com/v1/predictions/hckrk4hzrsrmr0d0f53b7va444",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-7dvtm5vtxrd4jc7bvn5moahhvnsge37uvpvy3dttq7cxec2wlpba",
+    "web": "https://replicate.com/p/hckrk4hzrsrmr0d0f53b7va444"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-imagen-3.json
+++ b/src/treg/catalog/examples/replicate.x.google-imagen-3.json
@@ -1,0 +1,21 @@
+{
+  "id": "tz1d2s26x5rmr0d0f538mnhjs0",
+  "model": "google/imagen-3",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.945Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/tz1d2s26x5rmr0d0f538mnhjs0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/tz1d2s26x5rmr0d0f538mnhjs0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-wqvmqb4pkejy55swgdnun7ym2bi6jxyflyk6xmwickrs3jcyvg7a",
+    "web": "https://replicate.com/p/tz1d2s26x5rmr0d0f538mnhjs0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-imagen-4-fast.json
+++ b/src/treg/catalog/examples/replicate.x.google-imagen-4-fast.json
@@ -1,0 +1,21 @@
+{
+  "id": "w1tset9xzdrmw0d0f538t113cg",
+  "model": "google/imagen-4-fast",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.659Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/w1tset9xzdrmw0d0f538t113cg/cancel",
+    "get": "https://api.replicate.com/v1/predictions/w1tset9xzdrmw0d0f538t113cg",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-6ltcgnhqw2hhx3kwb6tmzrloqkzc2neyyv5fymji2bar3hpd7uea",
+    "web": "https://replicate.com/p/w1tset9xzdrmw0d0f538t113cg"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-imagen-4-ultra.json
+++ b/src/treg/catalog/examples/replicate.x.google-imagen-4-ultra.json
@@ -1,0 +1,21 @@
+{
+  "id": "wbja97a8fhrmy0d0f539rpbz5g",
+  "model": "google/imagen-4-ultra",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.348Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/wbja97a8fhrmy0d0f539rpbz5g/cancel",
+    "get": "https://api.replicate.com/v1/predictions/wbja97a8fhrmy0d0f539rpbz5g",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-hjbniuc6etmhml5u2deqb7x6qvubfhahz7q42vcxzgdjwawwk5fa",
+    "web": "https://replicate.com/p/wbja97a8fhrmy0d0f539rpbz5g"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-imagen-4.json
+++ b/src/treg/catalog/examples/replicate.x.google-imagen-4.json
@@ -1,0 +1,21 @@
+{
+  "id": "0q1ghkt4tdrmt0d0f5393h9cac",
+  "model": "google/imagen-4",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.411Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/0q1ghkt4tdrmt0d0f5393h9cac/cancel",
+    "get": "https://api.replicate.com/v1/predictions/0q1ghkt4tdrmt0d0f5393h9cac",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-j3mf7cmaklckttti2r4kxagnz33pbr3uspynkxwrcip3xwzj2auq",
+    "web": "https://replicate.com/p/0q1ghkt4tdrmt0d0f5393h9cac"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-nano-banana-2.json
+++ b/src/treg/catalog/examples/replicate.x.google-nano-banana-2.json
@@ -1,0 +1,21 @@
+{
+  "id": "8sqcgqtfaxrmw0d0f539mntap0",
+  "model": "google/nano-banana-2",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.103Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/8sqcgqtfaxrmw0d0f539mntap0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/8sqcgqtfaxrmw0d0f539mntap0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ngughfhe25zyp7jgck5t2zpc454tg3mzy7vixmnhvy6akebbmo5a",
+    "web": "https://replicate.com/p/8sqcgqtfaxrmw0d0f539mntap0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-nano-banana-pro.json
+++ b/src/treg/catalog/examples/replicate.x.google-nano-banana-pro.json
@@ -1,0 +1,21 @@
+{
+  "id": "h98mpb2h9hrmt0d0f5393dwj9g",
+  "model": "google/nano-banana-pro",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.604Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/h98mpb2h9hrmt0d0f5393dwj9g/cancel",
+    "get": "https://api.replicate.com/v1/predictions/h98mpb2h9hrmt0d0f5393dwj9g",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-wf3qy5hwh6tagrslljic2iau6mpie7ak4mzoqnlhabqrpkciydva",
+    "web": "https://replicate.com/p/h98mpb2h9hrmt0d0f5393dwj9g"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.google-nano-banana.json
+++ b/src/treg/catalog/examples/replicate.x.google-nano-banana.json
@@ -1,0 +1,21 @@
+{
+  "id": "r073me22k9rmw0d0f538tjbcr4",
+  "model": "google/nano-banana",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.842Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/r073me22k9rmw0d0f538tjbcr4/cancel",
+    "get": "https://api.replicate.com/v1/predictions/r073me22k9rmw0d0f538tjbcr4",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-krb5eyoci3e7bcen3wrwsbrvashlfheyrdrxwkhloyojeuettuvq",
+    "web": "https://replicate.com/p/r073me22k9rmw0d0f538tjbcr4"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2-turbo.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2-turbo.json
@@ -1,0 +1,21 @@
+{
+  "id": "k8qbbpt70xrmt0d0f53a2y3090",
+  "model": "ideogram-ai/ideogram-v2-turbo",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.975Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/k8qbbpt70xrmt0d0f53a2y3090/cancel",
+    "get": "https://api.replicate.com/v1/predictions/k8qbbpt70xrmt0d0f53a2y3090",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-wyjxcghyv43fbg5oylptamt6ksvaf6rjbzuak6jugp2uunzpdc3a",
+    "web": "https://replicate.com/p/k8qbbpt70xrmt0d0f53a2y3090"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2.json
@@ -1,0 +1,21 @@
+{
+  "id": "ks79ea2aq5rmy0d0f5392j4rs8",
+  "model": "ideogram-ai/ideogram-v2",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.921Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/ks79ea2aq5rmy0d0f5392j4rs8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/ks79ea2aq5rmy0d0f5392j4rs8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-qexytek4g2tmvpbugyombrnlvv26pftkqojocquxpye23kmqiuia",
+    "web": "https://replicate.com/p/ks79ea2aq5rmy0d0f5392j4rs8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2a-turbo.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2a-turbo.json
@@ -1,0 +1,21 @@
+{
+  "id": "j00wegj0k5rmy0d0f5397c8c3w",
+  "model": "ideogram-ai/ideogram-v2a-turbo",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.329Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/j00wegj0k5rmy0d0f5397c8c3w/cancel",
+    "get": "https://api.replicate.com/v1/predictions/j00wegj0k5rmy0d0f5397c8c3w",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-25bvh4ph7iwqrubz2fklpgzg63idr4uuccmkjviprse3ovf3bwra",
+    "web": "https://replicate.com/p/j00wegj0k5rmy0d0f5397c8c3w"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2a.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v2a.json
@@ -1,0 +1,21 @@
+{
+  "id": "txp442a59drmy0d0f539cfs9c0",
+  "model": "ideogram-ai/ideogram-v2a",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.531Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/txp442a59drmy0d0f539cfs9c0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/txp442a59drmy0d0f539cfs9c0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ztc433cmfnmsb324kcueltprshehsqxeiemwb6uuhtmtrbbn5s7a",
+    "web": "https://replicate.com/p/txp442a59drmy0d0f539cfs9c0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-balanced.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-balanced.json
@@ -1,0 +1,21 @@
+{
+  "id": "5wpe65a9yhrmw0d0f53800qvsr",
+  "model": "ideogram-ai/ideogram-v3-balanced",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.724Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/5wpe65a9yhrmw0d0f53800qvsr/cancel",
+    "get": "https://api.replicate.com/v1/predictions/5wpe65a9yhrmw0d0f53800qvsr",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-5sllifwl6tvpgfthppdm3pla77nrvrm2q3e2mxgjvvpnrhahwoya",
+    "web": "https://replicate.com/p/5wpe65a9yhrmw0d0f53800qvsr"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-quality.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-quality.json
@@ -1,0 +1,21 @@
+{
+  "id": "2ez6b1jcw1rmr0d0f53a5k4myw",
+  "model": "ideogram-ai/ideogram-v3-quality",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.472Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/2ez6b1jcw1rmr0d0f53a5k4myw/cancel",
+    "get": "https://api.replicate.com/v1/predictions/2ez6b1jcw1rmr0d0f53a5k4myw",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-5aqvzxpsxjgrzostkpko46oo24hcjptum2sn7y232gupst3nffpq",
+    "web": "https://replicate.com/p/2ez6b1jcw1rmr0d0f53a5k4myw"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-turbo.json
+++ b/src/treg/catalog/examples/replicate.x.ideogram-ai-ideogram-v3-turbo.json
@@ -1,0 +1,21 @@
+{
+  "id": "kg1tmja169rmw0d0f53b9hhwx8",
+  "model": "ideogram-ai/ideogram-v3-turbo",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.482Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/kg1tmja169rmw0d0f53b9hhwx8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/kg1tmja169rmw0d0f53b9hhwx8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-r47xo2ycmfrqpck3cgwchamlustyjdo7k5nuknk5zrvbs7trgmrq",
+    "web": "https://replicate.com/p/kg1tmja169rmw0d0f53b9hhwx8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.leonardoai-lucid-origin.json
+++ b/src/treg/catalog/examples/replicate.x.leonardoai-lucid-origin.json
@@ -1,0 +1,21 @@
+{
+  "id": "temtk2477drmw0d0f5grwb9a7c",
+  "model": "leonardoai/lucid-origin",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T01:00:29.883Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/temtk2477drmw0d0f5grwb9a7c/cancel",
+    "get": "https://api.replicate.com/v1/predictions/temtk2477drmw0d0f5grwb9a7c",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-qnd6uzesndgezk7c3peqzjivwpptkpqa5vwvxqzfvvcngyfmse3q",
+    "web": "https://replicate.com/p/temtk2477drmw0d0f5grwb9a7c"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.luma-photon-flash.json
+++ b/src/treg/catalog/examples/replicate.x.luma-photon-flash.json
@@ -1,0 +1,21 @@
+{
+  "id": "fnrevksxg9rmr0d0f53bnfv0cm",
+  "model": "luma/photon-flash",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.538Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/fnrevksxg9rmr0d0f53bnfv0cm/cancel",
+    "get": "https://api.replicate.com/v1/predictions/fnrevksxg9rmr0d0f53bnfv0cm",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ng32c72paitepg4mtncbbzbvperw62qswaqy76lao6jt74wzfhnq",
+    "web": "https://replicate.com/p/fnrevksxg9rmr0d0f53bnfv0cm"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.luma-photon.json
+++ b/src/treg/catalog/examples/replicate.x.luma-photon.json
@@ -1,0 +1,21 @@
+{
+  "id": "nd14gvt2jnrmw0d0f538y1gzfr",
+  "model": "luma/photon",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.837Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/nd14gvt2jnrmw0d0f538y1gzfr/cancel",
+    "get": "https://api.replicate.com/v1/predictions/nd14gvt2jnrmw0d0f538y1gzfr",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-6wcazxysfiyazq3tqcptzzw5w6pikcpaivru66gqeh75yzoripma",
+    "web": "https://replicate.com/p/nd14gvt2jnrmw0d0f538y1gzfr"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.minimax-image-01.json
+++ b/src/treg/catalog/examples/replicate.x.minimax-image-01.json
@@ -1,0 +1,21 @@
+{
+  "id": "r4mbcmtd5xrmw0d0f539vp1t5g",
+  "model": "minimax/image-01",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.551Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/r4mbcmtd5xrmw0d0f539vp1t5g/cancel",
+    "get": "https://api.replicate.com/v1/predictions/r4mbcmtd5xrmw0d0f539vp1t5g",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-3lngzzggk5gr6euvhaunzdebh4v67ahvhqwmxe2n5uxaamc6ys2q",
+    "web": "https://replicate.com/p/r4mbcmtd5xrmw0d0f539vp1t5g"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.openai-gpt-image-1-5.json
+++ b/src/treg/catalog/examples/replicate.x.openai-gpt-image-1-5.json
@@ -1,0 +1,21 @@
+{
+  "id": "b6r4cd487drmw0d0f5gsxk9xbm",
+  "model": "openai/gpt-image-1.5",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T01:00:30.139Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/b6r4cd487drmw0d0f5gsxk9xbm/cancel",
+    "get": "https://api.replicate.com/v1/predictions/b6r4cd487drmw0d0f5gsxk9xbm",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-542vo3hje2fhq4sv4hp5fbytaauf6isq4q2sz3n4tzc5w2g75poq",
+    "web": "https://replicate.com/p/b6r4cd487drmw0d0f5gsxk9xbm"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.openai-gpt-image-2.json
+++ b/src/treg/catalog/examples/replicate.x.openai-gpt-image-2.json
@@ -1,0 +1,21 @@
+{
+  "id": "f3x4ddc7q1rmy0d0f5gtej9q8c",
+  "model": "openai/gpt-image-2",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T01:00:30.008Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/f3x4ddc7q1rmy0d0f5gtej9q8c/cancel",
+    "get": "https://api.replicate.com/v1/predictions/f3x4ddc7q1rmy0d0f5gtej9q8c",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-3gkbjys7fgv27obci6u3hjb4g4pimxlzm7uey32go4an3ueu44qq",
+    "web": "https://replicate.com/p/f3x4ddc7q1rmy0d0f5gtej9q8c"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.prunaai-flux-fast.json
+++ b/src/treg/catalog/examples/replicate.x.prunaai-flux-fast.json
@@ -1,0 +1,21 @@
+{
+  "id": "1cjydy1w4xrmt0d0f5389gd1ar",
+  "model": "prunaai/flux-fast",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.191Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/1cjydy1w4xrmt0d0f5389gd1ar/cancel",
+    "get": "https://api.replicate.com/v1/predictions/1cjydy1w4xrmt0d0f5389gd1ar",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-evxno44iyewvpz6qtcybng5z22otilf7mnib342dkgn3l4tgvl5a",
+    "web": "https://replicate.com/p/1cjydy1w4xrmt0d0f5389gd1ar"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.prunaai-hidream-l1-fast.json
+++ b/src/treg/catalog/examples/replicate.x.prunaai-hidream-l1-fast.json
@@ -1,0 +1,21 @@
+{
+  "id": "c23hkj1w4nrmr0d0f5388amydc",
+  "model": "prunaai/hidream-l1-fast",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.189Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/c23hkj1w4nrmr0d0f5388amydc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/c23hkj1w4nrmr0d0f5388amydc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ip3ykesxgsaotmwy7i2gks6h35n6lfsbcc5o53ohtz3p6uvsjqfq",
+    "web": "https://replicate.com/p/c23hkj1w4nrmr0d0f5388amydc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.prunaai-p-image-lora.json
+++ b/src/treg/catalog/examples/replicate.x.prunaai-p-image-lora.json
@@ -1,0 +1,21 @@
+{
+  "id": "59kmrs1x8nrmy0d0f5390swzhr",
+  "model": "prunaai/p-image-lora",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.477Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/59kmrs1x8nrmy0d0f5390swzhr/cancel",
+    "get": "https://api.replicate.com/v1/predictions/59kmrs1x8nrmy0d0f5390swzhr",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-aplwoektg2j6to2l67pq7olg2apk56ty6dnkzetjtuzpze7qzgua",
+    "web": "https://replicate.com/p/59kmrs1x8nrmy0d0f5390swzhr"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.prunaai-p-image.json
+++ b/src/treg/catalog/examples/replicate.x.prunaai-p-image.json
@@ -1,0 +1,21 @@
+{
+  "id": "399n901wvsrmt0d0f53bc6yzm0",
+  "model": "prunaai/p-image",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.374Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/399n901wvsrmt0d0f53bc6yzm0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/399n901wvsrmt0d0f53bc6yzm0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-pxuhd47syejt7nwvv2xxixp7korphe2nmoonpcnrhdsb2m5jt6bq",
+    "web": "https://replicate.com/p/399n901wvsrmt0d0f53bc6yzm0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.prunaai-wan-2-2-image.json
+++ b/src/treg/catalog/examples/replicate.x.prunaai-wan-2-2-image.json
@@ -1,0 +1,21 @@
+{
+  "id": "ahpwr01z31rne0d0f53a5s1et0",
+  "model": "prunaai/wan-2.2-image",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.944Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/ahpwr01z31rne0d0f53a5s1et0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/ahpwr01z31rne0d0f53a5s1et0",
+    "stream": "https://stream.replicate.com/v1/files/iovw-hvnhaq2lphl62yv6roqmvixrnuaqbgxky5p7ae3ac733ctfppavq",
+    "web": "https://replicate.com/p/ahpwr01z31rne0d0f53a5s1et0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.quiverai-arrow-1-1-max.json
+++ b/src/treg/catalog/examples/replicate.x.quiverai-arrow-1-1-max.json
@@ -1,0 +1,21 @@
+{
+  "id": "rwgr8hth4xrmy0d0f53bp8618g",
+  "model": "quiverai/arrow-1.1-max",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.567Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/rwgr8hth4xrmy0d0f53bp8618g/cancel",
+    "get": "https://api.replicate.com/v1/predictions/rwgr8hth4xrmy0d0f53bp8618g",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ksvblixexxpjg4uj3fslnwkt67cmkop3xw5agmtloaxmu5j6ynga",
+    "web": "https://replicate.com/p/rwgr8hth4xrmy0d0f53bp8618g"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.quiverai-arrow-1-1.json
+++ b/src/treg/catalog/examples/replicate.x.quiverai-arrow-1-1.json
@@ -1,0 +1,21 @@
+{
+  "id": "m8y8x4agmxrmr0d0f53bp7vphc",
+  "model": "quiverai/arrow-1.1",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.439Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/m8y8x4agmxrmr0d0f53bp7vphc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/m8y8x4agmxrmr0d0f53bp7vphc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-qsn3szfepjvamt4bb7nwljrfm5lcgntv3mgkyhgzyophxcs2sm4a",
+    "web": "https://replicate.com/p/m8y8x4agmxrmr0d0f53bp7vphc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.qwen-qwen-image.json
+++ b/src/treg/catalog/examples/replicate.x.qwen-qwen-image.json
@@ -1,0 +1,21 @@
+{
+  "id": "7dtm21a0e9rmt0d0f5384vr0w0",
+  "model": "qwen/qwen-image",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.29Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/7dtm21a0e9rmt0d0f5384vr0w0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/7dtm21a0e9rmt0d0f5384vr0w0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-wmnlij5qyt73ed2stxxshorrf6qgdrygjom4hbhdjhgmnqy4d4aa",
+    "web": "https://replicate.com/p/7dtm21a0e9rmt0d0f5384vr0w0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v3-svg.json
+++ b/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v3-svg.json
@@ -1,0 +1,21 @@
+{
+  "id": "cx54z02b6srmt0d0f53b7z47am",
+  "model": "recraft-ai/recraft-v3-svg",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.046Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/cx54z02b6srmt0d0f53b7z47am/cancel",
+    "get": "https://api.replicate.com/v1/predictions/cx54z02b6srmt0d0f53b7z47am",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-duwvtnpyhveelnmvoru6mlmzgi2ncjnivsb3hm4q7wixqop5ox3q",
+    "web": "https://replicate.com/p/cx54z02b6srmt0d0f53b7z47am"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v3.json
+++ b/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v3.json
@@ -1,0 +1,21 @@
+{
+  "id": "sternca5jhrmw0d0f53arxp0jr",
+  "model": "recraft-ai/recraft-v3",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.604Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/sternca5jhrmw0d0f53arxp0jr/cancel",
+    "get": "https://api.replicate.com/v1/predictions/sternca5jhrmw0d0f53arxp0jr",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-kitfmnfjmudzi34jfh52b5y4b6nuqv7eh3qgrdnxozmlquj34tnq",
+    "web": "https://replicate.com/p/sternca5jhrmw0d0f53arxp0jr"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-pro-svg.json
+++ b/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-pro-svg.json
@@ -1,0 +1,21 @@
+{
+  "id": "pzk7gt2jndrmy0d0f53bpj70b8",
+  "model": "recraft-ai/recraft-v4-pro-svg",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.955Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/pzk7gt2jndrmy0d0f53bpj70b8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/pzk7gt2jndrmy0d0f53bpj70b8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-zjdwrm2a3e5tzpm3ne5zt7inhko7wjie76bsmjfawxj2n3yyogkq",
+    "web": "https://replicate.com/p/pzk7gt2jndrmy0d0f53bpj70b8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-pro.json
+++ b/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-pro.json
@@ -1,0 +1,21 @@
+{
+  "id": "6qt2ed2hsdrmr0d0f53909kdn8",
+  "model": "recraft-ai/recraft-v4-pro",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:46.731Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/6qt2ed2hsdrmr0d0f53909kdn8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/6qt2ed2hsdrmr0d0f53909kdn8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-5zeahdureydl3dujpjnwjqujbpujwmmkhy3drjyqs5jo5fnvaaka",
+    "web": "https://replicate.com/p/6qt2ed2hsdrmr0d0f53909kdn8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-svg.json
+++ b/src/treg/catalog/examples/replicate.x.recraft-ai-recraft-v4-svg.json
@@ -1,0 +1,21 @@
+{
+  "id": "10wzmytbdsrmw0d0f53bzaq6k8",
+  "model": "recraft-ai/recraft-v4-svg",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.102Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/10wzmytbdsrmw0d0f53bzaq6k8/cancel",
+    "get": "https://api.replicate.com/v1/predictions/10wzmytbdsrmw0d0f53bzaq6k8",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-gyp6shdt32ya5cmv54akzetqueezvy7kkukmroy7pvnrzdhitibq",
+    "web": "https://replicate.com/p/10wzmytbdsrmw0d0f53bzaq6k8"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-large-turbo.json
+++ b/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-large-turbo.json
@@ -1,0 +1,21 @@
+{
+  "id": "mbr24n26b5rmw0d0f539qgz8pm",
+  "model": "stability-ai/stable-diffusion-3.5-large-turbo",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:43.801Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/mbr24n26b5rmw0d0f539qgz8pm/cancel",
+    "get": "https://api.replicate.com/v1/predictions/mbr24n26b5rmw0d0f539qgz8pm",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-eigwdjeb7355acwfwymfu2gesaipexggxzxwbka6u4nq6zlsqgqq",
+    "web": "https://replicate.com/p/mbr24n26b5rmw0d0f539qgz8pm"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-large.json
+++ b/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-large.json
@@ -1,0 +1,21 @@
+{
+  "id": "411xj9a9psrmw0d0f539spmf04",
+  "model": "stability-ai/stable-diffusion-3.5-large",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:44.662Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/411xj9a9psrmw0d0f539spmf04/cancel",
+    "get": "https://api.replicate.com/v1/predictions/411xj9a9psrmw0d0f539spmf04",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-ofuncqtk3boldcrjist3hvcmnamrrxi62njpfnbpwwywqvvvaica",
+    "web": "https://replicate.com/p/411xj9a9psrmw0d0f539spmf04"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-medium.json
+++ b/src/treg/catalog/examples/replicate.x.stability-ai-stable-diffusion-3-5-medium.json
@@ -1,0 +1,21 @@
+{
+  "id": "0enar4a311rmr0d0f53at05xkc",
+  "model": "stability-ai/stable-diffusion-3.5-medium",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:42.952Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/0enar4a311rmr0d0f53at05xkc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/0enar4a311rmr0d0f53at05xkc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-l5fdenua655tziwzd5n6b6bfacg3pxlsunpfeylflwmnbmlx4nxq",
+    "web": "https://replicate.com/p/0enar4a311rmr0d0f53at05xkc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.tencent-hunyuan-image-3.json
+++ b/src/treg/catalog/examples/replicate.x.tencent-hunyuan-image-3.json
@@ -1,0 +1,21 @@
+{
+  "id": "2t87zm2dm1rmr0d0f538gn1ff0",
+  "model": "tencent/hunyuan-image-3",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.664Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/2t87zm2dm1rmr0d0f538gn1ff0/cancel",
+    "get": "https://api.replicate.com/v1/predictions/2t87zm2dm1rmr0d0f538gn1ff0",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-rvq7hg5smy5dfejkvpxl6m2fj3gjizh3aln3bzaxpbhgbiu5j5gq",
+    "web": "https://replicate.com/p/2t87zm2dm1rmr0d0f538gn1ff0"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.wan-video-wan-2-7-image-pro.json
+++ b/src/treg/catalog/examples/replicate.x.wan-video-wan-2-7-image-pro.json
@@ -1,0 +1,21 @@
+{
+  "id": "wda6gqadtxrmw0d0f53a48cfsc",
+  "model": "wan-video/wan-2.7-image-pro",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.719Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/wda6gqadtxrmw0d0f53a48cfsc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/wda6gqadtxrmw0d0f53a48cfsc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-v4qkcdkssbjjjx7sqzbfi2urikegqpeu53nxn5qja65wijjcbgiq",
+    "web": "https://replicate.com/p/wda6gqadtxrmw0d0f53a48cfsc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.wan-video-wan-2-7-image.json
+++ b/src/treg/catalog/examples/replicate.x.wan-video-wan-2-7-image.json
@@ -1,0 +1,21 @@
+{
+  "id": "k3pvar2ee1rmr0d0f53an8r5bc",
+  "model": "wan-video/wan-2.7-image",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:45.872Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/k3pvar2ee1rmr0d0f53an8r5bc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/k3pvar2ee1rmr0d0f53an8r5bc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-t4ppjbl6qwcpb3u2o24w7vdt7qsfhfkms22w6j3m644kes2jwfhq",
+    "web": "https://replicate.com/p/k3pvar2ee1rmr0d0f53an8r5bc"
+  }
+}

--- a/src/treg/catalog/examples/replicate.x.xai-grok-imagine-image.json
+++ b/src/treg/catalog/examples/replicate.x.xai-grok-imagine-image.json
@@ -1,0 +1,21 @@
+{
+  "id": "vk7rkxhyp1rmt0d0f53afpx5wc",
+  "model": "xai/grok-imagine-image",
+  "version": "hidden",
+  "input": {
+    "prompt": "A small red kite above a calm beach."
+  },
+  "logs": "",
+  "output": null,
+  "data_removed": false,
+  "error": null,
+  "source": "api",
+  "status": "starting",
+  "created_at": "2026-09-07T00:30:41.84Z",
+  "urls": {
+    "cancel": "https://api.replicate.com/v1/predictions/vk7rkxhyp1rmt0d0f53afpx5wc/cancel",
+    "get": "https://api.replicate.com/v1/predictions/vk7rkxhyp1rmt0d0f53afpx5wc",
+    "stream": "https://stream.replicate.com/v1/files/jbxs-6nm3kzsajdvu5czsezboowjxqn3xodzjngtcy6kqbmabm6lq4tuq",
+    "web": "https://replicate.com/p/vk7rkxhyp1rmt0d0f53afpx5wc"
+  }
+}

--- a/src/treg/catalog/replicate.extended.yaml
+++ b/src/treg/catalog/replicate.extended.yaml
@@ -87,9 +87,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.06
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-1.1-pro-ultra
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-1.1-pro-ultra at $0.06 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-1.1-pro-ultra
 - id: replicate.x.black-forest-labs-flux-2-flex
   tier: extended
@@ -514,9 +518,28 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.num_outputs: 1
+      value: 0.032
+    - when:
+        body.input.num_outputs: 2
+      value: 0.064
+    - when:
+        body.input.num_outputs: 3
+      value: 0.096
+    - when:
+        body.input.num_outputs: 4
+      value: 0.128
+    fallback:
+      value: 0.128
+      note: 4 outputs at the dearest published rate ($0.032 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-dev-lora
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-dev-lora at $0.032 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-dev-lora
 - id: replicate.x.black-forest-labs-flux-dev
   tier: extended
@@ -604,9 +627,28 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.num_outputs: 1
+      value: 0.025
+    - when:
+        body.input.num_outputs: 2
+      value: 0.05
+    - when:
+        body.input.num_outputs: 3
+      value: 0.075
+    - when:
+        body.input.num_outputs: 4
+      value: 0.1
+    fallback:
+      value: 0.1
+      note: 4 outputs at the dearest published rate ($0.025 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-dev
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-dev at $0.025 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-dev
 - id: replicate.x.black-forest-labs-flux-kontext-max
   tier: extended
@@ -657,9 +699,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.08
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-kontext-max
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-kontext-max at $0.08 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-kontext-max
 - id: replicate.x.black-forest-labs-flux-kontext-pro
   tier: extended
@@ -710,9 +756,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-kontext-pro
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-kontext-pro at $0.04 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-kontext-pro
 - id: replicate.x.black-forest-labs-flux-pro
   tier: extended
@@ -803,9 +853,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.055
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/black-forest-labs/flux-pro
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists black-forest-labs/flux-pro at $0.055 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-pro
 - id: replicate.x.bria-fibo
   tier: extended
@@ -855,9 +909,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bria/fibo
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bria/fibo at $0.04 per output image.
   docs_url: https://replicate.com/bria/fibo
 - id: replicate.x.bria-image-3-2
   tier: extended
@@ -908,9 +966,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bria/image-3.2
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bria/image-3.2 at $0.04 per output image.
   docs_url: https://replicate.com/bria/image-3.2
 - id: replicate.x.bytedance-seedream-3
   tier: extended
@@ -966,9 +1028,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.03
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bytedance/seedream-3
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bytedance/seedream-3 at $0.03 per output image.
   docs_url: https://replicate.com/bytedance/seedream-3
 - id: replicate.x.bytedance-seedream-4-5
   tier: extended
@@ -1034,9 +1100,23 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.sequential_image_generation: disabled
+      value: 0.04
+    - when:
+        body.input.sequential_image_generation: auto
+      value: 0.04
+      times: body.input.max_images
+    fallback:
+      value: 0.6
+      note: 15 outputs at the dearest published rate ($0.04 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bytedance/seedream-4.5
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bytedance/seedream-4.5 at $0.04 per output image.
   docs_url: https://replicate.com/bytedance/seedream-4.5
 - id: replicate.x.bytedance-seedream-4
   tier: extended
@@ -1102,9 +1182,23 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.sequential_image_generation: disabled
+      value: 0.03
+    - when:
+        body.input.sequential_image_generation: auto
+      value: 0.03
+      times: body.input.max_images
+    fallback:
+      value: 0.45
+      note: 15 outputs at the dearest published rate ($0.03 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bytedance/seedream-4
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bytedance/seedream-4 at $0.03 per output image.
   docs_url: https://replicate.com/bytedance/seedream-4
 - id: replicate.x.bytedance-seedream-5-lite
   tier: extended
@@ -1155,9 +1249,23 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.sequential_image_generation: disabled
+      value: 0.035
+    - when:
+        body.input.sequential_image_generation: auto
+      value: 0.035
+      times: body.input.max_images
+    fallback:
+      value: 0.525
+      note: 15 outputs at the dearest published rate ($0.035 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/bytedance/seedream-5-lite
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists bytedance/seedream-5-lite at $0.035 per output image.
   docs_url: https://replicate.com/bytedance/seedream-5-lite
 - id: replicate.x.google-imagen-3-fast
   tier: extended
@@ -1192,9 +1300,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.025
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/imagen-3-fast
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/imagen-3-fast at $0.025 per output image.
   docs_url: https://replicate.com/google/imagen-3-fast
 - id: replicate.x.google-imagen-3
   tier: extended
@@ -1229,9 +1341,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.05
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/imagen-3
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/imagen-3 at $0.05 per output image.
   docs_url: https://replicate.com/google/imagen-3
 - id: replicate.x.google-imagen-4-fast
   tier: extended
@@ -1266,9 +1382,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.02
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/imagen-4-fast
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/imagen-4-fast at $0.02 per output image.
   docs_url: https://replicate.com/google/imagen-4-fast
 - id: replicate.x.google-imagen-4-ultra
   tier: extended
@@ -1307,9 +1427,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.06
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/imagen-4-ultra
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/imagen-4-ultra at $0.06 per output image.
   docs_url: https://replicate.com/google/imagen-4-ultra
 - id: replicate.x.google-imagen-4
   tier: extended
@@ -1348,9 +1472,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/imagen-4
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/imagen-4 at $0.04 per output image.
   docs_url: https://replicate.com/google/imagen-4
 - id: replicate.x.google-nano-banana-2
   tier: extended
@@ -1400,9 +1528,25 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.resolution: 1K
+      value: 0.067
+    - when:
+        body.input.resolution: 2K
+      value: 0.101
+    - when:
+        body.input.resolution: 4K
+      value: 0.151
+    fallback:
+      value: 0.151
+      note: the dearest published rate (1K $0.067 per output image, 2K $0.101 per output image, 4K $0.151 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/nano-banana-2
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/nano-banana-2 at 1K $0.067 per output image, 2K $0.101 per output image, 4K $0.151 per output image.
   docs_url: https://replicate.com/google/nano-banana-2
 - id: replicate.x.google-nano-banana-pro
   tier: extended
@@ -1451,9 +1595,28 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.resolution: 1K
+      value: 0.15
+    - when:
+        body.input.resolution: 2K
+      value: 0.15
+    - when:
+        body.input.resolution: 4K
+      value: 0.3
+    - when:
+        body.input.resolution: fallback
+      value: 0.035
+    fallback:
+      value: 0.3
+      note: the dearest published rate (1K $0.15 per output image, 2K $0.15 per output image, 4K $0.30 per output image, fallback $0.035 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/nano-banana-pro
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/nano-banana-pro at 1K $0.15 per output image, 2K $0.15 per output image, 4K $0.30 per output image, fallback $0.035 per output image.
   docs_url: https://replicate.com/google/nano-banana-pro
 - id: replicate.x.google-nano-banana
   tier: extended
@@ -1489,9 +1652,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.039
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/google/nano-banana
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists google/nano-banana at $0.039 per output image.
   docs_url: https://replicate.com/google/nano-banana
 - id: replicate.x.ideogram-ai-ideogram-v2-turbo
   tier: extended
@@ -1547,9 +1714,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.05
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v2-turbo
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v2-turbo at $0.05 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2-turbo
 - id: replicate.x.ideogram-ai-ideogram-v2
   tier: extended
@@ -1605,9 +1776,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.08
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v2
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v2 at $0.08 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2
 - id: replicate.x.ideogram-ai-ideogram-v2a-turbo
   tier: extended
@@ -1651,9 +1826,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.025
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v2a-turbo
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v2a-turbo at $0.025 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2a-turbo
 - id: replicate.x.ideogram-ai-ideogram-v2a
   tier: extended
@@ -1697,9 +1876,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v2a
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v2a at $0.04 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2a
 - id: replicate.x.ideogram-ai-ideogram-v3-balanced
   tier: extended
@@ -1759,9 +1942,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.06
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v3-balanced
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v3-balanced at $0.06 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-balanced
 - id: replicate.x.ideogram-ai-ideogram-v3-quality
   tier: extended
@@ -1821,9 +2008,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.09
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v3-quality
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v3-quality at $0.09 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-quality
 - id: replicate.x.ideogram-ai-ideogram-v3-turbo
   tier: extended
@@ -1883,9 +2074,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.03
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/ideogram-ai/ideogram-v3-turbo
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists ideogram-ai/ideogram-v3-turbo at $0.03 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-turbo
 - id: replicate.x.leonardoai-lucid-origin
   tier: extended
@@ -1936,9 +2131,24 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.generation_mode: standard
+      value: 0.0167
+      times: body.input.num_images
+    - when:
+        body.input.generation_mode: ultra
+      value: 0.0765
+      times: body.input.num_images
+    fallback:
+      value: 0.612
+      note: 8 outputs at the dearest published rate (standard $0.0167 per output image, ultra $0.0765 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/leonardoai/lucid-origin
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists leonardoai/lucid-origin at standard $0.0167 per output image, ultra $0.0765 per output image.
   docs_url: https://replicate.com/leonardoai/lucid-origin
 - id: replicate.x.luma-photon-flash
   tier: extended
@@ -2007,9 +2217,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.01
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/luma/photon-flash
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists luma/photon-flash at $0.01 per output image.
   docs_url: https://replicate.com/luma/photon-flash
 - id: replicate.x.luma-photon
   tier: extended
@@ -2066,9 +2280,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.03
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/luma/photon
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists luma/photon at $0.03 per output image.
   docs_url: https://replicate.com/luma/photon
 - id: replicate.x.minimax-image-01
   tier: extended
@@ -2111,9 +2329,43 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.number_of_images: 1
+      value: 0.01
+    - when:
+        body.input.number_of_images: 2
+      value: 0.02
+    - when:
+        body.input.number_of_images: 3
+      value: 0.03
+    - when:
+        body.input.number_of_images: 4
+      value: 0.04
+    - when:
+        body.input.number_of_images: 5
+      value: 0.05
+    - when:
+        body.input.number_of_images: 6
+      value: 0.06
+    - when:
+        body.input.number_of_images: 7
+      value: 0.07
+    - when:
+        body.input.number_of_images: 8
+      value: 0.08
+    - when:
+        body.input.number_of_images: 9
+      value: 0.09
+    fallback:
+      value: 0.09
+      note: 9 outputs at the dearest published rate ($0.01 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/minimax/image-01
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists minimax/image-01 at $0.01 per output image.
   docs_url: https://replicate.com/minimax/image-01
 - id: replicate.x.openai-gpt-image-1-5
   tier: extended
@@ -2186,9 +2438,32 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.quality: auto
+      value: 0.136
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: low
+      value: 0.013
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: medium
+      value: 0.05
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: high
+      value: 0.136
+      times: body.input.number_of_images
+    fallback:
+      value: 1.36
+      note: 10 outputs at the dearest published rate (auto $0.136 per output image, low $0.013 per output image, medium $0.05 per output image, high $0.136 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/openai/gpt-image-1.5
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists openai/gpt-image-1.5 at auto $0.136 per output image, low $0.013 per output image, medium $0.05 per output image, high $0.136 per output image.
   docs_url: https://replicate.com/openai/gpt-image-1.5
 - id: replicate.x.openai-gpt-image-2
   tier: extended
@@ -2260,9 +2535,32 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.quality: auto
+      value: 0.128
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: low
+      value: 0.012
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: medium
+      value: 0.047
+      times: body.input.number_of_images
+    - when:
+        body.input.quality: high
+      value: 0.128
+      times: body.input.number_of_images
+    fallback:
+      value: 1.28
+      note: 10 outputs at the dearest published rate (auto $0.128 per output image, low $0.012 per output image, medium $0.047 per output image, high $0.128 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/openai/gpt-image-2
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists openai/gpt-image-2 at auto $0.128 per output image, low $0.012 per output image, medium $0.047 per output image, high $0.128 per output image.
   docs_url: https://replicate.com/openai/gpt-image-2
 - id: replicate.x.prunaai-flux-fast
   tier: extended
@@ -2324,9 +2622,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.005
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/prunaai/flux-fast
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists prunaai/flux-fast at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/flux-fast
 - id: replicate.x.prunaai-hidream-l1-fast
   tier: extended
@@ -2388,9 +2690,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.005
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/prunaai/hidream-l1-fast
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists prunaai/hidream-l1-fast at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/hidream-l1-fast
 - id: replicate.x.prunaai-p-image-lora
   tier: extended
@@ -2458,9 +2764,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.005
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/prunaai/p-image-lora
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists prunaai/p-image-lora at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/p-image-lora
 - id: replicate.x.prunaai-p-image
   tier: extended
@@ -2528,9 +2838,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.005
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/prunaai/p-image
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists prunaai/p-image at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/p-image
 - id: replicate.x.prunaai-wan-2-2-image
   tier: extended
@@ -2581,9 +2895,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.02
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/prunaai/wan-2.2-image
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists prunaai/wan-2.2-image at $0.02 per output image.
   docs_url: https://replicate.com/prunaai/wan-2.2-image
 - id: replicate.x.prunaai-z-image-turbo
   tier: extended
@@ -2750,9 +3068,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.25
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/quiverai/arrow-1.1-max
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists quiverai/arrow-1.1-max at $0.25 per output image.
   docs_url: https://replicate.com/quiverai/arrow-1.1-max
 - id: replicate.x.quiverai-arrow-1-1
   tier: extended
@@ -2806,9 +3128,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.2
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/quiverai/arrow-1.1
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists quiverai/arrow-1.1 at $0.20 per output image.
   docs_url: https://replicate.com/quiverai/arrow-1.1
 - id: replicate.x.qwen-qwen-image
   tier: extended
@@ -2920,9 +3246,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.025
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/qwen/qwen-image
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists qwen/qwen-image at $0.025 per output image.
   docs_url: https://replicate.com/qwen/qwen-image
 - id: replicate.x.recraft-ai-recraft-v3-svg
   tier: extended
@@ -2957,9 +3287,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.08
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v3-svg
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v3-svg at $0.08 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v3-svg
 - id: replicate.x.recraft-ai-recraft-v3
   tier: extended
@@ -2994,9 +3328,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v3
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v3 at $0.04 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v3
 - id: replicate.x.recraft-ai-recraft-v4-pro-svg
   tier: extended
@@ -3027,9 +3365,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.3
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v4-pro-svg
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v4-pro-svg at $0.30 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-pro-svg
 - id: replicate.x.recraft-ai-recraft-v4-pro
   tier: extended
@@ -3060,9 +3402,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.25
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v4-pro
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v4-pro at $0.25 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-pro
 - id: replicate.x.recraft-ai-recraft-v4-styles-pro-svg
   tier: extended
@@ -3106,9 +3452,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.12
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v4-styles-pro-svg
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v4-styles-pro-svg at $0.12 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-styles-pro-svg
 - id: replicate.x.recraft-ai-recraft-v4-svg
   tier: extended
@@ -3139,9 +3489,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.08
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/recraft-ai/recraft-v4-svg
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists recraft-ai/recraft-v4-svg at $0.08 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-svg
 - id: replicate.x.sourceful-riverflow-2-0-pro
   tier: extended
@@ -3273,9 +3627,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.04
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large-turbo
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists stability-ai/stable-diffusion-3.5-large-turbo at $0.04 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large-turbo
 - id: replicate.x.stability-ai-stable-diffusion-3-5-large
   tier: extended
@@ -3332,9 +3690,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.065
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists stability-ai/stable-diffusion-3.5-large at $0.065 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large
 - id: replicate.x.stability-ai-stable-diffusion-3-5-medium
   tier: extended
@@ -3391,9 +3753,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.035
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-medium
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists stability-ai/stable-diffusion-3.5-medium at $0.035 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-medium
 - id: replicate.x.tencent-hunyuan-image-3
   tier: extended
@@ -3445,9 +3811,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.08
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/tencent/hunyuan-image-3
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists tencent/hunyuan-image-3 at $0.08 per output image.
   docs_url: https://replicate.com/tencent/hunyuan-image-3
 - id: replicate.x.wan-video-wan-2-7-image-pro
   tier: extended
@@ -3500,9 +3870,28 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.num_outputs: 1
+      value: 0.03
+    - when:
+        body.input.num_outputs: 2
+      value: 0.06
+    - when:
+        body.input.num_outputs: 3
+      value: 0.09
+    - when:
+        body.input.num_outputs: 4
+      value: 0.12
+    fallback:
+      value: 0.12
+      note: 4 outputs at the dearest published rate ($0.03 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/wan-video/wan-2.7-image-pro
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists wan-video/wan-2.7-image-pro at $0.03 per output image.
   docs_url: https://replicate.com/wan-video/wan-2.7-image-pro
 - id: replicate.x.wan-video-wan-2-7-image
   tier: extended
@@ -3555,9 +3944,28 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    table:
+    - when:
+        body.input.num_outputs: 1
+      value: 0.03
+    - when:
+        body.input.num_outputs: 2
+      value: 0.06
+    - when:
+        body.input.num_outputs: 3
+      value: 0.09
+    - when:
+        body.input.num_outputs: 4
+      value: 0.12
+    fallback:
+      value: 0.12
+      note: 4 outputs at the dearest published rate ($0.03 per output image) is the explicit request maximum.
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/wan-video/wan-2.7-image
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists wan-video/wan-2.7-image at $0.03 per output image.
   docs_url: https://replicate.com/wan-video/wan-2.7-image
 - id: replicate.x.xai-grok-imagine-image
   tier: extended
@@ -3588,9 +3996,13 @@ endpoints:
     bodyType: json
   cost:
     type: per_success
-    value: null
-    confidence: unknown
-    note: Replicate does not expose this model's price in the collection API; the generated row is BYOK-only.
+    value: 0.02
+    currency: USD
+    source: docs
+    source_url: https://replicate.com/xai/grok-imagine-image
+    checked: '2026-09-06'
+    confidence: documented
+    note: Replicate's model page lists xai/grok-imagine-image at $0.02 per output image.
   docs_url: https://replicate.com/xai/grok-imagine-image
 - id: replicate.x.alibaba-happyhorse-1-0
   tier: extended

--- a/src/treg/catalog/replicate.extended.yaml
+++ b/src/treg/catalog/replicate.extended.yaml
@@ -91,10 +91,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-1.1-pro-ultra
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-1.1-pro-ultra at $0.06 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-1.1-pro-ultra
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-1-1-pro-ultra.json
+  observed_time: 0.13
 - id: replicate.x.black-forest-labs-flux-2-flex
   tier: extended
   platform: image-gen
@@ -537,10 +544,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-dev-lora
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-dev-lora at $0.032 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-dev-lora
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-dev-lora.json
+  observed_time: 0.68
 - id: replicate.x.black-forest-labs-flux-dev
   tier: extended
   platform: image-gen
@@ -646,10 +660,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-dev
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-dev at $0.025 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-dev
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-dev.json
+  observed_time: 0.17
 - id: replicate.x.black-forest-labs-flux-kontext-max
   tier: extended
   platform: image-gen
@@ -703,10 +724,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-kontext-max
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-kontext-max at $0.08 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-kontext-max
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-kontext-max.json
+  observed_time: 0.05
 - id: replicate.x.black-forest-labs-flux-kontext-pro
   tier: extended
   platform: image-gen
@@ -760,10 +788,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-kontext-pro
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-kontext-pro at $0.04 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-kontext-pro
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-kontext-pro.json
+  observed_time: 0.05
 - id: replicate.x.black-forest-labs-flux-pro
   tier: extended
   platform: image-gen
@@ -857,10 +892,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/black-forest-labs/flux-pro
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists black-forest-labs/flux-pro at $0.055 per output image.
   docs_url: https://replicate.com/black-forest-labs/flux-pro
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.black-forest-labs-flux-pro.json
+  observed_time: 0.23
 - id: replicate.x.bria-fibo
   tier: extended
   platform: image-gen
@@ -913,10 +955,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bria/fibo
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bria/fibo at $0.04 per output image.
   docs_url: https://replicate.com/bria/fibo
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bria-fibo.json
+  observed_time: 0.3
 - id: replicate.x.bria-image-3-2
   tier: extended
   platform: image-gen
@@ -970,10 +1019,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bria/image-3.2
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bria/image-3.2 at $0.04 per output image.
   docs_url: https://replicate.com/bria/image-3.2
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bria-image-3-2.json
+  observed_time: 0.27
 - id: replicate.x.bytedance-seedream-3
   tier: extended
   platform: image-gen
@@ -1032,10 +1088,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bytedance/seedream-3
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bytedance/seedream-3 at $0.03 per output image.
   docs_url: https://replicate.com/bytedance/seedream-3
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bytedance-seedream-3.json
+  observed_time: 0.27
 - id: replicate.x.bytedance-seedream-4-5
   tier: extended
   platform: image-gen
@@ -1114,10 +1177,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bytedance/seedream-4.5
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bytedance/seedream-4.5 at $0.04 per output image.
   docs_url: https://replicate.com/bytedance/seedream-4.5
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bytedance-seedream-4-5.json
+  observed_time: 0.08
 - id: replicate.x.bytedance-seedream-4
   tier: extended
   platform: image-gen
@@ -1196,10 +1266,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bytedance/seedream-4
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bytedance/seedream-4 at $0.03 per output image.
   docs_url: https://replicate.com/bytedance/seedream-4
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bytedance-seedream-4.json
+  observed_time: 0.06
 - id: replicate.x.bytedance-seedream-5-lite
   tier: extended
   platform: image-gen
@@ -1263,10 +1340,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/bytedance/seedream-5-lite
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists bytedance/seedream-5-lite at $0.035 per output image.
   docs_url: https://replicate.com/bytedance/seedream-5-lite
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.bytedance-seedream-5-lite.json
+  observed_time: 0.05
 - id: replicate.x.google-imagen-3-fast
   tier: extended
   platform: image-gen
@@ -1304,10 +1388,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/imagen-3-fast
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/imagen-3-fast at $0.025 per output image.
   docs_url: https://replicate.com/google/imagen-3-fast
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-imagen-3-fast.json
+  observed_time: 0.2
 - id: replicate.x.google-imagen-3
   tier: extended
   platform: image-gen
@@ -1345,10 +1436,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/imagen-3
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/imagen-3 at $0.05 per output image.
   docs_url: https://replicate.com/google/imagen-3
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-imagen-3.json
+  observed_time: 0.14
 - id: replicate.x.google-imagen-4-fast
   tier: extended
   platform: image-gen
@@ -1386,10 +1484,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/imagen-4-fast
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/imagen-4-fast at $0.02 per output image.
   docs_url: https://replicate.com/google/imagen-4-fast
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-imagen-4-fast.json
+  observed_time: 0.11
 - id: replicate.x.google-imagen-4-ultra
   tier: extended
   platform: image-gen
@@ -1431,10 +1536,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/imagen-4-ultra
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/imagen-4-ultra at $0.06 per output image.
   docs_url: https://replicate.com/google/imagen-4-ultra
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-imagen-4-ultra.json
+  observed_time: 0.05
 - id: replicate.x.google-imagen-4
   tier: extended
   platform: image-gen
@@ -1476,10 +1588,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/imagen-4
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/imagen-4 at $0.04 per output image.
   docs_url: https://replicate.com/google/imagen-4
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-imagen-4.json
+  observed_time: 0.11
 - id: replicate.x.google-nano-banana-2
   tier: extended
   platform: image-gen
@@ -1544,10 +1663,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/nano-banana-2
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/nano-banana-2 at 1K $0.067 per output image, 2K $0.101 per output image, 4K $0.151 per output image.
   docs_url: https://replicate.com/google/nano-banana-2
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-nano-banana-2.json
+  observed_time: 0.07
 - id: replicate.x.google-nano-banana-pro
   tier: extended
   platform: image-gen
@@ -1614,10 +1740,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/nano-banana-pro
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/nano-banana-pro at 1K $0.15 per output image, 2K $0.15 per output image, 4K $0.30 per output image, fallback $0.035 per output image.
   docs_url: https://replicate.com/google/nano-banana-pro
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-nano-banana-pro.json
+  observed_time: 0.06
 - id: replicate.x.google-nano-banana
   tier: extended
   platform: image-gen
@@ -1656,10 +1789,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/google/nano-banana
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists google/nano-banana at $0.039 per output image.
   docs_url: https://replicate.com/google/nano-banana
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.google-nano-banana.json
+  observed_time: 0.04
 - id: replicate.x.ideogram-ai-ideogram-v2-turbo
   tier: extended
   platform: image-gen
@@ -1718,10 +1858,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v2-turbo
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v2-turbo at $0.05 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2-turbo
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v2-turbo.json
+  observed_time: 0.05
 - id: replicate.x.ideogram-ai-ideogram-v2
   tier: extended
   platform: image-gen
@@ -1780,10 +1927,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v2
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v2 at $0.08 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v2.json
+  observed_time: 0.12
 - id: replicate.x.ideogram-ai-ideogram-v2a-turbo
   tier: extended
   platform: image-gen
@@ -1830,10 +1984,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v2a-turbo
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v2a-turbo at $0.025 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2a-turbo
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v2a-turbo.json
+  observed_time: 0.28
 - id: replicate.x.ideogram-ai-ideogram-v2a
   tier: extended
   platform: image-gen
@@ -1880,10 +2041,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v2a
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v2a at $0.04 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v2a
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v2a.json
+  observed_time: 0.11
 - id: replicate.x.ideogram-ai-ideogram-v3-balanced
   tier: extended
   platform: image-gen
@@ -1946,10 +2114,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v3-balanced
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v3-balanced at $0.06 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-balanced
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v3-balanced.json
+  observed_time: 0.3
 - id: replicate.x.ideogram-ai-ideogram-v3-quality
   tier: extended
   platform: image-gen
@@ -2012,10 +2187,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v3-quality
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v3-quality at $0.09 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-quality
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v3-quality.json
+  observed_time: 0.19
 - id: replicate.x.ideogram-ai-ideogram-v3-turbo
   tier: extended
   platform: image-gen
@@ -2078,10 +2260,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/ideogram-ai/ideogram-v3-turbo
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists ideogram-ai/ideogram-v3-turbo at $0.03 per output image.
   docs_url: https://replicate.com/ideogram-ai/ideogram-v3-turbo
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.ideogram-ai-ideogram-v3-turbo.json
+  observed_time: 0.06
 - id: replicate.x.leonardoai-lucid-origin
   tier: extended
   platform: image-gen
@@ -2146,10 +2335,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/leonardoai/lucid-origin
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists leonardoai/lucid-origin at standard $0.0167 per output image, ultra $0.0765 per output image.
   docs_url: https://replicate.com/leonardoai/lucid-origin
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.leonardoai-lucid-origin.json
+  observed_time: 0.05
 - id: replicate.x.luma-photon-flash
   tier: extended
   platform: image-gen
@@ -2221,10 +2417,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/luma/photon-flash
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists luma/photon-flash at $0.01 per output image.
   docs_url: https://replicate.com/luma/photon-flash
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.luma-photon-flash.json
+  observed_time: 0.12
 - id: replicate.x.luma-photon
   tier: extended
   platform: image-gen
@@ -2284,10 +2487,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/luma/photon
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists luma/photon at $0.03 per output image.
   docs_url: https://replicate.com/luma/photon
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.luma-photon.json
+  observed_time: 0.29
 - id: replicate.x.minimax-image-01
   tier: extended
   platform: image-gen
@@ -2363,10 +2573,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/minimax/image-01
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists minimax/image-01 at $0.01 per output image.
   docs_url: https://replicate.com/minimax/image-01
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.minimax-image-01.json
+  observed_time: 0.13
 - id: replicate.x.openai-gpt-image-1-5
   tier: extended
   platform: image-gen
@@ -2461,10 +2678,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/openai/gpt-image-1.5
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists openai/gpt-image-1.5 at auto $0.136 per output image, low $0.013 per output image, medium $0.05 per output image, high $0.136 per output image.
   docs_url: https://replicate.com/openai/gpt-image-1.5
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.openai-gpt-image-1-5.json
+  observed_time: 0.05
 - id: replicate.x.openai-gpt-image-2
   tier: extended
   platform: image-gen
@@ -2558,10 +2782,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/openai/gpt-image-2
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists openai/gpt-image-2 at auto $0.128 per output image, low $0.012 per output image, medium $0.047 per output image, high $0.128 per output image.
   docs_url: https://replicate.com/openai/gpt-image-2
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.openai-gpt-image-2.json
+  observed_time: 0.04
 - id: replicate.x.prunaai-flux-fast
   tier: extended
   platform: image-gen
@@ -2626,10 +2857,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/prunaai/flux-fast
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists prunaai/flux-fast at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/flux-fast
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.prunaai-flux-fast.json
+  observed_time: 0.44
 - id: replicate.x.prunaai-hidream-l1-fast
   tier: extended
   platform: image-gen
@@ -2694,10 +2932,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/prunaai/hidream-l1-fast
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists prunaai/hidream-l1-fast at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/hidream-l1-fast
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.prunaai-hidream-l1-fast.json
+  observed_time: 0.31
 - id: replicate.x.prunaai-p-image-lora
   tier: extended
   platform: image-gen
@@ -2768,10 +3013,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/prunaai/p-image-lora
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists prunaai/p-image-lora at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/p-image-lora
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.prunaai-p-image-lora.json
+  observed_time: 0.31
 - id: replicate.x.prunaai-p-image
   tier: extended
   platform: image-gen
@@ -2842,10 +3094,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/prunaai/p-image
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists prunaai/p-image at $5 per thousand output images.
   docs_url: https://replicate.com/prunaai/p-image
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.prunaai-p-image.json
+  observed_time: 0.08
 - id: replicate.x.prunaai-wan-2-2-image
   tier: extended
   platform: image-gen
@@ -2899,10 +3158,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/prunaai/wan-2.2-image
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists prunaai/wan-2.2-image at $0.02 per output image.
   docs_url: https://replicate.com/prunaai/wan-2.2-image
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.prunaai-wan-2-2-image.json
+  observed_time: 0.29
 - id: replicate.x.prunaai-z-image-turbo
   tier: extended
   platform: image-gen
@@ -3072,10 +3338,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/quiverai/arrow-1.1-max
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists quiverai/arrow-1.1-max at $0.25 per output image.
   docs_url: https://replicate.com/quiverai/arrow-1.1-max
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.quiverai-arrow-1-1-max.json
+  observed_time: 0.27
 - id: replicate.x.quiverai-arrow-1-1
   tier: extended
   platform: image-gen
@@ -3132,10 +3405,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/quiverai/arrow-1.1
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists quiverai/arrow-1.1 at $0.20 per output image.
   docs_url: https://replicate.com/quiverai/arrow-1.1
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.quiverai-arrow-1-1.json
+  observed_time: 0.27
 - id: replicate.x.qwen-qwen-image
   tier: extended
   platform: image-gen
@@ -3250,10 +3530,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/qwen/qwen-image
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists qwen/qwen-image at $0.025 per output image.
   docs_url: https://replicate.com/qwen/qwen-image
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.qwen-qwen-image.json
+  observed_time: 0.12
 - id: replicate.x.recraft-ai-recraft-v3-svg
   tier: extended
   platform: image-gen
@@ -3291,10 +3578,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v3-svg
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v3-svg at $0.08 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v3-svg
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.recraft-ai-recraft-v3-svg.json
+  observed_time: 0.12
 - id: replicate.x.recraft-ai-recraft-v3
   tier: extended
   platform: image-gen
@@ -3332,10 +3626,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v3
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v3 at $0.04 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v3
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.recraft-ai-recraft-v3.json
+  observed_time: 0.06
 - id: replicate.x.recraft-ai-recraft-v4-pro-svg
   tier: extended
   platform: image-gen
@@ -3369,10 +3670,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v4-pro-svg
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v4-pro-svg at $0.30 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-pro-svg
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.recraft-ai-recraft-v4-pro-svg.json
+  observed_time: 0.28
 - id: replicate.x.recraft-ai-recraft-v4-pro
   tier: extended
   platform: image-gen
@@ -3406,10 +3714,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v4-pro
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v4-pro at $0.25 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-pro
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.recraft-ai-recraft-v4-pro.json
+  observed_time: 0.31
 - id: replicate.x.recraft-ai-recraft-v4-styles-pro-svg
   tier: extended
   platform: image-gen
@@ -3456,7 +3771,7 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v4-styles-pro-svg
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v4-styles-pro-svg at $0.12 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-styles-pro-svg
@@ -3493,10 +3808,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/recraft-ai/recraft-v4-svg
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists recraft-ai/recraft-v4-svg at $0.08 per output image.
   docs_url: https://replicate.com/recraft-ai/recraft-v4-svg
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.recraft-ai-recraft-v4-svg.json
+  observed_time: 0.06
 - id: replicate.x.sourceful-riverflow-2-0-pro
   tier: extended
   platform: image-gen
@@ -3631,10 +3953,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large-turbo
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists stability-ai/stable-diffusion-3.5-large-turbo at $0.04 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large-turbo
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.stability-ai-stable-diffusion-3-5-large-turbo.json
+  observed_time: 0.13
 - id: replicate.x.stability-ai-stable-diffusion-3-5-large
   tier: extended
   platform: image-gen
@@ -3694,10 +4023,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists stability-ai/stable-diffusion-3.5-large at $0.065 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-large
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.stability-ai-stable-diffusion-3-5-large.json
+  observed_time: 0.12
 - id: replicate.x.stability-ai-stable-diffusion-3-5-medium
   tier: extended
   platform: image-gen
@@ -3757,10 +4093,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/stability-ai/stable-diffusion-3.5-medium
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists stability-ai/stable-diffusion-3.5-medium at $0.035 per output image.
   docs_url: https://replicate.com/stability-ai/stable-diffusion-3.5-medium
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.stability-ai-stable-diffusion-3-5-medium.json
+  observed_time: 0.28
 - id: replicate.x.tencent-hunyuan-image-3
   tier: extended
   platform: image-gen
@@ -3815,10 +4158,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/tencent/hunyuan-image-3
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists tencent/hunyuan-image-3 at $0.08 per output image.
   docs_url: https://replicate.com/tencent/hunyuan-image-3
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.tencent-hunyuan-image-3.json
+  observed_time: 0.49
 - id: replicate.x.wan-video-wan-2-7-image-pro
   tier: extended
   platform: image-gen
@@ -3889,10 +4239,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/wan-video/wan-2.7-image-pro
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists wan-video/wan-2.7-image-pro at $0.03 per output image.
   docs_url: https://replicate.com/wan-video/wan-2.7-image-pro
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.wan-video-wan-2-7-image-pro.json
+  observed_time: 0.05
 - id: replicate.x.wan-video-wan-2-7-image
   tier: extended
   platform: image-gen
@@ -3963,10 +4320,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/wan-video/wan-2.7-image
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists wan-video/wan-2.7-image at $0.03 per output image.
   docs_url: https://replicate.com/wan-video/wan-2.7-image
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.wan-video-wan-2-7-image.json
+  observed_time: 0.07
 - id: replicate.x.xai-grok-imagine-image
   tier: extended
   platform: image-gen
@@ -4000,10 +4364,17 @@ endpoints:
     currency: USD
     source: docs
     source_url: https://replicate.com/xai/grok-imagine-image
-    checked: '2026-09-06'
+    checked: '2026-09-07'
     confidence: documented
     note: Replicate's model page lists xai/grok-imagine-image at $0.02 per output image.
   docs_url: https://replicate.com/xai/grok-imagine-image
+  test_request:
+    body:
+      input:
+        prompt: A small red kite above a calm beach.
+  verified: '2026-09-07'
+  example_response: examples/replicate.x.xai-grok-imagine-image.json
+  observed_time: 0.05
 - id: replicate.x.alibaba-happyhorse-1-0
   tier: extended
   platform: video-gen


### PR DESCRIPTION
## Summary
- Backfill documented per-image prices from each Replicate model page's `billingConfig` into `replicate.extended.yaml` (54/60 extended image models; megapixel/unspecified stay BYOK-only).
- Write minimal prompt-only `test_request`s and live-verify all 53 priced image-gen endpoints under the platform Replicate key (**PASS 53 / FAIL 0**), with trimmed example responses — so they become platform-eligible (tier 4) instead of BYOK-only.
- Include the verify-budget helper so table-priced rows reserve at their fallback ceiling.

## Test plan
- [x] `uv run python scripts/catalog_validate.py` → OK (3172 endpoints)
- [x] `catalog_replicate_prices.py --test-requests` → 54 priced / 6 skipped
- [x] `catalog_verify_extended.py replicate --budget … --platform image-gen` → PASS 53 / FAIL 0
- [ ] CI catalog / unit jobs green on this PR