### PR TITLE
fix(capacity): renew stamped overflow routes above the discovery cap

### DIFF
--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -201,14 +201,21 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
 - **`verify.py`** + `treg-worker overflow verify` — the weekly re-verify: one cheap call per
   route through the aggregator (and, when we hold the vendor key, directly), compare the shape
   fingerprint (keys and list/leaf markers, values ignored), stamp `last_verified_at` or disable
-  with the reason. `--max-usd` (default 2¢) is a per-route price cap, not a run budget: pricier
-  routes are skipped, as are routes whose endpoint has no `test_request`. Without `--all` only
-  enabled or previously-stamped rows are visited, so a never-verified pair never enters the rota;
-  run it with `--all`. `--only` restricts the run to comma-separated provider IDs, allowing a
-  higher per-route price cap for one provider without probing every pricier route in the table.
+  with the reason. Two per-route price caps and one run budget: a route that is enabled or was
+  stamped before is a **renewal**, held to `--renew-max-usd` (default $1); a never-verified pair is
+  **discovery**, visited only under `--all` and held to `--max-usd` (default 2¢). Renewals go first,
+  oldest stamp first, so the route nearest its 7-day decay is reached before `--budget-usd`
+  (default $15, relay fee plus the direct comparison when we hold the vendor key) runs out; a route
+  that does not fit the budget is skipped, not the rest of the run. Routes whose endpoint has no
+  `test_request` are skipped. One cap for both once cost real routes: on 2026-09-07 the weekly
+  `verify --all` at 2¢ skipped 134 routes, among them all 46 stamped on 2026-08-26 and priced
+  3¢–65¢ (branddev, predictleads, findymail, leadsforge, apollo, companyenrich, fiber-ai, pdl,
+  hunter, icypeas); they decayed off at the next sync and no run could ever bring them back.
+  `--only` restricts the run to comma-separated provider IDs.
   Verify only STAMPS - `overflow sync` is what re-derives `enabled` from the
-  stamps, so every verify must be followed by a sync (by hand today, `ops/deploy.md`); a route
-  disabled by one failed verify is only re-enabled by that sync. A failed route is a result, not a failed run: the command exits 0 after
+  stamps, so every verify must be followed by a sync (the weekly cron chains the two since
+  2026-09-08, `ops/deploy.md`); a route disabled by one failed verify is only re-enabled by that
+  sync, and a route past its 7 days keeps serving until a sync notices - the sync is the decay. A failed route is a result, not a failed run: the command exits 0 after
   completing (it used to exit 1 whenever any route failed, which made every Render run read
   "failed"). `verify.verdict` is the one place that decides what a verification means: `passed`
   stamps; `failed` (contract refusal, relay non-2xx, a 2xx of a different shape) disables with the

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -532,8 +532,9 @@ first as a cron service (`treg-capacity-sweep`, hourly), with the DB URL, Fernet
 > as a statement of intent until a Blueprint is registered - and register one only after the file
 > has been reconciled to the live services, because a Blueprint sync overwrites what it manages.
 > The overflow re-verify cron (`treg-overflow-verify`, Mondays 06:00 UTC, dashboard-made, command
-> `treg-worker overflow verify --all` since 2026-09-02) is deliberately absent from the file for
-> that reason.
+> `treg-worker overflow verify --all && treg-worker overflow sync` since 2026-09-08 - before that
+> `verify --all` alone, so its stamps never opened or decayed a route until someone synced by hand)
+> is deliberately absent from the file for that reason.
 
 **Running the overflow routine by hand** (until a Blueprint schedules verify → sync): two one-off
 jobs on the verify cron service, in order - `render jobs create <cron-id> --start-command
@@ -542,14 +543,14 @@ jobs on the verify cron service, in order - `render jobs create <cron-id> --star
 `enabled` count of the second. Verify only
 stamps; sync is what opens routes.
 
