### PR TITLE
feat(hub): phase 2 - the JSON road: graph, waves, steps

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -66,6 +66,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/alembic/versions/0024_membership_calls_today_counter.py` | architecture/data-model.md |
 | `src/treg/alembic/versions/0025_feedback.py` | architecture/feedback.md |
 | `src/treg/alembic/versions/0026_hub_tools.py` | architecture/hub.md |
+| `src/treg/alembic/versions/0027_hub_runs.py` | architecture/hub.md |
 | `src/treg/analytics.py` | architecture/data-model.md |
 | `src/treg/api.py` | architecture/archive.md, architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, architecture/super-admin.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md |
 | `src/treg/application/__init__.py` | architecture/import-boundaries.md |
@@ -89,6 +90,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/connect.py` | architecture/auth-secrets.md, architecture/composition.md, guides/expanding-a-category.md, interface/api.md |
 | `src/treg/application/feedback.py` | architecture/feedback.md |
 | `src/treg/application/hub/__init__.py` | architecture/hub.md |
+| `src/treg/application/hub/runner.py` | architecture/hub.md |
 | `src/treg/application/onboard.py` | interface/api.md |
 | `src/treg/application/onboard/__init__.py` | interface/landing-sandbox.md, interface/onboarding.md |
 | `src/treg/application/onboard/demo.py` | interface/onboarding.md |
@@ -216,7 +218,9 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/domain/governance/teams.py` | architecture/import-boundaries.md, architecture/multi-tenancy.md, interface/api.md |
 | `src/treg/domain/governance/usage.py` | architecture/import-boundaries.md, architecture/multi-tenancy.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/domain/hub/__init__.py` | architecture/hub.md |
+| `src/treg/domain/hub/graph.py` | architecture/hub.md |
 | `src/treg/domain/hub/manifest.py` | architecture/hub.md |
+| `src/treg/domain/hub/refs.py` | architecture/hub.md |
 | `src/treg/domain/identity/__init__.py` | architecture/import-boundaries.md |
 | `src/treg/domain/identity/access.py` | architecture/multi-tenancy.md, architecture/super-admin.md, interface/api.md |
 | `src/treg/domain/identity/health.py` | architecture/mcp-oauth.md |
