### PR TITLE
feat(mcp): sample feedback hints with a cached PostHog flag

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -235,6 +235,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/localrun.py` | architecture/local-run.md |
 | `src/treg/maintenance.py` | architecture/data-model.md, ops/deploy.md |
 | `src/treg/mcp.py` | architecture/instagram-oauth.md, architecture/mcp-oauth.md |
+| `src/treg/mcp_feedback.py` | architecture/mcp-oauth.md |
 | `src/treg/mcp_install.py` | interface/skill.md |
 | `src/treg/models.py` | architecture/data-model.md, architecture/money.md, architecture/multi-tenancy.md |
 | `src/treg/oauth.py` | architecture/auth-secrets.md |
@@ -316,6 +317,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_marketplace_call.py` | architecture/mcp-oauth.md, architecture/proxy-model.md |
 | `tests/test_mcp.py` | architecture/mcp-oauth.md |
 | `tests/test_mcp_directory.py` | architecture/mcp-oauth.md |
+| `tests/test_mcp_feedback.py` | architecture/mcp-oauth.md |
 | `tests/test_mcp_oauth.py` | architecture/mcp-oauth.md |
 | `tests/test_oauth_billed.py` | architecture/proxy-model.md |
 | `tests/test_oauth_refresh.py` | architecture/auth-secrets.md |