-Influencers Club's verified routes include $0.03 discovery calls and enrichment up to $0.66,
-so the default $0.02 verification cap cannot maintain them. After deploying the code and syncing
-the seed, run `treg-worker overflow verify --only influencersclub --max-usd 0.66`, followed by
-`treg-worker overflow sync`. Include that scoped verification in the weekly cron routine before
-its final sync; do not raise the price cap for every provider. The `--only` filter accepts
-comma-separated provider IDs. These calls spend the aggregator fee plus the direct comparison
-cost. Email enrichment has no test request and stays unverified; ten other mapped routes were
-compared successfully on 2026-09-08. A verification run alone does not enable routes.
+Pricier routes need no special run since 2026-09-08: a route that is enabled or was stamped
+before renews under `--renew-max-usd` (default $1), which covers Influencers Club's $0.66
+enrichment and the 3¢–65¢ routes the 2¢ cap had let decay; the whole run is bounded by
+`--budget-usd` (default $15). The 2¢ `--max-usd` only gates never-verified pairs under `--all`.
+A one-off `--only <provider>` run (comma-separated IDs) is still the way to bring a newly seeded
+provider in mid-week: `treg-worker overflow verify --only influencersclub`, then `overflow sync`.
+Email enrichment for Influencers Club has no test request and stays unverified. A verification
+run alone does not enable routes.
 
 Aggregator keys
 (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same

--- a/src/treg/worker.py
+++ b/src/treg/worker.py
@@ -94,6 +94,33 @@ async def _overflow_sync(args) -> int:
     return 0
 
 
+RENEW_MAX_USD = 1.00
+"""Per-route price cap for RENEWING a route that is enabled or was stamped before. The 2¢ default
+`--max-usd` is a discovery cap for never-verified pairs under `--all`; held to it, the weekly cron
+skipped every stamped route priced above 2¢ (46 of them on 2026-09-07, all mapped and verified on
+2026-08-26) and they decayed off with no run ever able to bring them back."""
+VERIFY_BUDGET_USD = 15.00
+"""What one verify run may spend in total (relay fee + direct comparison), whatever the caps say."""
+
+
+def _verify_plan(rows, *, all_rows: bool, only: set[str] | None, max_usd: float,
+                 renew_max_usd: float) -> list[tuple[object, float]]:
+    """Which routes this run visits, in order, each with the price cap it is held to. Renewals
+    (enabled or previously stamped) come first, oldest stamp first, so the route nearest its 7-day
+    decay is reached before the budget is; never-verified pairs follow only under `--all`."""
+    renew, discover = [], []
+    for r in rows:
+        if only and r.provider not in only:
+            continue
+        if r.enabled or r.last_verified_at:
+            renew.append(r)
+        elif all_rows:
+            discover.append(r)
+    renew.sort(key=lambda r: (r.last_verified_at is not None, r.last_verified_at or 0, r.endpoint_id))
+    discover.sort(key=lambda r: r.endpoint_id)
+    return [(r, renew_max_usd) for r in renew] + [(r, max_usd) for r in discover]
+
+
 async def _overflow_verify(args) -> int:
     import httpx
     from sqlalchemy import select
@@ -113,11 +140,13 @@ async def _overflow_verify(args) -> int:
     async with session_maker() as db:
         rows = (await db.execute(select(OverflowRoute))).scalars().all()
     only = {p.strip() for p in (getattr(args, "only", None) or "").split(",") if p.strip()}
-    todo = [r for r in rows if (args.all or r.enabled or r.last_verified_at)
-            and (not only or r.provider in only)]
+    renew_max_usd = getattr(args, "renew_max_usd", RENEW_MAX_USD)
+    budget_usd = getattr(args, "budget_usd", VERIFY_BUDGET_USD)
+    todo = _verify_plan(rows, all_rows=args.all, only=only or None,
+                        max_usd=args.max_usd, renew_max_usd=renew_max_usd)
     keys = {"orthogonal": s.overflow_key_orthogonal, "monid": s.overflow_key_monid}
     tally = {"passed": 0, "failed": 0, "aggregator": 0, "inconclusive": 0}
-    skipped, key_failures = 0, []
+    skipped, over_budget, spent_usd, key_failures = 0, 0, 0.0, []
     # One SHORT transaction per route. The first prod run (2026-08-28) kept a single session open
     # across every network round-trip: each `db.get` autoflushed the previous row's UPDATE, the row
     # locks piled up for minutes, and the run died at route 60 with LockNotAvailableError. Where
@@ -126,17 +155,25 @@ async def _overflow_verify(args) -> int:
     # database role carries one. Recorded as observed rather than explained: the fix (one short
     # transaction per route) is right whatever set it.
     async with httpx.AsyncClient(timeout=60) as c:
-        for r in todo:
+        for r, cap in todo:
             ep = by_id.get(r.endpoint_id)
             key = keys.get(r.aggregator)
             tr = (ep or {}).get("test_request")
             usd = (r.agg_price_micro or 0) / 1e6
-            if not ep or not key or not tr or usd > args.max_usd:
+            if not ep or not key or not tr or usd > cap:
                 skipped += 1
                 continue
             direct = None
             prov = oauth_providers.get(ep["provider"])
             pkey = getattr(s, platform_setting_name(ep["provider"]), "")
+            # The run budget bounds what one run may spend: the relay's fee plus, when we hold the
+            # vendor key, the direct comparison at the same list price. A route that does not fit
+            # is skipped, not the rest of the run - a cheaper route further down may still fit.
+            est_usd = usd * (2 if prov is not None and pkey else 1)
+            if spent_usd + est_usd > budget_usd:
+                over_budget += 1
+                continue
+            spent_usd += est_usd
             hdrs = {}
             if prov is not None and pkey:
                 url = prov.base_url.rstrip("/") + "/" + ep["path"].lstrip("/")
@@ -181,7 +218,8 @@ async def _overflow_verify(args) -> int:
                   f"direct={v.direct_status} relay={v.relay_status} cost={v.cost_micro} {v.note}")
     attempted = sum(tally.values())
     print(f"verified {tally['passed']}, failed {tally['failed']}, inconclusive {tally['inconclusive']}, "
-          f"aggregator errors {tally['aggregator']}, skipped {skipped}")
+          f"aggregator errors {tally['aggregator']}, skipped {skipped}, over budget {over_budget} "
+          f"(~${spent_usd:.2f} of ${budget_usd:g})")
     # A failed ROUTE is a result (its row is disabled with the reason). A failed RUN is one that
     # could not verify: our key or our balance refused on any route, every attempt lost to the
     # aggregator's side (a host down for the whole run, not one timeout), or nothing attempted at
