### PR TITLE
fix(billing): charge Tomba domain searches by page-size blocks

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -160,6 +160,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/catalog/replicate.extended.yaml` | architecture/catalog.md |
 | `src/treg/catalog/replicate.yaml` | architecture/catalog.md |
 | `src/treg/catalog/tikhub.extended.yaml` | architecture/catalog.md |
+| `src/treg/catalog/tomba.yaml` | architecture/money.md |
 | `src/treg/cli.py` | architecture/instagram-oauth.md, interface/cli.md, interface/onboarding.md, interface/shell.md |
 | `src/treg/client_identity.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/config.py` | architecture/auth-secrets.md, architecture/super-admin.md, guides/expanding-a-category.md, ops/deploy.md |
@@ -342,7 +343,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
 | `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_oauth.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
-| `architecture/money.md` | `__init__.py`, `settlement.py`, `__init__.py`, `models.py`, `billing.py`, `idempotency.py`, `intake.py`, `resolve.py`, `service.py`, `reserve.py`, `settle.py`, `asynctasks.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `referrals.py`, `budgets.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `api.py`, `signup.py`, `admin.py`, `billing.py`, `call.py`, `orgs.py`, `referrals.py`, `test_call_architecture.py`, `test_asynctasks.py` |
+| `architecture/money.md` | `__init__.py`, `settlement.py`, `__init__.py`, `models.py`, `billing.py`, `idempotency.py`, `intake.py`, `resolve.py`, `service.py`, `reserve.py`, `settle.py`, `tomba.yaml`, `asynctasks.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `referrals.py`, `budgets.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `api.py`, `signup.py`, `admin.py`, `billing.py`, `call.py`, `orgs.py`, `referrals.py`, `test_call_architecture.py`, `test_asynctasks.py` |
 | `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `asynctasks.py`, `resolve.py`, `signup.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `access.py`, `session.py`, `test_auth.py`, `test_token_revocation.py`, `auth.py`, `orgs.py`, `resources.py`, `bundles.py`, `db.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `test_router_dependencies.py`, `test_asynctasks.py` |
 | `architecture/proxy-model.md` | `relay.py`, `ssrf.py`, `api.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `asynctasks.py`, `client_identity.py`, `call_surface.py`, `sandbox_identity.py`, `access.py`, `publicdemo.py`, `usage.py`, `call.py`, `test_call_application_contract.py`, `test_call_cancellation.py`, `test_error_capture.py`, `test_marketplace_call.py`, `test_oauth_billed.py`, `test_passthrough.py`, `test_tag_billing.py`, `test_tag_billing_adversarial.py`, `test_call_architecture.py`, `test_asynctasks.py` |
 | `architecture/super-admin.md` | `api.py`, `admin.py`, `access.py`, `config.py` |

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -439,6 +439,7 @@ Provider-specific calculation stays outside the faithful relay.
 | Reported charge | DataForSEO `cost`, ScrapeCreators `credits_charged`, Akta `credits_consumed`, Lusha `billing.creditsCharged`, Exa `costDollars.total`; credit amounts use the catalog FX rate |
 | Crustdata | Read `X-Credits-Used` from response headers using the same FX rate |
 | Apollo | Known empty organization results are free |
+| Tomba domain search | One credit per email in `data.emails`; an empty list is free. Missing or malformed results fall back to the estimate; pagination totals do not determine the charge |
 | Hunter domain search | One whole search credit per ten returned emails, rounded up; an empty result is free |
 | Hunter email finder | One whole credit when an email is present; a known miss is free |
 | TikHub | Honor explicit no-charge prose; an embedded error that says it is charged still costs the estimate |

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -13,6 +13,7 @@ sources:
   - src/treg/application/call/service.py
   - src/treg/application/call/reserve.py
   - src/treg/application/call/settle.py
+  - src/treg/catalog/tomba.yaml
   - src/treg/application/asynctasks.py
   - src/treg/alembic/versions/0017_async_task_record.py
   - src/treg/alembic/versions/0018_async_resource_ownership.py
@@ -439,7 +440,7 @@ Provider-specific calculation stays outside the faithful relay.
 | Reported charge | DataForSEO `cost`, ScrapeCreators `credits_charged`, Akta `credits_consumed`, Lusha `billing.creditsCharged`, Exa `costDollars.total`; credit amounts use the catalog FX rate |
 | Crustdata | Read `X-Credits-Used` from response headers using the same FX rate |
 | Apollo | Known empty organization results are free |
