### PR TITLE
feat(cli): release 0.18.0 with anonymous PostHog telemetry

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -189,6 +189,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/catalog/tomba.yaml` | architecture/catalog.md, architecture/money.md |
 | `src/treg/catalog/trykitt.yaml` | architecture/catalog.md |
 | `src/treg/cli.py` | architecture/instagram-oauth.md, interface/cli.md, interface/onboarding.md, interface/shell.md |
+| `src/treg/cli_analytics.py` | interface/cli.md |
 | `src/treg/client_identity.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/config.py` | architecture/auth-secrets.md, architecture/feedback.md, architecture/super-admin.md, guides/expanding-a-category.md, ops/deploy.md |
 | `src/treg/convert.py` | interface/cli.md |
@@ -388,7 +389,7 @@ Regenerate via `scripts/build-map.py`.
 | `guides/expanding-a-category.md` | `oauth_providers.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `connect.py`, `connections.py`, `config.py` |
 | `interface/api.md` | `sitetrack.js`, `api.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `call_surface.py`, `caller_metadata.py`, `client_identity.py`, `auth.py`, `access.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `relay.py`, `connect.py`, `onboard.py`, `referrals.py`, `signup.py`, `__init__.py`, `admin.py`, `auth.py`, `auth_helpers.py`, `billing.py`, `call.py`, `catalog.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `signup_cookies.py`, `web.py`, `access.py`, `teams.py`, `access.py`, `budgets.py`, `publicdemo.py`, `usage.py`, `mcp_oauth.py`, `session.py`, `timeutil.py`, `store.py`, `email.py`, `runner.py`, `ratestore.py` |
 | `interface/catalog-review-proposal.md` | `store.py`, `capabilities.yaml` |
-| `interface/cli.md` | `cli.py`, `convert.py`, `agents.py` |
+| `interface/cli.md` | `cli.py`, `cli_analytics.py`, `convert.py`, `agents.py` |
 | `interface/dashboard.md` | `sitetrack.js`, `index.html`, `README.md`, `vue-3.5.41.global.prod.js`, `tutorial.js`, `tutorial.html`, `tour.js`, `index.html`, `api.py`, `web.py`, `session.py` |
 | `interface/env-import.md` | `providers.py`, `skills.py` |
 | `interface/landing-sandbox.md` | `sandbox.py`, `sandbox_identity.py`, `pubfeed.py`, `sandbox.py`, `__init__.py`, `sandbox.py`, `api.py`, `onboard.py`, `web.py`, `index.html`, `install.sh` |

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "treg",
   "displayName": "treg",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
-    "version": "0.17.0"
+    "version": "0.18.0"
   },
   "plugins": [
     {

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -53,7 +53,7 @@ regexes = [
   '''INDEXNOW_KEY\s*=|#\s*must match INDEX''',
   # Public PostHog ingestion token from https://treg.to/meta, not a personal API key.
   # Match this exact assignment only; other PostHog keys still trigger the scanner.
-  '''^POSTHOG_KEY = "phc_sAgf5A7TPRRA6faCzuqGVUo8pyb3x5Nq7TJYfn6ZVif9"$''',
+  '''POSTHOG_KEY = "phc_sAgf5A7TPRRA6faCzuqGVUo8pyb3x5Nq7TJYfn6ZVif9"''',
 ]
 # (An allowlist entry for a real dev/e2e Fernet key lived here as a stopgap while
 # `feat/error-capture` carried it in `e2e-server.sh`. That branch now generates a fresh key per run

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -49,7 +49,12 @@ paths = ['''src/treg/catalog/examples/.*\.json''']
 # it authorises nothing but "submit URLs for this host". Matched by the line, not the value, so a
 # real credential on the same line shape elsewhere still fires.
 regexTarget = "line"
-regexes = ['''INDEXNOW_KEY\s*=|#\s*must match INDEX''']
+regexes = [
+  '''INDEXNOW_KEY\s*=|#\s*must match INDEX''',
+  # Public PostHog ingestion token from https://treg.to/meta, not a personal API key.
+  # Match this exact assignment only; other PostHog keys still trigger the scanner.
+  '''^POSTHOG_KEY = "phc_sAgf5A7TPRRA6faCzuqGVUo8pyb3x5Nq7TJYfn6ZVif9"$''',
+]
 # (An allowlist entry for a real dev/e2e Fernet key lived here as a stopgap while
 # `feat/error-capture` carried it in `e2e-server.sh`. That branch now generates a fresh key per run
 # — the harness deletes its database between runs, so it never needed a constant — and the value has

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ treg oauth connect gsc --client-secret client_secret.json \
 
 Full options for every command: [`USAGE.md`](USAGE.md).
 
+The CLI sends anonymous command usage to PostHog when using treg.to (no arguments or credentials).
+Disable with `TREG_TELEMETRY=0` or `DO_NOT_TRACK=1`.
+See [analytics details](USAGE.md#anonymous-usage-analytics).
+
 ## Teams
 
 Everything is scoped to an **org**: a token = a `(user, org)` membership, and every secret, tool,

--- a/USAGE.md
+++ b/USAGE.md
@@ -460,3 +460,15 @@ credential that stops working and webhooks the owner (if a `webhook_url` was set
 - `secret_file` — a JSON token file; pull `secret_field`
 - `oauth` — a JSON OAuth token; pull `secret_field` (auto-refreshed if refreshable)
 - `cli_auth` — material lifted from a CLI's keychain (placed like a string)
+
+## Anonymous usage analytics
+
+When using treg.to, the CLI sends basic usage through PostHog: command name, success/exit code,
+duration, CLI version and OS, linked to a random local installation ID. It does not send command
+arguments, credentials, request/response content, email or team identifiers. Help and argument
+parsing errors are not tracked. Analytics adds at most 0.3 seconds of waiting at command exit;
+slow or offline delivery may be dropped.
+
+Disable it with `export TREG_TELEMETRY=0` (or `DO_NOT_TRACK=1`). Self-hosted registries default to
+no analytics; set `TREG_CLI_POSTHOG_KEY` and optionally `TREG_CLI_POSTHOG_HOST` to use your own
+PostHog project. The random ID is stored in `analytics-id` beside the CLI config file.

--- a/USAGE.md
+++ b/USAGE.md
@@ -466,7 +466,7 @@ credential that stops working and webhooks the owner (if a `webhook_url` was set
 When using treg.to, the CLI sends basic usage through PostHog: command name, success/exit code,
 duration, CLI version and OS, linked to a random local installation ID. It does not send command
 arguments, credentials, request/response content, email or team identifiers. Help and argument
-parsing errors are not tracked. Analytics adds at most 0.3 seconds of waiting at command exit;
+parsing errors are not tracked. Analytics adds at most 1 second of waiting at command exit;
 slow or offline delivery may be dropped.
 
 Disable it with `export TREG_TELEMETRY=0` (or `DO_NOT_TRACK=1`). Self-hosted registries default to

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -40,7 +40,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 |---|---|---|
 | [The API — the only brain (FastAPI)](interface/api.md) | shipped | sitetrack.js, api.py, bootstrap_handlers.py, bootstrap_http.py, … |
 | [Catalog browse review — categories, platform placement, and domain sections](interface/catalog-review-proposal.md) | reference | store.py, capabilities.yaml |
-| [The CLI (treg) + skill scaffolding](interface/cli.md) | shipped | cli.py, convert.py, agents.py |
+| [The CLI (treg) + skill scaffolding](interface/cli.md) | shipped | cli.py, cli_analytics.py, convert.py, agents.py |
 | [The web dashboard (Ledger, served from FastAPI)](interface/dashboard.md) | shipped | sitetrack.js, index.html, README.md, vue-3.5.41.global.prod.js, … |
 | [Import — scan a .env AND/OR a skills dir, auto-register as tools + bundles](interface/env-import.md) | in-progress | providers.py, skills.py |
 | [Landing sandbox backend - front-end entry removed](interface/landing-sandbox.md) | shipped | sandbox.py, sandbox_identity.py, pubfeed.py, sandbox.py, … |

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -3,6 +3,7 @@ title: The CLI (treg) + skill scaffolding
 status: shipped
 sources:
   - src/treg/cli.py
+  - src/treg/cli_analytics.py
   - src/treg/convert.py
   - src/treg/agents.py
 related:
@@ -508,3 +509,19 @@ Switching teams is unaffected: an explicit `X-Treg-Org` header always beats the 
 `treg catalog get <routed id>` prints the ROUTING PLAN (order, accepted identity, price, HIT, expected
 cost per hit) above the sibling table; the sibling table itself gained a HIT column (`stats.observed`
 `hit_rate`). `treg catalog <platform>` rows lead with the endpoint id and show the unified USD price.
+
+## Anonymous CLI analytics
+
+`main` calls `cli_analytics.track_command` after dispatch, including failures and interrupts.
+The PostHog Python SDK sends `cli_command_completed` with the handler's fixed command name,
+exit code, success, duration in milliseconds, package version and OS. Help/version flags and
+argument parsing failures exit before dispatch and emit nothing. No arguments, request/response
+bodies, paths, tokens, emails or team identifiers are collected. A random UUID in `analytics-id`
+beside `TREG_CONFIG` identifies an installation; it is independent of login/logout.
+
+The public treg.to ingestion token is the default only for the hosted registry and its legacy
+alias. Self-hosted URLs send nothing unless `TREG_CLI_POSTHOG_KEY` is set; the host override is
+`TREG_CLI_POSTHOG_HOST` (default EU ingestion). `TREG_TELEMETRY=0` or `DO_NOT_TRACK=1` disables
+all analytics and ID creation. SDK import and synchronous capture run in a daemon thread with
+no retries, a 0.2-second request timeout and a 0.3-second caller wait budget. Slow delivery may
+be dropped at exit; telemetry failures are silent and preserve command output and exit status.

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -523,5 +523,5 @@ The public treg.to ingestion token is the default only for the hosted registry a
 alias. Self-hosted URLs send nothing unless `TREG_CLI_POSTHOG_KEY` is set; the host override is
 `TREG_CLI_POSTHOG_HOST` (default EU ingestion). `TREG_TELEMETRY=0` or `DO_NOT_TRACK=1` disables
 all analytics and ID creation. SDK import and synchronous capture run in a daemon thread with
-no retries, a 0.2-second request timeout and a 0.3-second caller wait budget. Slow delivery may
+no retries, a 0.2-second request timeout and a 1-second caller wait budget. Slow delivery may
 be dropped at exit; telemetry failures are silent and preserve command output and exit status.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treg-dsh",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "main": "dsh/index.js",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Reach for this first for external or live data — 2,896 curated API endpoints across 60 providers (SEO, SERP, backlinks, social, enrichment, ads, web data), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/plugins/minimax/.minimax-plugin/plugin.json
+++ b/plugins/minimax/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "treg",
   "displayName": "treg",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription. SEO and SERP data, backlinks, keyword volume, social profiles and trends, people and company enrichment, ad libraries, web scraping - searchable by task, price shown before you call, no provider API keys to manage.",
   "author": "Superdesign dev, Inc.",
   "icon": "icon.png",

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.17.0
+version: 0.18.0
 ---
 
 ## First run: install the CLI

--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treg",
   "displayName": "treg",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "OpenRouter for tools — 2,896 agent-callable endpoints across 60 providers: SEO and SERP data, backlinks, social and trends, people and company enrichment, ads, scraping. Search by the task, see the price, then call it. Credentials are injected server-side, so the agent never holds a key. Pay per call, not per subscription.",
   "author": {
     "name": "Superdesign",

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.17.0
+version: 0.18.0
 ---
 
 ## First, check which treg you have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 # fast. Everything needed to RUN a registry server lives in the `[server]` extra below.
 dependencies = [
     "httpx>=0.27",
+    "posthog>=7.47.3",
     "questionary>=2.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.17.0"
+version = "0.18.0"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.17.0
+version: 0.18.0
 ---
 
 ## First run: finish the setup

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -6286,7 +6286,25 @@ def main(argv: list[str] | None = None) -> None:
     cfg = _load_config()
     if override:
         _ORG_OVERRIDE = override
-    args.fn(args, cfg)
+    started = time.monotonic()
+    exit_code = 0
+    try:
+        args.fn(args, cfg)
+    except SystemExit as exc:
+        exit_code = exc.code if isinstance(exc.code, int) else (0 if exc.code is None else 1)
+        raise
+    except KeyboardInterrupt:
+        exit_code = 130
+        raise
+    except BaseException:
+        exit_code = 1
+        raise
+    finally:
+        from .cli_analytics import track_command
+
+        track_command(command=args.fn.__name__.removeprefix("cmd_"), exit_code=exit_code,
+                      duration_ms=round((time.monotonic() - started) * 1000),
+                      base_url=cfg.get("base_url", PRODUCTION_BASE_URL), config_path=CONFIG_PATH)
 
 
 if __name__ == "__main__":

--- a/src/treg/cli_analytics.py
+++ b/src/treg/cli_analytics.py
@@ -1,0 +1,72 @@
+"""Best-effort anonymous CLI usage, isolated from the server analytics stack."""
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import threading
+import uuid
+from importlib.metadata import version
+from pathlib import Path
+
+# Public ingestion token, also published by https://treg.to/meta (not a personal API key).
+POSTHOG_KEY = "phc_sAgf5A7TPRRA6faCzuqGVUo8pyb3x5Nq7TJYfn6ZVif9"
+POSTHOG_HOST = "https://eu.i.posthog.com"
+EXIT_WAIT_SECONDS = 0.3
+
+
+def _installation_id(config_path: Path) -> str:
+    path = config_path.with_name("analytics-id")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x") as file:
+            identifier = str(uuid.uuid4())
+            file.write(identifier)
+            return identifier
+    except FileExistsError:
+        return str(uuid.UUID(path.read_text().strip()))
+
+
+def _send(key: str, host: str, config_path: Path, properties: dict) -> None:
+    try:
+        from posthog import Posthog
+
+        identifier = _installation_id(config_path)
+        properties = {**properties, "cli_version": version("tools-registry"),
+                      "os": platform.system(), "$process_person_profile": False}
+        # Synchronous SDK mode avoids its unbounded atexit flush. Our daemon gets a
+        # short exit budget; slow/offline ingestion may drop the event.
+        client = Posthog(key, host=host, sync_mode=True, timeout=0.2, max_retries=0,
+                         disable_geoip=True, is_server=False, enable_local_evaluation=False)
+        logger = logging.Logger("treg.cli.analytics")
+        logger.addHandler(logging.NullHandler())
+        client.log = logger
+        try:
+            client.capture("cli_command_completed", distinct_id=identifier, properties=properties)
+        finally:
+            client.shutdown()
+    except Exception:
+        pass  # Analytics must never change command output or its exit status.
+
+
+def track_command(*, command: str, exit_code: int, duration_ms: int,
+                  base_url: str, config_path: Path) -> None:
+    """Accept only fixed command names and coarse execution metadata, never argv/config."""
+    try:
+        if os.environ.get("TREG_TELEMETRY", "").lower() in {"0", "false", "off"}:
+            return
+        if os.environ.get("DO_NOT_TRACK") == "1":
+            return
+        hosted = base_url.rstrip("/") in {"https://treg.to", "https://treg.superdesign.dev"}
+        key = os.environ.get("TREG_CLI_POSTHOG_KEY", POSTHOG_KEY if hosted else "")
+        if not key:
+            return
+        host = os.environ.get("TREG_CLI_POSTHOG_HOST", POSTHOG_HOST)
+        worker = threading.Thread(target=_send, args=(key, host, config_path, {
+            "command": command, "exit_code": exit_code, "success": exit_code == 0,
+            "duration_ms": duration_ms,
+        }), daemon=True)
+        worker.start()
+        worker.join(EXIT_WAIT_SECONDS)
+    except Exception:
+        pass

--- a/src/treg/cli_analytics.py
+++ b/src/treg/cli_analytics.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Public ingestion token, also published by https://treg.to/meta (not a personal API key).
 POSTHOG_KEY = "phc_sAgf5A7TPRRA6faCzuqGVUo8pyb3x5Nq7TJYfn6ZVif9"
 POSTHOG_HOST = "https://eu.i.posthog.com"
-EXIT_WAIT_SECONDS = 0.3
+EXIT_WAIT_SECONDS = 1.0
 
 
 def _installation_id(config_path: Path) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 import os
 import tempfile
 
+# Tests and their CLI subprocesses must never emit production analytics.
+os.environ["TREG_TELEMETRY"] = "0"
+
 # Isolate the test DB from any .env / running dev server BEFORE importing treg (the engine is
 # built at import time). A real env var overrides the .env file in pydantic-settings.
 # TREG_TEST_DB_URL (not TREG_DATABASE_URL — a stray production URL in a shell must never become the

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -39,6 +39,7 @@ def test_real_cli_sdk_delivery_and_opt_out(tmp_path, ingestion):
     host, events = ingestion
     env = {**os.environ, 'TREG_CONFIG': str(tmp_path / 'config.json'),
            'TREG_TELEMETRY': '1', 'DO_NOT_TRACK': '0',
+           'PYTHONPYCACHEPREFIX': str(tmp_path / 'bytecode'),
            'TREG_CLI_POSTHOG_KEY': 'phc_test', 'TREG_CLI_POSTHOG_HOST': host}
 
     def run(*args):
@@ -122,7 +123,7 @@ def test_slow_ingestion_does_not_block_exit(monkeypatch, tmp_path):
     try:
         cli_analytics.track_command(command='version', exit_code=0, duration_ms=1,
                                     base_url='https://treg.to', config_path=tmp_path / 'config.json')
-        assert time.monotonic() - started < 1
+        assert time.monotonic() - started < 1.5
     finally:
         finished.set()
 

--- a/tests/test_cli_analytics.py
+++ b/tests/test_cli_analytics.py
@@ -1,0 +1,138 @@
+"""Exercise the installed SDK and real CLI process against local ingestion."""
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from treg import cli, cli_analytics
+
+
+@pytest.fixture
+def ingestion():
+    events = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            events.append(json.loads(self.rfile.read(int(self.headers['Content-Length']))))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{}')
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f'http://127.0.0.1:{server.server_port}', events
+    server.shutdown()
+    server.server_close()
+    thread.join()
+
+
+def test_real_cli_sdk_delivery_and_opt_out(tmp_path, ingestion):
+    host, events = ingestion
+    env = {**os.environ, 'TREG_CONFIG': str(tmp_path / 'config.json'),
+           'TREG_TELEMETRY': '1', 'DO_NOT_TRACK': '0',
+           'TREG_CLI_POSTHOG_KEY': 'phc_test', 'TREG_CLI_POSTHOG_HOST': host}
+
+    def run(*args):
+        return subprocess.run([sys.executable, '-m', 'treg.cli', *args], env=env,
+                              capture_output=True, text=True, timeout=10)
+
+    result = run('version')
+    assert result.returncode == 0
+    assert result.stdout.strip() and not result.stderr
+    assert len(events) == 1
+    event = events[0]['batch'][0]
+    assert event['event'] == 'cli_command_completed'
+    props = event['properties']
+    assert props['command'] == 'version'
+    assert props['success'] is True
+    assert props['exit_code'] == 0
+    assert props['duration_ms'] >= 0
+    assert props['cli_version'] and props['os']
+    identifier = (tmp_path / 'analytics-id').read_text()
+    assert event.get('distinct_id', props.get('distinct_id')) == identifier
+
+    # Raw argument contents must never enter an event.
+    result = run('secret', 'add', 'private-name', '--value', 'secret-token')
+    assert result.returncode != 0
+    assert len(events) == 2
+    failed = events[-1]['batch'][0]['properties']
+    assert failed['command'] == 'secret_add'
+    assert failed['success'] is False
+    assert failed['exit_code'] == result.returncode
+    assert events[-1]['batch'][0].get('distinct_id', failed.get('distinct_id')) == identifier
+    assert 'private-name' not in json.dumps(events)
+    assert run('--help').returncode == 0
+    assert len(events) == 2
+    assert 'secret-token' not in json.dumps(events)
+    env['TREG_TELEMETRY'] = '0'
+    count = len(events)
+    assert run('version').returncode == 0
+    assert len(events) == count
+    assert run('--help').returncode == 0
+
+
+@pytest.mark.parametrize('error, expected', [(None, 0), (SystemExit(3), 3),
+    (SystemExit('private error'), 1), (KeyboardInterrupt(), 130), (RuntimeError('private error'), 1)])
+def test_dispatch_result_preserved(monkeypatch, tmp_path, error, expected):
+    def cmd_version(args, cfg):
+        if error is not None:
+            raise error
+    monkeypatch.setattr(cli, 'cmd_version', cmd_version)
+    monkeypatch.setattr(cli, 'CONFIG_PATH', tmp_path / 'config.json')
+    captured = []
+    monkeypatch.setattr(cli_analytics, 'track_command', lambda **kwargs: captured.append(kwargs))
+    if error is None:
+        cli.main(['version'])
+    else:
+        with pytest.raises(type(error)) as raised:
+            cli.main(['version'])
+        assert raised.value is error
+    assert captured[0]['exit_code'] == expected
+    assert captured[0]['command'] == 'version'
+
+
+@pytest.mark.parametrize('env, base', [({'TREG_TELEMETRY': '0'}, 'https://treg.to'),
+    ({'DO_NOT_TRACK': '1'}, 'https://treg.to'), ({}, 'https://self.example')])
+def test_disabled_has_no_side_effects(monkeypatch, tmp_path, env, base):
+    for key in ('TREG_TELEMETRY', 'DO_NOT_TRACK', 'TREG_CLI_POSTHOG_KEY'):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(cli_analytics, '_send', lambda *args: pytest.fail('unexpected send'))
+    cli_analytics.track_command(command='version', exit_code=0, duration_ms=1,
+                                base_url=base, config_path=tmp_path / 'config.json')
+    assert not list(tmp_path.iterdir())
+
+
+def test_slow_ingestion_does_not_block_exit(monkeypatch, tmp_path):
+    monkeypatch.setenv('TREG_TELEMETRY', '1')
+    monkeypatch.delenv('DO_NOT_TRACK', raising=False)
+    finished = threading.Event()
+    monkeypatch.setattr(cli_analytics, '_send', lambda *args: finished.wait(5))
+    started = time.monotonic()
+    try:
+        cli_analytics.track_command(command='version', exit_code=0, duration_ms=1,
+                                    base_url='https://treg.to', config_path=tmp_path / 'config.json')
+        assert time.monotonic() - started < 1
+    finally:
+        finished.set()
+
+
+def test_sdk_failure_is_silent(monkeypatch, tmp_path, capsys):
+    import posthog
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("ingestion unavailable")
+
+    monkeypatch.setattr(posthog, "Posthog", fail)
+    cli_analytics._send("phc_test", "http://127.0.0.1:1", tmp_path / "config.json", {})
+    assert capsys.readouterr() == ("", "")

--- a/uv.lock
+++ b/uv.lock
@@ -1052,7 +1052,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -90,6 +90,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -224,6 +233,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
     { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
     { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -620,6 +638,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.47.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/0c/243c6259bfaa8b150e316c3f94c4002ce0cd2c3a4c42e416d8371dd478b2/posthog-7.47.3.tar.gz", hash = "sha256:515767a1f504a76039251e621948c40564b7a13d36d92b3aa658fdbfdfdea57e", size = 515062, upload-time = "2026-09-08T14:34:14.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/8c/8db98c0c0f096a6a81ecabf7afb1f42916918b20eef0b284d1ac412f3dca/posthog-7.47.3-py3-none-any.whl", hash = "sha256:3eb2e279c26dff31586ab151b9d907eef59a6df03bd51d90fb1c82871805f1b6", size = 607836, upload-time = "2026-09-08T14:34:12.918Z" },
 ]
 
 [[package]]
@@ -1023,6 +1056,7 @@ version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "posthog" },
     { name = "questionary" },
 ]
 
@@ -1066,6 +1100,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'server'", specifier = ">=2" },
+    { name = "posthog", specifier = ">=7.47.3" },
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.5" },
     { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6" },
     { name = "questionary", specifier = ">=2.0" },


### PR DESCRIPTION
## What this does

Releases 0.18.0 with basic CLI usage analytics through the PostHog Python SDK. After command dispatch, `cli_command_completed` records a fixed command name, success/exit code, duration, CLI version and OS against a random installation ID; arguments, credentials, payloads, emails and team identifiers are excluded.

Enabled by default for treg.to and its legacy alias, using the public ingestion token already published by `/meta`. Self-hosted registries default to off. `TREG_TELEMETRY=0` or `DO_NOT_TRACK=1` disables sending and ID creation; `TREG_CLI_POSTHOG_KEY` / `TREG_CLI_POSTHOG_HOST` support a separate project. Delivery is best-effort with a 1 second exit wait budget and preserves command output and exit status. Help/version flags and parsing errors are excluded.

Updates `docs/context/interface/cli.md`, its generated source map/index, README and USAGE. Synchronizes the package/plugin versions to 0.18.0 and narrowly allows the exact public ingestion token in gitleaks.

## How it was tested

- `uv run --with pytest-xdist pytest -n auto -q`: 3,194 passed, 5 skipped (27 warnings).
- `uv run lint-imports`: all 14 contracts passed.
- Real CLI subprocesses using the installed SDK against a local HTTP ingestion server verify success/failure events, stable anonymous identity, argument exclusion and opt-out. Additional tests cover interrupts, SDK errors and bounded waiting.
- Release follow-up: 50 CLI analytics, lightweight import and plugin tests passed; the full-history gitleaks scan passed.
- Built wheel and sdist from a clean Git archive; `twine check` passed. Installed the wheel in a fresh base-only environment and verified 0.18.0, cold-start SDK delivery to local ingestion, and `DO_NOT_TRACK=1`. The exit budget is 1 second to accommodate cold SDK imports; the new regression uses a fresh bytecode cache.
- Documentation drift mapping and `git diff --check` passed.

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (the PostHog project ingestion token is public, not a personal API key)