@@ -220,7 +258,12 @@ def main(argv: list[str] | None = None) -> int:
     ver = ovsub.add_parser("verify", help="re-verify routes with a cheap call (spends money; needs keys)")
     ver.add_argument("--all", action="store_true", help="every row, not only enabled/previously verified")
     ver.add_argument("--only", help="comma-separated providers (default: all)")
-    ver.add_argument("--max-usd", type=float, default=0.02, help="skip routes priced above this")
+    ver.add_argument("--max-usd", type=float, default=0.02,
+                     help="per-route price cap for never-verified routes (discovery under --all)")
+    ver.add_argument("--renew-max-usd", type=float, default=RENEW_MAX_USD,
+                     help="per-route price cap for routes already enabled or previously verified")
+    ver.add_argument("--budget-usd", type=float, default=VERIFY_BUDGET_USD,
+                     help="stop attempting routes once the run's estimated spend would exceed this")
     ver.set_defaults(fn=_overflow_verify)
     tasks = sub.add_parser("asynctasks", help="deferred asynchronous task settlement")
     tasksub = tasks.add_subparsers(dest="cmd", required=True)

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -661,3 +661,67 @@ async def test_a_vendor_402_overflow_did_not_rescue_keeps_the_vendor_error_event
     (e,) = await posthog_events()
     p = e["properties"]
     assert p["status_code"] == 402 and p["outcome"] == "vendor_error" and p["tier"] == "platform" and "served_via" not in p
