### PR TITLE
fix(capacity): enable Influencers Club fallback

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -316,6 +316,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
 | `tests/test_feedback.py` | architecture/feedback.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
+| `tests/test_influencersclub_overflow.py` | ops/capacity.md |
 | `tests/test_instagram_oauth_architecture.py` | architecture/instagram-oauth.md |
 | `tests/test_marketplace_call.py` | architecture/mcp-oauth.md, architecture/proxy-model.md |
 | `tests/test_mcp.py` | architecture/mcp-oauth.md |
@@ -364,6 +365,6 @@ Regenerate via `scripts/build-map.py`.
 | `interface/seo.md` | `api.py`, `web.py`, `agent_pages.py`, `robots.txt`, `catalog.css`, `usecase.css`, `index.html`, `landing.html`, `people-search.html`, `grokbot.html`, `fable-gtm.html`, `astra.html`, `page.css`, `page.js`, `llms.txt`, `indexnow_submit.py`, `support.html`, `og-card.html` |
 | `interface/shell.md` | `shell.py`, `cli.py` |
 | `interface/skill.md` | `skill.md`, `web.py`, `mcp_install.py`, `build_plugin.py`, `plugin.json`, `marketplace.json`, `plugin.json`, `plugin.json`, `package.json`, `cordis.patch.yml`, `index.js`, `plugin.json`, `minimax_plugin.py` |
-| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py`, `test_capacity_collectors.py` |
+| `ops/capacity.md` | `__init__.py`, `collectors.py`, `policy.py`, `sweep.py`, `view.py`, `routes.py`, `signatures.py`, `verify.py`, `marks.py`, `test_capacity_protect.py`, `limiter.py`, `overflow_spend.py`, `routes_view.py`, `overflow.py`, `0007_overflow_spend.py`, `test_capacity_overflow.py`, `test_capacity_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `test_capacity_smoothing.py`, `overflow_seed.json`, `__init__.py`, `orthogonal.py`, `monid.py`, `catalogs.py`, `0006_overflow_route.py`, `test_capacity_overflow_routes.py`, `test_influencersclub_overflow.py`, `worker.py`, `provider_balances.py`, `0005_capacity_policy_snapshot.py`, `test_capacity_know.py`, `test_capacity_collectors.py` |
 | `ops/deploy.md` | `pyproject.toml`, `__main__.py`, `maintenance.py`, `env.py`, `worker.py`, `selfhost.sh`, `config.py`, `db.py`, `email.py`, `audit.py`, `dev-local.sh`, `render.yaml` |
 | `reference/glossary.md` | `2026-06-30-jason-tools-registry.md` |

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -381,6 +381,14 @@ When the resolver already knows the account is out (the exhausted view) **and** 
 ladder skips the direct attempt entirely (`MarketplaceCall.skip_direct`): no parent hold, no vendor
 402, straight to the child - the plan's tier 4b.
 
+Influencers Club discovery/search and similar-creators routes have a verified flat Orthogonal
+price against our per-creator direct price. Both entry points pass the direct request estimate
+to the route view: `routes.route_for` excludes these routes when the fixed fee exceeds 4× that
+estimate, before any child hold or aggregator budget is reserved. The worker also bounds the fee
+by the verified $0.03 ceiling. A one-creator request currently cannot overflow; a request for two
+or more can. The original paging/filter body is relayed unchanged and the child settles once at
+the aggregator's reported price, even if the page is empty. See `ops/capacity.md` for verification.
+
 **An aggregator failure is data.** Its own 401/402/403 or a malformed envelope releases the child
 hold and marks `overflow:<name>` unhealthy for everyone; a relayed vendor answer the signature table
 reads as that vendor's own out-of-credit or quota dialect (`VENDOR_DRY`: a 402, Apollo's 422 through

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -28,6 +28,7 @@ sources:
   - src/treg/infra/upstream/aggregators/catalogs.py
   - src/treg/alembic/versions/0006_overflow_route.py
   - tests/test_capacity_overflow_routes.py
+  - tests/test_influencersclub_overflow.py
   - src/treg/worker.py
   - scripts/provider_balances.py
   - src/treg/alembic/versions/0005_capacity_policy_snapshot.py
@@ -137,13 +138,30 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   dry) · verified within 7 days. `match_catalogs` derives candidates from the aggregators' catalogs
   by exact `(host, method, path)` (Orthogonal) / `(provider, path)` (Monid); `apply_sync` upserts
   and re-derives `enabled`, and disables any row missing from the current sync.