-| Tomba domain search | One credit per email in `data.emails`; an empty list is free. Missing or malformed results fall back to the estimate; pagination totals do not determine the charge |
+| Tomba domain search | Non-empty pages cost ceil(`meta.pageSize` / 10) credits, even when partially filled; empty `data.emails` is free. Reservation uses requested `limit`, default 10. Missing/malformed page evidence falls back to the estimate. Upstream duplicate discounts are not detected |
 | Hunter domain search | One whole search credit per ten returned emails, rounded up; an empty result is free |
 | Hunter email finder | One whole credit when an email is present; a known miss is free |
 | TikHub | Honor explicit no-charge prose; an embedded error that says it is charged still costs the estimate |

--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -556,6 +556,13 @@ def _marketplace_pricing(
     estimate = _platform_estimate_micro(cost, query, body)
     unit = (_usd_to_micro(cost["usd"])
             if cost.get("type") in ("per_result", "quota_rows") and cost.get("usd") else 0)
+    if provider == "tomba" and endpoint_id == "tomba.companies.emails.list":
+        # Tomba bills requested page slots in blocks of ten, with a ten-slot default.
+        # A partial non-empty page still costs the full block; settlement frees empty pages.
+        raw = query.get("limit")
+        size = int(str(raw)) if raw is not None and str(raw).isdigit() else 10
+        credit = _usd_to_micro(float(cost.get("usd") or 0))
+        return max(1, (size + 9) // 10) * credit, credit
     if provider == "crustdata" and endpoint_id in (
         "crustdata.companies.enrich", "crustdata.people.enrich"
     ):

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -254,17 +254,17 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
             return int(credits * rate * 1_000_000 + 0.5)
         return None
     if provider == "tomba" and mk.endpoint_id == "tomba.companies.emails.list":
-        # Domain search bills one credit per returned email, not per requested page slot.
-        # https://docs.tomba.io/faqs and the catalog rate card agree on this unit.
-        # Missing/malformed results are unknown; an explicit empty list is free.
+        # Live billing evidence: a non-empty page costs ceil(pageSize / 10) credits,
+        # even when fewer emails are returned. The catalog supplies the frozen credit price.
         data = doc.get("data")
         emails = data.get("emails") if isinstance(data, dict) else None
         if isinstance(emails, list):
             if not emails:
                 return 0
-            rate = catalog_store.load().credit_rates.get("tomba")
-            if rate:
-                return int(len(emails) * rate * 1_000_000 + 0.5)
+            meta = doc.get("meta")
+            size = meta.get("pageSize") if isinstance(meta, dict) else None
+            if type(size) is int and size > 0 and mk.unit_micro > 0:
+                return ((size + 9) // 10) * mk.unit_micro
         return None
     if provider == "hunter" and mk.endpoint_id == "hunter.companies.emails":
         # DERIVED, like apollo. Hunter's domain search does not bill per row at all: it takes ONE

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -253,6 +253,19 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
                 and isinstance(credits, (int, float)) and not isinstance(credits, bool) and credits >= 0):
             return int(credits * rate * 1_000_000 + 0.5)
         return None
+    if provider == "tomba" and mk.endpoint_id == "tomba.companies.emails.list":
+        # Domain search bills one credit per returned email, not per requested page slot.
+        # https://docs.tomba.io/faqs and the catalog rate card agree on this unit.
+        # Missing/malformed results are unknown; an explicit empty list is free.
+        data = doc.get("data")
+        emails = data.get("emails") if isinstance(data, dict) else None
+        if isinstance(emails, list):
+            if not emails:
+                return 0
+            rate = catalog_store.load().credit_rates.get("tomba")
+            if rate:
+                return int(len(emails) * rate * 1_000_000 + 0.5)
+        return None
     if provider == "hunter" and mk.endpoint_id == "hunter.companies.emails":
         # DERIVED, like apollo. Hunter's domain search does not bill per row at all: it takes ONE
         # whole search credit per 10 emails RETURNED, rounded up, and a domain it knows nobody at is

--- a/src/treg/catalog/tomba.yaml
+++ b/src/treg/catalog/tomba.yaml
@@ -355,7 +355,7 @@ endpoints:
     input:
       queryParams:
         domain: {type: string, required: true, note: "company domain, no protocol or www", example: "stripe.com"}
-        limit: {type: integer, required: false, note: "results per page — an ENUM, not a free integer: 2 is rejected with 'Error validation on Limit:oneof'. 1 and 10 are known-good; treat it as the page-size dial", example: 1}
+        limit: {type: integer, required: false, note: "Start with 10 (the default): 1 and 10 both cost 1 credit. Non-empty pages cost ceil(limit/10) credits even when partially filled. Tested values: 1, 10, 20, 50; 30 is rejected. Check meta.total before requesting more pages", example: 10}
         page: {type: integer, required: false, note: "1-based page number"}
         department: {type: string, required: false, note: "filter by department, e.g. engineering, sales, executive"}
         type: {type: string, required: false, note: "personal | generic — generic means role addresses like sales@"}
@@ -363,16 +363,16 @@ endpoints:
     test_request:
       queryParams: {domain: "stripe.com", limit: 1}
     cost:
-      type: per_result
+      type: per_success
       value: 1
       currency: credit
       per: 1
-      unit: row
+      unit: call
       source: observed
       source_url: https://tomba.io/pricing
-      checked: '2026-08-20'
+      checked: '2026-09-08'
       confidence: verified
-      note: "rate card: 1 credit per email returned — `limit` is the price dial. /v1/logs reported cost=1 for the live limit=1 call"
+      note: "Base price for a non-empty page of up to 10 requested slots. Larger pages cost ceil(limit/10) credits, based on page size rather than returned email count. Empty pages are free. Upstream duplicate requests may be free, but treg does not detect that discount. Verified against /v1/logs with public test domains."
     verified: '2026-08-20'
     example_response: examples/tomba.companies.emails.list.json
     docs_url: https://docs.tomba.io/cli/search

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1858,3 +1858,41 @@ async def test_concurrent_settles_never_lose_a_block_draw(clients: AsyncClient):
     # 8 settles × margin(10,000µ$) each must ALL be drawn from the blocks — none lost.
     from treg.domain.money import with_margin
     assert drawn == 8 * with_margin(10_000)
+
+
+@pytest.mark.parametrize(('query', 'count'), [('', 0), ('&limit=20', 6)])
+async def test_tomba_domain_search_settles_returned_emails(
+    clients: AsyncClient, platform_on, monkeypatch, query, count,
+):
+    """An empty default page and a partially filled explicit page settle on delivered results."""
+    monkeypatch.setenv('TREG_PLATFORM_KEY_TOMBA', 'SYNTHETIC-TOMBA-KEY')
+    monkeypatch.setenv('TREG_PLATFORM_PROVIDERS', 'tomba')
+    get_settings.cache_clear()
+    body = json.dumps({'data': {
+        'domain': 'company.example',
+        'emails': [{'email': f'person{i}@company.example'} for i in range(count)],
+    }, 'meta': {'total': 100}}).encode()
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, body))
+    before = await _balance(clients)
+    response = await clients.get(f'/call/tomba.companies.emails.list?domain=company.example{query}')
+    assert response.status_code == 200
+    assert response.content == body
+    assert await _balance(clients) == before - count * 8_900
+    telemetry = await _telemetry(clients)
+    assert telemetry['cost_estimated_micro'] == 178_000
+    assert telemetry['cost_observed_micro'] == count * 8_900
+    assert telemetry['cost_charged_micro'] == count * 8_900
+
+
+@pytest.mark.parametrize('body', [
+    b'{}', b'{"data": {}}', b'{"data": {"emails": null}}',
+    b'{"data": {"emails": {}}}', b'{"data": null}', b'not json',
+])
+def test_tomba_domain_search_unknown_results_keep_estimate(body):
+    mk = _mk('tomba', endpoint_id='tomba.companies.emails.list', cost_type='per_result')
+    assert call_settle._observed_cost_micro(mk, body) is None
+
+
+def test_tomba_domain_search_count_does_not_apply_to_other_endpoints():
+    mk = _mk('tomba', endpoint_id='tomba.people.email.verify', cost_type='per_call')
+    assert call_settle._observed_cost_micro(mk, b'{"data": {"emails": []}}') is None

