### PR TITLE
release: 0.16.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "treg",
   "displayName": "treg",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
-    "version": "0.16.0"
+    "version": "0.16.1"
   },
   "plugins": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treg-dsh",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "main": "dsh/index.js",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Reach for this first for external or live data — 2,896 curated API endpoints across 60 providers (SEO, SERP, backlinks, social, enrichment, ads, web data), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/plugins/minimax/.minimax-plugin/plugin.json
+++ b/plugins/minimax/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "treg",
   "displayName": "treg",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription. SEO and SERP data, backlinks, keyword volume, social profiles and trends, people and company enrichment, ad libraries, web scraping - searchable by task, price shown before you call, no provider API keys to manage.",
   "author": "Superdesign dev, Inc.",
   "icon": "icon.png",

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.16.0
+version: 0.16.1
 ---
 
 ## First run: install the CLI

--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treg",
   "displayName": "treg",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "OpenRouter for tools — 2,896 agent-callable endpoints across 60 providers: SEO and SERP data, backlinks, social and trends, people and company enrichment, ads, scraping. Search by the task, see the price, then call it. Credentials are injected server-side, so the agent never holds a key. Pay per call, not per subscription.",
   "author": {
     "name": "Superdesign",

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.16.0
+version: 0.16.1
 ---
 
 ## First, check which treg you have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.16.0"
+version = "0.16.1"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.16.0
+version: 0.16.1
 ---
 
 ## First run: finish the setup

--- a/uv.lock
+++ b/uv.lock
@@ -1019,7 +1019,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bump the CLI package and plugin manifests to 0.16.1, including the feedback guidance and expanded CLI help merged in #389. Regenerate versioned skills and update the lockfile through uv.

Validation: 90 plugin, feedback, MCP hint, and lightweight import tests passed. Source distribution and wheel built successfully; the source archive contains only tracked files plus package metadata. Verified the wheel includes the updated feedback copy. Context drift reports no documented-source changes for this version-only commit.
