### PR TITLE
docs(catalog): say "verify before you send" where an agent will read it

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1374,11 +1374,16 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   `{linkedin_url}`), `derive` rules so the two name shapes match the same adapters, a small
   *output* core (`email` required; `confidence`, names, `verified` optional) and `miss` in
   canonical terms. `raw` — the winning provider's body — is always returned and never documented
-  as stable. `advice_unverified` (email and phone finds) is one sentence the router attaches as
-  `_treg.advice` to a hit whose `verified` is not true — a found contact is not a confirmed one
-  (Hunter's `accept_all`, LeadMagic's personal finder, every phone provider), and a team that sent
-  to such hits unverified bounced on most of them (2026-09-06). A suggestion only: treg never
-  chains the verify call, which would double every hit's price and change what the find bills.
+  as stable. `advice_unverified` (email and phone finds, and `people.search`) is one sentence the
+  router attaches as `_treg.advice` to a hit whose `verified` is not true — a found contact is not
+  a confirmed one (Hunter's `accept_all`, LeadMagic's personal finder, every phone provider), and a
+  team that sent to such hits unverified bounced on most of them (2026-09-06). A search contract
+  has no `verified` output, so its advice attaches to every hit: rows are directory listings, and
+  the same team's 79-address bounce list (2026-09-08) was 73 unverified Hunter domain-search rows
+  and agent-guessed `info@` addresses that one verify call each would have caught. The
+  `hunter.companies.emails` catalog summary carries the same warning for direct `/call/` users,
+  whose body is relayed verbatim. A suggestion only: treg never chains the verify call, which
+  would double every hit's price and change what the find bills.
 - **Adapters** — `adapters.yaml`, one per endpoint: `accepts` (identity variants), `in` (contract
   field → `queryParams.x` / `body.x`), `const` (fixed provider params), `out` (core field →
   expression over the body), `miss`. The expression language (`domain/catalog/routing/paths.py`)

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -166,6 +166,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task - generate a video or an image

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -169,6 +169,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task - generate a video or an image

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -150,6 +150,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task - generate a video or an image

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -164,6 +164,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task - generate a video or an image

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -148,6 +148,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 - An endpoint with no published price is refused rather than served free; connect your own key.
 
 ## Task - generate a video or an image

--- a/src/treg/catalog/contracts.yaml
+++ b/src/treg/catalog/contracts.yaml
@@ -266,6 +266,11 @@ contracts:
       next_cursor: {type: str}
     miss: "people == []"
     idempotent: true
+    # Search rows are directory listings. An email in a row is found, not confirmed deliverable,
+    # unless that row's own verification field says so — a team that mailed Hunter domain-search
+    # rows unverified (`verification: null`, confidence 10) bounced on 73 of 79 addresses that one
+    # $0.006 verify call each would have caught (2026-09-08).
+    advice_unverified: "Rows are provider directory listings: an email in a row is found, not confirmed deliverable, unless that row's own verification field says so. Run treg.people.email.verify on each address before outreach (a fraction of a cent), and never send to an address that is not in a row."
 
   # ---- batch 5: company enrichment (2026-08-28) -----------------------------------------------
   companies.enrich:

--- a/src/treg/catalog/hunter.yaml
+++ b/src/treg/catalog/hunter.yaml
@@ -112,7 +112,7 @@ endpoints:
     method: GET
     path: /domain-search
     name: "Find email addresses at a company domain, with roles"
-    summary: "People and email addresses Hunter knows at a company, with roles and confidence"
+    summary: "People and email addresses Hunter knows at a company, with roles and confidence. DELIVERABILITY WARNING: this is a directory listing, not a verified list — each row's `verification.status` is null unless Hunter has checked that mailbox, and `confidence` below ~50 is a pattern guess. Live 2026-09-08, a team that mailed generic rows (info@, sales@) straight from this endpoint bounced on 73 of 79; a hunter.people.email.verify call per address ($0.012, or leadmagic.people.email.verify at $0.006) would have caught all 73. Verify before outreach, and never invent info@ for a domain this returned nothing for."
     input:
       queryParams:
         domain: {type: string, required: false, note: "the company's domain — preferred over company", example: "stripe.com"}

--- a/src/treg/domain/catalog/routing/contracts.py
+++ b/src/treg/domain/catalog/routing/contracts.py
@@ -26,7 +26,9 @@ class Contract:
     default_max_cost_usd: float | None = None  # the per-call ceiling when the caller sends none
     # One sentence the router attaches as `_treg.advice` to a HIT whose `output.verified` is not
     # true — a found contact the provider did not confirm deliverable, which an agent should verify