-- **The seed** — `overflow_seed.json`: the 461 candidate pairs from the 2026-08-26 mapping run,
-  145 of them carrying `verified_at` (direct vs relay, identical body shape, in-band price = list
-  price). Under the rules, `treg-worker overflow sync` enables **113** of the 145 (pinned by test);
-  the rest are off for a named reason — 23 are our per-result price vs the aggregator's per-call
+- **Influencers Club discovery**: `request_priced` permits the two exact Orthogonal contracts
+  `influencersclub.creators.search` and `.similar` to compare the flat aggregator price against
+  the direct **request estimate**. `/v1/details` and live runs with 2 and 10 creators confirmed
+  $0.03 per request on 2026-09-08. The worker requires a fresh verification and a price at or below
+  the verified $0.03 ceiling; `route_for(estimate_micro=...)` enforces the existing 4× guard before
+  reserve on both the resolver's skip-direct path and the post-failure child cycle. At our current
+  $0.00598 per creator, a request for one creator is ineligible and two or more qualify. The
+  request is never enlarged to qualify. Other unit mismatches remain disabled. A fallback charges
+  the aggregator's actual flat fee, including an empty page, rather than multiplying by results.
+- **The seed** — `overflow_seed.json`: the 461 candidate pairs from the 2026-08-26 mapping run.
+  Its original 145 verification stamps recorded identical direct/relay body shapes and in-band
+  price matching list price. At the mapping date, `treg-worker overflow sync` enabled **113** of
+  those 145 (the historical baseline is pinned by test); the rest were off for a named reason —
+  23 were our per-result price vs the aggregator's per-call
   price (an open decision, plan §7), 7 are not platform-eligible, the remainder have no aggregator
   price, a 56× ratio, or a barred provider. The enabled count decays to 0 after 7 days without
-  `treg-worker overflow verify`.
+  `treg-worker overflow verify`. A separate 2026-09-08 live comparison adds ten verified
+  Influencers Club routes (discovery, similar creators, audience overlap, full/raw enrichment,
+  posts, post details, socials, languages and audience interests). The verification record is
+  `tests/fixtures/aggregators/verification/influencersclub.json`; a redacted discovery envelope is
+  `tests/fixtures/aggregators/orthogonal_influencersclub_search.json`. Email enrichment remains
+  unverified because its catalog entry has no test request; profile/analytics enrichment and
+  parameterized locations have no mapped fallback. The August baseline test keeps its original
+  timestamps; `test_live_verified_seed_enables_ten_routes_and_expires` pins the September addition.
 - **`signatures.py`** — the signature table: what a provider's error body means for OUR account
   (`balance` / `quota` → exhausted; `burst` → smoothed, never exhausted; `unknown` 429 → logged).
   Lusha's "Daily" 429 and Hunter's "per billing period" 429 are quota exhaustion wearing a 429;
@@ -152,7 +170,10 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   not one attempt, because no row matched. Moz says it with a **403** `{"issue": "insufficient-quota"}`
   (`quota`: the row allowance resets on Moz's billing day, which the body does not name → default
   lock), recorded after 2026-09-04: 115 of one org's calls went upstream to the spent key and came
