### PR TITLE
fix(review): one review per invitation

### DIFF
--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -82,7 +82,10 @@ ledger-only evidence, which lacks status/provider/cache attribution. Own-tool re
 400. A routed parent uses its successful child's endpoint/provider when present, retaining the
 parent endpoint as `routed_via`; otherwise it retains parent attribution. `invited` is recomputed
 from a 2xx, non-cached record with `credential_tier == "platform"` and the current review
-sampling rate. Routed and own-key catalog calls can still be reviewed uninvited. Retries return
+sampling rate. Routed and own-key catalog calls can still be reviewed uninvited. Every agent-facing
+text says one review per invitation: volunteered reviews are accepted and labelled `invited=false`,
+but they are not requested, and a future score must use invited rows only (an agent that reviews
+every call of a batch, seen in production on launch day, would otherwise weigh as much as a team). Retries return
 the original ID and `already_reviewed`; a unique index also arbitrates concurrent submissions. Its savepoint
 stays open until the application commit, avoiding SQLite deferred-BEGIN early commits. The sole writer
 is `domain.feedback.reviews`; the moved `reports` module preserves feedback behavior.

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -348,6 +348,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -351,6 +351,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -332,6 +332,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -346,6 +346,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -330,6 +330,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/src/treg/hints.py
+++ b/src/treg/hints.py
@@ -26,6 +26,7 @@ def review_hint(call_id: str) -> str:
     return (
         f"After you have used this result, rate it: review(call_id={call_id}, "
         "usefulness=useful|partly|not_useful|not_sure, reason?). "
+        "Only this call needs a review: one per invitation. "
         "Anything confusing or wrong: use feedback with this call_id in call_ids. "
         "No private data. Then keep going with the task."
     )

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -161,7 +161,8 @@ mcp = MCPServer(
         "catalog_get (params) → call. Multiple providers for one job? catalog_get ranks them by "
         "measured success, speed and price — you pick."
         " When a call result carries a review invitation, use the result first, then call "
-        "review(call_id, usefulness, reason?) and keep going with the task."
+        "review(call_id, usefulness, reason?) and keep going with the task. Only the invited call "
+        "needs a review: one per invitation."
     ),
     middleware=[_StaticSurfaceCapabilities()],
 )
@@ -1156,7 +1157,8 @@ directory_mcp = MCPServer(
         "catalog_get returns parameters, provider documentation, price and reliability; "
         "catalog_call_read and catalog_call_write execute the selected endpoint."
         " When a call result carries a review invitation, use the result first, then call "
-        "review(call_id, usefulness, reason?) and keep going with the task."
+        "review(call_id, usefulness, reason?) and keep going with the task. Only the invited call "
+        "needs a review: one per invitation."
     ),
     middleware=[_StaticSurfaceCapabilities()],
 )

--- a/src/treg/web/feedback.md
+++ b/src/treg/web/feedback.md
@@ -51,6 +51,8 @@ Reports are accessible to that team and registry administrators, not published t
 A review rates one catalog call after you have used its result. Feedback is a self-initiated
 free-text report and can have no call ID; a review is structured, usually invited, and stored
 once per call. Its optional reason stays on the review and never creates a feedback report.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 - `call_id`: required, the call's opaque reference (letters, digits, `_` or `-`, at most 128 characters).
 - `usefulness`: required, `useful`, `partly`, `not_useful`, or `not_sure`. Uncertainty is fine.

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -43,6 +43,7 @@ Repo: https://github.com/superdesigndev/treg
 Review: after using an invited catalog call's result, run `treg review CALL_ID USEFULNESS [--reason "..."]`
 or MCP `review(call_id, usefulness, reason?)`. Use `useful`, `partly`, `not_useful`, or `not_sure`;
 omit private data, use feedback for anything confusing or wrong, and keep going with the task.
+Only the invited call needs a review: one per invitation.
 
 Feedback: `treg feedback submit <quality|pricing|friction|other> "message"`, or the MCP `feedback` tool.
 Include call IDs when available and omit private information. Instructions: `{BASE}/feedback.md`.

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -311,6 +311,8 @@ When invited to review a catalog call, use its result first, then call
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
 Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
 use `feedback` for anything confusing or wrong, and keep going with the task afterward.
+Only the invited call needs a review: one per invitation. Calls that carried no invitation do
+not need one; a volunteered review is accepted but kept for reference only.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -722,5 +722,6 @@ async def test_server_instructions_explain_review_invitations(clients, path):
     assert response.status_code == 200
     assert response.json()['result']['instructions'].endswith(
         'When a call result carries a review invitation, use the result first, then call '
-        'review(call_id, usefulness, reason?) and keep going with the task.'
+        'review(call_id, usefulness, reason?) and keep going with the task. Only the invited call '
+        'needs a review: one per invitation.'
     )


### PR DESCRIPTION
On launch day a team's MCP agent received one review invitation in a batch of 14 `dataforseo.google.keywords.ideas` calls and then reviewed all 14 (13 uninvited, same reason). Nothing in the hint, the MCP instructions, skill.md, feedback.md or llms.txt said that only the invited call needs a review, so the agent generalised. This adds the sentence "Only the invited call needs a review: one per invitation" to every agent-facing copy (server-side hint, both MCP `instructions`, skill.md and its generated copies, feedback.md, llms.txt) and records in the feedback fragment that volunteered reviews are accepted and labelled but not requested, and that a future score must use invited rows only.

No behaviour change in code paths; the CLI stderr line already names one specific call and is unchanged, so no CLI release is needed. Tests updated for the instructions text; `build_plugin.py` regenerated the skill copies.