### PR TITLE
feat(hub): phase 5 - the case study, walked by hand

### DIFF
--- a/docs/HUB-DECISIONS.md
+++ b/docs/HUB-DECISIONS.md
@@ -282,7 +282,7 @@ caller sent, with `secret` inputs masked.
 
 ## The backlog, in the order it was named
 
-1. Templates for more data providers (the data tool as a template system).
+1. Templates for more data providers (the data tool as a template system), including `treg hub init --from <template>` (owner, 2026-09-09).
 2. Withdrawal of earned credit as cash.
 3. The listing road: pull request, verification, the three catalog states in search.
 4. A private-to-my-team switch on a hub tool.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -24,7 +24,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [ContactOut — LinkedIn enrichment, Starter billing and independent credit pools](architecture/contactout.md) | implemented; live connect and core surface verified, informational capacity monitoring | contactout.yaml, adapters.yaml, contactout.people.email.verify.json, test_routing.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Feedback - private intake for problems and suggestions](architecture/feedback.md) | shipped | feedback_contract.py, feedback.py, feedback.py, feedback.py, … |
-| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 4 of 8: the maker's road; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
+| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 5 of 8: the case study ran end to end; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, __init__.py, __init__.py, … |
 | [Instagram OAuth — direct Login and optional Facebook Page tools](architecture/instagram-oauth.md) | built; Meta configuration and live verification pending | catalog_ingest.py, access.py, resolve.py, service.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |

--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -1,6 +1,6 @@
 ---
 title: The tool hub — tools a maker publishes, made of other tools