-  back 403, and "quota" alone is not a tripwire word so nothing was even logged. Two guards against
+  back 403, and "quota" alone is not a tripwire word so nothing was even logged. Influencers Club's
+  documented HTTP 429 `Discovery API credit limit reached` is an endpoint quota signal; ordinary
+  per-minute 429s with Retry-After remain bursts. HTTP 402 still uses the shared balance signature.
+  Two guards against
   the next such vendor: `unrecorded`,
   a signal kind for a 4xx no row matched whose body still names credits/quota/balance (pattern =
   the table's own phrases plus generic nouns) - never a mark, only a log line and
@@ -183,7 +204,9 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   with the reason. `--max-usd` (default 2¢) is a per-route price cap, not a run budget: pricier
   routes are skipped, as are routes whose endpoint has no `test_request`. Without `--all` only
   enabled or previously-stamped rows are visited, so a never-verified pair never enters the rota;
-  run it with `--all`. Verify only STAMPS - `overflow sync` is what re-derives `enabled` from the
+  run it with `--all`. `--only` restricts the run to comma-separated provider IDs, allowing a
+  higher per-route price cap for one provider without probing every pricier route in the table.
+  Verify only STAMPS - `overflow sync` is what re-derives `enabled` from the
   stamps, so every verify must be followed by a sync (by hand today, `ops/deploy.md`); a route
   disabled by one failed verify is only re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
   completing (it used to exit 1 whenever any route failed, which made every Render run read
@@ -265,7 +288,7 @@ Own keys are never relayed regardless. The charter's "not built" row, `llms.txt`
 plugin), `README.md` and `USAGE.md` now say what treg may do and how it discloses it.
 
 **Rollout runbook (Jason):** 1. set `TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID` (rotated keys) in the
-Render web service; 2. `treg-worker overflow sync` (113 routes enable from the seed; `--live` also
+Render web service; 2. `treg-worker overflow sync` (recently verified eligible routes enable; `--live` also
 refreshes prices) and schedule `treg-worker overflow verify` weekly (routes decay off after 7 days
 without it); 3. `TREG_OVERFLOW_MODE=shadow` for a week — watch the `overflow SHADOW` log lines and
 the `platform-overflow` audit rows for shape mismatches and the daily `OverflowSpend`; 4.

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -542,6 +542,15 @@ jobs on the verify cron service, in order - `render jobs create <cron-id> --star
 `enabled` count of the second. Verify only
 stamps; sync is what opens routes.
 
+Influencers Club's verified routes include $0.03 discovery calls and enrichment up to $0.66,
+so the default $0.02 verification cap cannot maintain them. After deploying the code and syncing
+the seed, run `treg-worker overflow verify --only influencersclub --max-usd 0.66`, followed by
+`treg-worker overflow sync`. Include that scoped verification in the weekly cron routine before
+its final sync; do not raise the price cap for every provider. The `--only` filter accepts
+comma-separated provider IDs. These calls spend the aggregator fee plus the direct comparison
+cost. Email enrichment has no test request and stays unverified; ten other mapped routes were
+compared successfully on 2026-09-08. A verification run alone does not enable routes.
+
 Aggregator keys
 (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same
 way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -240,7 +240,7 @@ async def _maybe_overflow_attempt(
     why = force_trigger or _trigger(mk, status, headers, body)
     if why is None:
         return None
-    routes = routes_view.for_endpoint(mk.endpoint_id)
+    routes = routes_view.for_endpoint(mk.endpoint_id, estimate_micro=mk.estimate_micro)
     routes = [r for r in routes if settings.overflow_key_for(r.aggregator)
               and not capacity_view.is_exhausted(f"overflow:{r.aggregator}")
               and not capacity_view.is_exhausted(f"overflow:{r.aggregator}:{mk.provider}")]

--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -1351,7 +1351,7 @@ async def _resolve_marketplace_call(
         if lock is not None and capacity_marks.probe_due(lock.key):
             probe_lock_id = lock.lock_id
         elif (get_settings().overflow_mode == "on" and not caller.org.platform_overflow_disabled
-                and overflow_routes_view.for_endpoint(ep["id"])):
+                and overflow_routes_view.for_endpoint(ep["id"], estimate_micro=info_est)):
             skip_direct = True
         else:
             raise _provider_capacity_unavailable(

--- a/src/treg/domain/capacity/overflow_seed.json
+++ b/src/treg/domain/capacity/overflow_seed.json
@@ -1956,7 +1956,7 @@
   "method": "POST",
   "path": "/public/v1/creators/audience/overlap/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -1984,7 +1984,7 @@
   "method": "POST",
   "path": "/public/v1/creators/enrich/handle/full/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -1998,7 +1998,7 @@
   "method": "POST",
   "path": "/public/v1/creators/enrich/handle/raw/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2012,7 +2012,7 @@
   "method": "GET",
   "path": "/public/v1/discovery/classifier/audience-interests/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2026,7 +2026,7 @@
   "method": "GET",
   "path": "/public/v1/discovery/classifier/languages/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2040,7 +2040,7 @@
   "method": "POST",
   "path": "/public/v1/creators/content/details/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2054,7 +2054,7 @@
   "method": "POST",
   "path": "/public/v1/creators/content/posts/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2068,7 +2068,7 @@
   "method": "POST",
   "path": "/public/v1/discovery/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2082,7 +2082,7 @@
   "method": "POST",
   "path": "/public/v1/discovery/creators/similar/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {
@@ -2096,7 +2096,7 @@
   "method": "POST",
   "path": "/public/v1/creators/socials/",
   "matched_at": "2026-08-26",
-  "verified_at": null,
+  "verified_at": "2026-09-08T10:33:11",
   "single_result": null
  },
  {

--- a/src/treg/domain/capacity/routes.py
+++ b/src/treg/domain/capacity/routes.py
@@ -20,8 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from ...models import CapacityPolicy, OverflowRoute
 from ...timeutil import utcnow_naive
 
-MAX_RATIO = 4.0
-"""Caller pays the aggregator's real price; a route above this multiple of ours is never enabled."""
+MAX_RATIO = 4
+"""Maximum aggregator/direct price ratio, checked per event or per request for fixed discovery."""
 VERIFY_MAX_AGE = timedelta(days=7)
 FREE_ROUTE_MAX_USD = 0.01
 """A FREE endpoint of ours has no ratio (÷0). Its account still runs dry — tomba's free
@@ -29,6 +29,25 @@ FREE_ROUTE_MAX_USD = 0.01
 aggregator's price is at most this (disclosed like any other overflow charge)."""
 AGGREGATOR_ORDER = ("orthogonal", "monid")
 SEED_PATH = Path(__file__).with_name("overflow_seed.json")
+
+# Orthogonal /details reports a fixed $0.03 per request for these two discovery routes
+# (2026-09-08), while our direct account pays per creator. Compare against the REQUEST's
+# direct estimate at admission, not a single creator. Keep this exception confined to the
+# verified contracts; other per-result/per-call mismatches still require their own evidence.
+_FIXED_DISCOVERY_PATHS = {
+    "influencersclub.creators.search": "/public/v1/discovery/",
+    "influencersclub.creators.similar": "/public/v1/discovery/creators/similar/",
+}
+_FIXED_DISCOVERY_MAX_MICRO = 30_000
+
+
+def request_priced(route: OverflowRoute) -> bool:
+    """Does this exact fixed-fee contract require a request estimate for price admission?"""
+    path = _FIXED_DISCOVERY_PATHS.get(route.endpoint_id)
+    return bool(path and route.aggregator == "orthogonal" and route.provider == "influencersclub"
+                and route.agg_slug == "influencers-club" and route.method == "POST"
+                and route.path == path and route.agg_path == path and route.agg_unit == "call")
+
 
 # The vendor path-prefix normalizations the mapping run observed (plan §4.3): the aggregator writes
 # the base path into the endpoint path where our catalog keeps it on the provider's base URL.
@@ -92,16 +111,20 @@ def eligible(route: OverflowRoute, *, our_cost: dict | None, platform_eligible: 
     kind = our_unit_kind(our_cost)
     if kind is None:
         return Eligibility(False, "our price has no unit")
-    if route.agg_unit != kind and not (route.agg_unit == "result" and kind == "call"
-                                       and route.single_result):
+    per_request = request_priced(route) and kind == "result"
+    if route.agg_unit != kind and not per_request and not (route.agg_unit == "result" and kind == "call"
+                                                         and route.single_result):
         return Eligibility(False, f"unit mismatch: ours {kind}, aggregator {route.agg_unit}")
+    if per_request and (route.agg_price_micro is None
+                        or not 0 <= route.agg_price_micro <= _FIXED_DISCOVERY_MAX_MICRO):
+        return Eligibility(False, "fixed discovery price exceeds verified ceiling or is missing")
     agg_usd = (route.agg_price_micro or 0) / 1_000_000 if route.agg_price_micro is not None else None
     if our_usd == 0 and agg_usd is not None:
         if agg_usd > FREE_ROUTE_MAX_USD:
             return Eligibility(False, f"free for us, aggregator ${agg_usd:g} > ${FREE_ROUTE_MAX_USD}")
     elif route.ratio is None:
         return Eligibility(False, "no price on one side")
-    elif route.ratio > MAX_RATIO:
+    elif route.ratio > MAX_RATIO and not per_request:
         return Eligibility(False, f"ratio {route.ratio} > {MAX_RATIO}")
     if route.last_verified_at is None:
         return Eligibility(False, "never verified")
@@ -227,7 +250,13 @@ async def apply_sync(db: AsyncSession, candidates: list[dict], *, catalog, now: 
     return SyncResult(len(seen), enabled, disabled)
 
 
-def route_for(routes: list[OverflowRoute], endpoint_id: str) -> list[OverflowRoute]:
+def route_for(routes: list[OverflowRoute], endpoint_id: str, *,
+              estimate_micro: int | None = None) -> list[OverflowRoute]:
     """Enabled routes for an endpoint in aggregator order — Orthogonal first (plan decision)."""
     mine = [r for r in routes if r.endpoint_id == endpoint_id and r.enabled]
+    if estimate_micro is not None:
+        mine = [r for r in mine if not request_priced(r)
+                or (r.agg_price_micro is not None
+                    and 0 <= r.agg_price_micro <= min(_FIXED_DISCOVERY_MAX_MICRO,
+                                                    MAX_RATIO * max(0, estimate_micro)))]
     return sorted(mine, key=lambda r: AGGREGATOR_ORDER.index(r.aggregator) if r.aggregator in AGGREGATOR_ORDER else 99)

--- a/src/treg/domain/capacity/routes_view.py
+++ b/src/treg/domain/capacity/routes_view.py
@@ -31,9 +31,9 @@ class RouteView:
         self._routes, self._loaded_at = list(rows), time.monotonic()
         return self._routes
 
-    def for_endpoint(self, endpoint_id: str) -> list[OverflowRoute]:
+    def for_endpoint(self, endpoint_id: str, *, estimate_micro: int | None = None) -> list[OverflowRoute]:
         """Enabled routes, Orthogonal first. Sync."""
-        return route_for(self._routes, endpoint_id)
+        return route_for(self._routes, endpoint_id, estimate_micro=estimate_micro)
 
     def invalidate(self) -> None:
         self._loaded_at = -1.0

--- a/src/treg/domain/capacity/signatures.py
+++ b/src/treg/domain/capacity/signatures.py
@@ -48,6 +48,9 @@ _TABLE: list[tuple[str, int, str, str]] = [
     # unrecognised on 2026-09-04 (nothing here matched a 403, and "quota" alone is not a tripwire
     # word). The period resets on Moz's billing day, which the answer does not name.
     ("moz", 403, r"insufficient-quota", "quota"),
+    # Documented 2026-09-08: discovery's allowance is distinct from the shared credit pool.
+    # https://docs.influencers.club/guides/error-handling — ordinary burst 429s have Retry-After.
+    ("influencersclub", 429, r"Discovery API credit limit reached", "quota"),
     ("*", 402, r"", "balance"),
 ]
 
@@ -63,6 +66,7 @@ CAPACITY_PHRASES = (
     r"insufficient (?:credits?|balance|funds)", r"out of credits?", r"credits? (?:exhausted|remaining|left)",
     r"(?:account |api |credit )?(?:balance|quota)(?: (?:has been|is|was))? (?:exceeded|reached|exhausted|limit)",
     r"upgrade your plan", r"insufficient-quota", r"not have enough quota",
+    r"discovery api credit limit reached",
 )
 _UNRECORDED = re.compile(r"\b(?:" + "|".join(f"(?:{p})" for p in CAPACITY_PHRASES) + r")\b", re.IGNORECASE)
 

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -112,7 +112,9 @@ async def _overflow_verify(args) -> int:
     by_id = {e["id"]: e for e in cat.endpoints}
     async with session_maker() as db:
         rows = (await db.execute(select(OverflowRoute))).scalars().all()
-    todo = [r for r in rows if args.all or r.enabled or r.last_verified_at]
+    only = {p.strip() for p in (getattr(args, "only", None) or "").split(",") if p.strip()}
+    todo = [r for r in rows if (args.all or r.enabled or r.last_verified_at)
+            and (not only or r.provider in only)]
     keys = {"orthogonal": s.overflow_key_orthogonal, "monid": s.overflow_key_monid}
     tally = {"passed": 0, "failed": 0, "aggregator": 0, "inconclusive": 0}
     skipped, key_failures = 0, []
@@ -217,6 +219,7 @@ def main(argv: list[str] | None = None) -> int:
     sync.set_defaults(fn=_overflow_sync)
     ver = ovsub.add_parser("verify", help="re-verify routes with a cheap call (spends money; needs keys)")
     ver.add_argument("--all", action="store_true", help="every row, not only enabled/previously verified")
+    ver.add_argument("--only", help="comma-separated providers (default: all)")
     ver.add_argument("--max-usd", type=float, default=0.02, help="skip routes priced above this")
     ver.set_defaults(fn=_overflow_verify)
     tasks = sub.add_parser("asynctasks", help="deferred asynchronous task settlement")

--- a/tests/fixtures/aggregators/orthogonal_influencersclub_search.json
+++ b/tests/fixtures/aggregators/orthogonal_influencersclub_search.json
@@ -1,0 +1,52 @@
+{
+  "status": 200,
+  "body": {
+    "success": true,
+    "priceCents": 3,
+    "quotedPriceCents": 3,
+    "billing": {
+      "requestId": "hashed:f0f45c9493",
+      "parentRequestId": null,
+      "rootRequestId": "hashed:f0f45c9493",
+      "continuation": false,
+      "billable": true,
+      "quotedPriceCents": 3,
+      "chargedPriceCents": 3,
+      "aggregateChargedPriceCents": 3
+    },
+    "data": {
+      "total": 57,
+      "limit": 2,
+      "accounts": [
+        {
+          "user_id": "hashed:e6b1f226a1",
+          "profile": {
+            "full_name": "hashed:6b26b6335a",
+            "username": "hashed:f247b15817",
+            "picture": "hashed:694591d0ba",
+            "followers": 2314399,
+            "engagement_percent": 2.7200000286102295
+          }
+        },
+        {
+          "user_id": "hashed:993b647a91",
+          "profile": {
+            "full_name": "hashed:2bda887e4a",
+            "username": "hashed:5c31210466",
+            "picture": "hashed:7b3f76844f",
+            "followers": 1311466,
+            "engagement_percent": 9.279999732971191
+          }
+        }
+      ],
+      "credits_left": 2924,
+      "credits_cost": 0.02
+    },
+    "requestId": "hashed:f0f45c9493"
+  },
+  "expect": {
+    "upstream_status": 200,
+    "price": 3,
+    "ok": true
+  }
+}

--- a/tests/fixtures/aggregators/verification/influencersclub.json
+++ b/tests/fixtures/aggregators/verification/influencersclub.json
@@ -1,0 +1,102 @@
+{
+  "verified_at": "2026-09-08T10:33:11",
+  "source": "Live direct vs Orthogonal /v1/run, same test_request; /v1/details confirmed fixed pricing.",
+  "results": [
+    {
+      "endpoint_id": "influencersclub.creators.audience.overlap",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 660000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.enrich.full",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 660000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.enrich.raw",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 20000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.filters.audience_interests",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 0,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.filters.languages",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 0,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.post.details",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 20000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.posts",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 20000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.search",
+      "limit": 2,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 30000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.search",
+      "limit": 10,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 30000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.similar",
+      "limit": 2,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 30000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.similar",
+      "limit": 10,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 30000,
+      "same_shape": true
+    },
+    {
+      "endpoint_id": "influencersclub.creators.socials",
+      "limit": null,
+      "direct_status": 200,
+      "relay_status": 200,
+      "cost_micro": 330000,
+      "same_shape": true
+    }
+  ]
+}

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -96,7 +96,9 @@ def test_match_catalogs_by_exact_host_method_path_with_prefix_folding():
 
 async def test_sync_reproduces_the_verified_set_and_never_enables_a_bad_ratio(monkeypatch):
     await reset_db()
-    seed = R.load_seed()
+    # Preserve the August baseline; September's Influencers Club verification is tested separately.
+    seed = [{**x, "verified_at": None} if x["provider"] == "influencersclub" else x
+            for x in R.load_seed()]
     verified = {(x["endpoint_id"], x["aggregator"]) for x in seed if x["verified_at"]}
     assert len(verified) == 145, "the 2026-08-26 verified set (131 ROUTE + 11 tomba + 2 phone + hunter domain-search)"
     # Freeze "now" at the mapping date so the seed's stamps are within the 7-day window.
@@ -248,7 +250,7 @@ def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
 # gap, not a claim the vendor never runs dry: their 4xx trips `unrecorded` instead.
 _UNRECORDED_SIGNATURE = {
     "apify", "aviato", "branddev", "brightdata", "coingecko", "coresignal", "crustdata", "dataforseo",
-    "diffbot", "exa", "fiber-ai", "finnhub", "icypeas", "influencersclub", "justoneapi", "marketstack",
+    "diffbot", "exa", "fiber-ai", "finnhub", "icypeas", "justoneapi", "marketstack",
     "millionverifier",  # funded-account exhaustion not observed; trial still has credits
     "minimax", "oceanio", "openrouter", "pdl", "replicate", "scrapecreators", "seranking",
     "serpapi", "serpstat", "spyfu", "tiingo", "tikhub", "tomba", "twelvedata",

--- a/tests/test_influencersclub_overflow.py
+++ b/tests/test_influencersclub_overflow.py
@@ -1,0 +1,245 @@
+"""Influencers Club's fixed-price Orthogonal fallback, exercised through /call/."""
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from treg import ratestore, worker
+from treg.application.call import overflow as O, service as call_service
+from treg.config import get_settings
+from treg.domain.capacity import routes as R, signatures as S
+from treg.domain.capacity import verify as V
+from treg.domain.capacity.policy import LatestState
+from treg.domain.capacity.routes_view import view as routes_view
+from treg.domain.capacity.sweep import STATE_NS
+from treg.domain.capacity.view import view as capacity_view
+from treg.domain.catalog import store as catalog_store
+from treg.infra.db import reset_db, session_maker
+from treg.models import LedgerEntry, OverflowRoute, OverflowSpend
+from treg.timeutil import utcnow_naive
+
+from test_capacity_overflow import _holds, _orthogonal, _rows, overflow_on  # noqa: F401
+from test_marketplace_call import _balance, _fake_relay, platform_on  # noqa: F401
+
+FIX = Path(__file__).parent / "fixtures" / "aggregators"
+EVIDENCE = json.loads((FIX / "verification" / "influencersclub.json").read_text())
+VERIFIED_AT = datetime.fromisoformat(EVIDENCE["verified_at"])
+SEARCH = "influencersclub.creators.search"
+SIMILAR = "influencersclub.creators.similar"
+QUOTA = b'{"error":"Discovery API credit limit reached. Credits reset on subscription renewal."}'
+ENVELOPE = json.loads((FIX / "orthogonal_influencersclub_search.json").read_text())["body"]
+
+
+@pytest.fixture
+def influencers_on(monkeypatch, overflow_on):
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "influencersclub")
+    monkeypatch.setenv("TREG_PLATFORM_KEY_INFLUENCERSCLUB", "DIRECT-KEY")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _sync():
+    seed = [r for r in R.load_seed() if r["provider"] == "influencersclub"]
+    async with session_maker() as db:
+        result = await R.apply_sync(db, seed, catalog=catalog_store.load(), now=VERIFIED_AT)
+        await db.commit()
+    routes_view.invalidate()
+    capacity_view.invalidate()
+    return result
+
+
+def _body(endpoint=SEARCH, limit=2):
+    if endpoint == SIMILAR:
+        return {"platform": "instagram", "filter_key": "username", "filter_value": "nasa",
+                "paging": {"page": 0, "limit": limit}}
+    return {"platform": "instagram", "filters": {"keywords_in_bio": ["astronomy"]},
+            "paging": {"limit": limit, "page": 0}}
+
+
+def test_discovery_quota_is_exhaustion_but_burst_and_validation_are_not():
+    quota = S.classify("influencersclub", 429, {}, QUOTA)
+    assert quota.kind == "quota" and quota.resets_at is None and S.is_exhausting(quota)
+    assert S.classify("influencersclub", 402, {}, b'{}').kind == "balance"
+    burst = S.classify("influencersclub", 429, httpx.Headers({"Retry-After": "42"}),
+                       b'{"error":"Too many requests. Please try again later.","retry_after":42}')
+    assert burst.kind == "burst" and not S.is_exhausting(burst)
+    assert S.classify("influencersclub", 400, {}, b'{"message":"Invalid platform value"}') is None
+    assert S.classify("influencersclub", 403, {}, b'{"detail":"Not allowed for current plan"}') is None
+
+
+async def test_live_verified_seed_enables_ten_routes_and_expires():
+    await reset_db()
+    result = await _sync()
+    assert result.enabled == 10
+    rows = await _rows(OverflowRoute)
+    verified = {r["endpoint_id"] for r in EVIDENCE["results"] if r["same_shape"]}
+    assert {r.endpoint_id for r in rows if r.enabled} == verified
+    assert all(r["direct_status"] == r["relay_status"] == 200 for r in EVIDENCE["results"])
+    email = next(r for r in rows if r.endpoint_id.endswith("enrich.email"))
+    assert not email.enabled and email.disabled_reason == "never verified"
+    search = next(r for r in rows if r.endpoint_id == SEARCH)
+    assert search.agg_unit == "call" and search.agg_price_micro == 30_000
+    assert R.route_for(rows, SEARCH, estimate_micro=5_980) == []
+    assert R.route_for(rows, SEARCH, estimate_micro=11_960) == [search]
+    assert R.route_for(rows, SEARCH, estimate_micro=59_800) == [search]
+    for r in rows:
+        if r.enabled:
+            ep = next(e for e in catalog_store.load().endpoints if e["id"] == r.endpoint_id)
+            cv = catalog_store.load().cost_view(ep["cost"], ep["provider"])
+            verdict = R.eligible(r, our_cost=ep["cost"], platform_eligible=True, policy=None,
+                                 now=VERIFIED_AT + timedelta(days=8), our_usd=cv["usd"])
+            assert not verdict.enabled and "older than 7 days" in verdict.reason
+
+
+@pytest.mark.parametrize("changes,reason", [
+    ({"aggregator": "monid"}, "unit mismatch"),
+    ({"agg_path": "/unverified/"}, "unit mismatch"),
+    ({"agg_price_micro": 30_001}, "verified ceiling"),
+    ({"agg_price_micro": None}, "missing"),
+    ({"last_verified_at": None}, "never verified"),
+])
+async def test_fixed_discovery_exception_does_not_bypass_contract_or_price_checks(changes, reason):
+    await reset_db()
+    await _sync()
+    r = next(r for r in await _rows(OverflowRoute) if r.endpoint_id == SEARCH)
+    for k, v in changes.items():
+        setattr(r, k, v)
+    result = R.eligible(r, our_cost={"type": "per_result", "per": 1},
+                        platform_eligible=True, policy=None, now=VERIFIED_AT, our_usd=0.00598)
+    assert not result.enabled and reason in result.reason
+
+
+@pytest.mark.parametrize("endpoint", [SEARCH, SIMILAR])
+@pytest.mark.parametrize("status,error", [(402, b'{"detail":"Insufficient credits"}'), (429, QUOTA)])
+async def test_exhaustion_releases_parent_and_charges_flat_orthogonal_price(
+    clients, influencers_on, monkeypatch, endpoint, status, error,
+):
+    await _sync()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(status, error))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, ENVELOPE)], seen))
+    before = await _balance(clients)
+    body = _body(endpoint, limit=10)
+    response = await clients.post(f"/call/{endpoint}", json=body)
+    assert response.status_code == 200, response.text
+    assert response.json() == ENVELOPE["data"]
+    assert response.headers["X-Treg-Served-Via"] == "overflow:orthogonal"
+    assert response.headers["X-Treg-Cost-Micro"] == "30000"
+    assert before - await _balance(clients) == 30_000 and await _holds() == []
+    assert len(seen) == 1 and seen[0].json["api"] == "influencers-club"
+    assert seen[0].json["body"] == body
+    parent = response.headers["X-Treg-Call-Id"]
+    entries = [(r.kind, r.call_id) for r in await _rows(LedgerEntry) if r.kind != "grant"]
+    assert sorted(entries) == sorted([
+        ("reserve", parent), ("release", parent),
+        ("reserve", parent + ":overflow"), ("settle", parent + ":overflow"),
+    ])
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1 and spend[0].cost_micro == 30_000 and spend[0].calls == 1
+
+
+@pytest.mark.parametrize("limit,expected_status", [(1, 503), (2, 200)])
+async def test_known_empty_account_applies_request_price_guard_before_reserve(
+    clients, influencers_on, monkeypatch, limit, expected_status,
+):
+    await _sync()
+    now = utcnow_naive()
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "influencersclub", LatestState(
+            "influencersclub", 0.0, "credits", now, "exact",
+            exhausted_until=now + timedelta(hours=1), health="exhausted").to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+    async def no_direct(*args, **kwargs):
+        raise AssertionError("known exhausted account must not be called")
+    monkeypatch.setattr(call_service, "relay", no_direct)
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, ENVELOPE)], seen))
+    response = await clients.post(f"/call/{SEARCH}", json=_body(limit=limit),
+                                  headers={"Idempotency-Key": "discovery-empty"})
+    assert response.status_code == expected_status, response.text
+    entries = [r for r in await _rows(LedgerEntry) if r.kind != "grant"]
+    assert len(seen) == (1 if limit == 2 else 0)
+    assert await _holds() == []
+    if limit == 1:
+        assert entries == []
+    else:
+        assert sorted(r.kind for r in entries) == ["reserve", "settle"]
+        replay = await clients.post(f"/call/{SEARCH}", json=_body(limit=limit),
+                                    headers={"Idempotency-Key": "discovery-empty"})
+        assert replay.status_code == 200 and replay.headers["X-Treg-Idempotent-Replay"] == "true"
+        assert len(seen) == 1
+
+
+@pytest.mark.parametrize("case,status", [("small_page", 402), ("own_key", 402),
+                                        ("opt_out", 402), ("validation", 400)])
+async def test_no_fallback_or_charge_when_call_is_ineligible(
+    clients, influencers_on, monkeypatch, case, status,
+):
+    await _sync()
+    if case == "own_key":
+        response = await clients.post("/secrets", json={"name": "influencersclub", "value": "OWN-KEY"})
+        assert response.status_code < 300
+    if case == "opt_out":
+        org = (await clients.get("/orgs")).json()[0]["org_id"]
+        response = await clients.patch(f"/orgs/{org}/settings", json={"platform_overflow": False})
+        assert response.status_code == 200
+    error = b'{"message":"Invalid platform value"}' if status == 400 else b'{"detail":"Insufficient credits"}'
+    monkeypatch.setattr(call_service, "relay", _fake_relay(status, error))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, ENVELOPE)], seen))
+    before = await _balance(clients)
+    response = await clients.post(f"/call/{SEARCH}", json=_body(limit=1 if case == "small_page" else 2))
+    assert response.status_code == status and response.content == error
+    assert seen == [] and before == await _balance(clients) and await _holds() == []
+
+
+def test_worker_cli_can_scope_pricier_verification_to_influencersclub(monkeypatch):
+    seen = {}
+    async def fake(args):
+        seen.update(vars(args))
+        return 0
+    monkeypatch.setattr(worker, "_overflow_verify", fake)
+    assert worker.main(["overflow", "verify", "--all", "--only", "influencersclub", "--max-usd", "0.66"]) == 0
+    assert seen["only"] == "influencersclub" and seen["all"] and seen["max_usd"] == 0.66
+
+
+async def test_worker_verifies_only_selected_provider(clients, influencers_on, monkeypatch):
+    # The real worker verifies production configuration; PostgreSQL requires a persistent key.
+    monkeypatch.setattr(get_settings(), "secret_key", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+    await _sync()
+    from test_capacity_overflow import _route
+    await _route()  # unrelated enabled route, below the cap: it must never be contacted
+    seen = []
+    async def verify(client, route, **kwargs):
+        seen.append(route.endpoint_id)
+        return V.Verification(route.endpoint_id, route.aggregator, 200, 200, True,
+                              route.agg_price_micro, utcnow_naive())
+    monkeypatch.setattr(V, "verify_route", verify)
+    result = await worker._overflow_verify(SimpleNamespace(all=True, only="influencersclub", max_usd=0.66))
+    assert result == 0 and len(seen) == 10
+    assert all(e.startswith("influencersclub.") for e in seen)
+
+
+async def test_discovery_cancellation_releases_both_holds_and_keeps_unknown_spend(
+    clients, influencers_on, monkeypatch,
+):
+    await _sync()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{}'))
+    async def cancelled(client, req):
+        raise asyncio.CancelledError()
+    monkeypatch.setattr(O, "_send", cancelled)
+    before = await _balance(clients)
+    with pytest.raises(asyncio.CancelledError):
+        await clients.post(f"/call/{SEARCH}", json=_body())
+    assert before == await _balance(clients) and await _holds() == []
+    entries = [r.kind for r in await _rows(LedgerEntry) if r.kind != "grant"]
+    assert sorted(entries) == ["release", "release", "reserve", "reserve"]
+    spend = await _rows(OverflowSpend)
+    assert len(spend) == 1 and spend[0].cost_micro == 30_000


### PR DESCRIPTION
## What this does

Enables ten verified fallback routes when treg's Influencers Club account is exhausted, including recognition of the documented discovery-quota HTTP 429. Discovery and similar-creator calls compare the fallback's flat fee against the requested page's direct estimate before reserving funds, preserving the existing 4× price guard and the caller's original request.

Adds provider-scoped verification with `--only` so these routes can be maintained without raising verification spending for unrelated providers. Updates `docs/context/ops/capacity.md`, `docs/context/architecture/proxy-model.md`, and `docs/context/ops/deploy.md`.

Limitations: discovery requests for one creator remain outside the price guard; requests for two or more qualify at current prices. Email enrichment remains unverified. Own keys and team opt-outs retain their existing behavior.

## How it was tested

- Full suite with an isolated temporary directory: `uv run --locked --with pytest-xdist pytest -n auto -q --tb=short` — 2,851 passed, 5 skipped.
- PostgreSQL 16 checks for fallback, ledger accounting, cancellation, connection-pool discipline, and schema compatibility passed.
- `uv run --locked lint-imports` — all 14 contracts passed.
- Live direct/fallback comparisons passed for ten routes; discovery and similar creators were compared at both 2 and 10 results.
- A local `/call/` smoke test injected the documented quota error and contacted the real fallback API: two creators returned, $0.03 charged, parent hold released, child settled once, zero open holds.
- Context drift mapping and `git diff --check` passed.

After deployment, sync routes and include `treg-worker overflow verify --only influencersclub --max-usd 0.66`, followed by `treg-worker overflow sync`, in the weekly verification routine. The default $0.02 verification cap would skip some of these routes. Production settings have not been changed.

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
