### PR TITLE
feat(contactout): add enrichment catalog and Starter metering

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -73,6 +73,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/call/__init__.py` | architecture/import-boundaries.md |
 | `src/treg/application/call/access.py` | architecture/import-boundaries.md, architecture/instagram-oauth.md, interface/api.md |
 | `src/treg/application/call/authorize.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
+| `src/treg/application/call/contactout.py` | architecture/contactout.md |
 | `src/treg/application/call/evidence.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/idempotency.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/intake.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
@@ -107,6 +108,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/catalog/brightdata.yaml` | architecture/catalog.md |
 | `src/treg/catalog/capabilities.yaml` | interface/catalog-review-proposal.md |
 | `src/treg/catalog/companyenrich.yaml` | architecture/catalog.md |
+| `src/treg/catalog/contactout.yaml` | architecture/contactout.md |
 | `src/treg/catalog/contracts.yaml` | architecture/catalog.md |
 | `src/treg/catalog/crustdata.yaml` | architecture/catalog.md |
 | `src/treg/catalog/dataforseo.extended.yaml` | architecture/catalog.md |
@@ -280,6 +282,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/install.sh` | interface/landing-sandbox.md |
 | `src/treg/web/landing.html` | interface/seo.md |
 | `src/treg/web/llms.txt` | interface/seo.md |
+| `src/treg/web/logos/contactout.svg` | architecture/contactout.md |
 | `src/treg/web/media/astra/page.css` | interface/seo.md |
 | `src/treg/web/media/astra/page.js` | interface/seo.md |
 | `src/treg/web/people-search.html` | interface/seo.md |
@@ -313,6 +316,8 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_capacity_smoothing.py` | ops/capacity.md |
 | `tests/test_catalog_api.py` | architecture/catalog.md |
 | `tests/test_catalog_validate.py` | architecture/catalog.md |
+| `tests/test_contactout.py` | architecture/contactout.md |
+| `tests/test_contactout_live.py` | architecture/contactout.md |
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
 | `tests/test_feedback.py` | architecture/feedback.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
@@ -341,6 +346,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/auth-secrets.md` | `injectors.py`, `ssrf.py`, `crypto.py`, `oauth.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `oauth_exchange.py`, `oauth_refresh.py`, `oauth_providers.py`, `health.py`, `connect.py`, `connections.py`, `resources.py`, `__init__.py`, `bindings.py`, `bundles.py`, `test_oauth_refresh.py`, `config.py` |
 | `architecture/catalog.md` | `contracts.yaml`, `millionverifier.yaml`, `millionverifier.people.email.verify.json`, `millionverifier.account.usage.json`, `adapters.yaml`, `findymail.search.business-profile.json`, `__init__.py`, `contracts.py`, `paths.py`, `plan.py`, `synthetic.py`, `route.py`, `test_routing.py`, `catalog-drift.yml`, `catalog_drift.py`, `catalog_ingest.py`, `catalog_validate.py`, `aliases.yaml`, `fx.yaml`, `aviato.yaml`, `crustdata.yaml`, `aviato.companies.acquisitions.json`, `aviato.companies.employees.json`, `aviato.companies.enrich.bulk.json`, `aviato.companies.enrich.json`, `aviato.companies.founders.json`, `aviato.companies.funding_rounds.json`, `aviato.companies.investments.json`, `aviato.companies.outbound_investments.json`, `aviato.companies.search.json`, `aviato.linkedin.company.posts.json`, `aviato.linkedin.post.comments.json`, `aviato.linkedin.post.reactions.json`, `aviato.linkedin.post.reposts.json`, `aviato.linkedin.user.posts.json`, `aviato.people.contact.get.json`, `aviato.people.email.find.json`, `aviato.people.enrich.bulk.json`, `aviato.people.enrich.json`, `aviato.people.phone.find.json`, `aviato.people.search.json`, `aviato.people.search.simple.json`, `crustdata.companies.autocomplete.json`, `crustdata.companies.enrich.json`, `crustdata.companies.identify.json`, `crustdata.companies.jobs.search.json`, `crustdata.companies.search.json`, `crustdata.people.autocomplete.json`, `crustdata.people.enrich.json`, `crustdata.people.search.json`, `google-search-console.yaml`, `google-search-console.extended.yaml`, `google-tag-manager.yaml`, `google-tag-manager.extended.yaml`, `instagram.yaml`, `instagram.extended.yaml`, `justoneapi.extended.yaml`, `minimax.yaml`, `apify.yaml`, `brightdata.yaml`, `companyenrich.yaml`, `oceanio.yaml`, `akta.extended.yaml`, `dataforseo.extended.yaml`, `tikhub.extended.yaml`, `minimax.video-gen.result.retrieve.json`, `minimax.video-gen.from_image.json`, `minimax.video-gen.task.status.json`, `openrouter.yaml`, `openrouter.extended.yaml`, `openrouter.x.alibaba-wan-3-0.json`, `replicate.yaml`, `replicate.extended.yaml`, `replicate.image-gen.flux-schnell.json`, `__init__.py`, `store.py`, `settlement.py`, `stats.py`, `catalog_observations.py`, `catalog.py`, `test_aigc_pr_b.py`, `test_catalog_api.py`, `test_catalog_validate.py` |
 | `architecture/composition.md` | `bootstrap.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `call_surface.py`, `connect.py`, `mcp_oauth.py`, `session.py`, `admin.py`, `auth.py`, `billing.py`, `call.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `web.py`, `dump_surface.py`, `test_app_roles.py` |