--- a/tests/test_marketplace_call.py
+++ b/tests/test_marketplace_call.py
@@ -1860,28 +1860,32 @@ async def test_concurrent_settles_never_lose_a_block_draw(clients: AsyncClient):
     assert drawn == 8 * with_margin(10_000)
 
 
-@pytest.mark.parametrize(('query', 'count'), [('', 0), ('&limit=20', 6)])
+@pytest.mark.parametrize(('query', 'count', 'page_size', 'credits'), [
+    ('', 0, 10, 0), ('', 10, 10, 1), ('&limit=1', 1, 1, 1),
+    ('&limit=10', 6, 10, 1), ('&limit=20', 6, 20, 2),
+    ('&limit=50', 50, 50, 5), ('&limit=20&page=1000', 0, 20, 0),
+])
 async def test_tomba_domain_search_settles_returned_emails(
-    clients: AsyncClient, platform_on, monkeypatch, query, count,
+    clients: AsyncClient, platform_on, monkeypatch, query, count, page_size, credits,
 ):
-    """An empty default page and a partially filled explicit page settle on delivered results."""
+    """Bill non-empty pages by page size; empty pages are free regardless of total matches."""
     monkeypatch.setenv('TREG_PLATFORM_KEY_TOMBA', 'SYNTHETIC-TOMBA-KEY')
     monkeypatch.setenv('TREG_PLATFORM_PROVIDERS', 'tomba')
     get_settings.cache_clear()
     body = json.dumps({'data': {
         'domain': 'company.example',
         'emails': [{'email': f'person{i}@company.example'} for i in range(count)],
-    }, 'meta': {'total': 100}}).encode()
+    }, 'meta': {'total': 100, 'pageSize': page_size}}).encode()
     monkeypatch.setattr(call_service, 'relay', _fake_relay(200, body))
     before = await _balance(clients)
     response = await clients.get(f'/call/tomba.companies.emails.list?domain=company.example{query}')
     assert response.status_code == 200
     assert response.content == body