-    # before outreach. Empty = no advice (a search result is not something you "verify"). A
+    # before outreach. Empty = no advice. A search contract has no `verified` output, so advice
+    # set there attaches to EVERY hit — deliberate for `people.search`, whose rows carry emails
+    # nobody vouched for (2026-09-08: 73 of 79 bounces were unverified directory rows). A
     # suggestion only: treg never chains the verify call itself, which would double every hit's
     # price and change what the find bills for.
     advice_unverified: str = ""

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -224,6 +224,12 @@ A found contact is not a confirmed one: an email or phone find is the provider's
 only `output.verified: true` means it checked the mailbox. Otherwise the answer carries
 `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent) — run it
 before outreach, and never re-send the same find: every hit bills, repeats included.
+Verify before you send, every address, every time — including rows from a company or domain
+search (`treg.people.search`, `hunter.companies.emails`): those are directory listings, and a
+row's email is unconfirmed unless that row's own verification field says so. `invalid` is dead,
+`accept_all` is risky. Never send to an address the provider did not return: an empty domain
+search means `info@` is a guess, not a result. (Live 2026-09-08: 73 of one team's 79 bounces were
+unverified rows and guesses that one $0.006 verify call each would have caught.)
 Call a specific provider's endpoint when you need a particular one.
 
 <!--/routed-->

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -128,6 +128,13 @@ Notes:
     match; only `output.verified: true` means it checked the mailbox. When it is not, the answer
     carries `_treg.advice` naming the verify step (`treg.people.email.verify`, a fraction of a cent)
     — run it before outreach, and never re-send the same find: every hit bills, repeats included.
+  - **Verify before you send. Every address, every time.** This includes rows from a company or
+    domain search (`treg.people.search`, `hunter.companies.emails`, …): those are directory
+    listings, and a row's email is unconfirmed unless that row's own verification field says
+    otherwise. Treat `invalid` as dead and `accept_all` as risky. And never send to an address the
+    provider did not return — if a domain search came back empty, `info@` is a guess, not a result.
+    Live 2026-09-08: 73 of one team's 79 bounces were unverified rows and guesses that one $0.006
+    verify call each would have caught.
 <!--/routed-->
 - An endpoint with no published price is refused rather than served free; connect your own key.
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -262,6 +262,26 @@ async def test_an_unverified_hit_carries_verify_advice(clients: AsyncClient, enr
     assert before - await _balance(clients) == int(r.headers["X-Treg-Cost-Micro"]) == 8_900, "the find, nothing chained"
 
 
+async def test_a_people_search_hit_always_carries_verify_advice(clients: AsyncClient, enrichment_on, monkeypatch):
+    """Search rows are directory listings: a row's email is found, not confirmed deliverable. The
+    contract has no `verified` output, so the advice attaches to every hit — Hunter domain-search
+    rows with `verification: null` were 73 of one team's 79 bounces (2026-09-08). Still a
+    suggestion: one child call, the find's price, nothing chained."""
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider(
+        {"hunter": [(200, {"data": {"emails": [{"value": "info@royalfarms.com", "type": "generic", "confidence": 10,
+                                                 "verification": {"date": None, "status": None}}]},
+                            "meta": {"results": 1}})],
+         "*": [(200, {"persons": []})] * 12}, []))
+    before = await _balance(clients)
+    r = await clients.post("/call/treg.people.search", json={"company_domain": "royalfarms.com", "limit": 10})
+    assert r.status_code == 200, r.text
+    d = r.json()
+    assert d["_treg"]["served_by"] == "hunter.companies.emails" and d["_treg"]["outcome"] == "hit"
+    assert d["output"]["people"][0]["verification"]["status"] is None, "the row's own field, untouched"
+    assert "treg.people.email.verify" in d["_treg"]["advice"] and "directory" in d["_treg"]["advice"]
+    assert before - await _balance(clients) == int(r.headers["X-Treg-Cost-Micro"]), "the find, nothing chained"
+
+
 async def test_error_on_the_first_child_falls_back_to_the_second(clients: AsyncClient, enrichment_on, monkeypatch):
     seen = []
     monkeypatch.setattr(call_service, "relay", _relay_by_provider(


### PR DESCRIPTION
## What

A recruiting team (Financial Loop) sent us 79 bounced addresses. Only 1 had been through a verify call before sending. Re-verified through treg, **73 of 79 come back `invalid`** from LeadMagic ($0.006) or Hunter ($0.012); the 5 that pass are live mailboxes with "left the company" auto-replies or a gateway reject, which no verifier can see. The addresses were Hunter domain-search rows with `verification: null` (confidence as low as 10) and `info@` guesses for domains treg had returned nothing for.

A workflow gap, not a vendor gap. So this is copy and one contract field, not routing:

- **`people.search` gets `advice_unverified`.** A search contract has no `verified` output, so the advice attaches to every hit: rows are directory listings, verify each address, never send to one the provider did not return. This reverses the `contracts.py` comment "a search result is not something you verify"; the comment now says why.
- **`hunter.companies.emails` summary** carries the same deliverability warning, because a direct `/call/` relays the body verbatim and the catalog entry is the only thing that caller reads.
- **`skill.md` and `llms.txt`** get a "verify before you send, every address, every time" rule that covers search rows and guessed addresses. Plugin mirrors regenerated with `scripts/build_plugin.py`.
- Fragment `docs/context/architecture/catalog.md` updated in the same commit.

Nothing is chained: treg still never runs the verify call itself (non-negotiable 4 untouched).

## Tests

- New `test_a_people_search_hit_always_carries_verify_advice`: a Hunter row with null verification is a hit, `output` is the row untouched, `_treg.advice` names the verify endpoint, and the balance moves by the find alone.
- `tests/test_routing.py` 45 passed; catalog, plugin and skill test files 193 passed; `lint-imports` 14 kept.

## Fragments updated

`docs/context/architecture/catalog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKF4gnLT7N9snnZD2W5vFy