+| `architecture/contactout.md` | `contactout.yaml`, `contactout.py`, `contactout.svg`, `test_contactout.py`, `test_contactout_live.py` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `0020_callrecord_created_at_indexes.py`, `0021_ledgerentry_org_created_at_index.py`, `0022_org_spent_today_counter.py`, `0023_callrecord_org_user_created_at_index.py`, `0024_membership_calls_today_counter.py`, `0011_callrecord_archive_link.py`, `0015_idempotentcall_membership_cascade.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `bootstrap_handlers.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
 | `architecture/feedback.md` | `feedback_contract.py`, `feedback.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `feedback.md`, `test_feedback.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `feedback.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -21,6 +21,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [Auth & secrets — injectors, encryption, OAuth freshness, health](architecture/auth-secrets.md) | shipped | injectors.py, ssrf.py, crypto.py, oauth.py, … |
 | [Endpoint catalog — what you can DO with a connected key, and which provider should do it](architecture/catalog.md) | shipped | contracts.yaml, millionverifier.yaml, millionverifier.people.email.verify.json, millionverifier.account.usage.json, … |
 | [Application composition and deployment roles](architecture/composition.md) | shipped | bootstrap.py, bootstrap_handlers.py, bootstrap_http.py, call_surface.py, … |
+| [ContactOut — LinkedIn enrichment, Starter billing and independent credit pools](architecture/contactout.md) | implemented; live connect and core surface verified, capacity policy confirmation pending | contactout.yaml, contactout.py, contactout.svg, test_contactout.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Feedback - private intake for problems and suggestions](architecture/feedback.md) | shipped | feedback_contract.py, feedback.py, feedback.py, feedback.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, __init__.py, __init__.py, … |

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -373,3 +373,9 @@ someone else's key value. A tool's `base_url` is validated against the internal-
 metadata, incl. numeric IP encodings) at registration AND the proxy re-resolves the host at call time
 (`infra.upstream.ssrf.host_is_public`, also re-exported by `health`, gated by `proxy_ssrf_check`) — no
 SSRF, even via DNS rebinding.
+
+## ContactOut pasted API tokens
+
+`oauth_providers.CONTACTOUT` verifies against `/v1/stats` and requires `status_code: 200` as well
+as HTTP success. Its binding injects the raw `token` header. Both garbage rejection and valid
+connection creation were tested live; see [ContactOut](contactout.md).

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1638,3 +1638,9 @@ long strings clipped, ~10 KB cap) by the verifier, then human-reviewed for PII b
 
 The SEO pair and the social pair each implement the same capabilities on purpose — they are the
 first real test that the capability taxonomy supports cross-provider comparison.
+
+## ContactOut
+
+`contactout.yaml` adds the core LinkedIn/contact surface with explicit work/personal selectors,
+on-hit Starter rates supplied by the account owner, free verification, and deferred batches.
+See [ContactOut](contactout.md) for request limitations, derived settlement and live evidence.

--- a/docs/context/architecture/contactout.md
+++ b/docs/context/architecture/contactout.md
@@ -1,0 +1,115 @@
+---
+title: ContactOut — LinkedIn enrichment, Starter billing and independent credit pools
+status: implemented; live connect and core surface verified, capacity policy confirmation pending
+sources:
+  - src/treg/catalog/contactout.yaml
+  - src/treg/application/call/contactout.py
+  - src/treg/web/logos/contactout.svg
+  - tests/test_contactout.py
+  - tests/test_contactout_live.py
+related:
+  - architecture/catalog.md
+  - architecture/auth-secrets.md
+  - architecture/money.md
+  - ops/capacity.md
+---
+
+# ContactOut
+
+`oauth_providers.CONTACTOUT` is a pasted-key provider. It injects the raw credential in the
+`token` header and verifies via free `GET /v1/stats`, requiring both HTTP success and
+`status_code: 200`. A zero allowance does not invalidate a credential. The existing credential
+ladder makes an org's tool/key win over the platform key and bypass treg billing and capacity checks.
+`Settings.platform_key_contactout` reads `TREG_PLATFORM_KEY_CONTACTOUT`; `render.yaml` declares
+the server slot and forwards it to the worker. The existing platform provider allow-list still
+controls serving. No credential is committed or copied into a platform Secret row.
+
+## Surface and selectors
+
+The catalog covers count, personal/work email and phone availability, single email verification,
+people and company search, company domain enrichment, email-to-LinkedIn, decision makers,
+LinkedIn contact/profile enrichment, person enrichment and profile-from-email, plus own-account stats.
+Free availability/count tools have distinct capabilities so they cannot be advertised as free
+contact finders or profile searches. Work/personal contact splits use `email_type`; person
+enrichment splits use `include`.
+Phone-only contact uses `email_type=none&include_phone=true`. All split rows retain real upstream
+paths. Platform calls must explicitly supply each required fixed selector; the resolver rejects a
+mismatched selector before reserving or contacting the provider. BYOK keeps its ordinary relay.
+
+Search `data_types` filters availability; it is NOT a reveal selector. Search/decision-maker
+`reveal_info=true` can reveal both email types and phones. The work-only recipe is search without
+reveal followed by `people.contact.work`. LinkedIn profile enrichment documents `profile_only`,
+not `email_type`; profile-from-email only documents `include=work_email`. Those tools do not promise
+work-only contact responses. The logo is a neutral lettermark placeholder.
+
+Deferred: synchronous/asynchronous LinkedIn batches (v1/v2), batch email verification. Hashed-email
+and campaign endpoints are also outside this requested enrichment surface.
+
+## Starter cost model
+
+The account owner's supplied commercial rate is authoritative:
+
+| Unit | USD |
+|---|---:|
+| Work email hit | 0.15 |
+| Personal email hit | 0.25 |
+| Phone hit | 0.25 |
+| Profile/company returned by search; company found by domain enrichment | 0.02 |
+| Email-to-LinkedIn served call | 0.06 |
+| Count, availability, single email verification | 0 |
+
+Contact charges are per profile with the requested type present, not per address/phone in its
+array. Work plus phone is $0.40; personal plus phone is $0.50. Person enrichment adds $0.02 when
+it finds a profile. Search and decision makers add $0.02 per returned profile even without reveal.
+Availability booleans and `metadata.total_results` are never billing evidence. An echoed input
+email and combined email arrays are not billed again as personal-email reveals.
+
+`cost.contactout.rates_micro` carries integer micro-USD rates in YAML. `contactout.estimate`
+calculates a hold from actual request selectors, input domains, or a maximum 25-row page.
+`contactout.observed` derives the final charge from returned contacts and records. The existing
+reserve/settle/release lifecycle owns all money and failure cleanup. This is derived billing,
+not a claim that ContactOut reports dollar costs in each response. Responses without recognizable hit evidence, including malformed payloads,
+misses and embedded errors, cost zero rather than settling the maximum contact hold.
+
+The agreed LinkedIn-profile enrichment rate is contact-only, even though public ContactOut docs
+mention a search credit for profile-only/no-contact responses. Treg does not add that surcharge.
+Single email verification remains free under current commercial terms; recheck if ContactOut
+starts charging verifier credits. No public plan estimate replaces these commercial rates.
+
+## Capacity: informational only
+
+`collectors._contactout` reads `/v1/stats` through the existing worker sweep and balance script.
+It preserves email, phone and search counters in the observation note with `value=None` and
+`informational=True`. `snapshot_from` preserves that as a successful informational observation;
+`latest_state` never derives exhaustion from it and ages it stale after the existing six-hour limit.
+No independent scheduler, automatic purchase, overflow route, or guessed exhaustion signature is added.
+The existing sweep cadence remains unchanged; no new 15-minute polling schedule is installed.
+
+The public docs distinguish two meanings: prepaid `quota` is already remaining credits; postpaid
+`remaining` is quota minus count. Never subtract count from a prepaid quota. The three pools are
+not interchangeable and cannot honestly become one provider-wide remaining balance. The account
+owner has asked ContactOut whether exhaustion stops requests or permits overages, whether pools
+are isolated, and how quickly stats update / whether 15-minute free polling is supported. Until
+answered, funding mode stays unknown and the observations cannot block calls.
+
+## Live evidence — 2026-09-08
+
+Against `https://api.contactout.com/`, using the private root-env platform credential:
+
+- Stats: valid credential HTTP 200; garbage credential HTTP 401. The full treg
+  `/connections/token` flow returned 200 and 422 respectively in an isolated test database;
+  stored test credentials were removed afterward.
+- Count, all availability checkers, single verification: HTTP 200.
+- No-reveal people search returned one profile; company search two companies; domain enrichment
+  one company; no-reveal decision makers ten profiles. All HTTP 200.
+- Synthetic LinkedIn targets returned 404 on work/personal/phone contact and person enrichment;
+  LinkedIn profile enrichment returned 200 with an empty profile. Synthetic email targets returned
+  404 on email-to-LinkedIn and profile-from-email. These prove miss behavior, not positive contact hits.
+- Before: email count/quota 0/6000; phone 0/3000; search 0/5000. Immediately after: email and phone
+  unchanged; search count/quota 0/4986. The 14-credit decline matches the returned search/company
+  records and confirms prepaid quota semantics. It does not prove a general update-latency guarantee.
+
+No real contact responses were saved. Combined contact-hit billing is covered by synthetic tests;
+positive contact reveals and reveal-search upstream charges were not live-verified. The catalog
+therefore does not label their prices as observed. The opt-in `test_contactout_live` checks only
+free connection probes, never runs in ordinary CI, and does not print credentials.

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -790,3 +790,9 @@ success convention. An undecidable rule does not imply a free call.
 Coverage remains a catalog concern: providers without an adapter or `expect` can still return
 embedded errors. In particular, verify TikHub's success convention before adding a file-level rule;
 its existing explicit charge/no-charge prose handling is a separate billing signal.
+
+## ContactOut contact hits
+
+`application.call.contactout` calculates request-sized holds and derives contact/search charges
+from returned profiles using the YAML Starter micro-USD rates. It reuses the existing money lifecycle.
+Own keys are unmetered; see [ContactOut](contactout.md) for prices, free verification and evidence limits.

--- a/docs/context/guides/expanding-a-category.md
+++ b/docs/context/guides/expanding-a-category.md
@@ -171,3 +171,7 @@ Instagram direct Login plus optional Facebook Page tools is the reference implem
 - `test_default_capability_is_the_broadest` — OAuth: `write ⊇ read` (or one capability).
 - `test_every_requested_scope_has_a_label` — a `SCOPE_LABELS` entry per OAuth scope (key providers have none).
 - `test_key_providers` — the offerable + connect-flow coverage for `auth_kind="key"`.
