### PR TITLE
feat(hub): phase 3 - the script road: the sandbox

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -91,6 +91,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/feedback.py` | architecture/feedback.md |
 | `src/treg/application/hub/__init__.py` | architecture/hub.md |
 | `src/treg/application/hub/runner.py` | architecture/hub.md |
+| `src/treg/application/hub/sandbox.py` | architecture/hub.md |
 | `src/treg/application/onboard.py` | interface/api.md |
 | `src/treg/application/onboard/__init__.py` | interface/landing-sandbox.md, interface/onboarding.md |
 | `src/treg/application/onboard/demo.py` | interface/onboarding.md |
@@ -237,6 +238,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/feedback_contract.py` | architecture/feedback.md |
 | `src/treg/fsjail.py` | architecture/local-run.md |
 | `src/treg/health.py` | architecture/auth-secrets.md |
+| `src/treg/hub_sandbox.py` | architecture/hub.md |
 | `src/treg/infra/__init__.py` | architecture/money.md |
 | `src/treg/infra/catalog_observations.py` | architecture/catalog.md |
 | `src/treg/infra/db.py` | architecture/data-model.md, architecture/multi-tenancy.md, ops/deploy.md |
@@ -338,6 +340,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_error_capture.py` | architecture/proxy-model.md |
 | `tests/test_feedback.py` | architecture/feedback.md |
 | `tests/test_hub.py` | architecture/hub.md |
+| `tests/test_hub_sandbox.py` | architecture/hub.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
 | `tests/test_influencersclub_overflow.py` | ops/capacity.md |
 | `tests/test_instagram_oauth_architecture.py` | architecture/instagram-oauth.md |
@@ -369,7 +372,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/contactout.md` | `contactout.yaml`, `adapters.yaml`, `contactout.people.email.verify.json`, `test_routing.py`, `contactout.companies.search.json`, `contactout.companies.enrich.json`, `resolve.py`, `contactout.py`, `contactout.svg`, `test_marketplace_call.py`, `test_key_providers.py`, `test_capacity_collectors.py`, `test_catalog_validate.py`, `test_capacity_overflow.py`, `contactout_overflow_verify.py`, `contactout.json` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `0020_callrecord_created_at_indexes.py`, `0021_ledgerentry_org_created_at_index.py`, `0022_org_spent_today_counter.py`, `0023_callrecord_org_user_created_at_index.py`, `0024_membership_calls_today_counter.py`, `0011_callrecord_archive_link.py`, `0015_idempotentcall_membership_cascade.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `bootstrap_handlers.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
 | `architecture/feedback.md` | `feedback_contract.py`, `feedback.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `feedback.md`, `test_feedback.py` |
-| `architecture/hub.md` | `__init__.py`, `manifest.py`, `refs.py`, `graph.py`, `__init__.py`, `runner.py`, `hub.py`, `0026_hub_tools.py`, `0027_hub_runs.py`, `test_hub.py`, `test_hub_run.py` |
+| `architecture/hub.md` | `__init__.py`, `manifest.py`, `refs.py`, `graph.py`, `__init__.py`, `runner.py`, `sandbox.py`, `hub_sandbox.py`, `hub.py`, `0026_hub_tools.py`, `0027_hub_runs.py`, `test_hub.py`, `test_hub_run.py`, `test_hub_sandbox.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `feedback.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -24,7 +24,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [ContactOut — LinkedIn enrichment, Starter billing and independent credit pools](architecture/contactout.md) | implemented; live connect and core surface verified, informational capacity monitoring | contactout.yaml, adapters.yaml, contactout.people.email.verify.json, test_routing.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Feedback - private intake for problems and suggestions](architecture/feedback.md) | shipped | feedback_contract.py, feedback.py, feedback.py, feedback.py, … |
-| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 2 of 8: the JSON road runs; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
+| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 3 of 8: both roads run; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, __init__.py, __init__.py, … |
 | [Instagram OAuth — direct Login and optional Facebook Page tools](architecture/instagram-oauth.md) | built; Meta configuration and live verification pending | catalog_ingest.py, access.py, resolve.py, service.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |

--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -1,6 +1,6 @@
 ---
 title: The tool hub — tools a maker publishes, made of other tools
-status: in-progress (phase 2 of 8: the JSON road runs; behind TREG_HUB_ENABLED, off)
+status: in-progress (phase 3 of 8: both roads run; behind TREG_HUB_ENABLED, off)
 sources:
   - src/treg/domain/hub/__init__.py
   - src/treg/domain/hub/manifest.py
@@ -8,11 +8,14 @@ sources:
   - src/treg/domain/hub/graph.py
   - src/treg/application/hub/__init__.py
   - src/treg/application/hub/runner.py
+  - src/treg/application/hub/sandbox.py
+  - src/treg/hub_sandbox.py
   - src/treg/routers/hub.py
   - src/treg/alembic/versions/0026_hub_tools.py
   - src/treg/alembic/versions/0027_hub_runs.py
   - tests/test_hub.py
   - tests/callmatrix/test_hub_run.py
+  - tests/test_hub_sandbox.py
 related:
   - architecture/proxy-model.md
   - architecture/money.md
@@ -28,10 +31,9 @@ access rules, key injection and money already exist once per call. The decisions
 request each into `dev/hub`, behind `hub_enabled` (`TREG_HUB_ENABLED`, default off) so no merge
 along the way changes what users see.
 
-**Build state: phase 2 of 8.** A steps recipe runs end to end on the call road; a script recipe
-still answers **501 `hub_not_runnable`** (the sandbox is phase 3). The maker's check run, the
-seller's money and every surface are later phases, and no agent-facing file mentions the hub
-(CLAUDE.md: do not document what is not built).
+**Build state: phase 3 of 8.** Both roads run end to end on the call road: a steps recipe and a
+script in the sandbox. The maker's check run, the seller's money and every surface are later
+phases, and no agent-facing file mentions the hub (CLAUDE.md: do not document what is not built).
 
 ## The manifest (`domain/hub/manifest.py`)
 
@@ -120,3 +122,28 @@ cost_micro, key (treg|team), item`. `Idempotency-Key` covers the whole run throu
 store, exactly like a routed endpoint. `HubRun` (migration 0027) keeps one row per run — status,
 steps, cost, duration, masked inputs, trace, error — for 30 days; in the org cascade by
 `caller_org_id`.