@@ -312,6 +316,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/vendor/README.md` | interface/dashboard.md |
 | `src/treg/web/vendor/vue-3.5.41.global.prod.js` | interface/dashboard.md |
 | `src/treg/worker.py` | ops/capacity.md, ops/deploy.md |
+| `tests/callmatrix/test_hub_run.py` | architecture/hub.md |
 | `tests/fixtures/aggregators/verification/contactout.json` | architecture/contactout.md |
 | `tests/test_aigc_pr_b.py` | architecture/catalog.md |
 | `tests/test_alembic_expand_safety.py` | architecture/data-model.md |
@@ -364,7 +369,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/contactout.md` | `contactout.yaml`, `adapters.yaml`, `contactout.people.email.verify.json`, `test_routing.py`, `contactout.companies.search.json`, `contactout.companies.enrich.json`, `resolve.py`, `contactout.py`, `contactout.svg`, `test_marketplace_call.py`, `test_key_providers.py`, `test_capacity_collectors.py`, `test_catalog_validate.py`, `test_capacity_overflow.py`, `contactout_overflow_verify.py`, `contactout.json` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `0020_callrecord_created_at_indexes.py`, `0021_ledgerentry_org_created_at_index.py`, `0022_org_spent_today_counter.py`, `0023_callrecord_org_user_created_at_index.py`, `0024_membership_calls_today_counter.py`, `0011_callrecord_archive_link.py`, `0015_idempotentcall_membership_cascade.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `bootstrap_handlers.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
 | `architecture/feedback.md` | `feedback_contract.py`, `feedback.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `feedback.md`, `test_feedback.py` |
-| `architecture/hub.md` | `__init__.py`, `manifest.py`, `__init__.py`, `hub.py`, `0026_hub_tools.py`, `test_hub.py` |
+| `architecture/hub.md` | `__init__.py`, `manifest.py`, `refs.py`, `graph.py`, `__init__.py`, `runner.py`, `hub.py`, `0026_hub_tools.py`, `0027_hub_runs.py`, `test_hub.py`, `test_hub_run.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `feedback.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -24,7 +24,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [ContactOut — LinkedIn enrichment, Starter billing and independent credit pools](architecture/contactout.md) | implemented; live connect and core surface verified, informational capacity monitoring | contactout.yaml, adapters.yaml, contactout.people.email.verify.json, test_routing.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Feedback - private intake for problems and suggestions](architecture/feedback.md) | shipped | feedback_contract.py, feedback.py, feedback.py, feedback.py, … |
-| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 1 of 8: the manifest and the table; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, __init__.py, hub.py, … |
+| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 2 of 8: the JSON road runs; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, __init__.py, __init__.py, … |
 | [Instagram OAuth — direct Login and optional Facebook Page tools](architecture/instagram-oauth.md) | built; Meta configuration and live verification pending | catalog_ingest.py, access.py, resolve.py, service.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |

--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -1,13 +1,18 @@
 ---
 title: The tool hub — tools a maker publishes, made of other tools
-status: in-progress (phase 1 of 8: the manifest and the table; behind TREG_HUB_ENABLED, off)
+status: in-progress (phase 2 of 8: the JSON road runs; behind TREG_HUB_ENABLED, off)
 sources:
   - src/treg/domain/hub/__init__.py
   - src/treg/domain/hub/manifest.py
+  - src/treg/domain/hub/refs.py
+  - src/treg/domain/hub/graph.py
   - src/treg/application/hub/__init__.py
+  - src/treg/application/hub/runner.py
   - src/treg/routers/hub.py
   - src/treg/alembic/versions/0026_hub_tools.py
+  - src/treg/alembic/versions/0027_hub_runs.py
   - tests/test_hub.py
+  - tests/callmatrix/test_hub_run.py
 related:
   - architecture/proxy-model.md
   - architecture/money.md
@@ -23,10 +28,10 @@ access rules, key injection and money already exist once per call. The decisions
 request each into `dev/hub`, behind `hub_enabled` (`TREG_HUB_ENABLED`, default off) so no merge
 along the way changes what users see.
 
-**Build state: phase 1 of 8.** A tool can be validated and stored; nothing runs. The runner, the
-sandbox, the maker's check run, the seller's money and every surface are later phases. Until the
-runner exists, a hub tool found on the call road answers **501 `hub_not_runnable`**, never a
-silent 404, and no agent-facing file mentions the hub (CLAUDE.md: do not document what is not built).
+**Build state: phase 2 of 8.** A steps recipe runs end to end on the call road; a script recipe
+still answers **501 `hub_not_runnable`** (the sandbox is phase 3). The maker's check run, the
+seller's money and every surface are later phases, and no agent-facing file mentions the hub
+(CLAUDE.md: do not document what is not built).
 
 ## The manifest (`domain/hub/manifest.py`)
 
@@ -69,3 +74,49 @@ third, last step: an own tool wins, then a catalog id, then — only when both m
 and the flag is on — `application/hub.tool_for` looks up the newest `live` version (or `@N`).
 Phase 1 raises `ResolutionFailed("hub_not_runnable", 501)` with the tool id; the runner replaces
 that in phase 2. An unchecked version is never on the call road.
+
+## The reference language (`domain/hub/refs.py`)
+
+Complete and deliberately small: `$input.<field>`, `$<step>.<path>` (any depth, `[0]` for one
+item), `$<step>[]` (every answer of a repeated step), `$<step>.length`, `$0.<path>` (the position
+alias), `$<as>.<field>` inside a repeat. A string that is exactly one reference resolves to the
+value itself; a string with references among text resolves to text. A missing field reads as
+`None` (a missing answer is data); an unknown root is refused at publish. No arithmetic, no
+condition, no function: a recipe that needs those is a script.
+
+## The graph (`domain/hub/graph.py`)
+
+Edges come from the references, never from a declaration: a step that reads `$company.x` waits
+for `company`. Built at publish (so a cycle or an unknown step is refused before anyone pays) and
+again at run. `wave` is a step's depth, kept on the trace; the runner schedules dynamically.
+
+## The runner, JSON road (`application/hub/runner.py`)
+
+`POST /call/<team>.<name>` with the inputs as the JSON body (or as query params on GET). The
+runner coerces the inputs once (defaults, types, ints clamped to `min..max`, unknown or missing
+required inputs → 422 `hub_input_invalid` naming the field), reads the ceiling from
+`X-Treg-Run-Max-Cost` (default $1.00), builds the graph, then starts every ready step, four at a
+time, waiting on whichever finishes first. Each step is one `execute_call` under the child hold
+`{run}:s{n}` (`{run}:s{n}.{i}` for an item of a repeat): the same gates, the same key injection,
+the same reserve-and-settle as a direct call. **Two teams meet in one run:** a catalog step runs
+as the caller (their money, their rules, their key if they hold one, else treg's); a step on one
+of the maker's own tools (`call: "<tool>/<path>"`, optional `method`) runs as the maker — their
+registered key, unmetered — which is how a shared recipe uses a key the caller never holds.
+
+`for_each` fans a step into N units, one per item, all counted against `limits.steps`;
+`skip_if_empty` marks a unit `skipped` without a call; `allow_fail: true` lets a failed step
+read as `None` instead of stopping the run. The ceiling check counts what is already in flight.
+When a step fails (a non-2xx or a refusal), nothing new starts, in-flight steps finish, and the
+run answers **424 `hub_run_failed`** with `{error: hub_step_failed, step, status, trace,
+charged_micro}`; a global refusal (balance, caps) keeps its own kind and status; passing the
+ceiling is 402 `hub_run_max_cost`, the step cap 424 `hub_step_cap`. Money already spent on
+completed steps stays spent (the ledger has no undo); a failed step's own hold releases by the
+endpoint's normal billing rule.
+
+The reply: `{run_id, recipe: "<id>@<v>", output, usage: {cost_micro, steps, ms}, trace, log}`
+with `X-Treg-Run-Id` (= the parent call id), `X-Treg-Steps`, `X-Treg-Cost-Micro`. The trace has
+one entry per unit: `wave, name, call, outcome (ok|failed|failed_allowed|skipped), status, ms,
+cost_micro, key (treg|team), item`. `Idempotency-Key` covers the whole run through the parent's
+store, exactly like a routed endpoint. `HubRun` (migration 0027) keeps one row per run — status,
+steps, cost, duration, masked inputs, trace, error — for 30 days; in the org cascade by
+`caller_org_id`.

--- a/src/treg/alembic/versions/0027_hub_runs.py
+++ b/src/treg/alembic/versions/0027_hub_runs.py
@@ -1,0 +1,53 @@
+"""hubrun — one run of a hub tool: the trace a caller and a maker read (docs/HUB-DECISIONS.md)
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-09-09
+
+A new table, nothing else touched. Money stays in the ledger; this holds the trace.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0027"
+down_revision: str | Sequence[str] | None = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hubrun",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("run_id", sa.String(), nullable=False),
+        sa.Column("tool_id", sa.String(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("caller_org_id", sa.Integer(), sa.ForeignKey("org.id"), nullable=False),
+        sa.Column("maker_org_id", sa.Integer(), nullable=False),
+        sa.Column("caller_email", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("steps", sa.Integer(), nullable=False),
+        sa.Column("cost_micro", sa.Integer(), nullable=False),
+        sa.Column("price_micro", sa.Integer(), nullable=False),
+        sa.Column("duration_ms", sa.Integer(), nullable=False),
+        sa.Column("inputs", sa.JSON(), nullable=False),
+        sa.Column("trace", sa.JSON(), nullable=False),
+        sa.Column("log", sa.JSON(), nullable=False),
+        sa.Column("error", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index("ix_hubrun_run_id", "hubrun", ["run_id"])
+    op.create_index("ix_hubrun_tool_id", "hubrun", ["tool_id"])
+    op.create_index("ix_hubrun_caller_org_id", "hubrun", ["caller_org_id"])
+    op.create_index("ix_hubrun_maker_org_id", "hubrun", ["maker_org_id"])
+    op.create_index("ix_hubrun_started_at", "hubrun", ["started_at"])
+
+
+def downgrade() -> None:
+    for name in ("ix_hubrun_started_at", "ix_hubrun_maker_org_id", "ix_hubrun_caller_org_id",
+                 "ix_hubrun_tool_id", "ix_hubrun_run_id"):
+        op.drop_index(name, table_name="hubrun")
+    op.drop_table("hubrun")

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -14,6 +14,7 @@ import httpx
 
 from ... import analytics, archive, audit, oauth
 from ...application import hub as hub_app
+from ...application.hub import runner as hub_runner
 from ... import sandbox as demo_sandbox
 from ...client_identity import _norm_client
 from ...config import get_settings
@@ -420,6 +421,7 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
     mk: MarketplaceCall | None = None
     own_tool_miss: dict | None = None
     ep: dict | None = None
+    hub_row = None
     if request.context.input.catalog_only:
         # This reviewed surface accepts only a catalog id. A same-named team tool cannot shadow it.
         ep = _catalog_endpoint_for(rest)
@@ -438,19 +440,65 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             ep = _catalog_endpoint_for(rest) if exc.status_code == 404 else None
             if ep is None:
                 # Third and last: a hub tool (`<team-slug>.<name>`), only when nothing above
-                # claimed the id — an own tool or a catalog id always wins. Phase 1 stores hub
-                # tools but cannot run them yet, so a found tool answers 501, never a silent 404.
+                # claimed the id — an own tool or a catalog id always wins.
                 hub_row = await hub_app.tool_for(db, rest) if exc.status_code == 404 else None
-                if hub_row is not None:
-                    raise ResolutionFailed("hub_not_runnable", status_code=501, detail={
-                        "error": "hub_not_runnable",
-                        "tool_id": hub_row.tool_id, "version": hub_row.version,
-                        "message": "this hub tool exists but the hub runner is not deployed yet",
-                    })
-                raise
-            if (isinstance(exc.detail, dict)
+                if hub_row is None:
+                    raise
+            elif (isinstance(exc.detail, dict)
                     and str(exc.detail.get("hint", "")).startswith("your org has tool ")):
                 own_tool_miss = exc.detail
+    if hub_row is not None:
+        # A hub tool: the runner runs every step through THIS use case again (child contexts,
+        # own hold ids `{run}:s{n}`), then assembles one reply. The parent owns the idempotency
+        # label and the X-Treg-* stamping, exactly like a routed endpoint.
+        await db.commit()   # no pooled connection held across the steps' own sessions
+        try:
+            body_bytes = await _await_before_reserve(request.body(), request, call_ref)
+            response, charged = await hub_runner.run_hub_tool(
+                request.context, hub_row, body_bytes, request.headers.get, upstream_client,
+                execute_call, audit_client=_client_name(request))
+        except asyncio.CancelledError:
+            await _finish_cancelled_call(request, None, call_ref)
+            raise
+        except CallFailure as exc:
+            request.state.call_audited = True
+            charged = (int(exc.detail.get("charged_micro") or 0)
+                       if isinstance(exc.detail, dict) else 0)
+            request.state.call_cost_micro = charged
+            if idem_key and charged > 0 and exc.kind == "hub_run_failed":
+                error_body = json.dumps({"detail": exc.detail}, ensure_ascii=False,
+                                        allow_nan=False, separators=(",", ":")).encode()
+                try:
+                    await _store_idempotent(
+                        idem_key, caller, status_code=exc.status_code, body=error_body,
+                        media_type="application/json", charged_micro=charged, metered=True,
+                        call_ref=call_ref, terminal=True)
+                except asyncio.CancelledError:
+                    await _finish_cancelled_call(request, None, call_ref)
+                    raise
+                request.state.idem_claim = None
+            if exc.kind != "hub_run_failed":   # the runner audits its own terminal failures
+                audit.record_call(
+                    org_id=caller.org_id, user_email=caller.email, tool_name=hub_row.tool_id,
+                    method=request.method, path=rest, status_code=exc.status_code,
+                    client=_client_name(request), refused_by=_refusal_kind(exc.status_code),
+                    telemetry={"call_ref": call_ref, "endpoint_id": hub_row.tool_id,
+                               "provider": "hub", "credential_tier": "hub", **_tag_telemetry(meta)})
+            raise
+        request.state.call_audited = True
+        request.state.call_cost_micro = charged
+        if idem_key:
+            try:
+                await _store_idempotent(idem_key, caller, status_code=response.status,
+                                        body=await _drain(response), media_type="application/json",
+                                        charged_micro=charged, metered=True, call_ref=call_ref)
+            except asyncio.CancelledError:
+                await _finish_cancelled_call(request, None, call_ref)
+                raise
+            request.state.idem_claim = None
+        _set_response_header(response, "X-Treg-Cost-Micro", str(charged))
+        _set_response_header(response, "X-Treg-Call-Id", call_ref)
+        return response
     if ep is not None and ep.get("kind") == "routed":
         # A first-party routed endpoint (treg.<capability>): the router picks children and runs
         # each through THIS use case again (child contexts, own hold ids), then assembles one

--- a/src/treg/application/call/types.py
+++ b/src/treg/application/call/types.py
@@ -21,6 +21,8 @@ _BLAME_BY_KIND: dict[str, Blame] = {
     "tool_access_denied": "caller",
     "target_not_found": "caller",
     "hub_not_runnable": "treg",
+    "hub_input_invalid": "caller",
+    "hub_run_failed": "upstream",
     "target_ambiguous": "caller",
     "catalog_retired": "caller",
     "catalog_parameter_invalid": "caller",

--- a/src/treg/application/hub/runner.py
+++ b/src/treg/application/hub/runner.py
@@ -1,0 +1,437 @@
+"""The hub runner, JSON road: the graph, the waves, the steps (docs/HUB-DECISIONS.md).
+
+A run is `POST /call/<team>.<name>` with the inputs as a JSON body. The runner resolves the
+manifest's references into a graph, starts every ready step (four at a time), and runs each
+step as an ordinary treg call through `execute_call` — the same gates, the same key injection,
+the same reserve-and-settle, under a child hold `{run}:s{n}`. This module owns no money and no
+key: it only decides what to call next and reads the answers back into scope.
+
+Two teams meet in one run: the CALLER (identity and money) and the MAKER (the tools the recipe
+names). A catalog step runs as the caller: their balance, their rules, their key if they have
+one for the provider, else treg's. A step on one of the maker's own tools runs as the maker:
+their registered key, unmetered, their tool. That is how a shared recipe can use a key the
+caller never holds (HUB-DECISIONS round 2 q9).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, replace
+from typing import Any, Callable
+from urllib.parse import urlencode
+
+import httpx
+
+from ... import audit
+from ...domain.catalog import store as catalog_store
+from ...domain.hub import graph as hub_graph
+from ...domain.hub import refs
+from ...infra.db import session_maker
+from ...models import HubRun, HubTool, Org
+from ..call.types import CallContext, CallFailure, CallInput, ResolutionFailed, UpstreamResponse
+
+RUN_MAX_COST_HEADER = "X-Treg-Run-Max-Cost"
+DEFAULT_RUN_MAX_COST_MICRO = 1_000_000      # $1.00 for the whole run, seller price included later
+MAX_PARALLEL = 4                            # steps in flight at once inside one run
+_DROP_FROM_CHILD = frozenset({b"content-length", b"content-type", b"transfer-encoding",
+                              b"idempotency-key", b"x-treg-run-max-cost", b"host"})
+# Refusals that are the same for every step: no point starting anything else.
+_GLOBAL_REFUSALS = frozenset({"insufficient_balance", "tag_spend_cap_reached",
+                              "platform_daily_cap_reached", "daily_cap_reached"})
+
+
+class _Bytes:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    async def stream(self):
+        yield self._data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+@dataclass
+class _Step:
+    """One unit against the caps: a plain step, or one item of a repeated step."""
+    name: str
+    spec: dict[str, Any]
+    ref: str                    # the child call_ref
+    wave: int
+    item: int | None = None
+    item_value: Any = None
+
+
+class RunStopped(Exception):
+    """The run must not start anything new: a step failed, a cap was hit, or a global refusal."""
+
+    def __init__(self, kind: str, status: int, detail: dict) -> None:
+        super().__init__(kind)
+        self.kind, self.status, self.detail = kind, status, detail
+
+
+# ---------------------------------------------------------------------------------------------
+# Inputs
+
+class InputError(ValueError):
+    def __init__(self, field: str, rule: str) -> None:
+        super().__init__(f"{field}: {rule}")
+        self.field, self.rule = field, rule
+
+
+def coerce_inputs(specs: dict[str, dict[str, Any]], given: dict[str, Any]) -> dict[str, Any]:
+    """The manifest's contract applied once, in the runner (Crawl4AI lesson 6): defaults filled,
+    types checked, ints clamped to min..max, unknown inputs and missing required ones refused."""
+    for key in given:
+        if key not in specs:
+            raise InputError(key, "not an input of this tool")
+    out: dict[str, Any] = {}
+    for key, spec in specs.items():
+        if key not in given or given[key] is None:
+            if "default" in spec:
+                out[key] = spec["default"]
+                continue
+            raise InputError(key, "required (it has no default)")
+        v = given[key]
+        typ = spec["type"]
+        try:
+            if typ == "string":
+                v = v if isinstance(v, str) else json.dumps(v) if isinstance(v, (dict, list)) else str(v)
+            elif typ == "int":
+                if isinstance(v, bool):
+                    raise ValueError
+                v = int(v)
+                v = max(spec.get("min", -(2**31)), min(int(spec["max"]), v))
+            elif typ == "float":
+                if isinstance(v, bool):
+                    raise ValueError
+                v = float(v)
+            elif typ == "bool":
+                v = v if isinstance(v, bool) else str(v).lower() in ("1", "true", "yes", "on")
+            elif typ == "list":
+                v = v if isinstance(v, list) else json.loads(v) if isinstance(v, str) else [v]
+                if not isinstance(v, list):
+                    raise ValueError
+            elif typ == "object":
+                v = v if isinstance(v, dict) else json.loads(v) if isinstance(v, str) else None
+                if not isinstance(v, dict):
+                    raise ValueError
+        except (ValueError, TypeError):
+            raise InputError(key, f"must be a {typ}") from None
+        out[key] = v
+    return out
+
+
+def masked(specs: dict[str, dict[str, Any]], inputs: dict[str, Any]) -> dict[str, Any]:
+    return {k: ("***" if specs.get(k, {}).get("secret") else v) for k, v in inputs.items()}
+
+
+# ---------------------------------------------------------------------------------------------
+# The run
+
+async def run_hub_tool(
+    parent: CallContext, tool: HubTool, body_bytes: bytes, get_header: Callable[[str], str | None],
+    upstream_client: httpx.AsyncClient, execute_child, *, audit_client: str = "",
+) -> tuple[UpstreamResponse, int]:
+    """Execute one run under `parent`. Returns (the JSON reply, total charged to the caller)."""
+    if tool.kind != "steps":
+        raise ResolutionFailed("hub_not_runnable", status_code=501, detail={
+            "error": "hub_not_runnable", "tool_id": tool.tool_id, "version": tool.version,
+            "message": "this hub tool is a script; the script road is not deployed yet"})
+    manifest = tool.manifest
+    run_id = parent.call_ref
+    started = time.monotonic()
+    try:
+        given = json.loads(body_bytes or b"{}") if body_bytes.strip() else {}
+    except ValueError:
+        raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
+            "error": "hub_input_invalid", "field": "body", "rule": "a JSON object of inputs"})
+    if not isinstance(given, dict):
+        raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
+            "error": "hub_input_invalid", "field": "body", "rule": "a JSON object of inputs"})
+    if not given and parent.input.query_items:
+        given = dict(parent.input.query_items)
+    try:
+        inputs = coerce_inputs(manifest["inputs"], given)
+    except InputError as exc:
+        raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
+            "error": "hub_input_invalid", "field": exc.field, "rule": exc.rule})
+    ceiling = _ceiling(get_header(RUN_MAX_COST_HEADER))
+    g = hub_graph.build(manifest["steps"])
+    maker = await _maker_snapshot(parent, tool)
+    catalog = catalog_store.load()
+    own_tools = {u for u in manifest["uses"] if "." not in u}
+
+    scope: dict[str, Any] = {"input": inputs}
+    trace: list[dict[str, Any]] = []
+    spent = 0
+    counted = 0
+    stop: RunStopped | None = None
+    done: set[str] = set()
+    sem = asyncio.Semaphore(MAX_PARALLEL)
+    running: dict[asyncio.Task, str] = {}
+
+    async def one_call(step: _Step) -> tuple[_Step, dict[str, Any], Any]:
+        """One child call. Returns (step, trace entry, answer)."""
+        async with sem:
+            spec = step.spec
+            item_scope = dict(scope)
+            if step.item is not None:
+                item_scope[spec["as"]] = step.item_value
+            if spec.get("skip_if_empty") and refs.is_empty(
+                    refs.resolve(spec["skip_if_empty"], item_scope, g.positions)):
+                entry = _entry(step, "skipped", None, 0, 0, key=None)
+                return step, entry, None
+            call = spec["call"]
+            target = call.split("/", 1)[0]
+            ep = None if target in own_tools else catalog.by_id.get(call)
+            inp = refs.resolve(spec.get("input", {}), item_scope, g.positions)
+            method = (spec.get("method") or (ep["method"] if ep else "GET")).upper()
+            as_who = maker if target in own_tools else parent.input.caller
+            child = CallContext(input=_child_input(parent, call, method, inp, as_who),
+                                call_ref=step.ref, meta=parent.meta)
+            t0 = time.monotonic()
+            try:
+                response = await execute_child(child, upstream_client)
+            except CallFailure as exc:
+                ms = int((time.monotonic() - t0) * 1000)
+                entry = _entry(step, "failed", exc.status_code, ms, 0, key=None,
+                               error=_short(exc.detail))
+                if exc.kind in _GLOBAL_REFUSALS:
+                    entry["global"] = exc.kind
+                return step, entry, exc
+            raw = await _read(response)
+            ms = int((time.monotonic() - t0) * 1000)
+            charged = int(_header(response, "X-Treg-Cost-Micro") or 0)
+            key = "treg" if _header(response, "X-Treg-Cost-Micro") is not None else "team"
+            ok = 200 <= response.status < 300
+            try:
+                answer = json.loads(raw) if raw else None
+            except ValueError:
+                answer = raw.decode("utf-8", "replace")
+            entry = _entry(step, "ok" if ok else "failed", response.status, ms, charged, key=key,
+                           error=None if ok else _short(answer))
+            return step, entry, answer if ok else _StepFailed(response.status, answer)
+
+    def estimate(spec: dict[str, Any]) -> int:
+        target = spec["call"].split("/", 1)[0]
+        if target in own_tools:
+            return 0
+        ep = catalog.by_id.get(spec["call"])
+        cv = catalog.cost_view(ep.get("cost"), ep.get("provider")) if ep else None
+        usd = (cv or {}).get("usd")
+        return int(round(float(usd) * 1_000_000)) if usd else 0
+
+    def units_for(name: str) -> list[_Step]:
+        spec = g.steps[name]
+        wave = g.wave[name]
+        idx = g.order.index(name)
+        if spec.get("for_each"):
+            items = refs.resolve(spec["for_each"], scope, g.positions)
+            items = items if isinstance(items, list) else ([] if items is None else [items])
+            return [_Step(name, spec, f"{run_id}:s{idx}.{i}", wave, i, v) for i, v in enumerate(items)]
+        return [_Step(name, spec, f"{run_id}:s{idx}", wave)]
+
+    pending_units: dict[str, list[_Step]] = {}
+    results: dict[str, list[Any]] = {}
+    try:
+        while True:
+            if stop is None:
+                for name in g.order:
+                    if name in done or name in pending_units:
+                        continue
+                    if not g.parents[name] <= done:
+                        continue
+                    units = units_for(name)
+                    pending_units[name] = []
+                    results[name] = [None] * len(units)
+                    if not units:                 # a repeat over nothing: the step is done, empty
+                        done.add(name)
+                        scope[name] = []
+                        continue
+                    for u in units:
+                        if counted + 1 > manifest["limits"]["steps"]:
+                            stop = RunStopped("hub_step_cap", 424, {
+                                "error": "hub_step_cap", "step": name,
+                                "message": f"the run would pass its step cap ({manifest['limits']['steps']})"})
+                            break
+                        est = estimate(u.spec)
+                        if spent + _reserved(running, pending_units, estimate) + est > ceiling:
+                            stop = RunStopped("hub_run_max_cost", 402, {
+                                "error": "hub_run_max_cost", "step": name, "max_cost_micro": ceiling,
+                                "message": f"the next step would pass {RUN_MAX_COST_HEADER}"})
+                            break
+                        counted += 1
+                        task = asyncio.create_task(one_call(u))
+                        running[task] = name
+                        pending_units[name].append(u)
+                    if stop is not None:
+                        break
+            if not running:
+                break
+            finished, _ = await asyncio.wait(set(running), return_when=asyncio.FIRST_COMPLETED)
+            for task in finished:
+                name = running.pop(task)
+                step, entry, answer = task.result()
+                trace.append(entry)
+                spent += entry["cost_micro"]
+                failed = isinstance(answer, (_StepFailed, CallFailure))
+                if failed and not step.spec.get("allow_fail"):
+                    if stop is None:
+                        stop = RunStopped("hub_step_failed", 424, {
+                            "error": "hub_step_failed", "step": step.name, "status": entry.get("status"),
+                            **({"message": "a refusal that applies to every step"} if entry.get("global") else {})})
+                    if isinstance(answer, CallFailure) and entry.get("global"):
+                        stop = RunStopped(answer.kind, answer.status_code, {
+                            "error": answer.kind, "step": step.name, "detail": answer.detail})
+                    answer = None
+                elif failed:
+                    entry["outcome"] = "failed_allowed"
+                    answer = None
+                slot = step.item if step.item is not None else 0
+                results[name][slot] = answer
+                if len([t for t, n in running.items() if n == name]) == 0:
+                    done.add(name)
+                    scope[name] = results[name] if step.spec.get("for_each") else results[name][0]
+    except asyncio.CancelledError:
+        raise
+
+    trace.sort(key=lambda e: (e["wave"], e["name"], e.get("item") or 0))
+    ms_total = int((time.monotonic() - started) * 1000)
+    if stop is not None:
+        detail = {**stop.detail, "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}",
+                  "charged_micro": spent, "trace": trace}
+        await _record(tool, parent, run_id, "failed" if stop.kind == "hub_step_failed" else "stopped",
+                      counted, spent, ms_total, masked(manifest["inputs"], inputs), trace, error=detail)
+        _audit_parent(parent, tool, stop.status, spent, audit_client)
+        raise ResolutionFailed("hub_run_failed", status_code=stop.status, detail=detail)
+
+    output = refs.resolve(manifest["output"], scope, g.positions)
+    body_out = {
+        "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}", "output": output,
+        "usage": {"cost_micro": spent, "steps": counted, "ms": ms_total},
+        "trace": trace, "log": [],
+    }
+    await _record(tool, parent, run_id, "ok", counted, spent, ms_total,
+                  masked(manifest["inputs"], inputs), trace)
+    _audit_parent(parent, tool, 200, spent, audit_client)
+    return _json(body_out, 200, {"X-Treg-Run-Id": run_id, "X-Treg-Steps": str(counted)}), spent
+
+
+class _StepFailed:
+    def __init__(self, status: int, body: Any) -> None:
+        self.status, self.body = status, body
+
+
+def _reserved(running: dict, pending: dict, estimate) -> int:
+    """Estimates of the units still in flight: the ceiling check must count what is already out."""
+    names = list(running.values())
+    return sum(estimate(pending[n][-1].spec) for n in names if pending.get(n)) if names else 0
+
+
+def _ceiling(raw: str | None) -> int:
+    if not raw:
+        return DEFAULT_RUN_MAX_COST_MICRO
+    try:
+        return max(0, int(round(float(raw) * 1_000_000)))
+    except ValueError:
+        return DEFAULT_RUN_MAX_COST_MICRO
+
+
+def _entry(step: _Step, outcome: str, status: int | None, ms: int, cost: int, *, key: str | None,
+           error: Any = None) -> dict[str, Any]:
+    e: dict[str, Any] = {"wave": step.wave, "name": step.name, "call": step.spec["call"],
+                         "outcome": outcome, "status": status, "ms": ms, "cost_micro": cost, "key": key}
+    if step.item is not None:
+        e["item"] = step.item
+    if error is not None:
+        e["error"] = error
+    return e
+
+
+def _short(v: Any) -> Any:
+    s = v if isinstance(v, str) else json.dumps(v, ensure_ascii=False, default=str)
+    return s[:300]
+
+
+def _child_input(parent: CallContext, call: str, method: str, inp: dict[str, Any], as_who) -> CallInput:
+    has_body = method in ("POST", "PUT", "PATCH")
+    payload = json.dumps(inp, ensure_ascii=False).encode() if has_body else b""
+    headers = [(k, v) for k, v in parent.input.raw_headers if k.lower() not in _DROP_FROM_CHILD]
+    if has_body:
+        headers += [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())]
+    items = tuple() if has_body else tuple(
+        (k, v if isinstance(v, str) else json.dumps(v)) for k, v in inp.items() if v is not None)
+    return CallInput(method=method, raw_rest=call, raw_headers=tuple(headers), query_items=items,
+                     raw_query=urlencode(items), body=_Bytes(payload), caller=as_who,
+                     client_ip=parent.input.client_ip, catalog_only=False)
+
+
+async def _maker_snapshot(parent: CallContext, tool: HubTool):
+    """The caller's snapshot re-pointed at the maker's team for the maker's own tools: same
+    person, same client, the MAKER's tools and keys (unmetered, so no money follows this)."""
+    caller = parent.input.caller
+    if tool.org_id == caller.org_id:
+        return caller
+    async with session_maker() as s:
+        org = await s.get(Org, tool.org_id)
+    if org is None:
+        return caller
+    return replace(caller,
+                   membership=replace(caller.membership, org_id=tool.org_id, tool_access=None,
+                                      project_access=None),
+                   org=replace(caller.org, id=org.id, slug=org.slug, demo=org.demo,
+                               public_demo=org.public_demo))
+
+
+async def _read(response: UpstreamResponse) -> bytes:
+    chunks = []
+    async for chunk in response.body_stream:
+        chunks.append(chunk)
+    await response.close()
+    return b"".join(chunks)
+
+
+def _header(response: UpstreamResponse, name: str) -> str | None:
+    wanted = name.lower().encode("latin-1")
+    for k, v in response.raw_headers:
+        if k.lower() == wanted:
+            return v.decode("latin-1")
+    return None
+
+
+async def _record(tool: HubTool, parent: CallContext, run_id: str, status: str, steps: int,
+                  cost: int, ms: int, inputs: dict, trace: list, error: dict | None = None) -> None:
+    from datetime import datetime, timezone
+    caller = parent.input.caller
+    async with session_maker() as s:
+        s.add(HubRun(run_id=run_id, tool_id=tool.tool_id, version=tool.version,
+                     caller_org_id=caller.org_id, maker_org_id=tool.org_id, caller_email=caller.email,
+                     status=status, steps=steps, cost_micro=cost, duration_ms=ms, inputs=inputs,
+                     trace=trace, log=[], error=error,
+                     finished_at=datetime.now(timezone.utc).replace(tzinfo=None)))
+        await s.commit()
+
+
+def _audit_parent(parent: CallContext, tool: HubTool, status: int, charged: int, client: str) -> None:
+    c = parent.input.caller
+    audit.record_call(org_id=c.org_id, user_email=c.email, tool_name=tool.tool_id, method="POST",
+                      path=f"/call/{tool.tool_id}", status_code=status, client=client,
+                      telemetry={"call_ref": parent.call_ref, "endpoint_id": tool.tool_id,
+                                 "provider": "hub", "credential_tier": "hub",
+                                 "cost_charged_micro": charged})
+
+
+def _json(value, status: int, headers: dict[str, str]) -> UpstreamResponse:
+    body = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()
+
+    async def _one():
+        yield body
+
+    async def _closed():
+        return None
+    raw = [(b"content-length", str(len(body)).encode()), (b"content-type", b"application/json")]
+    raw += [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
+    return UpstreamResponse(status, tuple(raw), _one(), _closed)

--- a/src/treg/domain/governance/teams.py
+++ b/src/treg/domain/governance/teams.py
@@ -18,6 +18,7 @@ from ...models import (
     DenyRule,
     Feedback,
     Hold,
+    HubRun,
     HubTool,
     IdempotentCall,
     Invite,
@@ -183,6 +184,10 @@ async def cascade_delete_org(org: Org, db: AsyncSession) -> None:
     for referral in (await db.execute(select(Referral).where(
             Referral.referred_org_id == org.id))).scalars().all():
         await db.delete(referral)
+    # HubRun names the team that CALLED as `caller_org_id` (the foreign key) and the maker only
+    # by number: a caller's runs go with the caller; a maker's deletion leaves callers' traces.
+    for run in (await db.execute(select(HubRun).where(HubRun.caller_org_id == org.id))).scalars().all():
+        await db.delete(run)
     await db.flush()
     for model in ORG_SCOPED_MODELS:
         for r in (await db.execute(select(model).where(model.org_id == org.id))).scalars().all():

--- a/src/treg/domain/hub/graph.py
+++ b/src/treg/domain/hub/graph.py
@@ -1,0 +1,68 @@
+"""The graph of a steps recipe — derived from the references, never declared by hand.
+
+An edge goes from the step a reference names to the step that names it. A step that names no
+other step has no parent and starts at once. Refused at load: a reference to a step that does
+not exist, and any cycle. The `wave` of a step is its depth in the graph (longest path from a
+root), used for the trace; the runner schedules dynamically (every ready step, four at a time),
+which never runs a step before its wave.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import refs
+from .manifest import ManifestError
+
+
+@dataclass(frozen=True)
+class Graph:
+    order: tuple[str, ...]                  # a topological order, for determinism
+    parents: dict[str, frozenset[str]]      # step → the steps it reads
+    wave: dict[str, int]                    # step → depth, 0 for a root
+    positions: dict[str, str]               # "0" → first step's name (the $0 alias)
+    steps: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+def build(steps: list[dict[str, Any]]) -> Graph:
+    names = [s["name"] for s in steps]
+    by_name = {s["name"]: s for s in steps}
+    positions = {str(i): n for i, n in enumerate(names)}
+    parents: dict[str, set[str]] = {}
+    for i, step in enumerate(steps):
+        own_item = step.get("as")
+        roots: set[str] = set()
+        roots |= refs.roots_in(step.get("input", {}))
+        for key in ("for_each", "skip_if_empty"):
+            if step.get(key):
+                roots |= refs.roots_in(step[key])
+        deps: set[str] = set()
+        for root in roots:
+            if root == "input" or root == own_item:
+                continue
+            target = positions.get(root) if root.isdigit() else root
+            if target is None or target not in by_name:
+                raise ManifestError(f"steps[{i}]", f"references ${root}, which is not a step or an input")
+            if target == step["name"]:
+                raise ManifestError(f"steps[{i}]", f"step {target!r} references itself")
+            deps.add(target)
+        parents[step["name"]] = deps
+
+    # Kahn's algorithm: an order exists exactly when there is no cycle.
+    remaining = {n: set(p) for n, p in parents.items()}
+    order: list[str] = []
+    wave: dict[str, int] = {}
+    while remaining:
+        ready = [n for n in names if n in remaining and not remaining[n]]
+        if not ready:
+            cyc = ", ".join(sorted(remaining))
+            raise ManifestError("steps", f"a cycle: these steps wait on each other: {cyc}")
+        for n in ready:
+            wave[n] = max((wave[p] + 1 for p in parents[n]), default=0)
+            order.append(n)
+            del remaining[n]
+        for n in remaining:
+            remaining[n] -= set(ready)
+    return Graph(order=tuple(order), parents={n: frozenset(p) for n, p in parents.items()},
+                 wave=wave, positions=positions, steps=by_name)

--- a/src/treg/domain/hub/manifest.py
+++ b/src/treg/domain/hub/manifest.py
@@ -31,7 +31,7 @@ MAX_COST_USD = 100.0
 
 INPUT_TYPES = ("string", "int", "float", "bool", "list", "object")
 INPUT_KEYS = frozenset({"type", "default", "max", "min", "secret", "example", "note"})
-STEP_KEYS = frozenset({"name", "call", "input", "for_each", "as", "skip_if_empty", "writes"})
+STEP_KEYS = frozenset({"name", "call", "method", "input", "for_each", "as", "skip_if_empty", "writes", "allow_fail"})
 LIMIT_KEYS = frozenset({"steps", "wall_s", "cost_usd"})
 MANIFEST_KEYS = frozenset({
     "name", "version", "summary", "writes", "inputs", "uses", "limits", "price_usd",
@@ -269,8 +269,17 @@ def _validate_steps(raw: Any, uses: list[str], max_steps: int) -> list[dict[str,
             raise _fail(f"{path}.name", "`input` is reserved for the caller's inputs")
         names.add(name)
         call = step.get("call")
-        if call not in uses:
+        # A catalog id as is, or one of the maker's own tools as `<tool>/<path>` (the tool name
+        # must be in `uses`; the path is the upstream path under its base url).
+        target = call.split("/", 1)[0] if isinstance(call, str) else None
+        if not isinstance(call, str) or target not in uses:
             raise _fail(f"{path}.call", f"{call!r} is not in `uses`; every tool a step calls must be declared there")
+        if "/" in call and "." in target:
+            raise _fail(f"{path}.call", f"{target!r} is a catalog id; it takes no path (a path belongs to one of your own tools)")
+        method = step.get("method", None)
+        if method is not None and (not isinstance(method, str)
+                                   or method.upper() not in ("GET", "POST", "PUT", "PATCH", "DELETE")):
+            raise _fail(f"{path}.method", "one of GET, POST, PUT, PATCH, DELETE")
         inp = step.get("input", {})
         if not isinstance(inp, dict):
             raise _fail(f"{path}.input", "an object of parameter → value or reference")
@@ -287,8 +296,47 @@ def _validate_steps(raw: Any, uses: list[str], max_steps: int) -> list[dict[str,
             raise _fail(f"{path}.skip_if_empty", "a reference; the step is skipped when it is empty")
         if "writes" in step and not isinstance(step["writes"], bool):
             raise _fail(f"{path}.writes", "true or false")
+        if "allow_fail" in step and not isinstance(step["allow_fail"], bool):
+            raise _fail(f"{path}.allow_fail", "true or false")
+        for where, value in (("input", inp), ("for_each", for_each), ("skip_if_empty", skip)):
+            bad = _bad_ref(value)
+            if bad is not None:
+                raise _fail(f"{path}.{where}", f"{bad!r} is not a valid reference (see the reference language)")
         out.append({k: step[k] for k in STEP_KEYS if k in step} | {"input": inp})
+    from . import graph as _graph   # local: graph imports ManifestError from here
+    _graph.build(out)               # unknown-step references and cycles are refused at publish
     return out
+
+
+def own_names(uses: list[str]) -> set[str]:
+    """The entries of `uses` that are a team's own tool names (no dot) rather than catalog ids."""
+    return {u for u in uses if "." not in u}
+
+
+def _bad_ref(value: Any) -> str | None:
+    """The first reference-looking token that does not parse, or None."""
+    from . import refs
+    if isinstance(value, str):
+        for m in re.finditer(r"\$[A-Za-z0-9_.\[\]]+", value):
+            token = m.group(0)
+            try:
+                refs.parse(token)
+            except refs.RefError:
+                # a template may end a reference at punctuation; accept if a prefix parses
+                if not any(refs.find(token)):
+                    return token
+        return None
+    if isinstance(value, dict):
+        for v in value.values():
+            b = _bad_ref(v)
+            if b is not None:
+                return b
+    if isinstance(value, list):
+        for v in value:
+            b = _bad_ref(v)
+            if b is not None:
+                return b
+    return None
 
 
 def _validate_output_steps(raw: Any) -> dict[str, Any]:
@@ -301,6 +349,11 @@ def _validate_output_steps(raw: Any) -> dict[str, Any]:
             raise _fail(f"output.{key}", "field names are 1-32 characters, lowercase letters, digits and underscores")
         if not isinstance(ref, str) or not ref.startswith("$"):
             raise _fail(f"output.{key}", "a reference starting with $ (a literal value is not an output)")
+        from . import refs
+        try:
+            refs.parse(ref)
+        except refs.RefError:
+            raise _fail(f"output.{key}", f"{ref!r} is not a valid reference") from None
     return dict(raw)
 
 

--- a/src/treg/domain/hub/refs.py
+++ b/src/treg/domain/hub/refs.py
@@ -1,0 +1,151 @@
+"""The reference language of the JSON road — complete, and deliberately small.
+
+| form                      | means                                              |
+|---------------------------|----------------------------------------------------|
+| `$input.<field>`          | what the caller sent, after the manifest checked it |
+| `$<step>.<path>`          | a field of an earlier step's answer, any depth      |
+| `$<step>.<path>[0].<f>`   | one item of a list                                  |
+| `$<step>[]`               | every answer of a repeated step, as a list          |
+| `$<step>.length`          | how many answers a repeated step gave (or a list's) |
+| `$0.<path>`               | the same by position, kept as an alias              |
+| `$<as>.<field>`           | inside a repeat, the current item                   |
+
+There is nothing else: no arithmetic, no condition, no function. A string that is exactly one
+reference resolves to the value itself, whatever its type; a string with references inside text
+resolves to text (`"$company.data.name: $verify.length leads"`). Keeping this list short is
+what makes a review possible and what keeps the graph derivable from the file alone.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+_REF = re.compile(r"\$(?P<root>[a-z][a-z0-9_]*|\d+)(?P<path>(?:\.[a-z0-9_]+|\[\d*\])*)")
+_SEG = re.compile(r"\.([a-z0-9_]+)|\[(\d*)\]")
+
+
+class RefError(ValueError):
+    """A reference that cannot be read: unknown root, bad path, wrong shape."""
+
+
+@dataclass(frozen=True)
+class Ref:
+    root: str                       # "input", a step name, an `as` name, or a digit string
+    path: tuple[str | int | None, ...]   # str = field, int = index, None = `[]` (whole list)
+    text: str                       # the reference as written
+
+    @property
+    def is_positional(self) -> bool:
+        return self.root.isdigit()
+
+
+def parse(text: str) -> Ref:
+    """One reference, the whole string. Raises RefError on anything else."""
+    m = _REF.fullmatch(text)
+    if not m:
+        raise RefError(f"{text!r} is not a reference")
+    return Ref(root=m.group("root"), path=_segments(m.group("path")), text=text)
+
+
+def _segments(path: str) -> tuple[str | int | None, ...]:
+    out: list[str | int | None] = []
+    for field, index in _SEG.findall(path):
+        if field:
+            out.append(field)
+        elif index == "":
+            out.append(None)
+        else:
+            out.append(int(index))
+    return tuple(out)
+
+
+def find(text: str) -> list[Ref]:
+    """Every reference inside a string, in order (a template may hold several)."""
+    return [Ref(root=m.group("root"), path=_segments(m.group("path")), text=m.group(0))
+            for m in _REF.finditer(text)]
+
+
+def roots_in(value: Any) -> set[str]:
+    """Every reference root named anywhere in a value (a step's input object, a for_each, a
+    skip_if_empty): the graph reads its edges from this."""
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.update(r.root for r in find(value))
+    elif isinstance(value, dict):
+        for v in value.values():
+            found |= roots_in(v)
+    elif isinstance(value, list):
+        for v in value:
+            found |= roots_in(v)
+    return found
+
+
+def read(ref: Ref, scope: dict[str, Any], positions: dict[str, str] | None = None) -> Any:
+    """Read one reference against a scope: `{"input": {...}, "<step>": answer | [answers],
+    "<as>": item}`. A positional root (`$0`) is mapped through `positions` (digit → step name).
+    A missing field reads as None (a missing answer is data, never a crash); an unknown ROOT is
+    an error, because the graph should have refused it at load."""
+    root = ref.root
+    if ref.is_positional:
+        if not positions or root not in positions:
+            raise RefError(f"${root} names no step")
+        root = positions[root]
+    if root not in scope:
+        raise RefError(f"${root} is not an input, a step, or a repeat item")
+    cur: Any = scope[root]
+    segs = list(ref.path)
+    while segs:
+        seg = segs.pop(0)
+        if seg is None:                       # `[]` — the whole list, as is
+            if not isinstance(cur, list):
+                cur = [] if cur is None else [cur]
+            continue
+        if seg == "length" and not segs:      # trailing `.length`
+            return len(cur) if isinstance(cur, (list, str, dict)) else 0
+        if isinstance(seg, int):
+            cur = cur[seg] if isinstance(cur, list) and -len(cur) <= seg < len(cur) else None
+        elif isinstance(cur, dict):
+            cur = cur.get(seg)
+        else:
+            cur = None
+        if cur is None:
+            return None
+    return cur
+
+
+def resolve(value: Any, scope: dict[str, Any], positions: dict[str, str] | None = None) -> Any:
+    """Resolve every reference inside a value. A string that IS one reference becomes the value
+    it names (any type); a string with references among text becomes text; dicts and lists
+    resolve their members; everything else passes through."""
+    if isinstance(value, str):
+        refs = find(value)
+        if not refs:
+            return value
+        if len(refs) == 1 and refs[0].text == value:
+            return read(refs[0], scope, positions)
+        out = value
+        for r in refs:
+            v = read(r, scope, positions)
+            out = out.replace(r.text, "" if v is None else (v if isinstance(v, str) else _plain(v)), 1)
+        return out
+    if isinstance(value, dict):
+        return {k: resolve(v, scope, positions) for k, v in value.items()}
+    if isinstance(value, list):
+        return [resolve(v, scope, positions) for v in value]
+    return value
+
+
+def _plain(v: Any) -> str:
+    import json
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    return json.dumps(v, ensure_ascii=False, separators=(",", ":"))
+
+
+def is_empty(v: Any) -> bool:
+    """The one condition of the JSON road: skip a step when the value it reads is empty."""
+    return v is None or v == "" or v == [] or v == {} or v is False

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1176,6 +1176,32 @@ class HubTool(SQLModel, table=True):
     created_at: datetime = Field(default_factory=_now)
 
 
+class HubRun(SQLModel, table=True):
+    """One run of a hub tool: who called, which version, what ran, what it cost. Kept 30 days.
+    Every step is ALSO an ordinary CallRecord under `{run_id}:s{n}`, so nothing here is a second
+    source of truth for money — the ledger holds the holds and settles; this row holds the trace
+    a caller and a maker read (docs/HUB-DECISIONS.md rounds 2 and 5)."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    run_id: str = Field(index=True)                  # `r_<hex>`, also the parent call_ref
+    tool_id: str = Field(index=True)
+    version: int
+    caller_org_id: int = Field(foreign_key="org.id", index=True)
+    maker_org_id: int = Field(index=True)
+    caller_email: str = Field(default="")
+    status: str                                      # ok | failed | stopped
+    steps: int = Field(default=0)                    # steps counted against the caps (items included)
+    cost_micro: int = Field(default=0)               # what the steps charged the caller
+    price_micro: int = Field(default=0)              # the seller's price paid (phase 6; 0 until then)
+    duration_ms: int = Field(default=0)
+    inputs: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))   # secrets masked
+    trace: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    log: list = Field(default_factory=list, sa_column=Column(JSON, nullable=False))
+    error: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    started_at: datetime = Field(default_factory=_now, index=True)
+    finished_at: datetime | None = Field(default=None)
+
+
 class ToolRequest(SQLModel, table=True):
     """A "the catalog doesn't have X" report — filed from the catalog page, the CLI, or by an
     agent mid-search over MCP. Demand signal for which provider to key next; reviewed by querying

--- a/tests/callmatrix/test_hub_run.py
+++ b/tests/callmatrix/test_hub_run.py
@@ -1,0 +1,216 @@
+"""The hub runner, JSON road, on the real call path with the fake provider: waves, data flow
+between steps, for_each, skip_if_empty, allow_fail, the ceiling, the step cap, the failure
+rules, and the four books per step (money, audit, provider hits)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import AsyncClient
+
+from treg.config import get_settings
+
+from test_marketplace_call import EP, EP_MICRO, _balance, _entries, platform_on  # noqa: F401
+
+from .asserts import snapshot
+from .provider import FakeProvider
+
+BODY = {"data": {"domain": "figma.com", "id": 7}, "rows": [{"e": "a@x"}, {"e": ""}, {"e": "c@x"}]}
+
+
+@pytest.fixture
+def hub_on(monkeypatch):
+    monkeypatch.setattr(get_settings(), "hub_enabled", True)
+
+
+def _manifest(steps, output, **over):
+    m = {"name": "flow", "summary": "A test flow.", "uses": [EP],
+         "inputs": {"domain": {"type": "string", "example": "figma.com"},
+                    "limit": {"type": "int", "default": 2, "max": 5}},
+         "steps": steps, "output": output}
+    m.update(over)
+    return m
+
+
+async def _publish(clients: AsyncClient, manifest) -> str:
+    r = await clients.post("/hub/tools", json={
+        "manifest": manifest, "check": {"inputs": {"domain": "figma.com"}, "fields": list(manifest["output"])},
+        "readme": "test"})
+    assert r.status_code == 201, r.text
+    tool_id = r.json()["tool_id"]
+    from sqlalchemy import update
+    from treg.infra.db import session_maker
+    from treg.models import HubTool
+    async with session_maker() as s:                # the check run is phase 4; flip by hand here
+        await s.execute(update(HubTool).where(HubTool.tool_id == tool_id).values(status="live"))
+        await s.commit()
+    return tool_id
+
+
+FAKE = {"X-Fake-Body": json.dumps(BODY)}
+
+
+async def test_two_waves_data_flows_and_the_four_books(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[
+            {"name": "company", "call": EP, "input": {"aweme_id": "$input.domain"}},
+            {"name": "news", "call": EP, "input": {"aweme_id": "news-$input.domain"}},
+            {"name": "people", "call": EP, "input": {"aweme_id": "$company.data.domain", "count": "$input.limit"}},
+        ],
+        output={"name": "$company.data.domain", "n": "$news.rows.length", "people": "$people.data"}))
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["output"] == {"name": "figma.com", "n": 3, "people": {"domain": "figma.com", "id": 7}}
+    assert body["usage"]["steps"] == 3 and body["usage"]["cost_micro"] == 3 * EP_MICRO
+    assert [(e["wave"], e["name"], e["outcome"], e["key"]) for e in body["trace"]] == [
+        (0, "company", "ok", "treg"), (0, "news", "ok", "treg"), (1, "people", "ok", "treg")]
+    assert r.headers["X-Treg-Cost-Micro"] == str(3 * EP_MICRO)
+    assert r.headers["X-Treg-Steps"] == "3" and r.headers["X-Treg-Run-Id"] == r.headers["X-Treg-Call-Id"]
+    # the provider book: three hits, and step 3 carried step 1's answer in its query
+    hits = fake_provider.hits[before.hit_count:]
+    assert len(hits) == 3
+    people = [h for h in hits if ("count", "2") in h.query][0]
+    assert ("aweme_id", "figma.com") in people.query
+    # the money book: three child holds, each reserved and settled; nothing open
+    assert await _balance(matrix_clients) - before.balance_micro == -3 * EP_MICRO
+    fresh = [e for e in await _entries(matrix_clients) if e["id"] not in before.entry_ids]
+    assert sorted(e["kind"] for e in fresh) == ["reserve"] * 3 + ["settle"] * 3
+    assert {e["call_id"] for e in fresh} == {f"{body['run_id']}:s0", f"{body['run_id']}:s1", f"{body['run_id']}:s2"}
+    org = (await matrix_clients.get("/orgs")).json()[0]["org_id"]
+    assert (await matrix_clients.get(f"/orgs/{org}/balance")).json()["holds"] == []
+    # the run record
+    from sqlalchemy import select
+    from treg.infra.db import session_maker
+    from treg.models import HubRun
+    async with session_maker() as s:
+        run = (await s.execute(select(HubRun).where(HubRun.run_id == body["run_id"]))).scalars().one()
+    assert run.status == "ok" and run.steps == 3 and run.cost_micro == 3 * EP_MICRO and run.inputs == {"domain": "figma.com", "limit": 2}
+
+
+async def test_for_each_skip_if_empty_and_the_item_scope(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[
+            {"name": "people", "call": EP, "input": {"aweme_id": "$input.domain"}},
+            {"name": "verify", "call": EP, "for_each": "$people.rows", "as": "person",
+             "skip_if_empty": "$person.e", "input": {"aweme_id": "$person.e"}},
+        ],
+        output={"verified": "$verify[]", "count": "$verify.length"}))
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["usage"]["steps"] == 4                    # 1 + 3 items (a skipped item still counts)
+    outcomes = [(e["name"], e.get("item"), e["outcome"]) for e in body["trace"]]
+    assert outcomes == [("people", None, "ok"), ("verify", 0, "ok"), ("verify", 1, "skipped"), ("verify", 2, "ok")]
+    assert body["output"]["count"] == 3 and body["output"]["verified"][1] is None
+    assert len(fake_provider.hits) - before.hit_count == 3     # the skipped item never left
+    assert {("aweme_id", "a@x"), ("aweme_id", "c@x")} <= {q for h in fake_provider.hits[before.hit_count:] for q in h.query}
+    assert r.headers["X-Treg-Cost-Micro"] == str(3 * EP_MICRO)
+
+
+async def test_a_failed_step_stops_the_run_and_keeps_the_money_already_spent(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[
+            {"name": "first", "call": EP, "input": {"aweme_id": "$input.domain"}},
+            {"name": "second", "call": EP, "input": {"aweme_id": "$first.data.domain"}},
+            {"name": "third", "call": EP, "input": {"aweme_id": "$second.data.domain"}},
+        ],
+        output={"x": "$third.data"}))
+    before = await snapshot(matrix_clients, fake_provider)
+    # every step 500s; per_success ⇒ a 5xx is released, so nothing is kept
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"},
+                                  headers={**FAKE, "X-Fake-Status": "500"})
+    assert r.status_code == 424, r.text
+    d = r.json()["detail"]
+    assert d["error"] == "hub_step_failed" and d["step"] == "first" and d["status"] == 500
+    assert [e["outcome"] for e in d["trace"]] == ["failed"]        # nothing new started
+    assert r.headers.get("x-treg-error") == "1"
+    assert len(fake_provider.hits) - before.hit_count == 1
+    assert await _balance(matrix_clients) == before.balance_micro   # released, not charged
+
+
+async def test_allow_fail_lets_the_run_go_on(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[
+            {"name": "shaky", "call": EP, "input": {"aweme_id": "x"}, "allow_fail": True},
+            {"name": "after", "call": EP, "input": {"aweme_id": "$shaky.data.domain"}},
+        ],
+        output={"got": "$after.data.id", "shaky": "$shaky"}))
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"},
+                                  headers={**FAKE, "X-Fake-Status": "500"})
+    # both 500 here (one fake status for all); the first is allowed, the second is not
+    assert r.status_code == 424 and r.json()["detail"]["step"] == "after"
+    assert [e["outcome"] for e in r.json()["detail"]["trace"]] == ["failed_allowed", "failed"]
+
+
+async def test_the_ceiling_stops_the_run_before_the_step_that_would_pass_it(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}},
+               {"name": "b", "call": EP, "input": {"aweme_id": "$a.data.domain"}}],
+        output={"x": "$b.data"}))
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"},
+                                  headers={**FAKE, "X-Treg-Run-Max-Cost": "0.0015"})   # room for one step
+    assert r.status_code == 402, r.text
+    d = r.json()["detail"]
+    assert d["error"] == "hub_run_max_cost" and d["step"] == "b" and d["charged_micro"] == EP_MICRO
+    assert len(fake_provider.hits) - before.hit_count == 1
+    assert await _balance(matrix_clients) - before.balance_micro == -EP_MICRO
+
+
+async def test_the_step_cap_counts_every_item(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "people", "call": EP, "input": {"aweme_id": "x"}},
+               {"name": "each", "call": EP, "for_each": "$people.rows", "as": "p", "input": {"aweme_id": "$p.e"}}],
+        output={"x": "$each[]"}, limits={"steps": 3}))
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 424 and r.json()["detail"]["error"] == "hub_step_cap"
+
+
+async def test_an_own_tool_step_runs_on_the_makers_key_unmetered(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "sb", "value": "MAKER-SB-KEY"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "supabase", "base_url": "https://fake-provider.invalid/sb", "secret_id": sid})
+    m = _manifest(
+        steps=[{"name": "rows", "call": "supabase/rest/v1/leads", "input": {"select": "$input.domain"}}],
+        output={"rows": "$rows"}, uses=["supabase"])
+    tool_id = await _publish(matrix_clients, m)
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "e"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    assert r.json()["trace"][0]["key"] == "team" and r.json()["trace"][0]["cost_micro"] == 0
+    assert r.headers["X-Treg-Cost-Micro"] == "0"
+    hit = fake_provider.hits[-1]
+    assert hit.path == "/sb/rest/v1/leads" and ("select", "e") in hit.query
+    assert hit.headers["authorization"] == "Bearer MAKER-SB-KEY"
+    assert await _balance(matrix_clients) == before.balance_micro
+
+
+async def test_idempotency_key_covers_the_whole_run(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}))
+    h = {**FAKE, "Idempotency-Key": "run-once"}
+    r1 = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=h)
+    r2 = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=h)
+    assert r1.status_code == 200 and r2.status_code == 200
+    assert r2.headers.get("X-Treg-Idempotent-Replay") == "true"
+    assert r2.json()["run_id"] == r1.json()["run_id"]
+    assert len(fake_provider.hits) == 1

--- a/tests/test_db_pool_isolation.py
+++ b/tests/test_db_pool_isolation.py
@@ -42,6 +42,7 @@ EXPECTED_MAKERS: dict[str, set[str]] = {
     "application/call/reserve.py": {API}, "application/call/resolve.py": {API},
     "application/call/route.py": {API}, "application/call/service.py": {API},
     "application/call/settle.py": {API},
+    "application/hub/runner.py": {API},   # a run lives inside the caller's /call/; its record write is part of that request
     "domain/capacity/marks.py": {API}, "domain/capacity/routes_view.py": {API},
     "domain/capacity/view.py": {API},
     # `treg-worker` is its own process; it shares the API pool because nothing else is running in it.

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -227,12 +227,28 @@ async def _publish_live(clients: AsyncClient, name="leads-db") -> str:
     return tool_id
 
 
-async def test_hub_id_answers_501_until_the_runner_exists(clients: AsyncClient, hub_on):
-    tool_id = await _publish_live(clients)
-    r = await clients.get(f"/call/{tool_id}")
+async def test_a_script_tool_answers_501_until_the_script_road_exists(clients: AsyncClient, hub_on):
+    await _own_supabase(clients)
+    tool_id = (await clients.post("/hub/tools", json={
+        "manifest": _script_manifest(), "script": "export default async function run(ctx) { return {rows: [], count: 0}; }",
+        "check": {"inputs": {}, "fields": ["rows"]}, "readme": "x"})).json()["tool_id"]
+    from sqlalchemy import update
+    from treg.infra.db import session_maker
+    from treg.models import HubTool
+    async with session_maker() as s:
+        await s.execute(update(HubTool).where(HubTool.tool_id == tool_id).values(status="live"))
+        await s.commit()
+    r = await clients.post(f"/call/{tool_id}", json={})
     assert r.status_code == 501, r.text
-    assert r.json()["detail"]["error"] == "hub_not_runnable"
-    assert r.json()["detail"]["tool_id"] == tool_id
+    assert r.json()["detail"]["error"] == "hub_not_runnable" and r.json()["detail"]["tool_id"] == tool_id
+    assert r.headers.get("x-treg-error") == "1"
+
+
+async def test_a_steps_tool_refuses_a_missing_required_input_by_name(clients: AsyncClient, hub_on):
+    tool_id = await _publish_live(clients)
+    r = await clients.post(f"/call/{tool_id}", json={})          # `domain` has no default
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"] == {"error": "hub_input_invalid", "field": "domain", "rule": "required (it has no default)"}
     assert r.headers.get("x-treg-error") == "1"
 
 
@@ -266,3 +282,88 @@ async def test_a_catalog_id_is_never_a_hub_tool(clients: AsyncClient, hub_on):
         assert await hub_app.tool_for(s, EP) is None
     r = await clients.get(f"/call/{EP}")
     assert r.status_code != 501
+
+
+
+# ---------------------------------------------------------------------------------------------
+# The reference language and the graph (phase 2), pure
+
+from treg.domain.hub import graph as hub_graph
+from treg.domain.hub import refs
+
+
+def test_refs_parse_every_form_and_nothing_else():
+    assert refs.parse("$input.domain").root == "input"
+    assert refs.parse("$company.data.domain").path == ("data", "domain")
+    assert refs.parse("$news.results[0].title").path == ("results", 0, "title")
+    assert refs.parse("$verify[]").path == (None,)
+    assert refs.parse("$verify.length").path == ("length",)
+    assert refs.parse("$0.data").is_positional
+    for bad in ("company.data", "$", "$Company", "$a.b c", "$a[x]"):
+        with pytest.raises(refs.RefError):
+            refs.parse(bad)
+
+
+def test_refs_read_and_resolve():
+    scope = {"input": {"domain": "figma.com"},
+             "company": {"data": {"name": "Figma", "employee_count": 1200}},
+             "news": {"results": [{"title": "Funding"}, {"title": "Launch"}]},
+             "verify": [{"status": "valid"}, {"status": "invalid"}, None]}
+    pos = {"0": "company"}
+    assert refs.resolve("$company.data.name", scope, pos) == "Figma"
+    assert refs.resolve("$news.results[0].title", scope, pos) == "Funding"
+    assert refs.resolve("$news.results[9].title", scope, pos) is None        # missing is data
+    assert refs.resolve("$verify[]", scope, pos) == scope["verify"]
+    assert refs.resolve("$verify.length", scope, pos) == 3
+    assert refs.resolve("$0.data.employee_count", scope, pos) == 1200
+    assert refs.resolve("$company.data.name: $verify.length leads", scope, pos) == "Figma: 3 leads"
+    assert refs.resolve({"q": "$input.domain funding", "n": 3}, scope, pos) == {"q": "figma.com funding", "n": 3}
+    with pytest.raises(refs.RefError):
+        refs.resolve("$nobody.x", scope, pos)
+
+
+def _g(*steps):
+    return hub_graph.build([{"name": n, "call": "c", "input": i} for n, i in steps])
+
+
+def test_graph_examples_from_the_decisions():
+    # four needs nobody; two needs one; three needs two ⇒ one+four together, then two, then three
+    g = _g(("one", {}), ("two", {"a": "$one.x"}), ("three", {"b": "$two.y"}), ("four", {}))
+    assert g.wave == {"one": 0, "four": 0, "two": 1, "three": 2}
+    # three needs one and two; four needs nobody ⇒ one, two, four together; three after both
+    g = _g(("one", {}), ("two", {}), ("three", {"a": "$one.x", "b": "$two.y"}), ("four", {}))
+    assert g.wave == {"one": 0, "two": 0, "four": 0, "three": 1}
+    assert g.parents["three"] == frozenset({"one", "two"})
+    assert g.positions == {"0": "one", "1": "two", "2": "three", "3": "four"}
+
+
+def test_graph_refuses_cycles_and_unknown_steps():
+    with pytest.raises(ManifestError) as e:
+        _g(("a", {"x": "$b.y"}), ("b", {"x": "$a.y"}))
+    assert "cycle" in e.value.rule
+    with pytest.raises(ManifestError) as e:
+        _g(("a", {"x": "$ghost.y"}))
+    assert "$ghost" in e.value.rule
+    with pytest.raises(ManifestError) as e:
+        _g(("a", {"x": "$a.y"}))
+    assert "itself" in e.value.rule
+
+
+def test_a_cycle_is_refused_at_publish():
+    m = _steps_manifest(steps=[
+        {"name": "people", "call": EP, "input": {"aweme_id": "$rows.body"}},
+        {"name": "rows", "call": "supabase/rest/v1/x", "input": {"q": "$people.data"}},
+    ])
+    err = _refused(m)
+    assert "cycle" in err.rule
+
+
+def test_own_tool_step_takes_a_path_and_a_method():
+    m = _steps_manifest(steps=[
+        {"name": "people", "call": EP, "input": {"aweme_id": "$input.domain"}},
+        {"name": "rows", "call": "supabase/rest/v1/leads", "method": "POST", "input": {"q": "$people.data"}},
+    ])
+    v = validate(m, catalog_ids=CATALOG, own_tools=OWN)
+    assert v.steps[1]["call"] == "supabase/rest/v1/leads" and v.steps[1]["method"] == "POST"
+    err = _refused(_steps_manifest(steps=[{"name": "a", "call": EP + "/extra", "input": {}}]))
+    assert err.field == "steps[0].call" and "takes no path" in err.rule

--- a/tests/test_orgs.py
+++ b/tests/test_orgs.py
@@ -23,7 +23,7 @@ async def test_org_delete_clears_EVERY_org_scoped_table(clients):
     # is not named `org_id`: OAuthGrant.current_org_id (whole-family revocation) and
     # Referral.referred_org_id. A column-name walk missed Referral for as long as referrals existed,
     # so this walks FOREIGN KEYS to `org` instead: any way at all of pointing at a team counts.
-    handled_by_hand = {"OAuthGrant", "Referral"}
+    handled_by_hand = {"OAuthGrant", "Referral", "HubRun"}   # HubRun: caller_org_id, deleted by hand
     missing = []
     for name, obj in vars(m).items():
         if not (inspect.isclass(obj) and issubclass(obj, SQLModel) and obj is not SQLModel):


### PR DESCRIPTION
Phase 2 of the tool hub: the JSON road runs end to end. Reference language + graph derived from it (cycles refused at publish), a runner that starts every ready step four at a time as ordinary execute_calls under child holds, two-team semantics (catalog steps as the caller, own-tool steps on the maker's key), for_each/skip/allow_fail, the run ceiling, the step cap, 424 with the trace, HubRun rows (migration 0027). 53 hub tests incl. 8 four-book end-to-end runs; suite 2877; Postgres 16 verified.