+
+ContactOut uses the same pasted-key path with `token` header auth and a free `/v1/stats` probe.
+Its garbage-token rejection and valid connection were verified live; its independent pools stay
+informational pending account policy confirmation. See [ContactOut](../architecture/contactout.md).

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -279,3 +279,10 @@ Forecasts, recharge verification and every alert (`quota_exhausted`, `rate_press
 …) — step C, gated on the `money-funding-transactions` debt. Until the rollout above flips the mode,
 `TREG_OVERFLOW_MODE` is `off` and treg still relays a vendor's 402 unchanged (or answers the typed 503
 when the account is marked exhausted).
+
+## ContactOut independent pools
+
+`collectors._contactout` exposes the three raw credit pools through an informational observation,
+not a scalar balance. `snapshot_from` and `latest_state` preserve it without marking the provider
+exhausted. Prepaid quotas are already remaining credits. Polling/exhaustion semantics still await
+provider confirmation; see [ContactOut](../architecture/contactout.md).

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -598,3 +598,7 @@ the ALTER, both instances starved, and the shared Postgres stayed wedged until a
 If a deploy fails with a lock timeout in the logs, that is the mechanism working. If the database
 itself stops accepting connections, restart the POSTGRES resource, not the web service — an app
 restart cannot release server-side slots (learned the hard way).
+
+The ContactOut server platform-key slot (`TREG_PLATFORM_KEY_CONTACTOUT`) is forwarded to the
+worker by `render.yaml`. The provider allow-list still controls serving; see
+[ContactOut](../architecture/contactout.md) for informational capacity checks.

--- a/render.yaml
+++ b/render.yaml
@@ -101,6 +101,8 @@ services:
         sync: false
       - key: TREG_PLATFORM_KEY_HUNTER
         sync: false
+      - key: TREG_PLATFORM_KEY_CONTACTOUT
+        sync: false
       - key: TREG_PLATFORM_KEY_MILLIONVERIFIER
         sync: false
       - key: TREG_PLATFORM_KEY_LEADMAGIC
@@ -247,6 +249,11 @@ services:
           type: web
           name: treg
           envVarName: TREG_PLATFORM_KEY_HUNTER
+      - key: TREG_PLATFORM_KEY_CONTACTOUT
+        fromService:
+          type: web
+          name: treg
+          envVarName: TREG_PLATFORM_KEY_CONTACTOUT
       - key: TREG_PLATFORM_KEY_MILLIONVERIFIER
         fromService:
           type: web

--- a/scripts/catalog_validate.py
+++ b/scripts/catalog_validate.py
@@ -482,6 +482,18 @@ def check_cost(cost: dict, where: str, errors: list[str], warnings: list[str],
     per = cost.get("per")
     if per is not None and (not isinstance(per, int) or isinstance(per, bool) or per < 1):
         fail(errors, where, f"cost.per '{per}' must be a positive integer (the quantity `value` covers)")
+    if "contactout" in cost:
+        rule = cost["contactout"]
+        jobs = {"contact", "person", "email", "linkedin", "search", "decision",
+                "company_search", "domains", "reverse"}
+        rates = rule.get("rates_micro") if isinstance(rule, dict) else None
+        if not isinstance(rule, dict) or rule.get("job") not in jobs:
+            fail(errors, where, "cost.contactout needs a supported job")
+        if not isinstance(rates, dict) or set(rates) != {"work_email", "personal_email", "phone", "search"} \
+                or any(isinstance(v, bool) or not isinstance(v, int) or v <= 0 for v in rates.values()):
+            fail(errors, where, "cost.contactout.rates_micro needs four positive integer micro-USD rates")
+        if cost.get("currency") != "USD":
+            fail(errors, where, "cost.contactout requires USD")
     has_table = "table" in cost
     if has_table:
         if "value" in cost:

--- a/src/treg/application/call/contactout.py
+++ b/src/treg/application/call/contactout.py
@@ -1,0 +1,160 @@
+"""ContactOut's Starter rate: request-sized holds and contact hits per returned profile.
+
+Pure billing interpretation of the unmodified request/response. Prices live in catalog YAML;
+no balance polling or database access belongs in a call's settlement.
+"""
+
+from __future__ import annotations
+
+
+def _true(value):
+    return value is True or isinstance(value, str) and value.lower() in ("true", "1")
+
+
+def _selected(job, request):
+    if job == "contact":
+        selected = str(request.get("email_type", "personal,work")).split(",")
+        return (
+            "work" in selected,
+            "personal" in selected,
+            _true(request.get("include_phone")),
+        )
+    if job == "person":
+        included = request.get("include") or []
+        if not isinstance(included, (list, str)):
+            return (True,) * 3  # invalid input cannot reduce the maximum hold
+        return tuple(k in included for k in ("work_email", "personal_email", "phone"))
+    if job in ("search", "decision"):
+        return (_true(request.get("reveal_info")),) * 3
+    if job == "linkedin":
+        return (not _true(request.get("profile_only")),) * 3
+    if job == "email":
+        return (request.get("include") == "work_email", True, True)
+    return (False,) * 3
+
+
+def estimate(cost, request):
+    """Reserve for requested contact types and a documented maximum page/input size."""
+    rules = cost.get("contactout") or {}
+    job, rates = rules.get("job"), rules.get("rates_micro") or {}
+    if not job:
+        return 0
+    if job == "reverse":
+        return round(cost["usd"] * 1_000_000)
+    contact = sum(
+        rates[k]
+        for k, selected in zip(
+            ("work_email", "personal_email", "phone"), _selected(job, request)
+        )
+        if selected
+    )
+    search = (
+        rates["search"]
+        if job in ("search", "decision", "person", "company_search", "domains")
+        else 0
+    )
+    if job == "domains":
+        domains = request.get("domains")
+        n = len(domains) if isinstance(domains, list) else 30
+        n = max(1, min(30, n))
+    elif job in ("search", "decision", "company_search"):
+        # Only people search documents page_size. Unknown/invalid input never reduces a hold.
+        size = request.get("page_size", 25) if job == "search" else 25
+        n = (
+            size
+            if isinstance(size, int) and not isinstance(size, bool) and 1 <= size <= 25
+            else 25
+        )
+    else:
+        n = 1
+    return (search + contact) * n
+
+
+def _present(value):
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_present(v) for v in value)
+    # Availability flags and verification status maps are never contact hits.
+    return False
+
+
+def _hit(profile, *names):
+    return any(_present(profile.get(name)) for name in names)
+
+
+def _rows(doc, name):
+    value = doc.get(name)
+    if isinstance(value, dict):
+        values = value.values()
+    elif isinstance(value, list):
+        values = value
+    else:
+        return None
+    # An empty/null company/profile is not a hit. Do not count metadata.total_results.
+    return [v for v in values if isinstance(v, dict) and v]
+
+
+def observed(cost, evidence, doc):
+    """Derived charge, not a vendor-reported dollar bill. No hit evidence means no charge."""
+    rules = cost.get("contactout") or {}
+    job, rates = rules.get("job"), rules.get("rates_micro") or {}
+    if not job:
+        return 0
+    if doc.get("status_code") != 200:
+        return 0
+    if job == "reverse":
+        return round(cost["usd"] * 1_000_000)
+    request = (
+        evidence.get("body")
+        if job in ("person", "search", "domains", "company_search")
+        else evidence.get("queryParams")
+    ) or {}
+    if not isinstance(request, dict):
+        request = {}
+    if job in ("company_search", "domains"):
+        rows = _rows(doc, "companies")
+        return 0 if rows is None else len(rows) * rates["search"]
+    if job in ("search", "decision"):
+        rows = _rows(doc, "profiles")
+        if rows is None:
+            return 0
+    else:
+        profile = doc.get("profile")
+        if profile in (None, [], {}):
+            return 0
+        if not isinstance(profile, dict):
+            return 0
+        rows = [profile]
+    total = (
+        len(rows) * rates["search"] if job in ("search", "decision", "person") else 0
+    )
+    selected = _selected(job, request)
+    for profile in rows:
+        contacts = (
+            profile.get("contact_info") if job in ("search", "decision") else profile
+        )
+        if not isinstance(contacts, dict):
+            # No reveal on this profile. Availability booleans do not imply billable contacts.
+            continue
+        work = _hit(contacts, "work_email", "work_emails", "workEmail")
+        personal = _hit(contacts, "personal_email", "personal_emails")
+        # Camel-case enrichment uses `email` for personal. The submitted address is an echo,
+        # not a newly revealed email. LinkedIn's `email` array combines types; never count twice.
+        if (
+            job in ("person", "email")
+            and isinstance(contacts.get("email"), str)
+            and contacts.get("email") != request.get("email")
+        ):
+            personal = personal or _hit(contacts, "email")
+        phone = _hit(contacts, "phone", "phones")
+        total += sum(
+            rates[k]
+            for k, hit, allowed in zip(
+                ("work_email", "personal_email", "phone"),
+                (work, personal, phone),
+                selected,
+            )
+            if hit and allowed
+        )
+    return total

--- a/src/treg/application/call/resolve.py
+++ b/src/treg/application/call/resolve.py
@@ -553,6 +553,10 @@ def _marketplace_pricing(
     """
     if not cost:
         return 0, 0
+    if provider == "contactout":
+        from . import contactout
+        request = _json_object(body) if body else dict(query.multi_items())
+        return contactout.estimate(cost, request), 0
     estimate = _platform_estimate_micro(cost, query, body)
     unit = (_usd_to_micro(cost["usd"])
             if cost.get("type") in ("per_result", "quota_rows") and cost.get("usd") else 0)
@@ -1338,6 +1342,22 @@ async def _resolve_marketplace_call(
     async_owner_call_id = None
     if cost is not None:
         _enforce_platform_pricing_selectors(ep, body)
+        if service == "contactout":
+            # Fixed catalog splits must not silently fall into ContactOut's personal+work default.
+            inputs = ep.get("input") or {}
+            values = _json_object(body) if body else dict(query.multi_items())
+            for name, spec in (inputs.get("body") or inputs.get("queryParams") or {}).items():
+                if not isinstance(spec, dict) or not spec.get("required") or len(spec.get("enum", [])) != 1:
+                    continue
+                expected, actual = spec["enum"][0], values.get(name)
+                if isinstance(expected, bool) and isinstance(actual, str):
+                    actual = actual.lower() == "true" if actual.lower() in ("true", "false") else actual
+                if actual != expected:
+                    raise ResolutionFailed("catalog_parameter_invalid", status_code=400, detail={
+                        "error": "catalog_parameter_invalid", "endpoint_id": ep["id"],
+                        "parameter": name, "expected": expected,
+                        "message": f"{ep['id']} requires {name}={expected!r}; use the matching catalog tool.",
+                    })
         async_owner_call_id = await _enforce_platform_async_ownership(ep, query, caller, db)
     skip_direct = False
     probe_lock_id = None

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -174,7 +174,7 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
         if credits >= 0 and rate:
             return _usd_to_micro(credits * rate)
     if not body:
-        return None
+        return 0 if provider == "contactout" else None
     if provider == "brightdata" and mk.cost_type == "per_result" and mk.unit_micro > 0:
         # DERIVED by counting records — Bright Data's bill is per record delivered and the body is
         # the only place that number exists (see _brightdata_record_count for the shapes).
@@ -183,13 +183,13 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
     try:
         doc = json.loads(body)
     except (ValueError, UnicodeDecodeError):
-        return None
+        return 0 if provider == "contactout" else None
     if provider == "aviato" and mk.endpoint_id == "aviato.people.enrich.bulk":
         if isinstance(doc, list) and mk.unit_micro > 0:
             return sum(item is not None for item in doc) * mk.unit_micro
         return None
     if not isinstance(doc, dict):
-        return None
+        return 0 if provider == "contactout" else None
     if provider == "aviato" and mk.endpoint_id == "aviato.companies.enrich.bulk":
         rows = doc.get("companies")
         if isinstance(rows, list) and mk.unit_micro > 0:
@@ -216,6 +216,9 @@ def _observed_cost_micro(mk: MarketplaceCall, body: bytes, headers=None) -> int 
         if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
             return int(cost * 1_000_000 + 0.5)
         return None
+    if provider == "contactout" and cost:
+        from . import contactout
+        return contactout.observed(cost, mk.request_data, doc)
     if provider == "millionverifier" and mk.endpoint_id == "millionverifier.people.email.verify":
         # Risky results receive automatic credit returns for eligible accounts. Keep the verdict
         # as a routed answer, but never bill the caller for unknown/catch-all. `free` is the email

--- a/src/treg/catalog/contactout.yaml
+++ b/src/treg/catalog/contactout.yaml
@@ -1,0 +1,1090 @@
+# ContactOut v1. Starter rates are the account owner's commercial terms, not public plan estimates.
+# Deferred: sync/async LinkedIn batches, batch email verification, hashed email and campaigns.
+# Work/personal splits use real documented parameters; no invented upstream endpoints.
+# A neutral lettermark is used until an official logo asset is supplied.
+provider: contactout
+source:
+  docs: https://api.contactout.com/
+  openapi: null
+  curated: '2026-09-08'
+pricing_url: https://api.contactout.com/
+expect:
+  json_path: status_code
+  equals: 200
+endpoints:
+- id: contactout.people.count
+  domain: contacts
+  capability: people.count
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/count
+  name: Count matching profiles
+  summary: Count matching profiles
+  input:
+    bodyType: json
+    body:
+      job_title: &id002
+        type: array
+      past_job_title: &id003
+        type: array
+      job_function: &id004
+        type: array
+      seniority: &id005
+        type: array
+      skills: &id006
+        type: array
+      languages: &id007
+        type: array
+      education: &id008
+        type: array
+      educations: &id009
+        type: array
+      location: &id010
+        type: array
+      current_work_location: &id011
+        type: array
+      past_work_location: &id012
+        type: array
+      company: &id013
+        type: array
+      past_company: &id014
+        type: array
+      domain: &id015
+        type: array
+      industry: &id016
+        type: array
+      company_size: &id017
+        type: array
+      years_of_experience: &id018
+        type: array
+      years_in_current_role: &id019
+        type: array
+      exclude_job_titles: &id020
+        type: array
+      exclude_companies: &id021
+        type: array
+      name: &id022
+        type: string
+      keyword: &id023
+        type: string
+      company_filter: &id024
+        type: string
+      match_experience: &id025
+        type: string
+      current_titles_only: &id026
+        type: boolean
+      include_related_job_titles: &id027
+        type: boolean
+      recently_changed_jobs: &id028
+        type: boolean
+      is_currently_working: &id029
+        type: boolean
+      detailed_experience: &id030
+        type: boolean
+      detailed_education: &id031
+        type: boolean
+      location_radius: &id032
+        type: integer
+        min: 1
+        max: 500
+    note: Use the documented filters. recently_changed_jobs cannot combine with years_in_current_role.
+      match_experience cannot combine with current_titles_only or company_filter.
+      See docs for accepted industry, seniority and size values. Free; paid ContactOut
+      account required.
+  test_request:
+    body:
+      company:
+      - ContactOut
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: Use the documented filters. recently_changed_jobs cannot combine with years_in_current_role.
+      match_experience cannot combine with current_titles_only or company_filter.
+      See docs for accepted industry, seniority and size values. Free; paid ContactOut
+      account required.
+  docs_url: https://api.contactout.com/
+- id: contactout.people.personal_email.available
+  domain: contacts
+  capability: people.email.availability
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin/personal_email_status
+  name: Check personal email availability
+  summary: Check personal email availability
+  input:
+    queryParams:
+      profile: &id001
+        type: string
+        required: true
+        note: Full regular LinkedIn profile URL; Sales Navigator and Recruiter URLs
+          are not supported.
+        example: https://www.linkedin.com/in/rob-liu
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/rob-liu
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  docs_url: https://api.contactout.com/
+- id: contactout.people.work_email.available
+  domain: contacts
+  capability: people.email.availability
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin/work_email_status
+  name: Check work email availability
+  summary: Check work email availability
+  input:
+    queryParams:
+      profile: *id001
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/rob-liu
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  docs_url: https://api.contactout.com/
+- id: contactout.people.phone.available
+  domain: contacts
+  capability: people.phone.availability
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin/phone_status
+  name: Check phone number availability
+  summary: Check phone number availability
+  input:
+    queryParams:
+      profile: *id001
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/rob-liu
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: Availability only; no contact reveal. Free; paid ContactOut account required.
+  docs_url: https://api.contactout.com/
+- id: contactout.people.email.verify
+  domain: contacts
+  capability: people.email.verify
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/email/verify
+  name: Verify email deliverability
+  summary: Verify email deliverability
+  input:
+    queryParams:
+      email: &id034
+        type: string
+        required: true
+        example: support@contactout.com
+    note: 'Free under current commercial terms: verifier credits are not charged.
+      Recheck this rate if ContactOut starts metering verification.'
+  test_request:
+    queryParams:
+      email: support@contactout.com
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: 'Free under current commercial terms: verifier credits are not charged.
+      Recheck this rate if ContactOut starts metering verification.'
+  docs_url: https://api.contactout.com/
+- id: contactout.people.search
+  domain: contacts
+  capability: people.search
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/search
+  name: Search people without revealing contacts
+  summary: Search people without revealing contacts
+  input:
+    bodyType: json
+    body:
+      job_title: *id002
+      past_job_title: *id003
+      job_function: *id004
+      seniority: *id005
+      skills: *id006
+      languages: *id007
+      education: *id008
+      educations: *id009
+      location: *id010
+      current_work_location: *id011
+      past_work_location: *id012
+      company: *id013
+      past_company: *id014
+      domain: *id015
+      industry: *id016
+      company_size: *id017
+      years_of_experience: *id018
+      years_in_current_role: *id019
+      exclude_job_titles: *id020
+      exclude_companies: *id021
+      name: *id022
+      keyword: *id023
+      company_filter: *id024
+      match_experience: *id025
+      current_titles_only: *id026
+      include_related_job_titles: *id027
+      recently_changed_jobs: *id028
+      is_currently_working: *id029
+      detailed_experience: *id030
+      detailed_education: *id031
+      location_radius: *id032
+      page:
+        type: integer
+        default: 1
+      page_size:
+        type: integer
+        min: 1
+        max: 25
+        default: 25
+      data_types:
+        type: array
+        note: Availability filter, NOT a reveal selector.
+      reveal_info:
+        type: boolean
+        required: true
+        enum:
+        - false
+      output_fields:
+        type: array
+        note: Custom profile fields; do not omit contact_info when revealing contacts.
+    note: Use the documented filters. recently_changed_jobs cannot combine with years_in_current_role.
+      match_experience cannot combine with current_titles_only or company_filter.
+      See docs for accepted industry, seniority and size values. reveal_info=true
+      can return both email types and phones. For work-only contacts, search without
+      reveal then use the work-email contact tool.
+  test_request:
+    body:
+      company:
+      - ContactOut
+      page_size: 1
+      reveal_info: false
+  cost:
+    type: per_result
+    value: 0.02
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Use the documented filters. recently_changed_jobs
+      cannot combine with years_in_current_role. match_experience cannot combine with
+      current_titles_only or company_filter. See docs for accepted industry, seniority
+      and size values. reveal_info=true can return both email types and phones. For
+      work-only contacts, search without reveal then use the work-email contact tool.
+    contactout:
+      job: search
+      rates_micro: &id033
+        work_email: 150000
+        personal_email: 250000
+        phone: 250000
+        search: 20000
+  docs_url: https://api.contactout.com/
+- id: contactout.people.decision-makers
+  domain: contacts
+  capability: people.search
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/decision-makers
+  name: Find company decision makers without revealing contacts
+  summary: Find company decision makers without revealing contacts
+  input:
+    queryParams:
+      linkedin_url:
+        type: string
+      domain:
+        type: string
+      name:
+        type: string
+      page:
+        type: integer
+        default: 1
+      reveal_info:
+        type: boolean
+        required: true
+        enum:
+        - false
+    note: Supply at least one of linkedin_url, domain or name. Pages contain up to
+      25 profiles. Reveal may return both email types and phones; use no-reveal then
+      work-email contact for work-only enrichment.
+  test_request:
+    queryParams:
+      domain: contactout.com
+      reveal_info: false
+  cost:
+    type: per_result
+    value: 0.02
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Supply at least one of linkedin_url,
+      domain or name. Pages contain up to 25 profiles. Reveal may return both email
+      types and phones; use no-reveal then work-email contact for work-only enrichment.
+    contactout:
+      job: decision
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.search.reveal
+  domain: contacts
+  capability: people.search
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/search
+  name: Search people and reveal contacts
+  summary: Search people and reveal contacts
+  input:
+    bodyType: json
+    body:
+      job_title: *id002
+      past_job_title: *id003
+      job_function: *id004
+      seniority: *id005
+      skills: *id006
+      languages: *id007
+      education: *id008
+      educations: *id009
+      location: *id010
+      current_work_location: *id011
+      past_work_location: *id012
+      company: *id013
+      past_company: *id014
+      domain: *id015
+      industry: *id016
+      company_size: *id017
+      years_of_experience: *id018
+      years_in_current_role: *id019
+      exclude_job_titles: *id020
+      exclude_companies: *id021
+      name: *id022
+      keyword: *id023
+      company_filter: *id024
+      match_experience: *id025
+      current_titles_only: *id026
+      include_related_job_titles: *id027
+      recently_changed_jobs: *id028
+      is_currently_working: *id029
+      detailed_experience: *id030
+      detailed_education: *id031
+      location_radius: *id032
+      page:
+        type: integer
+        default: 1
+      page_size:
+        type: integer
+        min: 1
+        max: 25
+        default: 25
+      data_types:
+        type: array
+        note: Availability filter, NOT a reveal selector.
+      reveal_info:
+        type: boolean
+        required: true
+        enum:
+        - true
+      output_fields:
+        type: array
+        note: Custom profile fields; do not omit contact_info when revealing contacts.
+    note: Use the documented filters. recently_changed_jobs cannot combine with years_in_current_role.
+      match_experience cannot combine with current_titles_only or company_filter.
+      See docs for accepted industry, seniority and size values. reveal_info=true
+      can return both email types and phones. For work-only contacts, search without
+      reveal then use the work-email contact tool.
+  test_request:
+    body:
+      company:
+      - treg-verification-nonexistent-20260908
+      page_size: 1
+      reveal_info: true
+  cost:
+    type: per_result
+    value: 0.67
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Use the documented filters. recently_changed_jobs
+      cannot combine with years_in_current_role. match_experience cannot combine with
+      current_titles_only or company_filter. See docs for accepted industry, seniority
+      and size values. reveal_info=true can return both email types and phones. For
+      work-only contacts, search without reveal then use the work-email contact tool.
+    contactout:
+      job: search
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.decision-makers.reveal
+  domain: contacts
+  capability: people.search
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/decision-makers
+  name: Find company decision makers and reveal contacts
+  summary: Find company decision makers and reveal contacts
+  input:
+    queryParams:
+      linkedin_url:
+        type: string
+      domain:
+        type: string
+      name:
+        type: string
+      page:
+        type: integer
+        default: 1
+      reveal_info:
+        type: boolean
+        required: true
+        enum:
+        - true
+    note: Supply at least one of linkedin_url, domain or name. Pages contain up to
+      25 profiles. Reveal may return both email types and phones; use no-reveal then
+      work-email contact for work-only enrichment.
+  test_request:
+    queryParams:
+      domain: treg-verification-nonexistent.invalid
+      reveal_info: true
+  cost:
+    type: per_result
+    value: 0.67
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Supply at least one of linkedin_url,
+      domain or name. Pages contain up to 25 profiles. Reveal may return both email
+      types and phones; use no-reveal then work-email contact for work-only enrichment.
+    contactout:
+      job: decision
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.companies.search
+  domain: companies
+  capability: companies.search
+  platform: companies
+  scope: any_account
+  method: POST
+  path: /v1/company/search
+  name: Search companies
+  summary: Search companies
+  input:
+    bodyType: json
+    body:
+      name:
+        type: array
+      domain:
+        type: array
+      size:
+        type: array
+      location:
+        type: array
+      industry:
+        type: array
+      technologies:
+        type: array
+      page:
+        type: integer
+      min_revenue:
+        type: integer
+      max_revenue:
+        type: integer
+      year_founded_from:
+        type: integer
+      year_founded_to:
+        type: integer
+      hq_only:
+        type: boolean
+    note: $0.02 per company returned, not total_results. Default page contains 25
+      companies.
+  test_request:
+    body:
+      domain:
+      - contactout.com
+  cost:
+    type: per_result
+    value: 0.02
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. $0.02 per company returned, not total_results.
+      Default page contains 25 companies.
+    contactout:
+      job: company_search
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.companies.enrich
+  domain: companies
+  capability: companies.enrich
+  platform: companies
+  scope: any_account
+  method: POST
+  path: /v1/domain/enrich
+  name: Enrich company domains
+  summary: Enrich company domains
+  input:
+    bodyType: json
+    body:
+      domains:
+        type: array
+        required: true
+        note: Up to 30 domain names.
+    note: $0.02 per company found. Unmatched domains cost nothing.
+  test_request:
+    body:
+      domains:
+      - contactout.com
+  cost:
+    type: per_result
+    value: 0.02
+    currency: USD
+    per: 1
+    unit: result
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. $0.02 per company found. Unmatched domains
+      cost nothing.
+    contactout:
+      job: domains
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.linkedin.from-email
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/person
+  name: Find LinkedIn URL from email
+  summary: Find LinkedIn URL from email
+  input:
+    queryParams:
+      email: *id034
+    note: $0.06 per served call; rejected upstream requests are unbilled.
+  test_request:
+    queryParams:
+      email: treg-verification-nonexistent@example.com
+  cost:
+    type: per_call
+    value: 0.06
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. $0.06 per served call; rejected upstream
+      requests are unbilled.
+    contactout:
+      job: reverse
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.contact.work
+  domain: contacts
+  capability: people.email.find
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin
+  name: Get work email, optionally phone from LinkedIn
+  summary: Get work email, optionally phone from LinkedIn
+  input:
+    queryParams:
+      profile: *id001
+      email_type:
+        type: string
+        required: true
+        enum:
+        - work
+      include_phone:
+        type: boolean
+        default: false
+    note: Set email_type explicitly as shown. Phone adds $0.25 only on a hit; never
+      charged per phone/address in the returned array.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      email_type: work
+      include_phone: false
+  cost:
+    type: per_success
+    value: 0.15
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Set email_type explicitly as shown.
+      Phone adds $0.25 only on a hit; never charged per phone/address in the returned
+      array.
+    contactout:
+      job: contact
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.contact.personal
+  domain: contacts
+  capability: people.email.find
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin
+  name: Get personal email, optionally phone from LinkedIn
+  summary: Get personal email, optionally phone from LinkedIn
+  input:
+    queryParams:
+      profile: *id001
+      email_type:
+        type: string
+        required: true
+        enum:
+        - personal
+      include_phone:
+        type: boolean
+        default: false
+    note: Set email_type explicitly as shown. Phone adds $0.25 only on a hit; never
+      charged per phone/address in the returned array.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      email_type: personal
+      include_phone: false
+  cost:
+    type: per_success
+    value: 0.25
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Set email_type explicitly as shown.
+      Phone adds $0.25 only on a hit; never charged per phone/address in the returned
+      array.
+    contactout:
+      job: contact
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.contact.phone
+  domain: contacts
+  capability: people.phone.find
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/people/linkedin
+  name: Get phone only from LinkedIn
+  summary: Get phone only from LinkedIn
+  input:
+    queryParams:
+      profile: *id001
+      email_type:
+        type: string
+        required: true
+        enum:
+        - none
+      include_phone:
+        type: boolean
+        required: true
+        enum:
+        - true
+    note: Set email_type explicitly as shown. Phone adds $0.25 only on a hit; never
+      charged per phone/address in the returned array.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      email_type: none
+      include_phone: true
+  cost:
+    type: per_success
+    value: 0.25
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Set email_type explicitly as shown.
+      Phone adds $0.25 only on a hit; never charged per phone/address in the returned
+      array.
+    contactout:
+      job: contact
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.linkedin.enrich
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/linkedin/enrich
+  name: Enrich LinkedIn profile and contacts
+  summary: Enrich LinkedIn profile and contacts
+  input:
+    queryParams:
+      profile: *id001
+      profile_only:
+        type: boolean
+        default: false
+    note: This route does not document email_type or include selectors. It may return
+      both email types and phones. Use the dedicated work-email contact tool to avoid
+      personal-email reveal. Treg follows the agreed contact-only rate here; no search
+      surcharge.
+  test_request:
+    queryParams:
+      profile: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      profile_only: true
+  cost:
+    type: per_success
+    value: 0.65
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. This route does not document email_type
+      or include selectors. It may return both email types and phones. Use the dedicated
+      work-email contact tool to avoid personal-email reveal. Treg follows the agreed
+      contact-only rate here; no search surcharge.
+    contactout:
+      job: linkedin
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.enrich
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/enrich
+  name: Enrich person by identifiers
+  summary: Enrich person by identifiers
+  input:
+    bodyType: json
+    body:
+      linkedin_url: &id035
+        type: string
+      email: &id036
+        type: string
+      phone: &id037
+        type: string
+      full_name: &id038
+        type: string
+      first_name: &id039
+        type: string
+      last_name: &id040
+        type: string
+      location: &id041
+        type: string
+      job_title: &id042
+        type: string
+      company: &id043
+        type: array
+      company_domain: &id044
+        type: array
+      education: &id045
+        type: array
+      include:
+        type: array
+        note: 'Contact fields to reveal: work_email, personal_email, phone. Omit for
+          profile only.'
+    note: Provide linkedin_url, email or phone, OR name plus company/location/education.
+      $0.02 if a profile is found, plus requested contacts on hit.
+  test_request:
+    body:
+      linkedin_url: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+  cost:
+    type: per_success
+    value: 0.02
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Provide linkedin_url, email or phone,
+      OR name plus company/location/education. $0.02 if a profile is found, plus requested
+      contacts on hit.
+    contactout:
+      job: person
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.enrich.work_email
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/enrich
+  name: Enrich person with work email
+  summary: Enrich person with work email
+  input:
+    bodyType: json
+    body:
+      linkedin_url: *id035
+      email: *id036
+      phone: *id037
+      full_name: *id038
+      first_name: *id039
+      last_name: *id040
+      location: *id041
+      job_title: *id042
+      company: *id043
+      company_domain: *id044
+      education: *id045
+      include:
+        type: array
+        required: true
+        enum:
+        - - work_email
+        note: This split selects only work_email. Use the general enrich tool to combine
+          with phone.
+    note: Provide linkedin_url, email or phone, OR name plus company/location/education.
+      $0.02 if a profile is found, plus requested contacts on hit.
+  test_request:
+    body:
+      linkedin_url: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      include:
+      - work_email
+  cost:
+    type: per_success
+    value: 0.16999999999999998
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Provide linkedin_url, email or phone,
+      OR name plus company/location/education. $0.02 if a profile is found, plus requested
+      contacts on hit.
+    contactout:
+      job: person
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.enrich.personal_email
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: POST
+  path: /v1/people/enrich
+  name: Enrich person with personal email
+  summary: Enrich person with personal email
+  input:
+    bodyType: json
+    body:
+      linkedin_url: *id035
+      email: *id036
+      phone: *id037
+      full_name: *id038
+      first_name: *id039
+      last_name: *id040
+      location: *id041
+      job_title: *id042
+      company: *id043
+      company_domain: *id044
+      education: *id045
+      include:
+        type: array
+        required: true
+        enum:
+        - - personal_email
+        note: This split selects only personal_email. Use the general enrich tool
+          to combine with phone.
+    note: Provide linkedin_url, email or phone, OR name plus company/location/education.
+      $0.02 if a profile is found, plus requested contacts on hit.
+  test_request:
+    body:
+      linkedin_url: https://www.linkedin.com/in/treg-verification-nonexistent-20260908
+      include:
+      - personal_email
+  cost:
+    type: per_success
+    value: 0.27
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. Provide linkedin_url, email or phone,
+      OR name plus company/location/education. $0.02 if a profile is found, plus requested
+      contacts on hit.
+    contactout:
+      job: person
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.people.email.enrich
+  domain: contacts
+  capability: people.enrich
+  platform: people
+  scope: any_account
+  method: GET
+  path: /v1/email/enrich
+  name: Enrich profile from email
+  summary: Enrich profile from email
+  input:
+    queryParams:
+      email: *id034
+      include:
+        type: string
+        enum:
+        - work_email
+        note: Only documented include value; optional work email lookup.
+    note: May return personal email and phone; only work_email is a documented include
+      selector. Returned input email is not a new contact reveal.
+  test_request:
+    queryParams:
+      email: treg-verification-nonexistent@example.com
+      include: work_email
+  cost:
+    type: per_success
+    value: 0.65
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://api.contactout.com/
+    checked: '2026-09-08'
+    confidence: documented
+    note: Starter commercial rates supplied by the account owner. Work email $0.15,
+      personal email $0.25, phone $0.25 per profile with a hit; search $0.02 per returned
+      profile/company. Multiple addresses of one type consume one credit per profile.
+      No contact hit means no contact charge. May return personal email and phone;
+      only work_email is a documented include selector. Returned input email is not
+      a new contact reveal.
+    contactout:
+      job: email
+      rates_micro: *id033
+  docs_url: https://api.contactout.com/
+- id: contactout.account.usage
+  capability: account.usage
+  platform: account
+  scope: own_account
+  method: GET
+  path: /v1/stats
+  name: Read account usage and credit pools
+  summary: Read account usage and credit pools
+  input:
+    queryParams:
+      period:
+        type: string
+        note: YYYY-MM; defaults to current month.
+    note: Own account only. Prepaid quota fields are remaining credits; postpaid remaining
+      fields represent quota minus count. Email, phone and search are separate pools,
+      not a dollar balance.
+  test_request:
+    queryParams: {}
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    note: Own account only. Prepaid quota fields are remaining credits; postpaid remaining
+      fields represent quota minus count. Email, phone and search are separate pools,
+      not a dollar balance.
+  docs_url: https://api.contactout.com/
+  kind: account
+proposed_capabilities:
+  people.count: Count profiles matching filters without returning profiles
+  people.email.availability: Check whether email contact data exists without revealing
+    it
+  people.phone.availability: Check whether a phone exists without revealing it

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -166,6 +166,7 @@ class Settings(BaseSettings):
     platform_key_serpapi: str = ""
     platform_key_moz: str = ""          # base64 of "access_id:secret_key" (HTTP Basic)
     platform_key_seranking: str = ""
+    platform_key_contactout: str = ""  # raw API token; injected into the token header
     platform_key_millionverifier: str = ""  # raw key; injected as ?api=…
     platform_key_hunter: str = ""
     platform_key_leadmagic: str = ""

--- a/src/treg/domain/capacity/collectors.py
+++ b/src/treg/domain/capacity/collectors.py
@@ -91,6 +91,29 @@ async def _hunter(c, key):
                     f"resets {(d.get('data') or {}).get('reset_date')}"}
 
 
+async def _contactout(c, key):
+    d = await _get(c, "https://api.contactout.com/v1/stats",
+                   headers={"token": key, "Accept": "application/json"})
+    if not isinstance(d, dict) or d.get("status_code") != 200 or not isinstance(d.get("usage"), dict):
+        raise ValueError("ContactOut returned no valid usage stats")
+    usage = d["usage"]
+    pools = []
+    for label, prefix in (("email", ""), ("phone", "phone_"), ("search", "search_")):
+        count, quota = usage.get(prefix + "count"), usage.get(prefix + "quota")
+        if any(isinstance(v, bool) or not isinstance(v, (int, float)) for v in (count, quota)):
+            raise ValueError("ContactOut returned incomplete credit pools")
+        remaining = usage.get(prefix + "remaining")
+        if remaining is not None and (isinstance(remaining, bool) or not isinstance(remaining, (int, float))):
+            raise ValueError("ContactOut returned invalid remaining credits")
+        # Prepaid: quota is remaining already. Postpaid supplies remaining explicitly.
+        pools.append(f"{label}: used={count}, quota={quota}" +
+                     (f", remaining={remaining}" if remaining is not None else ""))
+    # Three non-interchangeable pools cannot become one provider-wide exhaustion number.
+    # Keep raw counters visible until account overage/pool isolation semantics are confirmed.
+    return {"value": None, "unit": "credit pools", "informational": True,
+            "note": "; ".join(pools) + "; informational: overages and pool isolation unconfirmed"}
+
+
 async def _millionverifier(c, key):
     # Free balance probe. Do not add bulk_credits to credits: they can name the same pool.
     try:
@@ -387,6 +410,7 @@ BALANCE_ROUTES = {
     "moz": _moz,
     "seranking": _seranking,
     "hunter": _hunter,
+    "contactout": _contactout,
     "millionverifier": _millionverifier,
     "leadmagic": _leadmagic,
     "lusha": _lusha,

--- a/src/treg/domain/capacity/policy.py
+++ b/src/treg/domain/capacity/policy.py
@@ -23,6 +23,7 @@ _KNOWN: dict[str, tuple[str, str, str]] = {
     "tikhub": ("cash", "auto_recharge", "api"),
     "lusha": ("credits", "auto_recharge", "api"),
     "scrapecreators": ("credits", "manual", "api"),
+    "contactout": ("credits", "unknown", "api"),  # independent pools; overages unconfirmed
     "leadmagic": ("credits", "manual", "api"),
     "findymail": ("credits", "manual", "api"),
     "leadsforge": ("credits", "manual", "api"),
@@ -72,7 +73,7 @@ def policy_population(configured_keys: set[str] | None = None) -> list[str]:
 
 # Decided 2026-08-26/28: tikhub is out of overflow scope (429s, auto top-up works, Monid re-shapes
 # its responses); scrapecreators is funded, not routed (every aggregator route is ~10× our price).
-_NO_OVERFLOW = frozenset({"tikhub", "scrapecreators"})
+_NO_OVERFLOW = frozenset({"tikhub", "scrapecreators", "contactout"})
 
 
 def default_policy(provider: str, *, has_key: bool) -> CapacityPolicy:
@@ -159,6 +160,11 @@ def latest_state(policy: CapacityPolicy, snap: CapacitySnapshot | None,
     if snap is None:
         return LatestState(policy.provider, None, "", None, "stale", health="unknown",
                            note="no observation yet", rate_limit=rl)
+    if snap.confidence == "informational" and not snap.error:
+        old = now - snap.observed_at > STALE_AFTER
+        return LatestState(policy.provider, None, snap.unit, snap.observed_at,
+                           "stale" if old else "informational", health="stale" if old else "unknown",
+                           note=snap.note, rate_limit=rl)
     if snap.error or snap.remaining is None:
         return LatestState(policy.provider, None, snap.unit, snap.observed_at, "stale",
                            health="stale", note=snap.error or snap.note, rate_limit=rl)

--- a/src/treg/domain/capacity/sweep.py
+++ b/src/treg/domain/capacity/sweep.py
@@ -44,7 +44,7 @@ def snapshot_from(provider: str, row: dict, observed_at=None) -> CapacitySnapsho
     """A collector's dict → the row. Never carries a credential: the note is clipped and checked."""
     note = str(row.get("note") or "")[:300]
     error = ""
-    if row.get("value") is None:
+    if row.get("value") is None and not row.get("informational"):
         if row.get("no_api"):
             error = "no_balance_api"
         elif row.get("no_key"):
@@ -58,7 +58,7 @@ def snapshot_from(provider: str, row: dict, observed_at=None) -> CapacitySnapsho
     return CapacitySnapshot(
         provider=provider, observed_at=observed_at or utcnow_naive(),
         remaining=float(value) if isinstance(value, (int, float)) else None,
-        unit=str(row.get("unit") or ""), source="api", confidence="exact" if error == "" else "stale",
+        unit=str(row.get("unit") or ""), source="api", confidence=("informational" if row.get("informational") else "exact" if error == "" else "stale"),
         note=note, error=error,
     )
 

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1256,6 +1256,22 @@ HUNTER = OAuthProvider(
     probe_path="/account",  # free — consumes no search/verification/enrichment credits
 )
 
+CONTACTOUT = OAuthProvider(
+    service="contactout", display_name="ContactOut", auth_kind="key",
+    token_label="API token", token_placeholder="your ContactOut API token",
+    token_header="token", token_format="{secret}",
+    setup_url="https://contactout.com/meeting",
+    setup_action_label="Get your ContactOut API token",
+    setup_steps=("Request API access from ContactOut and copy your API token.",),
+    setup_note="Your own key is billed by ContactOut, never metered by treg. Connection checks use the account stats endpoint.",
+    auth_uri="", token_uri="", scopes={}, client_id_setting="", client_secret_setting="",
+    category="Enrichment",
+    summary="Find work emails, personal emails and phones from LinkedIn; search people and companies.",
+    base_url="https://api.contactout.com", docs_url="https://api.contactout.com/",
+    probe_path="/v1/stats", token_ok_field="status_code", token_ok_value="200",
+    # Live: garbage token returns HTTP 401; the supplied platform token returns 200.
+)
+
 MILLIONVERIFIER = OAuthProvider(
     service="millionverifier",
     display_name="MillionVerifier",
@@ -2740,7 +2756,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, MILLIONVERIFIER, CRUNCHBASE, MINIMAX, OPENROUTER, REPLICATE,
+        APOLLO, PDL, AKTA, HUNTER, CONTACTOUT, MILLIONVERIFIER, CRUNCHBASE, MINIMAX, OPENROUTER, REPLICATE,
         TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers

--- a/src/treg/web/logos/contactout.svg
+++ b/src/treg/web/logos/contactout.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#475569"/><text x="32" y="43" text-anchor="middle" font-family="Arial,sans-serif" font-size="32" font-weight="700" fill="white">C</text></svg>

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -249,6 +249,7 @@ def test_an_unrecorded_vendor_phrase_is_a_tripwire_never_a_mark():
 _UNRECORDED_SIGNATURE = {
     "apify", "aviato", "branddev", "brightdata", "coingecko", "coresignal", "crustdata", "dataforseo",
     "diffbot", "exa", "fiber-ai", "finnhub", "icypeas", "influencersclub", "justoneapi", "marketstack",
+    "contactout",  # pool-specific exhaustion and overages pending provider confirmation
     "millionverifier",  # funded-account exhaustion not observed; trial still has credits
     "minimax", "oceanio", "openrouter", "pdl", "replicate", "scrapecreators", "seranking",
     "serpapi", "serpstat", "spyfu", "tiingo", "tikhub", "tomba", "twelvedata",

--- a/tests/test_contactout.py
+++ b/tests/test_contactout.py
@@ -1,0 +1,455 @@
+"""ContactOut billing, faithful BYOK and independent pool monitoring."""
+
+import json
+from datetime import timedelta
+
+import httpx
+import pytest
+
+from treg.api import app
+from treg import oauth_providers as P
+from treg.config import get_settings, Settings
+from treg.application.call import contactout
+from treg.application.call import service as call_service
+from treg.application.call.types import UpstreamResponse
+from treg.domain.catalog import store
+from treg.domain.capacity import collectors, policy, sweep
+from treg.timeutil import utcnow_naive
+
+
+def cost(eid):
+    return store.load().cost_view(
+        store.load().by_id["contactout." + eid]["cost"], "contactout"
+    )
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    monkeypatch.setenv("TREG_PLATFORM_KEY_CONTACTOUT", "PLATFORM-TEST")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "contactout")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "work,personal,phone,expected",
+    [
+        (False, False, False, 0),
+        (True, False, False, 150000),
+        (False, True, False, 250000),
+        (True, False, True, 400000),
+        (False, True, True, 500000),
+        (True, True, True, 650000),
+    ],
+)
+def test_contact_hits_are_per_type_per_profile(work, personal, phone, expected):
+    c = cost("people.linkedin.enrich")
+    doc = {
+        "status_code": 200,
+        "profile": {
+            "work_email": ["a@example.test", "b@example.test"] if work else [],
+            "personal_email": ["c@example.test"] if personal else [],
+            "phone": ["123", "456"] if phone else [],
+            "email": ["duplicate-combined@example.test"],
+            "contact_availability": {"phone": True},
+        },
+    }
+    assert contactout.observed(c, {"queryParams": {}}, doc) == expected
+    assert contactout.estimate(c, {}) == 650000
+
+
+def test_search_counts_returned_profiles_and_contacts_not_availability_or_total():
+    c = cost("people.search.reveal")
+    doc = {
+        "status_code": 200,
+        "metadata": {"total_results": 10000},
+        "profiles": {
+            "one": {
+                "contact_info": {
+                    "work_emails": ["a@example.test", "b@example.test"],
+                    "phones": ["1"],
+                }
+            },
+            "two": {"contact_availability": {"personal_email": True}},
+            "three": {"contact_info": {"personal_emails": ["c@example.test"]}},
+        },
+    }
+    assert contactout.observed(c, {"body": {"reveal_info": True}}, doc) == 710000
+    assert contactout.observed(c, {"body": {"reveal_info": False}}, doc) == 60000
+    assert contactout.estimate(c, {"page_size": 3, "reveal_info": True}) == 2010000
+    assert contactout.estimate(c, {"reveal_info": False}) == 500000
+    assert (
+        contactout.observed(c, {"body": {}}, {"status_code": 200, "profiles": []}) == 0
+    )
+
+
+def test_person_and_email_echo_and_search_surcharge():
+    doc = {
+        "status_code": 200,
+        "profile": {
+            "email": "input@example.test",
+            "workEmail": "work@example.test",
+            "phone": "123",
+        },
+    }
+    c = cost("people.enrich")
+    request = {
+        "email": "input@example.test",
+        "include": ["work_email", "personal_email", "phone"],
+    }
+    assert contactout.observed(c, {"body": request}, doc) == 420000
+    assert contactout.observed(c, {"body": {}}, doc) == 20000
+    assert (
+        contactout.observed(
+            cost("people.email.enrich"),
+            {"queryParams": {"email": "input@example.test", "include": "work_email"}},
+            doc,
+        )
+        == 400000
+    )
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [],
+        [{"name": "A"}, None, {}],
+        {"example.test": {"name": "A"}, "missing.test": None},
+    ],
+)
+def test_company_counts(rows):
+    expected = 0 if rows == [] else 20000
+    assert (
+        contactout.observed(
+            cost("companies.enrich"), {}, {"status_code": 200, "companies": rows}
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "eid,params,amount",
+    [
+        ("people.contact.work", {"email_type": "work"}, 150000),
+        (
+            "people.contact.work",
+            {"email_type": "work", "include_phone": "true"},
+            400000,
+        ),
+        (
+            "people.contact.personal",
+            {"email_type": "personal", "include_phone": "true"},
+            500000,
+        ),
+        ("people.contact.phone", {"email_type": "none", "include_phone": True}, 250000),
+        ("people.enrich", {"include": ["phone"]}, 270000),
+        ("companies.enrich", {"domains": ["a.test", "b.test"]}, 40000),
+        ("people.linkedin.from-email", {}, 60000),
+        ("people.email.verify", {}, 0),
+    ],
+)
+def test_holds(eid, params, amount):
+    assert contactout.estimate(cost(eid), params) == amount
+
+
+async def test_connect_rejects_garbage_and_accepts_zero_pools(clients, monkeypatch):
+    def reply(request):
+        assert request.url.path == "/v1/stats"
+        assert request.headers["token"] in ("garbage", "valid-test")
+        if request.headers["token"] == "garbage":
+            return httpx.Response(
+                401, json={"status_code": 401, "message": "Bad credentials"}
+            )
+        return httpx.Response(
+            200,
+            json={
+                "status_code": 200,
+                "usage": {"quota": 0, "phone_quota": 0, "search_quota": 0},
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(reply)) as upstream:
+        monkeypatch.setattr(app.state, "http", upstream)
+        bad = await clients.post(
+            "/connections/token", json={"provider": "contactout", "token": "garbage"}
+        )
+        assert bad.status_code == 422
+        assert not (await clients.get("/tools")).json()
+        good = await clients.post(
+            "/connections/token", json={"provider": "contactout", "token": "valid-test"}
+        )
+        assert good.status_code == 200, good.text
+        binding = (await clients.get("/tools")).json()[0]["bindings"][0]
+        assert binding["name"] == "token" and binding["format"] == "{secret}"
+
+
+def test_platform_binding(platform):
+    assert Settings(_env_file=None).platform_key_for("contactout") == "PLATFORM-TEST"
+    assert P.platform_bindings(P.get("contactout")) == [
+        {
+            "platform_setting": "platform_key_contactout",
+            "injector": "env",
+            "location": "header",
+            "name": "token",
+            "format": "{secret}",
+        }
+    ]
+    assert not store.load().platform_eligible(
+        store.load().by_id["contactout.account.usage"]
+    )
+
+
+async def test_pool_stats_are_informational_even_when_empty(platform):
+    for extra in ({}, {"remaining": -5, "phone_remaining": 0, "search_remaining": 20}):
+        usage = {
+            "count": 10,
+            "quota": 0,
+            "phone_count": 20,
+            "phone_quota": 0,
+            "search_count": 30,
+            "search_quota": 20,
+        } | extra
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json={"status_code": 200, "usage": usage})
+            )
+        ) as c:
+            row = await collectors.provider_balance("contactout", c)
+        snap = sweep.snapshot_from("contactout", row)
+        assert not snap.error and snap.remaining is None
+        assert "email: used=10, quota=0" in snap.note
+        state = policy.latest_state(
+            policy.default_policy("contactout", has_key=True), snap
+        )
+        assert state.confidence == "informational" and state.exhausted_until is None
+        old = policy.latest_state(
+            policy.default_policy("contactout", has_key=True),
+            snap,
+            now=utcnow_naive() + timedelta(hours=7),
+        )
+        assert old.health == "stale" and old.exhausted_until is None
+
+
+async def _balance(client):
+    org = (await client.get("/orgs")).json()[0]["org_id"]
+    return (await client.get(f"/orgs/{org}/balance")).json()
+
+
+@pytest.mark.parametrize(
+    "own,status,doc,charge",
+    [
+        (
+            False,
+            200,
+            {
+                "status_code": 200,
+                "profile": {"work_email": ["a@example.test"], "phone": ["123"]},
+            },
+            400000,
+        ),
+        (False, 200, {"status_code": 200, "profile": {"work_email": []}}, 0),
+        (False, 200, {"status_code": 403, "message": "No access"}, 0),
+        (False, 403, {"status_code": 403, "message": "Out of credits"}, 0),
+        (False, 429, {"status_code": 429}, 0),
+        (
+            True,
+            200,
+            {
+                "status_code": 200,
+                "profile": {"work_email": ["a@example.test"], "phone": ["123"]},
+            },
+            0,
+        ),
+    ],
+)
+async def test_platform_settles_once_and_own_key_wins(
+    clients, platform, monkeypatch, own, status, doc, charge
+):
+    if own:
+        await clients.post("/secrets", json={"name": "contactout", "value": "OWN-TEST"})
+
+    async def relay(request, upstream_url, tool, secrets, client, **kwargs):
+        assert "/v1/people/linkedin" in upstream_url
+        binding = tool.bindings[0]
+        assert ("secret_id" in binding) == own
+        assert binding["name"] == "token"
+
+        async def stream():
+            yield json.dumps(doc).encode()
+
+        async def close():
+            pass
+
+        return UpstreamResponse(status, (), stream(), close)
+
+    monkeypatch.setattr(call_service, "relay", relay)
+    before = await _balance(clients)
+    response = await clients.get(
+        "/call/contactout.people.contact.work",
+        params={
+            "profile": "https://linkedin.com/in/test",
+            "email_type": "work",
+            "include_phone": "true",
+        },
+    )
+    assert response.status_code == status, response.text
+    assert response.json() == doc
+    after = await _balance(clients)
+    assert before["balance_micro"] - after["balance_micro"] == charge
+    entries = after["entries"]["items"]
+    closing = [e for e in entries if e["kind"] in ("settle", "release")]
+    assert len(closing) == (0 if own else 1)
+
+
+async def test_split_must_be_explicit_and_stats_are_private(clients, platform):
+    response = await clients.get(
+        "/call/contactout.people.contact.work",
+        params={"profile": "https://linkedin.com/in/test"},
+    )
+    assert response.status_code == 400
+    assert "email_type" in response.text
+    response = await clients.get("/call/contactout.account.usage")
+    assert response.status_code in (404, 428)
+
+
+def test_combined_email_array_is_not_billed_twice():
+    doc = {
+        "status_code": 200,
+        "profile": {
+            "work_email": ["work@example.test"],
+            "personal_email": [],
+            "email": ["work@example.test"],
+        },
+    }
+    c = cost("people.enrich")
+    assert (
+        contactout.observed(
+            c, {"body": {"include": ["work_email", "personal_email"]}}, doc
+        )
+        == 170000
+    )
+
+
+async def test_search_settlement_matches_14_live_results_shape(
+    clients, platform, monkeypatch
+):
+    doc = {
+        "status_code": 200,
+        "metadata": {"total_results": 5000},
+        "profiles": {"one": {"full_name": "Synthetic"}},
+    }
+
+    async def relay(request, upstream_url, tool, secrets, client, **kwargs):
+        async def stream():
+            yield json.dumps(doc).encode()
+
+        async def close():
+            pass
+
+        return UpstreamResponse(200, (), stream(), close)
+
+    monkeypatch.setattr(call_service, "relay", relay)
+    before = await _balance(clients)
+    response = await clients.post(
+        "/call/contactout.people.search", json={"page_size": 25, "reveal_info": False}
+    )
+    assert response.status_code == 200, response.text
+    after = await _balance(clients)
+    assert before["balance_micro"] - after["balance_micro"] == 20000
+
+
+async def test_free_verify_never_reserves_or_settles_money(
+    clients, platform, monkeypatch
+):
+    async def relay(request, upstream_url, tool, secrets, client, **kwargs):
+        async def stream():
+            yield b'{"status_code":200,"data":{"status":"valid"}}'
+
+        async def close():
+            pass
+
+        return UpstreamResponse(200, (), stream(), close)
+
+    monkeypatch.setattr(call_service, "relay", relay)
+    before = await _balance(clients)
+    response = await clients.get(
+        "/call/contactout.people.email.verify", params={"email": "test@example.test"}
+    )
+    assert response.status_code == 200, response.text
+    after = await _balance(clients)
+    assert before["balance_micro"] == after["balance_micro"]
+    assert all(
+        e["amount_micro"] == 0
+        for e in after["entries"]["items"]
+        if e["kind"] in ("reserve", "settle")
+    )
+
+
+async def test_transport_failure_releases_hold(clients, platform, monkeypatch):
+    async def relay(*args, **kwargs):
+        raise httpx.ReadTimeout("synthetic timeout")
+
+    monkeypatch.setattr(call_service, "relay", relay)
+    before = await _balance(clients)
+    response = await clients.get(
+        "/call/contactout.people.contact.work",
+        params={"profile": "https://linkedin.com/in/test", "email_type": "work"},
+    )
+    assert response.status_code >= 500
+    after = await _balance(clients)
+    assert before["balance_micro"] == after["balance_micro"]
+    assert len([e for e in after["entries"]["items"] if e["kind"] == "release"]) == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"status_code": 401},
+        {"status_code": 200, "usage": {}},
+        {"status_code": 200, "usage": {"count": True, "quota": 1}},
+    ],
+)
+async def test_bad_stats_are_not_valid_observations(platform, payload):
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(200, json=payload))
+    ) as c:
+        row = await collectors.provider_balance("contactout", c)
+    assert row["value"] is None and not row.get("informational")
+    assert "PLATFORM-TEST" not in str(row)
+    assert sweep.snapshot_from("contactout", row).error
+
+
+def test_catalog_prices_validate_and_surface_is_bounded():
+    from scripts.catalog_validate import check_cost
+
+    cat = store.load()
+    entries = [e for e in cat.endpoints if e.get("provider") == "contactout"]
+    assert len(entries) == 21
+    assert not any("batch" in e["path"] for e in entries)
+    errors = []
+    for e in entries:
+        check_cost(e["cost"], e["id"], errors, [], e["input"])
+    assert errors == []
+    broken = cost("people.contact.work") | {
+        "contactout": {"job": "contact", "rates_micro": {"phone": -1}}
+    }
+    check_cost(broken, "test", errors, [])
+    assert errors
+
+
+def test_free_checkers_are_not_advertised_as_contact_finders():
+    cat = store.load()
+    for eid in ("people.work_email.available", "people.personal_email.available", "people.phone.available"):
+        assert cat.by_id["contactout." + eid]["capability"].endswith(".availability")
+    assert cat.by_id["contactout.people.count"]["capability"] == "people.count"
+
+
+@pytest.mark.parametrize("body", [b"", b"not json", b"[]", b"{}", b'{"status_code":200}', b'{"status_code":200,"profile":"unexpected"}'])
+def test_contact_reveals_require_recognizable_hit_evidence(body):
+    from types import SimpleNamespace
+    from treg.application.call.settle import _observed_cost_micro
+    mk = SimpleNamespace(provider="contactout", endpoint_id="contactout.people.contact.work",
+                         cost_type="per_success", unit_micro=0, billed_oauth=False, request_data={})
+    assert _observed_cost_micro(mk, body) == 0

--- a/tests/test_contactout_live.py
+++ b/tests/test_contactout_live.py
@@ -1,0 +1,43 @@
+"""Opt-in free live connection check. Never enabled by CI or ordinary pytest runs."""
+
+import os
+
+import httpx
+import pytest
+
+from treg.api import app
+from treg.infra.db import reset_db
+
+
+@pytest.mark.skipif(
+    os.environ.get("TREG_CONTACTOUT_LIVE_VERIFY") != "1",
+    reason="explicit live verification only",
+)
+async def test_live_contactout_connect(clients, monkeypatch):
+    from dotenv import dotenv_values
+
+    credential = dotenv_values(".env").get("TREG_PLATFORM_KEY_CONTACTOUT")
+    if not credential:
+        pytest.fail("ContactOut platform credential missing")
+    async with httpx.AsyncClient(timeout=30) as upstream:
+        monkeypatch.setattr(app.state, "http", upstream)
+        try:
+            bad = await clients.post(
+                "/connections/token",
+                json={
+                    "provider": "contactout",
+                    "token": "treg-intentionally-invalid-20260908",
+                },
+            )
+            assert bad.status_code == 422
+            good = await clients.post(
+                "/connections/token",
+                json={"provider": "contactout", "token": credential},
+            )
+            assert good.status_code == 200
+            tools = (await clients.get("/tools")).json()
+            tool = next(t for t in tools if t["name"] == "contactout")
+            assert tool["bindings"][0]["name"] == "token"
+        finally:
+            # This is the isolated pytest database, never the developer or production database.
+            await reset_db()

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -18,7 +18,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "millionverifier", "crunchbase", "tikhub", "brightdata", "semrush",
+    for svc in ("apollo", "pdl", "akta", "hunter", "contactout", "millionverifier", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "cloro",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -47,7 +47,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "millionverifier", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "apollo", "pdl", "akta", "hunter", "contactout", "millionverifier", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
         "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "cloro",


### PR DESCRIPTION
Adds ContactOut to the catalog with BYOK connection verification, a platform key slot, and Starter metering for the requested LinkedIn/contact enrichment jobs. Work/personal splits use documented upstream selectors; free availability checks and counts have distinct capabilities so they cannot appear as free contact finders.

- Prices follow the account owner's commercial terms: work email $0.15, personal email $0.25, phone $0.25 per profile with a hit; search/company results $0.02 each; email-to-LinkedIn $0.06 per served call. Person enrichment adds the search charge on a profile hit. Contact holds reflect requested fields and page/input sizes; settlement counts returned records and contact types, not availability flags or total-results metadata. Missing/unrecognized hit evidence costs zero.
- Count, availability checkers and single email verification are free. Verification must be rechecked if ContactOut starts charging verifier credits. The agreed LinkedIn-profile contact-only rate takes precedence over the public docs' profile-only search surcharge.
- Existing own-key precedence, unmetered BYOK, relay behavior, reserve/settle/release and cancellation handling are retained. Server/worker deployment slots are wired; the provider allow-list still controls platform serving. The logo is a neutral lettermark placeholder.
- `/v1/stats` joins the existing hourly capacity sweep as informational separate email/phone/search pools. Prepaid quotas already mean remaining credits. No provider-wide exhaustion block, automatic funding, overflow route, or new polling schedule is inferred while ContactOut confirms overages, pool isolation and stats latency.

Live verification used the private credential without storing contact details: valid/garbage tokens passed/rejected through treg's full connection flow (200/422), then the isolated test credentials were removed. Count, all checkers, verify, no-reveal search, company search/domain enrichment and decision makers returned 200. Fourteen returned search/company records matched a 14-credit prepaid pool decline; contact targets produced expected misses. Positive contact-hit/reveal-search upstream billing remains unverified; synthetic billing tests cover the combinations. Prices remain documented, not claimed as observed.

Deferred: synchronous/asynchronous LinkedIn batches (v1/v2) and batch email verification. Hashed email and campaign APIs are outside this scope.

Validation: catalog validator, import-linter, complete parallel pytest suite with `TREG_PUBLIC_URL=https://treg.to`, focused metering regression tests, and opt-in live connection test. The public URL override avoids inheriting the local `.env` setting that intentionally disables hosted pages. No secrets or unrelated planning files are included.

Fragments updated: new `architecture/contactout.md`; `architecture/catalog.md`, `architecture/auth-secrets.md`, `architecture/money.md`, `ops/capacity.md`, `ops/deploy.md`, and `guides/expanding-a-category.md`, plus regenerated context indexes.