@@ -342,7 +344,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
-| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_oauth.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
+| `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `mcp_feedback.py`, `test_mcp_feedback.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_oauth.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
 | `architecture/money.md` | `__init__.py`, `settlement.py`, `__init__.py`, `models.py`, `billing.py`, `idempotency.py`, `intake.py`, `resolve.py`, `service.py`, `reserve.py`, `settle.py`, `tomba.yaml`, `asynctasks.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `referrals.py`, `budgets.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `api.py`, `signup.py`, `admin.py`, `billing.py`, `call.py`, `orgs.py`, `referrals.py`, `test_call_architecture.py`, `test_asynctasks.py` |
 | `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `asynctasks.py`, `resolve.py`, `signup.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `access.py`, `session.py`, `test_auth.py`, `test_token_revocation.py`, `auth.py`, `orgs.py`, `resources.py`, `bundles.py`, `db.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `test_router_dependencies.py`, `test_asynctasks.py` |
 | `architecture/proxy-model.md` | `relay.py`, `ssrf.py`, `api.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `asynctasks.py`, `client_identity.py`, `call_surface.py`, `sandbox_identity.py`, `access.py`, `publicdemo.py`, `usage.py`, `call.py`, `test_call_application_contract.py`, `test_call_cancellation.py`, `test_error_capture.py`, `test_marketplace_call.py`, `test_oauth_billed.py`, `test_passthrough.py`, `test_tag_billing.py`, `test_tag_billing_adversarial.py`, `test_call_architecture.py`, `test_asynctasks.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -27,7 +27,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [Instagram OAuth — direct Login and optional Facebook Page tools](architecture/instagram-oauth.md) | built; Meta configuration and live verification pending | catalog_ingest.py, access.py, resolve.py, service.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |
 | [Local CLI runs — run a vendor CLI as a dedicated user with a server-held credential (`treg run`)](architecture/local-run.md) | shipped | localrun.py, egress.py, fsjail.py |
-| [MCP — the front door for assistants, and treg as an OAuth authorization server](architecture/mcp-oauth.md) | shipped | auth.py, mcp.py, health.py, mcp_oauth.py, … |
+| [MCP — the front door for assistants, and treg as an OAuth authorization server](architecture/mcp-oauth.md) | shipped | auth.py, mcp.py, mcp_feedback.py, test_mcp_feedback.py, … |
 | [Money — prepaid balance, the ledger, Stripe, and the reports that check it](architecture/money.md) | shipped | __init__.py, settlement.py, __init__.py, models.py, … |
 | [Multi-tenancy — orgs, memberships, invites, per-org scoping](architecture/multi-tenancy.md) | shipped | models.py, api.py, caller_metadata.py, auth.py, … |
 | [The proxy — faithful credential-injecting relay + tool resolution](architecture/proxy-model.md) | shipped | relay.py, ssrf.py, api.py, authorize.py, … |

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -4,6 +4,8 @@ status: shipped
 sources:
   - src/treg/application/auth.py
   - src/treg/mcp.py
+  - src/treg/mcp_feedback.py
+  - tests/test_mcp_feedback.py
   - src/treg/domain/identity/health.py
   - src/treg/domain/identity/mcp_oauth.py
   - src/treg/domain/identity/session.py
@@ -30,6 +32,31 @@ Both transports expose `feedback(category, message, call_ids?, endpoint_id?)`, u
 category enum and the shared HTTP intake. This is an additive, non-destructive write on treg,
 not an upstream call. It requires the existing transport identity and spends no balance.
 See [feedback](feedback.md). V2 retains its catalog-only calling boundary.
+
+## Optional feedback hint rollout
+
+Both MCP call surfaces expose the API's `X-Treg-Call-Id` as optional `call_id`. Successful 2xx
+calls may also include a task-oriented `hint`; existing hints and idempotent replays take priority.
+The provider `body` is unchanged. CLI and direct HTTP responses do not gain a feedback hint.
+
+`mcp_feedback` reads PostHog `/flags?v=2` with the existing `TREG_POSTHOG_KEY` and host. Configure
+boolean flag `mcp-feedback-hint`, enabled for fixed distinct ID `treg-mcp-feedback-hint` (100%
+rollout for that identity), with its enabled payload `{"sample_rate": 0.01}`. This is global
+configuration, not user targeting: **the payload controls per-call sampling**, not the PostHog
+rollout percentage. No new SDK or personal API key is required by the running service.
+
+One background poller is shared by both MCP lifespans, refreshes every 60 seconds with a 3-second
+request timeout, and is cancelled and awaited when the last transport stops. Calls only read the
+cache. Missing/disabled flags, invalid rates, fetch failures, and configuration older than 90 seconds
+disable hints. The payload accepts rates from 0 to 1; use 0 or disable the flag to stop the rollout.
+Changes apply after refresh without a deployment. A new deployment is required to install the code.
+
+Sampling hashes the call ID; when no reference exists it uses a fresh random identifier without
+inventing a public call reference. `mcp_feedback_hint_attached` is a best-effort analytics event
+containing surface, available call ID and the flag marker, never upstream content or credentials.
+It records a hint attached to a result, not proof that a client displayed it or an agent read it.
+Call references can associate reports with exposures; reports without references remain unattributed.
+This initial rollout does not maintain a session-level reminder cap.
 
 ## Provider authorization remediation
 

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -42,6 +42,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl, urlsplit
+from uuid import uuid4
 
 import httpx
 from mcp.server import MCPServer
@@ -51,7 +52,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import METHOD_NOT_FOUND, ToolAnnotations
 
-from . import audit
+from . import analytics, audit, mcp_feedback
 from .domain.catalog import store as catalog_store
 from .config import PUBLIC_HOST_ALIASES, get_settings
 from .feedback_contract import FeedbackCategory, FEEDBACK_DESCRIPTION
@@ -237,6 +238,7 @@ class CatalogGetOut(TypedDict, total=False):
 
 
 class CallOut(TypedDict, total=False):
+    call_id: str | None
     status: int | None              # the UPSTREAM status, relayed
     endpoint_id: str | None
     replayed: bool | None           # answered from an earlier call with the same idempotency_key
@@ -962,6 +964,8 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
         r = await client.request(method, f"{route}/{endpoint_id}", **kw)
 
     out: dict[str, Any] = {"status": r.status_code, "endpoint_id": endpoint_id, "body": _body(r)}
+    if call_id := r.headers.get("X-Treg-Call-Id"):
+        out["call_id"] = call_id
     if r.headers.get("X-Treg-Idempotent-Replay") == "true":
         out["replayed"] = True
         out["hint"] = ("this is the stored answer from the earlier call with the same "
@@ -976,6 +980,13 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
             out["cost_usd"] = round(int(spent) / 1_000_000, 6)
         except ValueError:
             pass
+    if 200 <= r.status_code < 300 and not out.get("hint") and not out.get("replayed"):
+        if mcp_feedback.sampled(out.get("call_id") or uuid4().hex):
+            out["hint"] = mcp_feedback.HINT
+            analytics.capture(analytics.SERVER_DISTINCT_ID, "mcp_feedback_hint_attached", {
+                "call_id": out.get("call_id"), "surface": surface.client_name,
+                f"$feature/{mcp_feedback.FLAG}": True,
+            })
     if r.status_code == 402:
         # States the fact and stops. No link, and `topup_url` is stripped from the relayed body, so
         # nothing on this path points a user at a payment page.
@@ -1567,8 +1578,9 @@ async def mcp_lifespan(target=None):
     inner = target
     while not hasattr(inner, "router"):      # unwrap NoTransformResponses / RequireAuthForProtectedTools
         inner = inner.app
-    async with inner.router.lifespan_context(inner):
-        yield
+    async with mcp_feedback.lifespan():
+        async with inner.router.lifespan_context(inner):
+            yield
 
 
 @asynccontextmanager

--- a/src/treg/mcp_feedback.py
+++ b/src/treg/mcp_feedback.py
@@ -1,0 +1,96 @@
+"""Optional MCP feedback hints, controlled by cached PostHog configuration."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+import hashlib
+import json
+import math
+import time
+
+import httpx
+
+from .config import get_settings
+
+FLAG = "mcp-feedback-hint"
+DISTINCT_ID = "treg-mcp-feedback-hint"
+HINT = (
+    "If this result fell short of your task or took extra work to use, consider using the "
+    "feedback tool. Briefly describe what you needed and what got in the way; omit private "
+    "data. Include this call_id when available. Report the same issue once per task."
+)
+REFRESH_SECONDS = 60
+MAX_AGE_SECONDS = 90
+_rate = 0.0
+_updated_at = 0.0
+_users = 0
+_task: asyncio.Task | None = None
+
+
+def _parse_rate(doc: dict) -> float:
+    if doc.get("errorsWhileComputingFlags") or doc.get("quotaLimited"):
+        return 0.0
+    flag = doc.get("flags", {}).get(FLAG, {})
+    if flag.get("enabled") is not True or flag.get("variant"):
+        return 0.0
+    payload = flag.get("metadata", {}).get("payload")
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    rate = payload.get("sample_rate") if isinstance(payload, dict) else None
+    if type(rate) not in (int, float) or not math.isfinite(rate) or not 0 <= rate <= 1:
+        return 0.0
+    return float(rate)
+
+
+async def refresh(client: httpx.AsyncClient) -> None:
+    """Failure disables hints; no customer identity or request data leaves through this read."""
+    global _rate, _updated_at
+    rate = 0.0
+    settings = get_settings()
+    if settings.posthog_key:
+        try:
+            response = await client.post(
+                f"{settings.posthog_host.rstrip('/')}/flags?v=2",
+                json={"api_key": settings.posthog_key, "distinct_id": DISTINCT_ID},
+                timeout=3.0,
+            )
+            response.raise_for_status()
+            rate = _parse_rate(response.json())
+        except Exception:
+            pass  # Optional product hint: neither log credentials nor fail a call.
+    _rate, _updated_at = rate, time.monotonic()
+
+
+def sampled(sample_id: str) -> bool:
+    """Local, stable sampling; a stale cache or unconfigured deployment is off."""
+    if not get_settings().posthog_key or time.monotonic() - _updated_at > MAX_AGE_SECONDS:
+        return False
+    bucket = int.from_bytes(hashlib.sha256(f"{FLAG}:{sample_id}".encode()).digest()[:8], "big")
+    return bucket < _rate * 2**64
+
+
+async def _poll() -> None:
+    async with httpx.AsyncClient() as client:
+        while True:
+            await refresh(client)
+            await asyncio.sleep(REFRESH_SECONDS)
+
+
+@asynccontextmanager
+async def lifespan():
+    """Both MCP surfaces share one poller; the final owner cancels and awaits it."""
+    global _users, _task, _rate, _updated_at
+    _users += 1
+    if _users == 1 and get_settings().posthog_key:
+        _task = asyncio.create_task(_poll())
+    try:
+        yield
+    finally:
+        _users -= 1
+        if _users == 0:
+            task, _task = _task, None
+            if task is not None:
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+            _rate, _updated_at = 0.0, 0.0

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -377,7 +377,10 @@ async def test_team_and_directory_catalog_call_results_match_except_attribution(
         directory = await _call_tool(client, "catalog_call_read", args, token)
     await audit.drain()
 
-    assert team == directory
+    assert team["call_id"] != directory["call_id"]
+    assert {k: v for k, v in team.items() if k != "call_id"} == {
+        k: v for k, v in directory.items() if k != "call_id"
+    }
     assert team["status"] == 200
     assert team["body"]["auth"] == "Bearer PAIRED-KEY"
     assert team["body"]["headers"]["x-paired-test"] == "same"
@@ -617,3 +620,45 @@ def test_transport_factory_refuses_a_server_audience_mismatch():
         mcp.build_mcp_app(server=mcp.directory_mcp, resource_version="v1")
     with pytest.raises(ValueError, match="same public surface"):
         mcp.build_mcp_app(server=mcp.mcp, resource_version="v2")
+
+
+@pytest.mark.parametrize(('path', 'tool'), [('/mcp/', 'call'), ('/mcp/v2/', 'catalog_call_read')])
+@pytest.mark.parametrize('sampled', [False, True])
+async def test_feedback_hint_only_wraps_successful_sampled_calls(clients, monkeypatch, path, tool, sampled):
+    from treg import analytics, mcp_feedback
+    from treg.application.call import service as call_service
+    from test_marketplace_call import _fake_relay
+
+    monkeypatch.setenv('TREG_PLATFORM_KEY_TIKHUB', 'SYNTHETIC-PLATFORM-KEY')
+    monkeypatch.setenv('TREG_PLATFORM_PROVIDERS', 'tikhub')
+    get_settings.cache_clear()
+    monkeypatch.setattr(mcp_feedback, 'sampled', lambda _: sampled)
+    events = []
+    monkeypatch.setattr(analytics, 'capture', lambda *args, **kw: events.append((args, kw)))
+    body = b'{"data":{"items":[]}}'
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, body))
+    token = clients.headers['X-Treg-Token']
+    args = {'endpoint_id': 'tikhub.tiktok.video.comments', 'params': {'aweme_id': '7'},
+            'idempotency_key': 'feedback-hint-test'}
+    try:
+        async with paired_mcp_session() as client:
+            first = await _call_tool(client, tool, args, token, path=path)
+            replay = await _call_tool(client, tool, args, token, path=path)
+            monkeypatch.setattr(call_service, 'relay', _fake_relay(503, b'{"error":"unavailable"}'))
+            failed = await _call_tool(client, tool, {**args, 'idempotency_key': 'failed'}, token, path=path)
+        assert first['status'] == 200
+        assert first['body'] == json.loads(body)
+        assert first.get('hint') == (mcp_feedback.HINT if sampled else None)
+        assert first['call_id']
+        assert replay['replayed'] is True
+        assert 'stored answer' in replay['hint']
+        assert replay['call_id'] == first['call_id']
+        assert failed['status'] == 503
+        assert failed.get('hint') != mcp_feedback.HINT
+        exposures = [a for a, _ in events if a[1] == 'mcp_feedback_hint_attached']
+        assert len(exposures) == int(sampled)
+        if sampled:
+            assert exposures[0][2]['call_id'] == first['call_id']
+            assert 'body' not in exposures[0][2]
+    finally:
+        get_settings.cache_clear()

--- a/tests/test_mcp_feedback.py
+++ b/tests/test_mcp_feedback.py
@@ -1,0 +1,94 @@
+"""Flag failures must never delay or change a tool result."""
+import asyncio
+import json
+import time
+
+import httpx
+import pytest
+
+from treg import mcp_feedback as hints
+from treg.config import get_settings
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setenv('TREG_POSTHOG_KEY', 'synthetic-project-key')
+    get_settings.cache_clear()
+    monkeypatch.setattr(hints, '_rate', 0.0)
+    monkeypatch.setattr(hints, '_updated_at', 0.0)
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.parametrize('payload', [{'sample_rate': 0.01}, '{"sample_rate":0.01}'])
+async def test_flag_payload_refresh_and_disable(configured, payload):
+    enabled = True
+    def handler(request):
+        assert request.url.path == '/flags'
+        assert json.loads(request.content) == {
+            'api_key': 'synthetic-project-key', 'distinct_id': hints.DISTINCT_ID,
+        }
+        return httpx.Response(200, json={'flags': {hints.FLAG: {
+            'enabled': enabled, 'metadata': {'payload': payload},
+        }}})
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hints.refresh(client)
+        assert hints._rate == 0.01
+        enabled = False
+        await hints.refresh(client)
+        assert hints._rate == 0
+
+
+@pytest.mark.parametrize('doc', [
+    {}, None, {'flags': None}, {'errorsWhileComputingFlags': True},
+    {'quotaLimited': ['feature_flags']},
+    *[{'flags': {hints.FLAG: {'enabled': True, 'metadata': {'payload': p}}}}
+      for p in [None, 'invalid', {}, {'sample_rate': True}, {'sample_rate': -1},
+                {'sample_rate': 2}, {'sample_rate': '0.01'}, {'sample_rate': float('inf')}]],
+])
+async def test_invalid_config_disables_previous_value(configured, monkeypatch, doc):
+    monkeypatch.setattr(hints, '_rate', 1.0)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(
+        lambda _: httpx.Response(200, content=json.dumps(doc))
+    )) as client:
+        await hints.refresh(client)
+    assert hints._rate == 0
+
+
+async def test_network_failure_disables_hints(configured, monkeypatch):
+    monkeypatch.setattr(hints, '_rate', 1.0)
+    def fail(_):
+        raise httpx.ReadTimeout('timeout')
+    async with httpx.AsyncClient(transport=httpx.MockTransport(fail)) as client:
+        await hints.refresh(client)
+    assert hints._rate == 0
+
+
+def test_sampling_is_stable_and_stale_config_is_off(configured, monkeypatch):
+    monkeypatch.setattr(hints, '_rate', 0.01)
+    monkeypatch.setattr(hints, '_updated_at', time.monotonic())
+    first = [hints.sampled(str(i)) for i in range(10000)]
+    assert first == [hints.sampled(str(i)) for i in range(10000)]
+    assert 60 < sum(first) < 140
+    monkeypatch.setattr(hints, '_updated_at', time.monotonic() - hints.MAX_AGE_SECONDS - 1)
+    assert not any(hints.sampled(str(i)) for i in range(100))
+
+
+async def test_lifespans_share_poller_and_await_shutdown(configured, monkeypatch):
+    started, stopped = asyncio.Event(), asyncio.Event()
+    async def poll():
+        started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            stopped.set()
+    monkeypatch.setattr(hints, '_poll', poll)
+    async with hints.lifespan():
+        await started.wait()
+        task = hints._task
+        async with hints.lifespan():
+            assert hints._task is task
+        assert not stopped.is_set()
+    assert stopped.is_set()
+    assert hints._task is None
+    assert hints._rate == 0


### PR DESCRIPTION
## What this does

Successful MCP calls can include a brief, optional feedback hint about task fit and extra work needed to use a result. Both MCP surfaces share the behavior. Existing hints and idempotent replays take precedence; upstream bodies, CLI output and direct HTTP responses remain unchanged. The MCP envelope also exposes an available call ID for reporting.

The PostHog boolean flag `mcp-feedback-hint` supplies an enabled payload such as `{"sample_rate":0.01}`. A fixed server identity reads this global configuration; the percentage in the payload controls stable per-call sampling, not a user rollout. A shared background task refreshes every 60 seconds. Calls never wait for PostHog; missing, invalid, disabled, failed or stale configuration disables hints. This uses the existing project ingestion key, with no new SDK or runtime secret.

A best-effort `mcp_feedback_hint_attached` event records surface and available call ID. It does not record request/response contents or claim the agent read the hint. No session-level reminder cap is implemented.

Updated fragment: `docs/context/architecture/mcp-oauth.md`; source mappings regenerated.

## How it was tested

- `python -m pytest tests/test_mcp_feedback.py tests/test_mcp.py tests/test_mcp_directory.py tests/test_app_roles.py -q`: 128 passed using an isolated local SQLite database.
- Covers both MCP transports, sampled and unsampled successes, failures, idempotent replays, call references, unchanged bodies, configuration parsing/failures, stable sampling, stale expiry and shared-poller shutdown.
- `lint-imports`: 14 contracts kept, 0 broken.
- `git diff --check` and fragment drift mapping completed.

## Rollout

Not deployed. The production PostHog flag still needs provisioning in the correct project. Configure the boolean flag with 100% rollout and enabled payload `{"sample_rate":0.01}`; disable it or set the rate to zero to stop hints after refresh. No production flag was changed with an unrelated project's credentials.

## Checklist

- [ ] `uv run --with pytest-xdist pytest -n auto -q` passes locally (targeted suites passed; full suite left to CI)
- [x] Added or updated tests for the change
- [x] Updated the relevant context fragment
- [x] No secrets or customer data in the diff
