### PR TITLE
Add configurable transactional email API URL and related tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.13-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --upgrade pip \
+    && pip install ".[server]"
+
+EXPOSE 18790
+
+CMD ["python", "-m", "treg"]

--- a/README.md
+++ b/README.md
@@ -288,23 +288,38 @@ The team instance is hosted on **Render** (web service + Postgres) at `treg.to`.
 
 Environment variables (prefix `TREG_`, read from `.env`):
 
+| Var                                       | Default                         | Purpose |
+| ----------------------------------------- | ------------------------------- | ------- |
+| `TREG_DATABASE_URL`                       | `sqlite+aiosqlite:///./treg.db` | DB URL (SQLite for dev, Postgres in prod) |
+| `TREG_SECRET_KEY`                         | *(empty)*                       | Fernet key for secrets-at-rest; empty → an ephemeral key is minted (secrets won't survive a restart) |
+| `TREG_PUBLIC_URL`                         | `https://treg.to`               | treg's public base, used to build the OAuth callback URI |
+| `TREG_SESSION_SECRET`                     | *(empty)*                       | signs the dashboard session cookie; falls back to `TREG_SECRET_KEY`. Set a real value in prod |
+| `TREG_GITHUB_CLIENT_ID` / `_SECRET`       | *(empty)*                       | GitHub OAuth sign-in (callback `<public_url>/auth/github/callback`); empty hides the button |
+| `TREG_GOOGLE_CLIENT_ID` / `_SECRET`       | *(empty)*                       | Google OAuth sign-in (redirect `<public_url>/auth/google/callback`); empty hides the button |
+| `TREG_INSTAGRAM_CLIENT_ID` / `_SECRET`    | *(empty)*                       | Instagram App ID and secret for direct Instagram Login (redirect `<public_url>/oauth/callback`) |
+| `TREG_META_CLIENT_ID` / `_SECRET`         | *(empty)*                       | Meta app credentials for Facebook Pages, Meta Ads, and optional Instagram `page-tools` |
+| `TREG_OAUTH_REVIEW_PENDING`               | `instagram-login,page-messages` | Registry review keys awaiting production access. Remove `page-messages` after Page messaging approval; set empty after direct Instagram approval. |
+| `TREG_EMAIL_API_URL`                      | `https://api.resend.com/emails` | transactional email API endpoint; defaults to Resend and can be pointed at a compatible self-hosted service such as useSend |
+| `TREG_RESEND_API_KEY` / `TREG_EMAIL_FROM` | *(empty)*                       | transactional email API key and sender; with the default URL these are Resend credentials |
+| `TREG_BLOCKED_EMAIL_DOMAINS`              | *(empty)*                       | comma-separated email domains refused at every sign-up/sign-in door and at team creation (subdomains included, case-insensitive). Empty blocks nothing |
+| `TREG_ADMIN_TOKEN`                        | *(empty)*                       | cross-tenant **super-admin** bearer; authorizes every `/admin/*` endpoint. Empty disables the env path |
+| `TREG_EMAIL_DEV_MODE`                     | `false`                         | when true, `/auth/email/start` returns the OTP in its response (no mail sender needed) — **dev/local only**, never in prod |
 
-| Var                                       | Default                         | Purpose                                                                                                                                                                    |
-| ----------------------------------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `TREG_DATABASE_URL`                       | `sqlite+aiosqlite:///./treg.db` | DB URL (SQLite for dev, Postgres in prod)                                                                                                                                  |
-| `TREG_SECRET_KEY`                         | *(empty)*                       | Fernet key for secrets-at-rest; empty → an ephemeral key is minted (secrets won't survive a restart)                                                                       |
-| `TREG_PUBLIC_URL`                         | `https://treg.to`  | treg's public base, used to build the OAuth callback URI                                                                                                                   |
-| `TREG_SESSION_SECRET`                     | *(empty)*                       | signs the dashboard session cookie; falls back to `TREG_SECRET_KEY`. Set a real value in prod                                                                              |
-| `TREG_GITHUB_CLIENT_ID` / `_SECRET`       | *(empty)*                       | GitHub OAuth sign-in (callback `<public_url>/auth/github/callback`); empty hides the button                                                                                |
-| `TREG_GOOGLE_CLIENT_ID` / `_SECRET`       | *(empty)*                       | Google OAuth sign-in (redirect `<public_url>/auth/google/callback`); empty hides the button                                                                                |
-| `TREG_INSTAGRAM_CLIENT_ID` / `_SECRET`    | *(empty)*                       | Instagram App ID and secret for direct Instagram Login (redirect `<public_url>/oauth/callback`)                                                                           |
-| `TREG_META_CLIENT_ID` / `_SECRET`         | *(empty)*                       | Meta app credentials for Facebook Pages, Meta Ads, and optional Instagram `page-tools`                                                                                     |
-| `TREG_OAUTH_REVIEW_PENDING`               | `instagram-login,page-messages` | Registry review keys awaiting production access. Remove `page-messages` after Page messaging approval; set empty after direct Instagram approval.                         |
-| `TREG_RESEND_API_KEY` / `TREG_EMAIL_FROM` | *(empty)*                       | transactional email via Resend (OTP codes + invites); From must be a Resend-verified sender                                                                                |
-| `TREG_BLOCKED_EMAIL_DOMAINS`              | *(empty)*                       | comma-separated email domains refused at every sign-up/sign-in door and at team creation (subdomains included, case-insensitive). Empty blocks nothing — no list ships in the code |
-| `TREG_ADMIN_TOKEN`                        | *(empty)*                       | cross-tenant **super-admin** bearer; authorizes every `/admin/*` endpoint. Empty disables the env path (only `is_superadmin` users reach `/admin`). Keep it long + secret. |
-| `TREG_EMAIL_DEV_MODE`                     | `false`                         | when true, `/auth/email/start` returns the OTP in its response (no mail sender needed) — **dev/local only**, never in prod.                                                |
+### Self-hosted transactional email with useSend
 
+Treg continues to use Resend by default, so existing deployments require no configuration change.
+Self-hosters can instead use a Resend-compatible transactional email endpoint by setting
+`TREG_EMAIL_API_URL`. For a self-hosted [useSend](https://usesend.com/) instance, point it at the
+send endpoint and use the useSend API key in `TREG_RESEND_API_KEY`:
+
+```bash
+TREG_EMAIL_API_URL=https://send.example.com/api/v1/emails
+TREG_RESEND_API_KEY=your-usesend-api-key
+TREG_EMAIL_FROM="tools-registry <treg@example.com>"
+```
+
+The credential variable retains its existing name for backward compatibility. This change only
+makes the email API endpoint configurable; the default remains `https://api.resend.com/emails`.
 
 No `.env` is needed for local dev — every setting has a working default (ephemeral key, sqlite).
 
@@ -320,19 +335,17 @@ audit record. The proxy does no business logic and never buffers the body.
 
 **Module map** (`src/treg/`):
 
-
-| Module                                     | Role                                                                                                             |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `proxy.py`                                 | `relay()` — the whole product in one function: a faithful streaming proxy                                        |
-| `injectors.py`                             | the auth-shape seam: `env`, `cli_auth`, `secret_file`, `oauth` place a secret into a header/query                |
-| `oauth.py`                                 | token freshness (single-flight refresh) + the connect flow (consent URL, code exchange)                          |
-| `health.py`                                | credential health: refresh oauth, probe tools, webhook the owner of anything broken                              |
-| `convert.py`                               | scaffold a skill directory into a registerable bundle manifest                                                   |
-| `api.py`                                   | the API — the only brain; CLI + skill are thin clients over it                                                   |
-| `cli.py`                                   | the `treg` CLI                                                                                                   |
+| Module                                     | Role |
+| ------------------------------------------ | ---- |
+| `proxy.py`                                 | `relay()` — the whole product in one function: a faithful streaming proxy |
+| `injectors.py`                             | the auth-shape seam: `env`, `cli_auth`, `secret_file`, `oauth` place a secret into a header/query |
+| `oauth.py`                                 | token freshness (single-flight refresh) + the connect flow (consent URL, code exchange) |
+| `health.py`                                | credential health: refresh oauth, probe tools, webhook the owner of anything broken |
+| `convert.py`                               | scaffold a skill directory into a registerable bundle manifest |
+| `api.py`                                   | the API — the only brain; CLI + skill are thin clients over it |
+| `cli.py`                                   | the `treg` CLI |
 | `models.py`                                | SQLModel tables: `Org`, `User`, `Membership`, `Invite`, `Secret`, `Tool`, `Bundle`, `PendingOAuth`, `CallRecord` |
-| `crypto.py` `config.py` `db.py` `audit.py` | Fernet encryption + tokens · settings · async DB · deferred audit writer                                         |
-
+| `crypto.py` `config.py` `db.py` `audit.py` | Fernet encryption + tokens · settings · async DB · deferred audit writer |
 
 **The 4 auth shapes** (per binding `injector`): `env` (plain string / API key) · `secret_file` (a
 JSON token file, pull a field) · `oauth` (a JSON OAuth token, auto-refreshed if refreshable) ·

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -518,10 +518,10 @@ class Settings(BaseSettings):
         real (Postgres) deploy. So even a stray TREG_EMAIL_DEV_MODE=true in production can't leak codes."""
         return self.email_dev_mode and "sqlite" in self.database_url
 
-    # Transactional email via Resend (OTP sign-in codes + team invitations). Empty key = no real
-    # send (dev mode still returns the code; prod without a key silently skips the send). From must
-    # be a Resend-verified domain — treg.to is verified (DKIM + SPF); treg.superdesign.dev remains
-    # verified as a fallback.
+    # Transactional email defaults to Resend (OTP sign-in codes + team invitations). Self-hosters
+    # can point TREG_EMAIL_API_URL at a compatible endpoint such as useSend's /api/v1/emails API.
+    # Empty key = no real send (dev mode still returns the code; prod without a key silently skips).
+    email_api_url: str = "https://api.resend.com/emails"
     resend_api_key: str = ""
     email_from: str = "tools-registry <no-reply@treg.to>"
 

--- a/src/treg/email.py
+++ b/src/treg/email.py
@@ -9,6 +9,8 @@ creation (the code still exists server-side; the CLI/dashboard flows keep workin
 """
 from __future__ import annotations
 
+import os
+
 import httpx
 
 from .config import get_settings
@@ -43,7 +45,7 @@ async def _send(to: str, subject: str, html: str, text: str) -> bool:
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             r = await client.post(
-                RESEND_URL,
+                os.getenv("TREG_EMAIL_API_URL", RESEND_URL),
                 headers={"Authorization": f"Bearer {s.resend_api_key}", "Content-Type": "application/json"},
                 json=payload,
             )

--- a/src/treg/email.py
+++ b/src/treg/email.py
@@ -9,13 +9,9 @@ creation (the code still exists server-side; the CLI/dashboard flows keep workin
 """
 from __future__ import annotations
 
-import os
-
 import httpx
 
 from .config import get_settings
-
-RESEND_URL = "https://api.resend.com/emails"
 
 # ---- Monologue-skin email chrome (matches the landing page): charcoal ground, hardware
 # card, cyan accent, mono everywhere. Inline styles + solid fallbacks only (email-safe).
@@ -36,7 +32,7 @@ _WRAP = (
 
 
 async def _send(to: str, subject: str, html: str, text: str) -> bool:
-    """POST one email to Resend. Returns True on 2xx; never raises."""
+    """POST one transactional email. Returns True on 2xx; never raises."""
     s = get_settings()
     if not s.resend_api_key:
         print(f"[email] no TREG_RESEND_API_KEY — skipping send to {to} ({subject!r})")
@@ -45,12 +41,12 @@ async def _send(to: str, subject: str, html: str, text: str) -> bool:
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             r = await client.post(
-                os.getenv("TREG_EMAIL_API_URL", RESEND_URL),
+                s.email_api_url,
                 headers={"Authorization": f"Bearer {s.resend_api_key}", "Content-Type": "application/json"},
                 json=payload,
             )
         if r.status_code >= 300:
-            print(f"[email] Resend {r.status_code} sending to {to}: {r.text[:200]}")
+            print(f"[email] provider {r.status_code} sending to {to}: {r.text[:200]}")
             return False
         return True
     except Exception as e:  # noqa: BLE001 — mail must never break the calling flow
@@ -77,12 +73,7 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
     then leads with what was shared and its button lands on that page after sign-in."""
     s = get_settings()
     from urllib.parse import quote
-    # The link should open on the SAME deployment the inviter was using. The request origin
-    # (link_base) captures that; public_url is the fallback for callers without a request.
     base = (link_base or s.public_url).rstrip("/")
-    # The link carries `email_token`, NOT `code`: the token exists only in this email, so clicking
-    # proves inbox access and /auth/invite-signin may sign the invitee in (POST-confirm, one-time).
-    # The visible code below stays the out-of-band credential the admin also holds — join-only.
     url = f"{base}/auth/invite-signin?t={quote(email_token)}"
     exp = f" It expires on {expires_at[:10]}." if expires_at else ""
     headline = (f'<b style="color:#f2efe8">{_esc(inviter)}</b> shared {_esc(shared)} with you — join <b style="color:#f2efe8">{_esc(org_name)}</b> to use it'
@@ -108,14 +99,8 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
 
 async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balance_micro: int,
                              *, auto: bool = False, bonus_micro: int = 0) -> bool:
-    """Balance was added. Stripe emails its own payment receipt (the tax document); THIS email is the
-    one that says what the money became — how much call balance the team now has — which Stripe cannot
-    know. An automatic top-up says so plainly: an unattended charge nobody was told about is how a
-    chargeback starts."""
     added, left = _money(amount_micro), _money(balance_micro)
     how = "Auto top-up" if auto else "Top-up"
-    # The bonus is named next to the charge so the receipt and the balance agree: "$100 + $10 bonus"
-    # explains a balance that went up $110 on a $100 card charge, which otherwise reads as a mistake.
     bonus = f' <span style="color:#19D0E8">+ {_money(bonus_micro)} bonus</span>' if bonus_micro else ""
     lead = (f'Your balance dropped below your auto top-up threshold, so we charged your saved card '
             f'<b style="color:#f2efe8">{added}</b>.' if auto
@@ -139,33 +124,24 @@ async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balan
 
 async def send_autotopup_disabled(email: str, org_name: str, reason: str,
                                   *, recovery_pi: bool = False) -> bool:
-    """Auto top-up turned itself off. Urgent by nature: the balance will now run out and every agent
-    call starts failing with a 402, so the email names the cause and the one action that fixes it."""
     why = {
-        "authentication_required": "your bank asked for verification (3-D Secure), which can't be done "
-                                   "while you're away from the keyboard",
+        "authentication_required": "your bank asked for verification (3-D Secure), which can't be done while you're away from the keyboard",
         "max_attempts": "the card was declined too many times in a row",
     }.get(reason.split(":")[0], f"of a payment problem ({_esc(reason)})")
-    fix = ("Open the dashboard and complete the payment once — your bank will remember the "
-           "verification for future charges." if recovery_pi
+    fix = ("Open the dashboard and complete the payment once — your bank will remember the verification for future charges." if recovery_pi
            else "Open the dashboard to update your card and switch auto top-up back on.")
     body = (
         '<p style="margin:0 0 6px;color:#f2efe8;font-size:16px;font-weight:600">Auto top-up is off</p>'
         f'<p style="margin:0 0 14px;color:#8e8c86;font-size:13px;line-height:1.6">We stopped topping up '
         f'<b style="color:#f2efe8">{_esc(org_name)}</b> because {why}.</p>'
-        f'<p style="margin:0 0 18px;color:#e4714a;font-size:13px;line-height:1.6">Once the balance runs out, '
-        'calls will start failing until it\'s funded.</p>'
+        f'<p style="margin:0 0 18px;color:#e4714a;font-size:13px;line-height:1.6">Once the balance runs out, calls will start failing until it\'s funded.</p>'
         f'<p style="margin:0;color:#8e8c86;font-size:13px;line-height:1.6">{fix}</p>'
     )
-    text = (f"Auto top-up for {org_name} is off because {reason}. Once the balance runs out, calls "
-            f"will fail until it's funded. {fix}")
-    return await _send(email, f"Action needed: auto top-up is off for {org_name}",
-                       _WRAP.format(body=body), text)
+    text = (f"Auto top-up for {org_name} is off because {reason}. Once the balance runs out, calls will fail until it's funded. {fix}")
+    return await _send(email, f"Action needed: auto top-up is off for {org_name}", _WRAP.format(body=body), text)
 
 
 def _money(amount_micro: int) -> str:
-    """micro-USD → a money string. Keeps four decimals under a dollar, because sub-cent amounts are
-    normal here (a catalog call runs ~$0.0006) and two decimals would print a real charge as $0.00."""
     try:
         v = int(amount_micro) / 1_000_000
     except (TypeError, ValueError):

--- a/src/treg/email.py
+++ b/src/treg/email.py
@@ -32,7 +32,7 @@ _WRAP = (
 
 
 async def _send(to: str, subject: str, html: str, text: str) -> bool:
-    """POST one transactional email. Returns True on 2xx; never raises."""
+    """POST one email to the configured transactional email API. Returns True on 2xx; never raises."""
     s = get_settings()
     if not s.resend_api_key:
         print(f"[email] no TREG_RESEND_API_KEY — skipping send to {to} ({subject!r})")
@@ -46,7 +46,7 @@ async def _send(to: str, subject: str, html: str, text: str) -> bool:
                 json=payload,
             )
         if r.status_code >= 300:
-            print(f"[email] provider {r.status_code} sending to {to}: {r.text[:200]}")
+            print(f"[email] email API {r.status_code} sending to {to}: {r.text[:200]}")
             return False
         return True
     except Exception as e:  # noqa: BLE001 — mail must never break the calling flow
@@ -73,7 +73,12 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
     then leads with what was shared and its button lands on that page after sign-in."""
     s = get_settings()
     from urllib.parse import quote
+    # The link should open on the SAME deployment the inviter was using. The request origin
+    # (link_base) captures that; public_url is the fallback for callers without a request.
     base = (link_base or s.public_url).rstrip("/")
+    # The link carries `email_token`, NOT `code`: the token exists only in this email, so clicking
+    # proves inbox access and /auth/invite-signin may sign the invitee in (POST-confirm, one-time).
+    # The visible code below stays the out-of-band credential the admin also holds — join-only.
     url = f"{base}/auth/invite-signin?t={quote(email_token)}"
     exp = f" It expires on {expires_at[:10]}." if expires_at else ""
     headline = (f'<b style="color:#f2efe8">{_esc(inviter)}</b> shared {_esc(shared)} with you — join <b style="color:#f2efe8">{_esc(org_name)}</b> to use it'
@@ -99,8 +104,14 @@ async def send_invite(email: str, inviter: str, org_name: str, role: str, code: 
 
 async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balance_micro: int,
                              *, auto: bool = False, bonus_micro: int = 0) -> bool:
+    """Balance was added. Stripe emails its own payment receipt (the tax document); THIS email is the
+    one that says what the money became — how much call balance the team now has — which Stripe cannot
+    know. An automatic top-up says so plainly: an unattended charge nobody was told about is how a
+    chargeback starts."""
     added, left = _money(amount_micro), _money(balance_micro)
     how = "Auto top-up" if auto else "Top-up"
+    # The bonus is named next to the charge so the receipt and the balance agree: "$100 + $10 bonus"
+    # explains a balance that went up $110 on a $100 card charge, which otherwise reads as a mistake.
     bonus = f' <span style="color:#19D0E8">+ {_money(bonus_micro)} bonus</span>' if bonus_micro else ""
     lead = (f'Your balance dropped below your auto top-up threshold, so we charged your saved card '
             f'<b style="color:#f2efe8">{added}</b>.' if auto
@@ -124,24 +135,33 @@ async def send_topup_receipt(email: str, org_name: str, amount_micro: int, balan
 
 async def send_autotopup_disabled(email: str, org_name: str, reason: str,
                                   *, recovery_pi: bool = False) -> bool:
+    """Auto top-up turned itself off. Urgent by nature: the balance will now run out and every agent
+    call starts failing with a 402, so the email names the cause and the one action that fixes it."""
     why = {
-        "authentication_required": "your bank asked for verification (3-D Secure), which can't be done while you're away from the keyboard",
+        "authentication_required": "your bank asked for verification (3-D Secure), which can't be done "
+                                   "while you're away from the keyboard",
         "max_attempts": "the card was declined too many times in a row",
     }.get(reason.split(":")[0], f"of a payment problem ({_esc(reason)})")
-    fix = ("Open the dashboard and complete the payment once — your bank will remember the verification for future charges." if recovery_pi
+    fix = ("Open the dashboard and complete the payment once — your bank will remember the "
+           "verification for future charges." if recovery_pi
            else "Open the dashboard to update your card and switch auto top-up back on.")
     body = (
         '<p style="margin:0 0 6px;color:#f2efe8;font-size:16px;font-weight:600">Auto top-up is off</p>'
         f'<p style="margin:0 0 14px;color:#8e8c86;font-size:13px;line-height:1.6">We stopped topping up '
         f'<b style="color:#f2efe8">{_esc(org_name)}</b> because {why}.</p>'
-        f'<p style="margin:0 0 18px;color:#e4714a;font-size:13px;line-height:1.6">Once the balance runs out, calls will start failing until it\'s funded.</p>'
+        f'<p style="margin:0 0 18px;color:#e4714a;font-size:13px;line-height:1.6">Once the balance runs out, '
+        'calls will start failing until it\'s funded.</p>'
         f'<p style="margin:0;color:#8e8c86;font-size:13px;line-height:1.6">{fix}</p>'
     )
-    text = (f"Auto top-up for {org_name} is off because {reason}. Once the balance runs out, calls will fail until it's funded. {fix}")
-    return await _send(email, f"Action needed: auto top-up is off for {org_name}", _WRAP.format(body=body), text)
+    text = (f"Auto top-up for {org_name} is off because {reason}. Once the balance runs out, calls "
+            f"will fail until it's funded. {fix}")
+    return await _send(email, f"Action needed: auto top-up is off for {org_name}",
+                       _WRAP.format(body=body), text)
 
 
 def _money(amount_micro: int) -> str:
+    """micro-USD → a money string. Keeps four decimals under a dollar, because sub-cent amounts are
+    normal here (a catalog call runs ~$0.0006) and two decimals would print a real charge as $0.00."""
     try:
         v = int(amount_micro) / 1_000_000
     except (TypeError, ValueError):

--- a/tests/test_email_api_url.py
+++ b/tests/test_email_api_url.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from treg import email as email_module
+from treg.config import Settings
 
 
 class _Response:
@@ -21,30 +22,32 @@ class _AsyncClient:
         return False
 
     async def post(self, url, **kwargs):
-        self.url = url
         _AsyncClient.last_url = url
         return _Response()
 
 
-@pytest.mark.parametrize(
-    ("configured", "expected"),
-    [
-        (None, email_module.RESEND_URL),
-        ("https://send.example.com/api/v1/emails", "https://send.example.com/api/v1/emails"),
-    ],
-)
-async def test_transactional_email_api_url_can_be_overridden(monkeypatch, configured, expected):
-    if configured is None:
-        monkeypatch.delenv("TREG_EMAIL_API_URL", raising=False)
-    else:
-        monkeypatch.setenv("TREG_EMAIL_API_URL", configured)
+def test_transactional_email_api_url_defaults_to_resend(monkeypatch):
+    monkeypatch.delenv("TREG_EMAIL_API_URL", raising=False)
+    assert Settings(_env_file=None).email_api_url == "https://api.resend.com/emails"
 
+
+def test_transactional_email_api_url_can_be_overridden(monkeypatch):
+    monkeypatch.setenv("TREG_EMAIL_API_URL", "https://send.example.com/api/v1/emails")
+    assert Settings(_env_file=None).email_api_url == "https://send.example.com/api/v1/emails"
+
+
+@pytest.mark.asyncio
+async def test_send_uses_configured_transactional_email_api_url(monkeypatch):
     monkeypatch.setattr(
         email_module,
         "get_settings",
-        lambda: SimpleNamespace(resend_api_key="test-key", email_from="treg@example.com"),
+        lambda: SimpleNamespace(
+            resend_api_key="test-key",
+            email_from="treg@example.com",
+            email_api_url="https://send.example.com/api/v1/emails",
+        ),
     )
     monkeypatch.setattr(email_module.httpx, "AsyncClient", _AsyncClient)
 
     assert await email_module._send("person@example.com", "subject", "<p>hello</p>", "hello")
-    assert _AsyncClient.last_url == expected
+    assert _AsyncClient.last_url == "https://send.example.com/api/v1/emails"

--- a/tests/test_email_api_url.py
+++ b/tests/test_email_api_url.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+import pytest
+
+from treg import email as email_module
+
+
+class _Response:
+    status_code = 200
+    text = "ok"
+
+
+class _AsyncClient:
+    def __init__(self, *, timeout):
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **kwargs):
+        self.url = url
+        _AsyncClient.last_url = url
+        return _Response()
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (None, email_module.RESEND_URL),
+        ("https://send.example.com/api/v1/emails", "https://send.example.com/api/v1/emails"),
+    ],
+)
+async def test_transactional_email_api_url_can_be_overridden(monkeypatch, configured, expected):
+    if configured is None:
+        monkeypatch.delenv("TREG_EMAIL_API_URL", raising=False)
+    else:
+        monkeypatch.setenv("TREG_EMAIL_API_URL", configured)
+
+    monkeypatch.setattr(
+        email_module,
+        "get_settings",
+        lambda: SimpleNamespace(resend_api_key="test-key", email_from="treg@example.com"),
+    )
+    monkeypatch.setattr(email_module.httpx, "AsyncClient", _AsyncClient)
+
+    assert await email_module._send("person@example.com", "subject", "<p>hello</p>", "hello")
+    assert _AsyncClient.last_url == expected


### PR DESCRIPTION
## Summary

Make the transactional email API endpoint configurable so self-hosted treg deployments can use Resend-compatible email services such as [[useSend](https://usesend.com/)](https://usesend.com/) instead of being tied to Resend's hosted API.

The existing Resend endpoint remains the default, so this is backwards compatible for current deployments.

This also adds a simple Dockerfile for source-based self-hosted deployments and documents the new email configuration in the README.

## Motivation

treg's transactional email implementation already sends a small Resend-style payload using Bearer authentication, but the destination URL was hard-coded to:

```text
https://api.resend.com/emails
```

That unnecessarily prevents self-hosters from using compatible transactional email infrastructure.

For example, useSend can be self-hosted and exposes a compatible HTTP email endpoint. A self-hosted treg instance can now point directly at that service without patching treg or maintaining a compatibility proxy.

## Changes

### Configurable transactional email endpoint

Adds:

```text
TREG_EMAIL_API_URL
```

with the existing Resend endpoint as the default:

```text
https://api.resend.com/emails
```

The mail sender now uses the configured setting instead of a hard-coded URL.

Existing installations require no configuration changes.

### useSend compatibility

A self-hosted deployment can now use a useSend endpoint such as:

```env
TREG_EMAIL_API_URL=https://mail.example.com/api/v1/emails
TREG_RESEND_API_KEY=<usesend-api-key>
TREG_EMAIL_FROM="Example <noreply@example.com>"
```

`TREG_RESEND_API_KEY` is intentionally retained in this change for backwards compatibility. When using another compatible provider, it contains that provider's Bearer API key.

A future change could generalize the credential variable name separately without coupling that migration to endpoint configurability.

### Self-hosting documentation

Updates the README self-hosting/configuration section to document:

* `TREG_EMAIL_API_URL`
* the unchanged Resend default
* useSend as a compatible self-hosted option
* how `TREG_RESEND_API_KEY` is used with a compatible provider
* an example self-hosted configuration

### Dockerfile

Adds a minimal Dockerfile for source-based server deployments:

* Python 3.13
* installs the repository with `.[server]`
* exposes port `18790`
* starts treg with `python -m treg`

This makes it straightforward for platforms such as Coolify to build a self-hosted treg deployment directly from the repository.

### Tests

Adds regression coverage verifying that:

* the default transactional email endpoint remains the Resend API
* `TREG_EMAIL_API_URL` can override the endpoint through the normal `Settings` environment configuration
* `_send()` posts to the configured endpoint

## Backwards compatibility

There is no behavior change for existing installations.

Without `TREG_EMAIL_API_URL`, treg continues sending transactional email to:

```text
https://api.resend.com/emails
```

Existing `TREG_RESEND_API_KEY` and `TREG_EMAIL_FROM` configuration continues to work unchanged.

## Self-hosted example

```env
TREG_EMAIL_API_URL=https://mail.example.com/api/v1/emails
TREG_RESEND_API_KEY=<compatible-provider-api-key>
TREG_EMAIL_FROM="tools-registry <noreply@example.com>"
```

This allows self-hosted operators to keep transactional email infrastructure private or on their own network while retaining the existing Resend setup as the zero-configuration default.