+
+
+# ---- the weekly verify: renewals are held to their own cap and the run to a budget -------------
+# On 2026-09-07 the cron (`verify --all`, 2¢ cap) skipped every stamped route priced above 2¢ - 46
+# routes mapped and verified on 2026-08-26 decayed off and no run could ever bring them back. A
+# stamped route renews under `--renew-max-usd`; the 2¢ `--max-usd` is only for discovery.
+
+def test_verify_plan_renews_stamped_routes_first_and_discovers_only_with_all():
+    from datetime import timedelta
+    from types import SimpleNamespace
+    from treg import worker
+    now = utcnow_naive()
+    old = SimpleNamespace(endpoint_id="a.old", provider="a", enabled=True, last_verified_at=now - timedelta(days=6))
+    fresh = SimpleNamespace(endpoint_id="a.fresh", provider="a", enabled=True, last_verified_at=now - timedelta(days=1))
+    lapsed = SimpleNamespace(endpoint_id="b.lapsed", provider="b", enabled=False, last_verified_at=now - timedelta(days=9))
+    never = SimpleNamespace(endpoint_id="b.never", provider="b", enabled=False, last_verified_at=None)
+    plan = worker._verify_plan([fresh, never, old, lapsed], all_rows=True, only=None, max_usd=0.02, renew_max_usd=1.0)
+    assert [(r.endpoint_id, cap) for r, cap in plan] == [
+        ("b.lapsed", 1.0), ("a.old", 1.0), ("a.fresh", 1.0), ("b.never", 0.02)]
+    without_all = worker._verify_plan([fresh, never, old, lapsed], all_rows=False, only=None, max_usd=0.02, renew_max_usd=1.0)
+    assert [r.endpoint_id for r, _ in without_all] == ["b.lapsed", "a.old", "a.fresh"]
+    only_b = worker._verify_plan([fresh, never, old, lapsed], all_rows=True, only={"b"}, max_usd=0.02, renew_max_usd=1.0)
+    assert [r.endpoint_id for r, _ in only_b] == ["b.lapsed", "b.never"]
+
+
+async def test_verify_run_visits_pricey_renewals_within_budget_and_skips_pricey_discovery(
+    clients, overflow_on, monkeypatch,
+):
+    from datetime import timedelta
+    from types import SimpleNamespace
+    from treg import worker
+    from treg.domain.capacity import verify as V
+    from treg.domain.catalog import store as catalog_store
+    monkeypatch.setattr(get_settings(), "secret_key", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+    eps = [e for e in catalog_store.load().endpoints if e.get("test_request")][:3]
+    assert len(eps) == 3
+    now = utcnow_naive()
+    specs = [  # (endpoint, price, enabled, stamped)
+        (eps[0], 500_000, True, now - timedelta(days=6)),   # renewal, 50¢: above the 2¢ discovery cap
+        (eps[1], 10_000, True, now - timedelta(days=1)),    # renewal, 1¢
+        (eps[2], 500_000, False, None),                     # discovery, 50¢: held to the 2¢ cap
+    ]
+    async with session_maker() as db:
+        for ep, price, enabled, stamped in specs:
+            db.add(OverflowRoute(endpoint_id=ep["id"], aggregator="orthogonal", provider=ep["provider"],
+                                 method=ep["method"], path=ep["path"], agg_slug=ep["provider"], agg_path=ep["path"],
+                                 agg_price_micro=price, agg_unit="call", ratio=1.0, enabled=enabled,
+                                 last_verified_at=stamped))
+        await db.commit()
+    from treg import oauth_providers
+    monkeypatch.setattr(oauth_providers, "get", lambda *_: None)  # no direct key: spend = relay fee
+    seen = []
+    async def verify(client, route, **kwargs):
+        seen.append(route.endpoint_id)
+        return V.Verification(route.endpoint_id, route.aggregator, None, 200, True,
+                              route.agg_price_micro, utcnow_naive())
+    monkeypatch.setattr(V, "verify_route", verify)
+    args = SimpleNamespace(all=True, only=None, max_usd=0.02, renew_max_usd=1.0, budget_usd=15.0)
+    assert await worker._overflow_verify(args) == 0
+    assert seen == [eps[0]["id"], eps[1]["id"]]   # oldest renewal first; the 50¢ discovery pair is skipped
+    seen.clear()
+    args.budget_usd = 0.30                          # the 50¢ renewal no longer fits; the 1¢ one still does
+    assert await worker._overflow_verify(args) == 0
+    assert seen == [eps[1]["id"]]

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -510,3 +510,6 @@ def test_worker_cli_parses_overflow_commands(monkeypatch):
     monkeypatch.setattr(worker, "_overflow_verify", fake)
     assert worker.main(["overflow", "sync", "--live"]) == 0 and seen["live"] is True
     assert worker.main(["overflow", "verify", "--max-usd", "0.05"]) == 0 and seen["max_usd"] == 0.05
+    assert seen["renew_max_usd"] == worker.RENEW_MAX_USD and seen["budget_usd"] == worker.VERIFY_BUDGET_USD
+    assert worker.main(["overflow", "verify", "--renew-max-usd", "0.7", "--budget-usd", "3"]) == 0
+    assert seen["renew_max_usd"] == 0.7 and seen["budget_usd"] == 3.0


### PR DESCRIPTION
## What this does

The weekly `treg-worker overflow verify --all` held every route to the 2¢ `--max-usd` cap. That cap was meant for discovering never-verified pairs, but it also skipped every already-stamped route priced above 2¢. On 2026-09-07 the cron skipped 134 routes, among them all 46 stamped on 2026-08-26 at 3¢–65¢ (branddev, predictleads, findymail, leadsforge, apollo, companyenrich, fiber-ai, pdl, hunter, icypeas). They decayed off at the next sync and no run could ever bring them back.

- A route that is enabled or was stamped before is a **renewal**, held to `--renew-max-usd` (default $1). Never-verified pairs stay **discovery** under `--all` at `--max-usd` (default 2¢).
- Renewals run first, oldest stamp first, so the route nearest its 7-day decay is reached before `--budget-usd` (default $15; relay fee plus the direct comparison when we hold the vendor key) runs out. A route that does not fit is skipped, not the rest of the run.
- The summary line reports `over budget N (~$spent of $budget)`.
- With the renewal cap, the Influencers Club runbook no longer needs a weekly scoped `--only influencersclub --max-usd 0.66` run.

**Already changed in the Render dashboard (2026-09-08):** the `treg-overflow-verify` cron command is now `treg-worker overflow verify --all && treg-worker overflow sync`. It previously ran verify alone, so its stamps neither opened nor decayed a route until someone synced by hand. That chain works with today's code and with this PR.

Fragments updated: `docs/context/ops/capacity.md` (verify caps, budget, sync-is-the-decay), `docs/context/ops/deploy.md` (cron command, Influencers Club paragraph).

## How it was tested

- `tests/test_capacity_overflow.py`: a pure planner test (renewals first, oldest stamp first, discovery only with `--all`, `--only` filter) and a run test through `_overflow_verify` with a patched `verify_route`: a 50¢ renewal is visited, a 50¢ never-verified pair is skipped by the 2¢ cap, and a $0.30 budget skips the 50¢ renewal while the 1¢ one still runs.
- `tests/test_capacity_overflow_routes.py`: CLI defaults and parsing for the two new flags.
- `uv run --with pytest-xdist pytest -n auto -q tests/test_capacity_overflow.py tests/test_capacity_overflow_routes.py tests/test_influencersclub_overflow.py`: 74 passed. `uv run lint-imports`: 14 kept.
- Evidence for the diagnosis: Monday's cron log (`verified 198, failed 102, inconclusive 17, aggregator errors 20, skipped 134`) has no per-route line for any of the 46 stale rows, and every one of them is priced above 2¢.

## After merge

The cron auto-deploys from main. Next Monday's run renews the 46 routes under the $1 cap, then syncs; expect the `enabled` count to rise from 93. Estimated weekly verify spend for renewals is on the order of $10, bounded by the $15 budget.

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally (capacity suites; full suite left to CI)
- [x] Added or updated tests for the change
- [x] Updated the relevant `docs/context/` fragment
- [x] No secrets in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc5m8A5ugX4GgkJc2HpUQj
