### PR TITLE
feat(feedback): encourage proactive reports and clarify CLI help

### DIFF
--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -22,7 +22,9 @@ related:
 `FeedbackCategory` is the shared four-value vocabulary: `quality`, `pricing`, `friction`, `other`.
 `FeedbackIn` accepts only `category`, `message` (trimmed, 1-2,000 characters), optional `call_ids`
 (at most 100 bounded opaque references, deduplicated), and optional public `endpoint_id`.
-Extra fields are rejected. Privacy instructions ask callers to replace sensitive values and omit
+Guidance explicitly welcomes observed friction even after successful workarounds, without requiring
+a proven bug. It directs agents to pass references in `call_ids` (CLI `--call-id`), not only prose,
+and to continue the task after reporting an issue once. Extra fields are rejected. Privacy instructions ask callers to replace sensitive values and omit
 raw payloads; free-text content is not guaranteed anonymous or automatically sanitized.
 
 `POST /feedback` uses `require_member`, including agent identities and the existing public-demo

--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -22,7 +22,7 @@ related:
 `FeedbackCategory` is the shared four-value vocabulary: `quality`, `pricing`, `friction`, `other`.
 `FeedbackIn` accepts only `category`, `message` (trimmed, 1-2,000 characters), optional `call_ids`
 (at most 100 bounded opaque references, deduplicated), and optional public `endpoint_id`.
-Guidance explicitly welcomes observed friction even after successful workarounds, without requiring
+Guidance encourages proactive reports of small annoyances and observed friction even after successful workarounds, without requiring
 a proven bug. It directs agents to pass references in `call_ids` (CLI `--call-id`), not only prose,
 and to continue the task after reporting an issue once. Extra fields are rejected. Privacy instructions ask callers to replace sensitive values and omit
 raw payloads; free-text content is not guaranteed anonymous or automatically sanitized.

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -37,6 +37,8 @@ See [feedback](feedback.md). V2 retains its catalog-only calling boundary.
 
 Both MCP call surfaces expose the API's `X-Treg-Call-Id` as optional `call_id`. Successful 2xx
 calls may also include a task-oriented `hint`; existing hints and idempotent replays take priority.
+The hint names concrete friction (guessing, workarounds, unexpected results or charges), welcomes
+reports even when the task succeeds, and names the feedback tool's `call_ids` argument explicitly.
 The provider `body` is unchanged. CLI and direct HTTP responses do not gain a feedback hint.
 
 `mcp_feedback` reads PostHog `/flags?v=2` with the existing `TREG_POSTHOG_KEY` and host. Configure

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -37,7 +37,7 @@ See [feedback](feedback.md). V2 retains its catalog-only calling boundary.
 
 Both MCP call surfaces expose the API's `X-Treg-Call-Id` as optional `call_id`. Successful 2xx
 calls may also include a task-oriented `hint`; existing hints and idempotent replays take priority.
-The hint names concrete friction (guessing, workarounds, unexpected results or charges), welcomes
+The hint encourages proactive reporting of small annoyances and names concrete friction (guessing, workarounds, unexpected results or charges), welcomes
 reports even when the task succeeds, and names the feedback tool's `call_ids` argument explicitly.
 The provider `body` is unchanged. CLI and direct HTTP responses do not gain a feedback hint.
 

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -16,6 +16,8 @@ related:
 
 `cmd_feedback` implements `treg feedback submit <category> <message> [--call-id ID] [--endpoint-id ID]`.
 The category choices and help description come from the lightweight `feedback_contract` module.
+Both parent and submit help explain fields, category meanings, optional call-reference mapping,
+privacy and receipt semantics; a reference mentioned only in prose is not automatically linked.
 `--call-id` repeats; message `-` reads stdin. `_client` applies the configured registry and team,
 and `_feedback_request` prints JSON or exits nonzero with an actionable error without echoing
 rejected input. `cmd_feedback_get` implements `treg feedback get <feedback_id>`. Submission transport