-status: in-progress (phase 4 of 8: the maker's road; behind TREG_HUB_ENABLED, off)
+status: in-progress (phase 5 of 8: the case study ran end to end; behind TREG_HUB_ENABLED, off)
 sources:
   - src/treg/domain/hub/__init__.py
   - src/treg/domain/hub/manifest.py
@@ -173,3 +173,31 @@ kind, message, trace, log, charged_micro}`; money spent on completed calls stays
 
 Known limit of version one: `ctx.call` is synchronous underneath the engine, so two calls inside
 one `Promise.all` run one after the other; real parallelism is the JSON road's.
+
+## The case study (phase 5, 2026-09-09) and what it taught
+
+The owner and the assistant walked the maker's road by hand against a real Supabase table
+(2,592 SEO rank-tracking rows in schema `hubdemo` of the owner's `krew-saas` project), on a
+local server with the flag on: `treg hub init` (neutral skeleton) → the four files written
+together → a run with no tool registered (refused: `uses[0]`, the rule, the two fix commands) →
+`treg secret add` + `treg tool add supabase` with two bindings (`Authorization: Bearer` and
+`apikey`) → `treg hub run .` → `treg hub publish .` (check passed, 0 µ$: the only step ran on the
+maker's own key) → a second team called `unclecode-superdesign-dev.keyword-rankings` and got rows,
+the maker's key served the step, and neither the Supabase URL nor any key material appeared in
+the reply or headers.
+
+Two runner rules came out of it:
+
+- **A step is never answered compressed.** The runner reads every step's bytes itself (a script
+  gets `json` and `text`), so the caller's `Accept-Encoding` is dropped from every child call and
+  `identity` is asked instead. Found live: a 20-row Supabase answer came back gzip (Cloudflare
+  compresses bigger bodies) and the script saw an empty list, while a 2-row answer was fine.
+- **A script may set headers on `ctx.call`** (`Accept-Profile` for a PostgREST schema, a vendor's
+  `Accept`), minus the ones that carry identity or framing: `authorization`, `cookie`, `apikey`,
+  `host`, `content-length`, `x-treg-*` are treg's and are dropped; the tool's binding always wins.
+
+Also from the walk: `init` writes a vendor-neutral skeleton (`my-api`, a `query` input, comments
+that say what to replace); the hub commands print in the house style (numbered section bars,
+ticks, a trace table, refusals as a "✗ Refused" block with field, rule and the fix command);
+`treg hub init --from <template>` is backlog (templates for data providers); `treg hub retire`
+is phase 7.

--- a/src/treg/application/hub/runner.py
+++ b/src/treg/application/hub/runner.py
@@ -36,7 +36,13 @@ RUN_MAX_COST_HEADER = "X-Treg-Run-Max-Cost"
 DEFAULT_RUN_MAX_COST_MICRO = 1_000_000      # $1.00 for the whole run, seller price included later
 MAX_PARALLEL = 4                            # steps in flight at once inside one run
 _DROP_FROM_CHILD = frozenset({b"content-length", b"content-type", b"transfer-encoding",
-                              b"idempotency-key", b"x-treg-run-max-cost", b"host"})
+                              b"idempotency-key", b"x-treg-run-max-cost", b"host",
+                              # The RUNNER reads every step's bytes itself (a script gets `json`
+                              # and `text`), so a step must never be answered compressed: the
+                              # caller's accept-encoding is dropped and identity is asked below.
+                              # Found live 2026-09-09: a 20-row Supabase answer came back gzip
+                              # and the script saw an empty list; a 2-row one was fine.
+                              b"accept-encoding"})
 # Refusals that are the same for every step: no point starting anything else.
 _GLOBAL_REFUSALS = frozenset({"insufficient_balance", "tag_spend_cap_reached",
                               "platform_daily_cap_reached", "daily_cap_reached"})
@@ -355,11 +361,20 @@ def _short(v: Any) -> Any:
     return s[:300]
 
 
+_SCRIPT_HEADER_DENY = frozenset({"authorization", "cookie", "host", "content-length", "transfer-encoding",
+                                 "connection", "idempotency-key", "apikey"})
+
+
 def _child_input(parent: CallContext, call: str, method: str, inp: dict[str, Any], as_who,
-                 extra_query: dict[str, Any] | None = None) -> CallInput:
+                 extra_query: dict[str, Any] | None = None,
+                 extra_headers: dict[str, str] | None = None) -> CallInput:
     has_body = method in ("POST", "PUT", "PATCH")
     payload = json.dumps(inp, ensure_ascii=False).encode() if has_body else b""
-    headers = [(k, v) for k, v in parent.input.raw_headers if k.lower() not in _DROP_FROM_CHILD]
+    drop = set(_DROP_FROM_CHILD) | {k.lower().encode("latin-1") for k in (extra_headers or {})}
+    headers = [(k, v) for k, v in parent.input.raw_headers if k.lower() not in drop]
+    headers += [(k.lower().encode("latin-1"), v.encode("latin-1", "replace")) for k, v in (extra_headers or {}).items()
+                if k.lower() != "accept-encoding"]
+    headers.append((b"accept-encoding", b"identity"))
     if has_body:
         headers += [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())]
     q = (extra_query or {}) if has_body else inp
@@ -490,7 +505,14 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
             inp = {}
         as_who = maker if target in own_tools else parent.input.caller
         step = _Step(name=f"call{n + 1}", spec={"call": call}, ref=f"{run_id}:s{n}", wave=n)
-        child = CallContext(input=_child_input(parent, call, method, inp, as_who, extra_query=query if inp is not query else None),
+        # Headers a script sets on ctx.call ride to the upstream (a PostgREST `Accept-Profile`, a
+        # vendor's `Accept`), minus the ones that carry identity or framing: those are treg's.
+        raw_headers = opts.get("headers") if isinstance(opts.get("headers"), dict) else {}
+        extra_headers = {str(k): str(v) for k, v in raw_headers.items()
+                         if str(k).lower() not in _SCRIPT_HEADER_DENY and not str(k).lower().startswith("x-treg-")}
+        child = CallContext(input=_child_input(parent, call, method, inp, as_who,
+                                               extra_query=query if inp is not query else None,
+                                               extra_headers=extra_headers),
                             call_ref=step.ref, meta=parent.meta)
         t0 = time.monotonic()
         try:

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -5008,35 +5008,40 @@ HUB_FILES = ("recipe.json", "run.js", "check.json", "README.md")
 _HUB_STEPS_SKELETON = {
     "name": None,
     "summary": "One sentence an agent reads first: what this tool returns.",
-    "inputs": {"domain": {"type": "string", "example": "figma.com"},
+    "inputs": {"query": {"type": "string", "example": "example query"},
                "limit": {"type": "int", "default": 10, "max": 100}},
-    "uses": ["hunter.people.email.find"],
-    "steps": [{"name": "people", "call": "hunter.people.email.find",
-               "input": {"domain": "$input.domain", "limit": "$input.limit"}}],
-    "output": {"people": "$people.data"},
+    "uses": ["my-api"],
+    "steps": [{"name": "fetch", "call": "my-api/v1/items",
+               "input": {"q": "$input.query", "limit": "$input.limit"}}],
+    "output": {"items": "$fetch"},
     "price_usd": 0,
 }
 _HUB_SCRIPT_SKELETON = {
     "name": None,
     "summary": "One sentence an agent reads first: what this tool returns.",
-    "inputs": {"search": {"type": "string", "default": ""},
+    "inputs": {"query": {"type": "string", "default": ""},
                "limit": {"type": "int", "default": 20, "max": 100}},
-    "uses": ["supabase"],
+    "uses": ["my-api"],
     "script": "run.js",
-    "output": {"fields": ["rows", "count"]},
+    "output": {"fields": ["items", "count"]},
     "price_usd": 0,
 }
-_HUB_RUN_JS = """// The whole surface a script gets: ctx.inputs, ctx.call(target, {method, query, body}), ctx.log(text).
+_HUB_RUN_JS = """// The whole surface a script gets:
+//   ctx.inputs                                  the caller's inputs, checked against recipe.json
+//   ctx.call(target, {method, query, body, headers})   one treg call -> {status, headers, json, text}
+//   ctx.log(text)                               one line the maker reads in the run log
 // No network, no files, no require: every road out is ctx.call. Never paste a key here - register
-// it first (treg secret add / treg tool add) and name the tool in `uses`.
+// it first (treg secret add / treg tool add), list the tool in `uses`, and name it in ctx.call.
+//
+// `target` is a catalog id (treg catalog search) or one of your team's tools as "<tool>/<path>".
+// Replace `my-api` below with the name from `treg tool ls`.
 export default async function run(ctx) {
-  const { search, limit } = ctx.inputs;
-  const r = await ctx.call("supabase/rest/v1/leads", {
-    query: { select: "*", limit: String(limit), ...(search ? { email: `ilike.*${search}*` } : {}) },
-  });
-  ctx.log(`${r.status} from supabase`);
-  const rows = Array.isArray(r.json) ? r.json : [];
-  return { rows, count: rows.length };
+  const { query, limit } = ctx.inputs;
+  const r = await ctx.call("my-api/v1/items", { query: { q: query, limit: String(limit) } });
+  if (r.status !== 200) throw new Error("my-api answered " + r.status);
+  const items = Array.isArray(r.json) ? r.json : [];
+  ctx.log(items.length + " items");
+  return { items, count: items.length };
 }
 """
 _HUB_README = """# {name}
@@ -5062,25 +5067,74 @@ def _hub_read_folder(path: str) -> dict:
     return body
 
 
+def _hub_refusal(payload: dict, status: int) -> None:
+    """One refusal, the house way: what was refused, the field and the rule, and the command that fixes it."""
+    d = payload.get("detail", payload) if isinstance(payload, dict) else payload
+    _section("✗ Refused")
+    if isinstance(d, dict) and d.get("error") == "manifest_invalid":
+        _kv("field", f"{_B}{d['field']}{_R}")
+        _kv("rule", d["rule"])
+        rule = str(d.get("rule", ""))
+        if "register it first" in rule or "not one of your team's tools" in rule:
+            _arrow("treg secret add <NAME> --value <key>     then  treg tool add <name> --base-url <url> --secret <NAME>")
+        elif "not a catalog id" in rule:
+            _arrow("treg catalog search \"<what you want to do>\"  finds the id")
+    elif isinstance(d, dict) and d.get("error") == "hub_busy":
+        _kv("error", f"{d['active']} of {d['max']} runs in flight for your team")
+        _arrow(f"try again in {d.get('retry_after_s', 5)} s")
+    elif isinstance(d, dict):
+        _kv("status", str(status))
+        for k in ("error", "message", "step", "kind", "field", "rule"):
+            if d.get(k):
+                _kv(k, str(d[k])[:300])
+        for e in d.get("trace", [])[-3:]:
+            if e.get("error"):
+                _kv("step", f"{e['name']} → {e['call']}: {str(e['error'])[:400]}")
+    else:
+        _kv("status", str(status)); _kv("detail", str(d)[:400])
+
+
+def _hub_trace(out: dict) -> None:
+    u = out.get("usage", {})
+    _section("③ What ran")
+    print(f"  {_M}{'WAVE':<5}{'STEP':<14}{'CALL':<42}{'RESULT':<9}{'STATUS':<7}{'COST µ$':>8}  {'MS':>6}{_R}")
+    for e in out.get("trace", []):
+        colour = _G if e["outcome"] == "ok" else _M if e["outcome"] == "skipped" else _AM
+        name = e["name"] + (f"[{e['item']}]" if e.get("item") is not None else "")
+        print(f"  {e['wave']:<5}{name:<14}{e['call'][:41]:<42}{colour}{e['outcome']:<9}{_R}{str(e.get('status') or ''):<7}{e['cost_micro']:>8}  {e['ms']:>6}")
+    for line in out.get("log", []):
+        _dim(f"  log  {line}")
+    _kv("run", str(out.get("run_id")))
+    _kv("steps", f"{u.get('steps')}   cost {u.get('cost_micro')} µ$ (${(u.get('cost_micro') or 0) / 1e6:.4f})   {u.get('ms')} ms")
+
+
 def _hub_report(r, *, json_out: bool) -> None:
     payload = r.json() if r.headers.get("content-type", "").startswith("application/json") else {"text": r.text}
     if json_out:
         print(json.dumps(payload, indent=2))
     elif r.status_code in (200, 201):
-        print(f"{payload.get('tool_id')}@{payload.get('version')}  {payload.get('status')}")
-        if payload.get("call"):
-            print(f"  call it:  {payload['call']}")
         chk = payload.get("check") or {}
-        if chk.get("error"):
-            print(f"  check failed: {json.dumps(chk['error'])[:400]}")
-        elif chk:
-            print(f"  check passed  run {chk.get('run_id')}  charged {chk.get('charged_micro', 0)} micro-USD")
+        live = payload.get("status") == "live"
+        _section("✓ Published" if live else "Published, but the check failed")
+        _kv("tool", f"{_B}{payload.get('tool_id')}{_R}  version {payload.get('version')}  {_G if live else _AM}{payload.get('status')}{_R}")
+        if chk:
+            if chk.get("status") == "passed":
+                _ok(f"check passed   run {chk.get('run_id')}   charged {chk.get('charged_micro', 0)} µ$ to your balance")
+            else:
+                err = chk.get("error") or {}
+                _kv("check", f"{_AM}failed{_R}  {err.get('error', '')}  {err.get('message', '')}".strip())
+                for k in ("step", "status", "missing", "hint"):
+                    if err.get(k) is not None:
+                        _kv(k, str(err[k]))
+                for e in (chk.get("trace") or err.get("trace") or [])[-3:]:
+                    if e.get("error"):
+                        _kv("step", f"{e['name']} → {e['call']}: {str(e['error'])[:400]}")
+        if live:
+            _section("④ Call it")
+            _arrow(f"treg call {payload.get('tool_id')} --data '{{\"domain\": \"figma.com\"}}'")
+            _arrow(f"POST /call/{payload.get('tool_id')}   with X-Treg-Token, a JSON body of inputs")
     else:
-        d = payload.get("detail", payload)
-        if isinstance(d, dict) and d.get("error") == "manifest_invalid":
-            print(f"refused: {d['field']}: {d['rule']}")
-        else:
-            print(f"HTTP {r.status_code}: {json.dumps(d)[:600]}")
+        _hub_refusal(payload, r.status_code)
     if r.status_code not in (200, 201):
         sys.exit(1)
 
@@ -5094,15 +5148,23 @@ def cmd_hub_init(args, cfg) -> None:
     (folder / "recipe.json").write_text(json.dumps(skeleton, indent=2) + "\n")
     if args.script:
         (folder / "run.js").write_text(_HUB_RUN_JS)
-        check = {"inputs": {"search": "", "limit": 3}, "fields": ["rows"]}
+        check = {"inputs": {"query": "example query", "limit": 3}, "fields": ["items", "count"]}
     else:
-        check = {"inputs": {"domain": "figma.com", "limit": 2}, "fields": ["people"]}
+        check = {"inputs": {"query": "example query", "limit": 2}, "fields": ["items"]}
     (folder / "check.json").write_text(json.dumps(check, indent=2) + "\n")
     (folder / "README.md").write_text(_HUB_README.format(name=name))
-    print(f"wrote {folder}/: " + ", ".join(f for f in HUB_FILES if (folder / f).exists()))
-    print("next: edit recipe.json (every tool in `uses` must exist: a catalog id, or one of your team's tools),")
-    print("      treg hub run . --input k=v   (a real run on your own token, nothing stored)")
-    print("      treg hub publish .            (validate, run check.json once, live on pass)")
+    _section(f"① New hub tool: {name}")
+    for f in HUB_FILES:
+        if (folder / f).exists():
+            what = {"recipe.json": "the manifest: inputs, uses, output, price",
+                    "run.js": "the script: one exported run(ctx)",
+                    "check.json": "sample inputs + the fields the check must find",
+                    "README.md": "what it does, for a human"}[f]
+            _ok(f"{folder / f}   {_M}{what}{_R}")
+    _section("② Next")
+    _arrow("edit recipe.json — every tool in `uses` must exist: a catalog id, or one of your team's tools")
+    _arrow(f"treg hub run {folder} --input k=v     a real run on your own token; nothing stored")
+    _arrow(f"treg hub publish {folder}              validate, run check.json once, live on pass")
 
 
 def cmd_hub_run(args, cfg) -> None:
@@ -5119,13 +5181,9 @@ def cmd_hub_run(args, cfg) -> None:
         r = c.post("/hub/run", json=body, timeout=httpx.Timeout(190.0, connect=10.0))
     if r.status_code == 200 and not getattr(args, "json", False):
         out = r.json()
-        print(json.dumps(out.get("output"), indent=2))
-        u = out.get("usage", {})
-        print(f"-- run {out.get('run_id')}: {u.get('steps')} steps, {u.get('cost_micro')} micro-USD, {u.get('ms')} ms")
-        for e in out.get("trace", []):
-            print(f"   wave {e['wave']}  {e['name']:<14} {e['call']:<40} {e['outcome']:<8} {e.get('status')}  {e['cost_micro']} µ$  {e['ms']} ms")
-        for line in out.get("log", []):
-            print(f"   log: {line}")
+        _section(f"② Output of {out.get('recipe')}")
+        print(json.dumps(out.get("output"), indent=2, ensure_ascii=False)[:6000])
+        _hub_trace(out)
         return
     _hub_report(r, json_out=getattr(args, "json", False))
 
@@ -5145,11 +5203,13 @@ def cmd_hub_ls(args, cfg) -> None:
     rows = r.json()
     if getattr(args, "json", False):
         print(json.dumps(rows, indent=2)); return
+    _section("Your hub tools")
     if not rows:
-        print("no hub tools yet (treg hub init <name>)"); return
-    print(f"{'TOOL':<40} {'VER':>3}  {'STATUS':<8} {'KIND':<6} {'PRICE':>8}  USES")
+        _dim("  none yet — treg hub init <name>"); return
+    print(f"  {_M}{'TOOL':<44}{'VER':>3}  {'STATUS':<8}{'KIND':<7}{'PRICE':>7}  USES{_R}")
     for t in rows:
-        print(f"{t['tool_id']:<40} {t['version']:>3}  {t['status']:<8} {t['kind']:<6} ${t['price_usd']:<7g}  {', '.join(t['uses'])[:60]}")
+        colour = _G if t["status"] == "live" else _AM if t["status"] == "failed" else _M
+        print(f"  {t['tool_id']:<44}{t['version']:>3}  {colour}{t['status']:<8}{_R}{t['kind']:<7}${t['price_usd']:<6g}  {', '.join(t['uses'])[:60]}")
 
 
 def cmd_feedback_get(args, cfg) -> None:

--- a/tests/callmatrix/test_hub_run.py
+++ b/tests/callmatrix/test_hub_run.py
@@ -316,3 +316,38 @@ export default async function run(ctx) {
     d = r.json()["detail"]
     assert d["kind"] == "script" and "after paying" in d["message"] and d["charged_micro"] == EP_MICRO
     assert await _balance(matrix_clients) - before.balance_micro == -EP_MICRO
+
+
+async def test_a_script_header_reaches_the_upstream_but_identity_headers_do_not(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "sb", "value": "MAKER-SB-KEY"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "supabase", "base_url": "https://fake-provider.invalid/sb", "secret_id": sid})
+    tool_id = await _publish_script(matrix_clients, """
+export default async function run(ctx) {
+  const r = await ctx.call("supabase/rest/v1/keyword_rankings", {
+    query: { select: "keyword" },
+    headers: { "Accept-Profile": "hubdemo", "Authorization": "Bearer STOLEN", "X-Treg-Token": "nope", "apikey": "x" },
+  });
+  return { n: r.json.rows.length };
+}""", ["supabase"], ["n"])
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    hit = fake_provider.hits[-1]
+    assert hit.headers.get("accept-profile") == "hubdemo"
+    assert hit.headers["authorization"] == "Bearer MAKER-SB-KEY"      # the tool's binding, never the script's
+    assert "x-treg-token" not in hit.headers and hit.headers.get("apikey") != "x"
+
+
+async def test_a_step_never_accepts_a_compressed_answer(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    """The runner reads every step's bytes itself, so a step asks for identity encoding whatever
+    the caller sent (live 2026-09-09: a gzip-compressed 20-row answer read as an empty list)."""
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}))
+    hits_before = len(fake_provider.hits)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "figma.com"},
+                                  headers={**FAKE, "Accept-Encoding": "gzip, deflate, br"})
+    assert r.status_code == 200
+    assert fake_provider.hits[hits_before].headers.get("accept-encoding") == "identity"


### PR DESCRIPTION
Phase 5 of the tool hub: the case study walked by hand against a real Supabase table. Two runner rules it taught, both pinned: steps never accept a compressed answer (a gzip 20-row body read as an empty list), and a script may set headers on ctx.call minus identity/framing headers. Neutral init template; house-style CLI output. Suite 2912.