+
+## The script road: the sandbox (`application/hub/sandbox.py`, `treg/hub_sandbox.py`)
+
+A script recipe's `run.js` runs in a separate short-lived process per run: `python -m
+treg.hub_sandbox`, spawned with `runner.py`'s discipline — a scrubbed environment (never the
+server's), a private temporary HOME, its own process group, POSIX rlimits (CPU, file size, no
+core, RLIMIT_AS on Linux), a wall-clock kill, the whole group killed on every exit. Inside, QuickJS
+(the `quickjs` package, server extra; Python 3.12 wheels in production, sdist locally) has no
+network, no file system, no `require`, no `process`, no timers: `typeof fetch` is `undefined`.
+The engine's own heap is capped at 64 MB and its clock at the manifest's `wall_s`; a memory bomb
+ends as `memory`, an endless loop as `timeout`, a thrown error as `script`, each one line the
+maker reads in the run log.
+
+The whole surface a script gets: `ctx.inputs` (coerced by the same rules as the JSON road),
+`ctx.call(target, {method, query, body})` → `{status, headers, json, text}`, and `ctx.log(text)`
+(50 lines × 2 KB). `ctx.call` crosses to the parent as one JSON line over stdin/stdout and is
+run through the same child call the JSON road makes: `uses` enforced per call (a call outside the
+list, a URL, or an unknown catalog id is refused and the run stops), the 20-call cap, the run
+ceiling, `{run}:s{n}` holds, a catalog call as the caller, an own-tool call as the maker. The
+returned object must be JSON under 2 MB and carry every field in `output.fields`, else 424
+`hub_output_invalid`. A failed run is 424 `hub_run_failed` with `{error: hub_script_failed,
+kind, message, trace, log, charged_micro}`; money spent on completed calls stays spent.
+
+Known limit of version one: `ctx.call` is synchronous underneath the engine, so two calls inside
+one `Promise.all` run one after the other; real parallelism is the JSON road's.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ server = [
     "pyyaml>=6",   # the endpoint catalog's data files (src/treg/catalog/*.yaml) — server-side only
     "stripe>=12",  # balance top-ups (src/treg/infra/stripe.py) — the payment rail, server-side only
     "mcp>=2",      # the MCP front door (src/treg/mcp.py) — server-side only; pulls httpx2 ALONGSIDE
+    "quickjs>=1.19.4",  # the hub's script sandbox engine (src/treg/hub_sandbox.py) — server-side only
                    # httpx (they coexist), so the light CLI's dependency set is untouched
 ]
 # The LOCAL PROXY (`treg shell` catching the agent's own outgoing calls). It needs to generate a

--- a/src/treg/application/hub/runner.py
+++ b/src/treg/application/hub/runner.py
@@ -136,10 +136,6 @@ async def run_hub_tool(
     upstream_client: httpx.AsyncClient, execute_child, *, audit_client: str = "",
 ) -> tuple[UpstreamResponse, int]:
     """Execute one run under `parent`. Returns (the JSON reply, total charged to the caller)."""
-    if tool.kind != "steps":
-        raise ResolutionFailed("hub_not_runnable", status_code=501, detail={
-            "error": "hub_not_runnable", "tool_id": tool.tool_id, "version": tool.version,
-            "message": "this hub tool is a script; the script road is not deployed yet"})
     manifest = tool.manifest
     run_id = parent.call_ref
     started = time.monotonic()
@@ -159,10 +155,13 @@ async def run_hub_tool(
         raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
             "error": "hub_input_invalid", "field": exc.field, "rule": exc.rule})
     ceiling = _ceiling(get_header(RUN_MAX_COST_HEADER))
-    g = hub_graph.build(manifest["steps"])
     maker = await _maker_snapshot(parent, tool)
     catalog = catalog_store.load()
     own_tools = {u for u in manifest["uses"] if "." not in u}
+    if tool.kind == "script":
+        return await _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_tools,
+                                      upstream_client, execute_child, started, audit_client)
+    g = hub_graph.build(manifest["steps"])
 
     scope: dict[str, Any] = {"input": inputs}
     trace: list[dict[str, Any]] = []
@@ -356,14 +355,15 @@ def _short(v: Any) -> Any:
     return s[:300]
 
 
-def _child_input(parent: CallContext, call: str, method: str, inp: dict[str, Any], as_who) -> CallInput:
+def _child_input(parent: CallContext, call: str, method: str, inp: dict[str, Any], as_who,
+                 extra_query: dict[str, Any] | None = None) -> CallInput:
     has_body = method in ("POST", "PUT", "PATCH")
     payload = json.dumps(inp, ensure_ascii=False).encode() if has_body else b""
     headers = [(k, v) for k, v in parent.input.raw_headers if k.lower() not in _DROP_FROM_CHILD]
     if has_body:
         headers += [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())]
-    items = tuple() if has_body else tuple(
-        (k, v if isinstance(v, str) else json.dumps(v)) for k, v in inp.items() if v is not None)
+    q = (extra_query or {}) if has_body else inp
+    items = tuple((k, v if isinstance(v, str) else json.dumps(v)) for k, v in q.items() if v is not None)
     return CallInput(method=method, raw_rest=call, raw_headers=tuple(headers), query_items=items,
                      raw_query=urlencode(items), body=_Bytes(payload), caller=as_who,
                      client_ip=parent.input.client_ip, catalog_only=False)
@@ -403,14 +403,15 @@ def _header(response: UpstreamResponse, name: str) -> str | None:
 
 
 async def _record(tool: HubTool, parent: CallContext, run_id: str, status: str, steps: int,
-                  cost: int, ms: int, inputs: dict, trace: list, error: dict | None = None) -> None:
+                  cost: int, ms: int, inputs: dict, trace: list, error: dict | None = None,
+                  log: list | None = None) -> None:
     from datetime import datetime, timezone
     caller = parent.input.caller
     async with session_maker() as s:
         s.add(HubRun(run_id=run_id, tool_id=tool.tool_id, version=tool.version,
                      caller_org_id=caller.org_id, maker_org_id=tool.org_id, caller_email=caller.email,
                      status=status, steps=steps, cost_micro=cost, duration_ms=ms, inputs=inputs,
-                     trace=trace, log=[], error=error,
+                     trace=trace, log=log or [], error=error,
                      finished_at=datetime.now(timezone.utc).replace(tzinfo=None)))
         await s.commit()
 
@@ -435,3 +436,118 @@ def _json(value, status: int, headers: dict[str, str]) -> UpstreamResponse:
     raw = [(b"content-length", str(len(body)).encode()), (b"content-type", b"application/json")]
     raw += [(k.lower().encode("latin-1"), v.encode("latin-1")) for k, v in headers.items()]
     return UpstreamResponse(status, tuple(raw), _one(), _closed)
+
+
+# ---------------------------------------------------------------------------------------------
+# The script road: the same child call, asked for by run.js through the sandbox bridge
+
+async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_tools,
+                           upstream_client, execute_child, started, audit_client):
+    from . import sandbox
+
+    manifest = tool.manifest
+    run_id = parent.call_ref
+    uses = set(manifest["uses"])
+    trace: list[dict[str, Any]] = []
+    log: list[str] = []
+    spent = 0
+    counted = 0
+    fields = manifest["output"]["fields"]
+
+    def estimate_for(call: str) -> int:
+        target = call.split("/", 1)[0]
+        if target in own_tools:
+            return 0
+        ep = catalog.by_id.get(call)
+        cv = catalog.cost_view(ep.get("cost"), ep.get("provider")) if ep else None
+        usd = (cv or {}).get("usd")
+        return int(round(float(usd) * 1_000_000)) if usd else 0
+
+    async def execute(req: sandbox.CallRequest) -> dict[str, Any]:
+        nonlocal spent, counted
+        call = req.target
+        target = call.split("/", 1)[0]
+        if call.startswith("http"):
+            raise sandbox.SandboxError("refused", "a script calls a catalog id or one of the team's tools by name, never a URL")
+        if not (call in uses or (target in own_tools and "/" in call) or target in uses and target in own_tools):
+            raise sandbox.SandboxError("refused", f"{call!r} is not in the manifest's `uses`")
+        if target not in own_tools and call not in catalog.by_id:
+            raise sandbox.SandboxError("refused", f"{call!r} is not a catalog id")
+        if counted + 1 > manifest["limits"]["steps"]:
+            raise sandbox.SandboxError("refused", f"the run would pass its step cap ({manifest['limits']['steps']})")
+        est = estimate_for(call)
+        if spent + est > ceiling:
+            raise sandbox.SandboxError("refused", f"the next call would pass {RUN_MAX_COST_HEADER}")
+        counted += 1
+        n = counted - 1
+        opts = req.opts
+        ep = None if target in own_tools else catalog.by_id.get(call)
+        method = str(opts.get("method") or (ep["method"] if ep else "GET")).upper()
+        query = opts.get("query") if isinstance(opts.get("query"), dict) else {}
+        body = opts.get("body")
+        inp = body if (isinstance(body, dict) and method in ("POST", "PUT", "PATCH")) else query
+        if method in ("POST", "PUT", "PATCH") and not isinstance(inp, dict):
+            inp = {}
+        as_who = maker if target in own_tools else parent.input.caller
+        step = _Step(name=f"call{n + 1}", spec={"call": call}, ref=f"{run_id}:s{n}", wave=n)
+        child = CallContext(input=_child_input(parent, call, method, inp, as_who, extra_query=query if inp is not query else None),
+                            call_ref=step.ref, meta=parent.meta)
+        t0 = time.monotonic()
+        try:
+            response = await execute_child(child, upstream_client)
+        except CallFailure as exc:
+            ms = int((time.monotonic() - t0) * 1000)
+            trace.append(_entry(step, "failed", exc.status_code, ms, 0, key=None, error=_short(exc.detail)))
+            if exc.kind in _GLOBAL_REFUSALS:
+                raise sandbox.SandboxError("refused", f"{exc.kind}: a refusal that applies to every call")
+            return {"status": exc.status_code, "headers": {}, "json": exc.detail if isinstance(exc.detail, dict) else None,
+                    "text": str(exc.detail)[:4000]}
+        raw = await _read(response)
+        ms = int((time.monotonic() - t0) * 1000)
+        charged = int(_header(response, "X-Treg-Cost-Micro") or 0)
+        spent += charged
+        key = "treg" if _header(response, "X-Treg-Cost-Micro") is not None else "team"
+        ok = 200 <= response.status < 300
+        try:
+            doc = json.loads(raw) if raw else None
+        except ValueError:
+            doc = None
+        trace.append(_entry(step, "ok" if ok else "failed", response.status, ms, charged, key=key,
+                            error=None if ok else _short(doc if doc is not None else raw[:300].decode("utf-8", "replace"))))
+        headers = {k.decode("latin-1"): v.decode("latin-1") for k, v in response.raw_headers
+                   if not k.lower().startswith(b"x-treg-")}
+        return {"status": response.status, "headers": headers, "json": doc,
+                "text": raw[:MAX_TEXT].decode("utf-8", "replace")}
+
+    try:
+        output = await sandbox.run_script(tool.script or "", inputs, wall_s=manifest["limits"]["wall_s"],
+                                          execute=execute, log=log)
+    except sandbox.SandboxError as exc:
+        ms_total = int((time.monotonic() - started) * 1000)
+        detail = {"error": "hub_script_failed", "kind": exc.kind, "message": exc.message,
+                  "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}",
+                  "charged_micro": spent, "trace": trace, "log": log}
+        await _record(tool, parent, run_id, "failed", counted, spent, ms_total,
+                      masked(manifest["inputs"], inputs), trace, error=detail, log=log)
+        _audit_parent(parent, tool, 424, spent, audit_client)
+        raise ResolutionFailed("hub_run_failed", status_code=424, detail=detail)
+    missing = [f for f in fields if f not in output]
+    ms_total = int((time.monotonic() - started) * 1000)
+    if missing:
+        detail = {"error": "hub_output_invalid", "missing": missing, "run_id": run_id,
+                  "recipe": f"{tool.tool_id}@{tool.version}", "charged_micro": spent,
+                  "trace": trace, "log": log,
+                  "message": "run(ctx) returned an object without the fields the manifest declares"}
+        await _record(tool, parent, run_id, "failed", counted, spent, ms_total,
+                      masked(manifest["inputs"], inputs), trace, error=detail, log=log)
+        _audit_parent(parent, tool, 424, spent, audit_client)
+        raise ResolutionFailed("hub_run_failed", status_code=424, detail=detail)
+    body_out = {"run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}", "output": output,
+                "usage": {"cost_micro": spent, "steps": counted, "ms": ms_total}, "trace": trace, "log": log}
+    await _record(tool, parent, run_id, "ok", counted, spent, ms_total,
+                  masked(manifest["inputs"], inputs), trace, log=log)
+    _audit_parent(parent, tool, 200, spent, audit_client)
+    return _json(body_out, 200, {"X-Treg-Run-Id": run_id, "X-Treg-Steps": str(counted)}), spent
+
+
+MAX_TEXT = 1_000_000

--- a/src/treg/application/hub/sandbox.py
+++ b/src/treg/application/hub/sandbox.py
@@ -1,0 +1,176 @@
+"""The hub's script sandbox — the PARENT side (docs/HUB-DECISIONS.md round 2).
+
+Spawns `python -m treg.hub_sandbox` as a separate short-lived process with the discipline
+`treg/runner.py` already has for vendor CLIs: a scrubbed environment (never the server's), a
+private temporary HOME, its own process group, POSIX rlimits, a wall-clock kill, and the whole
+group killed on every exit. Inside, QuickJS has no network, no file system, no `require`, no
+`process`; the only road out is `ctx.call`, which arrives here as one JSON line and is run
+through the same step executor the JSON road uses — the same gates, the same key injection, the
+same reserve-and-settle, under `{run}:s{n}`.
+
+What this file enforces that the engine cannot: `uses` (a call to a tool outside the manifest's
+list is refused and the run stops), the 20-call cap, the run ceiling, the output's declared
+fields, and the log caps.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import signal
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+try:
+    import resource
+except ImportError:  # pragma: no cover — Windows
+    resource = None  # type: ignore[assignment]
+
+MEMORY_MB = 64                 # the engine's own heap cap
+PROCESS_RSS_MB = 512           # the whole child process: interpreter + engine + buffers
+MAX_CALLS = 20
+MAX_LOG_LINES = 50
+MAX_LOG_CHARS = 2000
+MAX_OUTPUT_BYTES = 2_000_000
+MAX_LINE_BYTES = 8 * 1024 * 1024   # one bridge line (a step's answer travels here)
+
+
+class SandboxError(Exception):
+    """The run ended without an output: `kind` is script | timeout | memory | stack | output |
+    refused | protocol; `message` is what the maker reads in the run log."""
+
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(f"{kind}: {message}")
+        self.kind, self.message = kind, message
+
+
+@dataclass
+class CallRequest:
+    target: str
+    opts: dict[str, Any]
+
+
+# One ctx.call, executed by the runner. Returns the reply dict the script sees, or raises
+# SandboxError("refused", ...) to stop the run.
+CallExecutor = Callable[[CallRequest], Awaitable[dict[str, Any]]]
+
+
+def _child_env(home: str) -> dict[str, str]:
+    """NOT the server's env (it holds TREG_SECRET_KEY and every other secret): PATH, a private
+    HOME, and what the interpreter needs to find its own packages."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": home, "TMPDIR": home,
+        "LANG": "C.UTF-8", "LC_ALL": "C.UTF-8", "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    for key in ("VIRTUAL_ENV", "PYTHONPATH", "PYTHONHOME"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+    return env
+
+
+def _preexec() -> None:
+    if resource is None:
+        return
+    for res, want in ((resource.RLIMIT_CPU, 130), (resource.RLIMIT_FSIZE, 1_000_000),
+                      (resource.RLIMIT_CORE, 0), (resource.RLIMIT_NOFILE, 32)):
+        try:
+            soft, hard = resource.getrlimit(res)
+            target = want if hard == resource.RLIM_INFINITY else min(want, hard)
+            resource.setrlimit(res, (target, hard))
+        except (ValueError, OSError):
+            pass
+    # RLIMIT_AS is the memory wall for the whole process. Darwin ignores it; Linux (prod) honours it.
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (PROCESS_RSS_MB * 1024 * 1024, PROCESS_RSS_MB * 1024 * 1024))
+    except (ValueError, OSError):
+        pass
+
+
+def _kill_group(pgid: int) -> None:
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+
+
+async def run_script(
+    script: str, inputs: dict[str, Any], *, wall_s: int, execute: CallExecutor,
+    log: list[str],
+) -> dict[str, Any]:
+    """Run one script to its output. `execute` runs each ctx.call; `log` receives the script's
+    lines. Raises SandboxError when the run cannot produce an output."""
+    home = tempfile.mkdtemp(prefix="treg-hub-")
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable, "-m", "treg.hub_sandbox",
+        stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        env=_child_env(home), cwd=home, start_new_session=True, preexec_fn=_preexec,
+        limit=MAX_LINE_BYTES,
+    )
+    pgid = proc.pid
+    assert proc.stdin and proc.stdout and proc.stderr
+    calls = 0
+    try:
+        proc.stdin.write((json.dumps({"op": "run", "script": script, "inputs": inputs,
+                                      "memory_mb": MEMORY_MB, "wall_s": wall_s},
+                                     ensure_ascii=False) + "\n").encode())
+        await proc.stdin.drain()
+        deadline = asyncio.get_running_loop().time() + wall_s + 2
+        while True:
+            left = deadline - asyncio.get_running_loop().time()
+            if left <= 0:
+                raise SandboxError("timeout", f"the run passed its {wall_s} s wall clock")
+            try:
+                line = await asyncio.wait_for(proc.stdout.readline(), timeout=left)
+            except asyncio.TimeoutError:
+                raise SandboxError("timeout", f"the run passed its {wall_s} s wall clock") from None
+            if not line:
+                err = (await proc.stderr.read(4000)).decode("utf-8", "replace").strip()
+                raise SandboxError("script", err[-600:] or "the sandbox exited without an answer")
+            try:
+                msg = json.loads(line)
+            except ValueError:
+                raise SandboxError("protocol", "the sandbox wrote a line that is not JSON") from None
+            op = msg.get("op")
+            if op == "log":
+                if len(log) < MAX_LOG_LINES:
+                    log.append(str(msg.get("text", ""))[:MAX_LOG_CHARS])
+            elif op == "call":
+                calls += 1
+                req = CallRequest(target=str(msg.get("target", "")), opts=dict(msg.get("opts") or {}))
+                if calls > MAX_CALLS:
+                    reply = {"op": "refused", "id": msg["id"],
+                             "error": f"the run passed its cap of {MAX_CALLS} calls"}
+                    proc.stdin.write((json.dumps(reply) + "\n").encode())
+                    await proc.stdin.drain()
+                    raise SandboxError("refused", reply["error"])
+                try:
+                    result = await execute(req)
+                    reply = {"op": "result", "id": msg["id"], **result}
+                except SandboxError as exc:
+                    reply = {"op": "refused", "id": msg["id"], "error": exc.message}
+                    proc.stdin.write((json.dumps(reply, ensure_ascii=False) + "\n").encode())
+                    await proc.stdin.drain()
+                    raise
+                proc.stdin.write((json.dumps(reply, ensure_ascii=False) + "\n").encode())
+                await proc.stdin.drain()
+            elif op == "done":
+                out = msg.get("output")
+                if not isinstance(out, dict):
+                    raise SandboxError("output", "run(ctx) must return one JSON object")
+                return out
+            elif op == "error":
+                raise SandboxError(str(msg.get("kind", "script")), str(msg.get("message", ""))[:600])
+            else:
+                raise SandboxError("protocol", f"unknown message {op!r} from the sandbox")
+    finally:
+        _kill_group(pgid)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except (asyncio.TimeoutError, ProcessLookupError, asyncio.CancelledError):
+            pass
+        shutil.rmtree(home, ignore_errors=True)

--- a/src/treg/hub_sandbox.py
+++ b/src/treg/hub_sandbox.py
@@ -1,0 +1,139 @@
+"""The hub's script sandbox — the CHILD process (docs/HUB-DECISIONS.md round 2).
+
+Runs one maker's `run.js` inside QuickJS, an embedded JavaScript engine with no network, no file
+system, no `require`, no `process`, no timers. The only road out is `ctx.call`, which crosses
+to the parent over stdin/stdout as one JSON line and comes back as one JSON line; the parent runs
+the call through treg's own call path. This file imports nothing from the server: it is spawned
+with a scrubbed environment and must stay that small.
+
+Protocol, JSON lines, one per message:
+  parent → child   {"op": "run", "script": "...", "inputs": {...}, "memory_mb": 64, "wall_s": 120}
+  child  → parent  {"op": "call", "id": 1, "target": "...", "opts": {...}}
+  parent → child   {"op": "result", "id": 1, "status": 200, "headers": {...}, "json": ..., "text": "..."}
+                   {"op": "refused", "id": 1, "error": "..."}      (the script sees a thrown Error)
+  child  → parent  {"op": "log", "text": "..."}
+  child  → parent  {"op": "done", "output": {...}} | {"op": "error", "kind": "...", "message": "..."}
+
+`ctx.call` is synchronous underneath (the engine blocks on the answer), so two calls inside one
+`Promise.all` run one after the other in version one; the JSON road is where real parallelism lives.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+MAX_LOG_LINES = 50
+MAX_LOG_CHARS = 2000
+MAX_OUTPUT_BYTES = 2_000_000
+_EXPORT = re.compile(r"^\s*export\s+default\s+", re.M)
+
+PRELUDE = """
+globalThis.__logs = [];
+globalThis.ctx = {
+  inputs: JSON.parse(__inputs_json),
+  call: async function (target, opts) {
+    const reply = JSON.parse(__bridge_call(JSON.stringify([String(target), opts || {}])));
+    if (reply.op === "refused") { throw new Error(reply.error); }
+    return { status: reply.status, headers: reply.headers, json: reply.json, text: reply.text };
+  },
+  log: function (text) { __bridge_log(String(text)); },
+};
+"""
+
+
+def _emit(msg: dict) -> None:
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def _read() -> dict | None:
+    line = sys.stdin.readline()
+    if not line:
+        return None
+    return json.loads(line)
+
+
+def main() -> int:
+    import quickjs  # the one dependency; server extra
+
+    start = _read()
+    if not start or start.get("op") != "run":
+        _emit({"op": "error", "kind": "protocol", "message": "expected a run message"})
+        return 2
+    script = _EXPORT.sub("globalThis.__run = ", start["script"], count=1)
+    if "globalThis.__run = " not in script:
+        _emit({"op": "error", "kind": "script", "message": "run.js must `export default async function run(ctx)`"})
+        return 2
+
+    ctx = quickjs.Context()
+    ctx.set_memory_limit(int(start.get("memory_mb", 64)) * 1024 * 1024)
+    # No engine time limit: quickjs refuses to call into Python (the bridge) while one is set.
+    # The wall clock is the PARENT's: it kills this whole process group at `wall_s`, and the
+    # CPU rlimit is the belt under that. An endless loop therefore ends as `timeout` upstairs.
+    ctx.set_max_stack_size(1024 * 1024)
+    call_id = 0
+    logs = 0
+
+    def bridge_call(packed: str) -> str:
+        nonlocal call_id
+        call_id += 1
+        target, opts = json.loads(packed)
+        _emit({"op": "call", "id": call_id, "target": target, "opts": opts})
+        reply = _read()
+        if reply is None:
+            reply = {"op": "refused", "id": call_id, "error": "the runner went away"}
+        return json.dumps(reply, ensure_ascii=False)
+
+    def bridge_log(text: str) -> None:
+        nonlocal logs
+        if logs < MAX_LOG_LINES:
+            logs += 1
+            _emit({"op": "log", "text": text[:MAX_LOG_CHARS]})
+
+    ctx.add_callable("__bridge_call", bridge_call)
+    ctx.add_callable("__bridge_log", bridge_log)
+    ctx.set("__inputs_json", json.dumps(start.get("inputs", {}), ensure_ascii=False))
+    try:
+        ctx.eval(PRELUDE)
+        ctx.eval(script)
+        ctx.eval("""
+globalThis.__state = "pending"; globalThis.__out = null; globalThis.__err = null;
+Promise.resolve().then(() => globalThis.__run(globalThis.ctx))
+  .then(v => { globalThis.__out = JSON.stringify(v === undefined ? null : v); globalThis.__state = "done"; })
+  .catch(e => { globalThis.__err = (e === null || e === undefined) ? "InternalError: out of memory"
+                                   : (e && e.message !== undefined ? (e.name + ": " + e.message) : String(e))
+                                   + (e && e.stack ? "\\n" + e.stack : ""); globalThis.__state = "error"; });
+""")
+        # Drain the job queue until the promise settles. Every ctx.call runs INSIDE a job, so this
+        # loop is also where the bridge round-trips happen.
+        while ctx.eval("globalThis.__state") == "pending":
+            if not ctx.execute_pending_job():
+                break
+        state = ctx.eval("globalThis.__state")
+    except Exception as exc:  # noqa: BLE001 — every engine failure becomes one honest message
+        text = str(exc)
+        kind = ("memory" if "out of memory" in text else "timeout" if "interrupted" in text
+                else "stack" if "stack overflow" in text else "script")
+        _emit({"op": "error", "kind": kind, "message": text[:600]})
+        return 1
+    if state == "error":
+        text = str(ctx.eval("globalThis.__err"))
+        kind = ("memory" if "out of memory" in text else "timeout" if "interrupted" in text
+                else "stack" if "stack overflow" in text else "script")
+        _emit({"op": "error", "kind": kind, "message": text[:600]})
+        return 1
+    if state != "done":
+        _emit({"op": "error", "kind": "script", "message": "run(ctx) never settled (an await that waits on nothing)"})
+        return 1
+    out = ctx.eval("globalThis.__out")
+    if out is None or len(out.encode("utf-8")) > MAX_OUTPUT_BYTES:
+        _emit({"op": "error", "kind": "output", "message": f"the returned object must be JSON under {MAX_OUTPUT_BYTES} bytes"})
+        return 1
+    _emit({"op": "done", "output": json.loads(out)})
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/callmatrix/test_hub_run.py
+++ b/tests/callmatrix/test_hub_run.py
@@ -214,3 +214,99 @@ async def test_idempotency_key_covers_the_whole_run(
     assert r2.headers.get("X-Treg-Idempotent-Replay") == "true"
     assert r2.json()["run_id"] == r1.json()["run_id"]
     assert len(fake_provider.hits) == 1
+
+
+# ---------------------------------------------------------------------------------------------
+# The script road on the real call path (phase 3)
+
+SCRIPT = """
+export default async function run(ctx) {
+  const c = await ctx.call("%s", { query: { aweme_id: ctx.inputs.domain } });
+  ctx.log("company status " + c.status);
+  const rows = await ctx.call("supabase/rest/v1/leads", { query: { select: c.json.data.domain } });
+  return { name: c.json.data.domain, rows: rows.json.rows.length, cost_seen: c.status };
+}
+""" % EP
+
+
+async def _publish_script(clients: AsyncClient, script: str, uses, fields) -> str:
+    r = await clients.post("/hub/tools", json={
+        "manifest": {"name": "scripted", "summary": "A scripted flow.", "uses": uses,
+                     "inputs": {"domain": {"type": "string", "example": "figma.com"}},
+                     "script": "run.js", "output": {"fields": fields}},
+        "script": script,
+        "check": {"inputs": {"domain": "figma.com"}, "fields": fields}, "readme": "test"})
+    assert r.status_code == 201, r.text
+    tool_id = r.json()["tool_id"]
+    from sqlalchemy import update
+    from treg.infra.db import session_maker
+    from treg.models import HubTool
+    async with session_maker() as s:
+        await s.execute(update(HubTool).where(HubTool.tool_id == tool_id).values(status="live"))
+        await s.commit()
+    return tool_id
+
+
+async def test_a_script_runs_a_catalog_call_and_an_own_tool_call(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "sb", "value": "MAKER-SB-KEY"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "supabase", "base_url": "https://fake-provider.invalid/sb", "secret_id": sid})
+    tool_id = await _publish_script(matrix_clients, SCRIPT, [EP, "supabase"], ["name", "rows", "cost_seen"])
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["output"] == {"name": "figma.com", "rows": 3, "cost_seen": 200}
+    assert body["log"] == ["company status 200"]
+    assert body["usage"]["steps"] == 2 and body["usage"]["cost_micro"] == EP_MICRO
+    assert [(e["call"], e["key"], e["cost_micro"]) for e in body["trace"]] == [(EP, "treg", EP_MICRO), ("supabase/rest/v1/leads", "team", 0)]
+    assert r.headers["X-Treg-Cost-Micro"] == str(EP_MICRO)
+    hits = fake_provider.hits[before.hit_count:]
+    assert len(hits) == 2
+    assert hits[1].path == "/sb/rest/v1/leads" and ("select", "figma.com") in hits[1].query
+    assert hits[1].headers["authorization"] == "Bearer MAKER-SB-KEY"
+    assert await _balance(matrix_clients) - before.balance_micro == -EP_MICRO
+
+
+async def test_a_script_call_outside_uses_is_refused_and_the_run_stops(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish_script(matrix_clients, """
+export default async function run(ctx) {
+  await ctx.call("hunter.people.email.find", { query: { domain: "x" } });
+  return { ok: true };
+}""", [EP], ["ok"])
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 424, r.text
+    d = r.json()["detail"]
+    assert d["error"] == "hub_script_failed" and d["kind"] == "refused" and "uses" in d["message"]
+    assert len(fake_provider.hits) - before.hit_count == 0
+    assert await _balance(matrix_clients) == before.balance_micro
+
+
+async def test_a_script_missing_a_declared_output_field_is_refused(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish_script(matrix_clients,
+        "export default async function run(ctx) { return { name: 'x' }; }", [EP], ["name", "rows"])
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 424 and r.json()["detail"]["error"] == "hub_output_invalid"
+    assert r.json()["detail"]["missing"] == ["rows"]
+
+
+async def test_a_script_failure_keeps_the_money_of_calls_that_completed(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish_script(matrix_clients, """
+export default async function run(ctx) {
+  await ctx.call("%s", { query: { aweme_id: "x" } });
+  throw new Error("after paying");
+}""" % EP, [EP], ["ok"])
+    before = await snapshot(matrix_clients, fake_provider)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 424
+    d = r.json()["detail"]
+    assert d["kind"] == "script" and "after paying" in d["message"] and d["charged_micro"] == EP_MICRO
+    assert await _balance(matrix_clients) - before.balance_micro == -EP_MICRO

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -227,10 +227,10 @@ async def _publish_live(clients: AsyncClient, name="leads-db") -> str:
     return tool_id
 
 
-async def test_a_script_tool_answers_501_until_the_script_road_exists(clients: AsyncClient, hub_on):
+async def test_a_script_tool_runs_in_the_sandbox(clients: AsyncClient, hub_on):
     await _own_supabase(clients)
     tool_id = (await clients.post("/hub/tools", json={
-        "manifest": _script_manifest(), "script": "export default async function run(ctx) { return {rows: [], count: 0}; }",
+        "manifest": _script_manifest(), "script": "export default async function run(ctx) { return {rows: [ctx.inputs.search], count: ctx.inputs.limit}; }",
         "check": {"inputs": {}, "fields": ["rows"]}, "readme": "x"})).json()["tool_id"]
     from sqlalchemy import update
     from treg.infra.db import session_maker
@@ -238,10 +238,10 @@ async def test_a_script_tool_answers_501_until_the_script_road_exists(clients: A
     async with session_maker() as s:
         await s.execute(update(HubTool).where(HubTool.tool_id == tool_id).values(status="live"))
         await s.commit()
-    r = await clients.post(f"/call/{tool_id}", json={})
-    assert r.status_code == 501, r.text
-    assert r.json()["detail"]["error"] == "hub_not_runnable" and r.json()["detail"]["tool_id"] == tool_id
-    assert r.headers.get("x-treg-error") == "1"
+    r = await clients.post(f"/call/{tool_id}", json={"search": "figma", "limit": 500})   # limit clamps to max 100
+    assert r.status_code == 200, r.text
+    assert r.json()["output"] == {"rows": ["figma"], "count": 100}
+    assert r.headers["X-Treg-Steps"] == "0" and r.headers["X-Treg-Cost-Micro"] == "0"
 
 
 async def test_a_steps_tool_refuses_a_missing_required_input_by_name(clients: AsyncClient, hub_on):

--- a/tests/test_hub_sandbox.py
+++ b/tests/test_hub_sandbox.py
@@ -1,0 +1,135 @@
+"""The hub's script sandbox, hostile suite: what a script cannot do, and how the run ends when it
+tries. Runs the real child process (`python -m treg.hub_sandbox`) with a fake call executor —
+no treg call path here; that is tests/callmatrix/test_hub_run.py."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from treg.application.hub import sandbox
+from treg.application.hub.sandbox import SandboxError, run_script
+
+
+async def _echo(req: sandbox.CallRequest) -> dict:
+    return {"status": 200, "headers": {"content-type": "application/json"},
+            "json": {"target": req.target, "opts": req.opts}, "text": ""}
+
+
+async def _run(script: str, inputs=None, *, execute=_echo, wall_s: int = 10) -> tuple[dict, list[str]]:
+    log: list[str] = []
+    out = await run_script(script, inputs or {}, wall_s=wall_s, execute=execute, log=log)
+    return out, log
+
+
+async def test_a_script_returns_its_object_and_reads_inputs():
+    out, log = await _run("""
+export default async function run(ctx) {
+  ctx.log("hello " + ctx.inputs.name);
+  return { greeting: "hi " + ctx.inputs.name, n: ctx.inputs.n + 1 };
+}""", {"name": "mitchel", "n": 41})
+    assert out == {"greeting": "hi mitchel", "n": 42}
+    assert log == ["hello mitchel"]
+
+
+async def test_ctx_call_crosses_the_bridge_and_comes_back():
+    out, _ = await _run("""
+export default async function run(ctx) {
+  const a = await ctx.call("supabase/rest/v1/leads", { query: { select: "email" } });
+  const b = await ctx.call("hunter.people.email.find", { method: "POST", body: { domain: "x.com" } });
+  return { a: a.json.target, aq: a.json.opts.query.select, b: b.json.opts.body.domain, status: a.status };
+}""")
+    assert out == {"a": "supabase/rest/v1/leads", "aq": "email", "b": "x.com", "status": 200}
+
+
+@pytest.mark.parametrize("expr", ["fetch", "require", "process", "setTimeout", "XMLHttpRequest", "WebSocket", "os"])
+async def test_no_road_out_but_ctx_call(expr):
+    out, _ = await _run(f"export default async function run(ctx) {{ return {{ t: typeof {expr} }}; }}")
+    assert out == {"t": "undefined"}
+
+
+async def test_a_refused_call_stops_the_run():
+    async def refuse(req):
+        raise SandboxError("refused", f"{req.target!r} is not in the manifest's `uses`")
+    with pytest.raises(SandboxError) as e:
+        await _run("""
+export default async function run(ctx) {
+  try { await ctx.call("evil.tool"); } catch (err) { /* the script cannot swallow a refusal */ }
+  return { reached: true };
+}""", execute=refuse)
+    assert e.value.kind == "refused" and "evil.tool" in e.value.message
+
+
+async def test_a_memory_bomb_dies_inside_the_cap():
+    with pytest.raises(SandboxError) as e:
+        await _run("""
+export default async function run(ctx) {
+  const a = []; while (true) { a.push("x".repeat(1000000)); }
+}""")
+    assert e.value.kind == "memory"
+
+
+async def test_an_endless_loop_dies_at_the_wall():
+    with pytest.raises(SandboxError) as e:
+        await _run("export default async function run(ctx) { while (true) {} }", wall_s=2)
+    assert e.value.kind == "timeout"
+
+
+async def test_a_thrown_error_is_reported_as_a_script_failure():
+    with pytest.raises(SandboxError) as e:
+        await _run("export default async function run(ctx) { throw new Error('boom'); }")
+    assert e.value.kind == "script" and "boom" in e.value.message
+
+
+async def test_a_script_without_the_export_is_refused():
+    with pytest.raises(SandboxError) as e:
+        await _run("function run(ctx) { return {}; }")
+    assert e.value.kind == "script" and "export default" in e.value.message
+
+
+async def test_a_non_object_return_is_refused():
+    with pytest.raises(SandboxError) as e:
+        await _run("export default async function run(ctx) { return [1, 2]; }")
+    assert e.value.kind == "output"
+
+
+async def test_the_log_is_capped_at_fifty_lines():
+    _, log = await _run("""
+export default async function run(ctx) {
+  for (let i = 0; i < 80; i++) ctx.log("line " + i + " " + "y".repeat(5000));
+  return { ok: true };
+}""")
+    assert len(log) == 50 and all(len(line) <= 2000 for line in log)
+
+
+async def test_the_call_cap_is_enforced_by_the_parent():
+    calls = 0
+
+    async def count(req):
+        nonlocal calls
+        calls += 1
+        return await _echo(req)
+    with pytest.raises(SandboxError) as e:
+        await _run("""
+export default async function run(ctx) {
+  for (let i = 0; i < 30; i++) await ctx.call("hunter.people.email.find");
+  return { ok: true };
+}""", execute=count)
+    assert e.value.kind == "refused" and "cap of 20" in e.value.message
+    assert calls == 20
+
+
+async def test_the_child_sees_no_server_environment(monkeypatch):
+    monkeypatch.setenv("TREG_SECRET_KEY", "must-not-leak")
+    # the engine has no env API at all; prove the process env is scrubbed by the parent's builder
+    env = sandbox._child_env("/tmp/x")
+    assert "TREG_SECRET_KEY" not in env and env["HOME"] == "/tmp/x"
+
+
+async def test_two_runs_in_parallel_do_not_mix():
+    a, b = await asyncio.gather(
+        _run("export default async function run(ctx) { return { who: ctx.inputs.who }; }", {"who": "a"}),
+        _run("export default async function run(ctx) { return { who: ctx.inputs.who }; }", {"who": "b"}),
+    )
+    assert a[0] == {"who": "a"} and b[0] == {"who": "b"}

--- a/uv.lock
+++ b/uv.lock
@@ -853,6 +853,18 @@ wheels = [
 ]
 
 [[package]]
+name = "quickjs"
+version = "1.19.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a7/8fac2e213db8108d8108e9f1ee8d6c2abfcbe943238b0960585c26666862/quickjs-1.19.4.tar.gz", hash = "sha256:1205953abc24ff757f4a795304d5d61e4bf1e555c9ef6ec96a132d4b95535484", size = 456179 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/4f/df90bde103703cd052fd76ad7bddfcb9a4f908ab6c940ad05fdb3997e173/quickjs-1.19.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1bc38a840144a54e90668fb1f99441148429ab1d1b1355ecafbbe656eaeff788", size = 1004472 },
+    { url = "https://files.pythonhosted.org/packages/26/59/1689a6f59f26d8f68c082dc6dfbbb38d9b7eaa3e243a775f8be2c876b561/quickjs-1.19.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:45d0e68570425d8322c48fb8989865df9b8c3e3ad3a01726151e0451d3c637eb", size = 2179639 },
+    { url = "https://files.pythonhosted.org/packages/f5/cd/8fd683236b976487bbd4c99e24334b25fc0542367164f2348bca08572490/quickjs-1.19.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac4b6d40b90553e9b135b35b3eaca264d10cdf92bfafce36ed9fb9acfdc5b420", size = 2173664 },
+    { url = "https://files.pythonhosted.org/packages/be/10/58064fe6beeb72c122f2ecb4729cf437055d89891d29cc2cd20ed88c1d66/quickjs-1.19.4-cp312-cp312-win_amd64.whl", hash = "sha256:3ebe018eaef1957a21264b98877c6217d7bfc4e28cbc5d87e75f879e1f45fc85", size = 382359 },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1037,6 +1049,7 @@ server = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "mcp" },
+    { name = "quickjs" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -1066,6 +1079,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'server'", specifier = ">=2" },
+    { name = "quickjs", marker = "extra == 'server'", specifier = ">=1.19.4" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.5" },
     { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6" },
     { name = "questionary", specifier = ">=2.0" },


### PR DESCRIPTION
Phase 3 of the tool hub: the script road. QuickJS in a separate short-lived process (scrubbed env, own group, rlimits, wall-clock kill), a JSON-lines bridge, ctx.call through the same step executor as the JSON road (uses enforced per call, caps, ceiling, caller/maker semantics), output checked against declared fields. 13 hostile sandbox tests + 4 end-to-end script runs; suite 2900; Postgres 16 verified. quickjs hand-added to the server extra and uv.lock.