--- a/docs/context/interface/skill.md
+++ b/docs/context/interface/skill.md
@@ -26,6 +26,9 @@ related:
 registry (distinct from `.claude/skills/tools-registry-context/`, which maintains *these* design docs).
 Its frontmatter `name: treg` + `description` make it loadable by a coding agent.
 
+The feedback section welcomes concrete friction and workarounds even when a task succeeds,
+asks for observations rather than a proven bug, and names MCP `call_ids` / CLI `--call-id`.
+
 One skill, three personas:
 - **consumer** — discover + call tools with no credentials locally. Teaches the agent-native
   **URL-passthrough** first: take the real upstream URL and prefix it with `{BASE}/call/`

--- a/docs/context/interface/skill.md
+++ b/docs/context/interface/skill.md
@@ -26,7 +26,7 @@ related:
 registry (distinct from `.claude/skills/tools-registry-context/`, which maintains *these* design docs).
 Its frontmatter `name: treg` + `description` make it loadable by a coding agent.
 
-The feedback section welcomes concrete friction and workarounds even when a task succeeds,
+The feedback section encourages proactive reports of small annoyances and concrete friction and workarounds even when a task succeeds,
 asks for observations rather than a proven bug, and names MCP `call_ids` / CLI `--call-id`.
 
 One skill, three personas:

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -332,12 +332,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -332,10 +332,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -335,12 +335,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -335,10 +335,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -316,12 +316,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -316,10 +316,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -330,10 +330,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -330,12 +330,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -314,12 +314,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -314,10 +314,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions](https://treg.to/feedback.md).
 
 ## Rules

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -31,6 +31,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import textwrap
 import threading
 import time
 import webbrowser
@@ -6017,18 +6018,42 @@ def build_parser() -> argparse.ArgumentParser:
 
     fb = mk(sub, "feedback", "Submit or retrieve private team feedback.",
             'treg feedback submit friction "The pagination example is unclear."',
+            'treg feedback submit quality "The result is outdated." --call-id CALL_ID --endpoint-id PROVIDER.ENDPOINT',
+            'treg feedback submit other - < sanitized-feedback.txt',
             'treg feedback get 123')
+    fb.description = textwrap.fill(FEEDBACK_DESCRIPTION, width=88)
+    feedback_fields = (
+        "\n\nSubmission fields:\n"
+        "  category       Required: quality (results), pricing (charges/prices),\n"
+        "                 friction (using treg), other (requests/suggestions).\n"
+        "  message        Required: what you needed and what happened, 1-2000 characters.\n"
+        "                 State uncertainty; use - to read sanitized text from stdin.\n"
+        "  --call-id ID   Optional: the treg call ID returned with the relevant call.\n"
+        "                 Repeat for multiple calls (up to 100); sent as call_ids.\n"
+        "                 IDs written only in message are not linked automatically.\n"
+        "  --endpoint-id ID\n"
+        "                 Optional: public catalog endpoint ID; sent as endpoint_id.\n"
+        "\nReceipt: JSON with feedback_id and status=received. Retrieve with:\n"
+        "  treg feedback get FEEDBACK_ID\n"
+        "Reports go to your configured registry and active team, cost nothing, and\n"
+        "are visible to that team and registry administrators. No automatic reply.\n"
+    )
+    fb.epilog += feedback_fields + "\nFull syntax: treg feedback submit --help"
     fb.set_defaults(fn=lambda args, cfg: fb.print_help())
     feedback_commands = fb.add_subparsers(dest="sub", metavar="<subcommand>")
-    submit = mk(feedback_commands, "submit", FEEDBACK_DESCRIPTION,
+    submit = mk(feedback_commands, "submit", "Submit a problem or suggestion.",
                 'treg feedback submit friction "The pagination example is unclear."',
                 'treg feedback submit quality "The returned data is outdated." --call-id CALL_ID',
                 'treg feedback submit other - < sanitized-feedback.txt')
-    submit.add_argument("category", choices=FEEDBACK_CATEGORIES, help="the kind of feedback")
-    submit.add_argument("message", help="sanitized description, 1-2000 characters; - reads stdin")
-    submit.add_argument("--call-id", action="append", help="related treg call ID (repeat, up to 100)")
+    submit.description = textwrap.fill(FEEDBACK_DESCRIPTION, width=88)
+    submit.add_argument("category", choices=FEEDBACK_CATEGORIES,
+                        help="quality: results; pricing: charges/prices; friction: using treg; other: requests/suggestions")
+    submit.add_argument("message",
+                        help="what you needed and observed, 1-2000 characters; state uncertainty; - reads stdin")
+    submit.add_argument("--call-id", action="append",
+                        help="returned treg call ID; repeat up to 100; sent as call_ids, not extracted from message")
     submit.add_argument("--endpoint-id", help="public catalog endpoint ID, if known")
-    submit.epilog += "\nMore: <your registry base URL>/feedback.md"
+    submit.epilog += feedback_fields + "\nMore: <your registry base URL>/feedback.md"
     submit.set_defaults(fn=cmd_feedback)
     get = mk(feedback_commands, "get", "Retrieve a feedback report from the active team.",
              "treg feedback get 123")

--- a/src/treg/feedback_contract.py
+++ b/src/treg/feedback_contract.py
@@ -5,11 +5,14 @@ from typing import Literal, get_args
 FeedbackCategory = Literal["quality", "pricing", "friction", "other"]
 FEEDBACK_CATEGORIES = get_args(FeedbackCategory)
 FEEDBACK_DESCRIPTION = (
-    "Report problems or suggestions about treg, including confusing results or charges, "
-    "unclear instructions, and limitations you worked around, even if the task succeeded. "
+    "Proactively share problems and suggestions about treg. Small annoyances that slowed "
+    "your task down are useful feedback too: confusing results or charges, unclear "
+    "instructions, unhelpful errors, or missing capabilities you worked around. "
+    "Report these even if the task succeeded. "
     "Describe what you needed and what you observed; you do not need to prove a bug. "
     "Categories: quality (tool results), pricing (charges or prices), friction (using treg), "
     "other (requests or suggestions). Pass related call IDs in call_ids (CLI: --call-id), "
     "not only in message. References are optional. Omit private information, credentials, "
-    "and raw requests, responses or logs. Report each issue once, then continue the user's task."
+    "and raw requests, responses or logs. Report each issue once. Feedback goes to the treg "
+    "team to improve the product; it does not complete the user's task. Keep going afterward."
 )

--- a/src/treg/feedback_contract.py
+++ b/src/treg/feedback_contract.py
@@ -5,8 +5,11 @@ from typing import Literal, get_args
 FeedbackCategory = Literal["quality", "pricing", "friction", "other"]
 FEEDBACK_CATEGORIES = get_args(FeedbackCategory)
 FEEDBACK_DESCRIPTION = (
-    "Share a problem or suggestion about treg. Categories: quality (tool results), "
-    "pricing (charges or prices), friction (using treg), other (requests or suggestions). "
-    "Describe what happened in your own words. Include related call IDs if available. "
-    "Omit private information, credentials, and raw requests, responses or logs."
+    "Report problems or suggestions about treg, including confusing results or charges, "
+    "unclear instructions, and limitations you worked around, even if the task succeeded. "
+    "Describe what you needed and what you observed; you do not need to prove a bug. "
+    "Categories: quality (tool results), pricing (charges or prices), friction (using treg), "
+    "other (requests or suggestions). Pass related call IDs in call_ids (CLI: --call-id), "
+    "not only in message. References are optional. Omit private information, credentials, "
+    "and raw requests, responses or logs. Report each issue once, then continue the user's task."
 )

--- a/src/treg/mcp_feedback.py
+++ b/src/treg/mcp_feedback.py
@@ -15,9 +15,11 @@ from .config import get_settings
 FLAG = "mcp-feedback-hint"
 DISTINCT_ID = "treg-mcp-feedback-hint"
 HINT = (
-    "If this result fell short of your task or took extra work to use, consider using the "
-    "feedback tool. Briefly describe what you needed and what got in the way; omit private "
-    "data. Include this call_id when available. Report the same issue once per task."
+    "If you had to guess, work around a limitation, or explain unexpected results or charges, "
+    "report that friction using treg's feedback tool, even if the task succeeded. "
+    "Describe what you observed; you do not need to prove a bug. Pass this call_id in the "
+    "call_ids argument when available. Omit private data. Report each issue once, "
+    "then continue your task."
 )
 REFRESH_SECONDS = 60
 MAX_AGE_SECONDS = 90

--- a/src/treg/mcp_feedback.py
+++ b/src/treg/mcp_feedback.py
@@ -15,11 +15,12 @@ from .config import get_settings
 FLAG = "mcp-feedback-hint"
 DISTINCT_ID = "treg-mcp-feedback-hint"
 HINT = (
-    "If you had to guess, work around a limitation, or explain unexpected results or charges, "
-    "report that friction using treg's feedback tool, even if the task succeeded. "
-    "Describe what you observed; you do not need to prove a bug. Pass this call_id in the "
-    "call_ids argument when available. Omit private data. Report each issue once, "
-    "then continue your task."
+    "Proactively share friction using treg's feedback tool. Small annoyances count: "
+    "confusing results or charges, unclear instructions, or a limitation you worked around, "
+    "even if your task succeeded. Describe what you observed; you do not need to prove a bug. "
+    "Pass related call IDs in call_ids when available. Omit private data and report each "
+    "issue once. Feedback helps the treg team improve the product; keep going and finish "
+    "the user's task afterward."
 )
 REFRESH_SECONDS = 60
 MAX_AGE_SECONDS = 90

--- a/src/treg/web/feedback.md
+++ b/src/treg/web/feedback.md
@@ -1,6 +1,9 @@
 # Feedback
 
-Share problems or suggestions in your own words. Choose one category:
+Report confusing results or charges, unclear instructions, and limitations you worked around,
+even if the task succeeded. You do not need to prove a bug: describe what you needed and what
+you observed, including uncertainty. Report each issue once, then continue the user's task.
+Choose one category:
 
 - `quality`: problems with tool results.
 - `pricing`: unexpected charges or unclear prices.
@@ -19,11 +22,12 @@ Use your configured registry and active team. Sign in first if needed (`treg log
 treg feedback submit friction "The pagination example is unclear."
 ```
 
-Add `--call-id ID` (repeatable) or `--endpoint-id ID` when available. Neither is required.
+Add `--call-id ID` (repeatable) or `--endpoint-id ID` when available. Neither is required. IDs written only in the message are not linked automatically.
 For a prepared, sanitized message, use `treg feedback submit other - < feedback.txt`.
 See `treg feedback submit --help` for syntax.
 
-Over MCP, use `feedback(category, message, call_ids?, endpoint_id?)`.
+Over MCP, use `feedback(category, message, call_ids?, endpoint_id?)`. Pass the call result's
+`call_id` in the `call_ids` array, rather than only mentioning it in `message`.
 Over HTTP, POST the same fields to `{BASE}/feedback` with your `X-Treg-Token`:
 
 ```json

--- a/src/treg/web/feedback.md
+++ b/src/treg/web/feedback.md
@@ -1,8 +1,10 @@
 # Feedback
 
-Report confusing results or charges, unclear instructions, and limitations you worked around,
-even if the task succeeded. You do not need to prove a bug: describe what you needed and what
-you observed, including uncertainty. Report each issue once, then continue the user's task.
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down are useful feedback too: confusing results or charges, unclear instructions, unhelpful
+errors, and missing capabilities you worked around, even if the task succeeded. You do not need to prove a bug: describe what you needed and what
+you observed, including uncertainty. Report each issue once. Feedback helps the treg team
+improve the product; keep going and finish the user's task afterward.
 Choose one category:
 
 - `quality`: problems with tool results.

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -295,10 +295,12 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-When you discover a concrete problem with treg, its pricing, or a tool result, submit a brief
-sanitized report if you have enough evidence. Distinguish observations from suspected causes.
-Report the same issue once per task and continue with the user's work. Suggestions are welcome too.
-Include related call IDs when available; keep them with saved results when practical.
+If you had to guess, work around a limitation, or explain unexpected results or charges,
+submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+observed; you do not need to prove a bug. Distinguish observations from suspected causes.
+Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
+in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
+Report each issue once, then continue the user's task. Suggestions are welcome too.
 Keep private information out of the report. See [feedback instructions]({BASE}/feedback.md).
 
 ## Rules

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -295,12 +295,14 @@ a probe so treg can validate it: `health_check: {method, path, expect_status}` (
 
 ## Feedback
 
-If you had to guess, work around a limitation, or explain unexpected results or charges,
-submit a brief sanitized report, even if the task succeeded. Describe what you needed and
+Proactively share problems and suggestions about treg. Small annoyances that slowed your task
+down count too: unclear instructions, confusing results or charges, unhelpful errors, and
+missing capabilities you worked around, even if the task succeeded. Describe what you needed and
 observed; you do not need to prove a bug. Distinguish observations from suspected causes.
 Use the `feedback` tool over MCP, or `treg feedback submit` over CLI. Pass related call IDs
 in `call_ids` (CLI: `--call-id`), not only in the message; references are optional.
-Report each issue once, then continue the user's task. Suggestions are welcome too.
+Report each issue once. Feedback helps the treg team improve the product; it does not complete
+the user's task. Keep going afterward.
 Keep private information out of the report. See [feedback instructions]({BASE}/feedback.md).
 
 ## Rules

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -300,6 +300,10 @@ def test_cli_feedback_without_arguments_shows_help_without_network(monkeypatch, 
     args.fn(args, {})
     output = capsys.readouterr().out
     assert "submit" in output and "get" in output
+    for field in ("category", "message", "--call-id", "--endpoint-id", "feedback_id"):
+        assert field in output
+    assert "call_ids" in output and "not linked automatically" in output
+    assert "1-2000" in output and "up to 100" in output
 
 
 def test_cli_feedback_keeps_category_first_shorthand(monkeypatch):


### PR DESCRIPTION
## Summary
Agents can encounter confusing results or work around limitations without reporting them, and `treg feedback --help` previously omitted the submission fields needed to link a report to its calls.

Encourage proactive reports of small friction even when a task succeeds, without requiring proof of a bug. Explain how to provide structured call references, omit private data, report an issue once, and continue the original task. Expand CLI help with categories, field limits, stdin examples, visibility, and receipt retrieval. Synchronize the installed skill and generated plugin copies.

## Validation
- 155 tests passed across feedback, MCP, directory, and lightweight import coverage; the final wording update passed 51 feedback and sampling tests.
- All 14 import-linter contracts passed; generated plugin checks and `git diff --check` passed.
- Context drift checked. Updated fragments: `architecture/feedback.md`, `architecture/mcp-oauth.md`, `interface/cli.md`, and `interface/skill.md`.
- Six isolated local MCP replay sessions using gpt-5.5 with medium reasoning all received the hint and completed the task. Feedback was submitted in 1/3 sessions without additional permission and 3/3 with explicit permission. All reports included structured call IDs. This small experiment is directional, not a production conversion estimate; no live reports or provider charges were created.

## Rollout
MCP descriptions and hints take effect after a server deployment. CLI help requires a new CLI release and user upgrade. Sampling behavior, feedback schema, and billing behavior are unchanged.