-    assert await _balance(clients) == before - count * 8_900
+    assert await _balance(clients) == before - credits * 8_900
     telemetry = await _telemetry(clients)
-    assert telemetry['cost_estimated_micro'] == 178_000
-    assert telemetry['cost_observed_micro'] == count * 8_900
-    assert telemetry['cost_charged_micro'] == count * 8_900
+    assert telemetry['cost_estimated_micro'] == max(1, (page_size + 9) // 10) * 8_900
+    assert telemetry['cost_observed_micro'] == credits * 8_900
+    assert telemetry['cost_charged_micro'] == credits * 8_900
 
 
 @pytest.mark.parametrize('body', [
@@ -1896,3 +1900,11 @@ def test_tomba_domain_search_unknown_results_keep_estimate(body):
 def test_tomba_domain_search_count_does_not_apply_to_other_endpoints():
     mk = _mk('tomba', endpoint_id='tomba.people.email.verify', cost_type='per_call')
     assert call_settle._observed_cost_micro(mk, b'{"data": {"emails": []}}') is None
+
+
+@pytest.mark.parametrize('page_size', [None, 0, -1, True, "20", 1.5])
+def test_tomba_unknown_page_size_does_not_guess_from_email_count(page_size):
+    mk = _mk('tomba', endpoint_id='tomba.companies.emails.list', unit_micro=8_900)
+    body = json.dumps({'data': {'emails': [{'email': 'person@company.example'}]},
+                       'meta': {'pageSize': page_size}}).encode()
+    assert call_settle._observed_cost_micro(mk, body) is None


### PR DESCRIPTION
## What this does

Tomba domain search reserves and settles by requested page size: one credit per ten slots, rounded up, with a default page size of ten. A non-empty partial page costs the same as a full page; empty results are free. This replaces the incorrect per-returned-email calculation. Caller parameters and upstream response bytes remain unchanged.

The catalog now describes the base successful-call price and recommends starting with `limit=10`. Live probes using public test domains verified limits 1, 10, 20 and 50, partial pages, and empty pages against Tomba's own billing logs. Regression fixtures contain only synthetic `.example` domains and email addresses.

Known limitation: upstream duplicate requests can cost zero, but the response does not expose that discount. This change does not implement duplicate billing detection or historical balance corrections.

Updated fragment: `docs/context/architecture/money.md`; regenerated the fragment map.

## How it was tested

- Updated regression tests failed against the previous implementation before the fix.
- `python -m pytest tests/test_marketplace_call.py -q`: 130 passed.
- `python -m pytest tests/test_catalog_validate.py tests/test_catalog_api.py tests/test_call_architecture.py -q`: 142 passed.
- Tests used isolated local SQLite databases.
- `lint-imports`: 14 contracts kept, 0 broken.
- `git diff --check` and fragment drift mapping completed.

## Checklist

- [ ] `uv run --with pytest-xdist pytest -n auto -q` passes locally (full suite not run; targeted suites passed)
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
