### PR TITLE
feat(overflow): disclose the relay on MCP; scope an aggregator's own 4xx to the request

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1291,6 +1291,15 @@ sample size** per endpoint from `CallRecord` — which has recorded `endpoint_id
 `/catalog/endpoints/{id}`, attached to the endpoint **and every sibling**, because the choice is made
 on that page and an agent will not make a second round-trip to compare reliability.
 
+The same page states the one price the `cost` block cannot: what the call bills when treg's own
+account is out and the overflow relay serves it. `routers.catalog._overflow_disclosure` reads the
+enabled `OverflowRoute` through `domain.capacity.routes_view` (a read, the worker stays the only
+writer) and puts `overflow_price_usd`, `overflow_price_unit` and `overflow_via` on the endpoint view
+plus a hint, only when the deployment can actually relay it (`TREG_OVERFLOW_MODE=on`, a key for the
+aggregator, `platform_eligible`, an enabled route). A catalog-free endpoint with an overflow route is
+the case that made this necessary (`apollo.people.search`, 2026-09-08); the MCP `catalog_get` lifts
+the three fields onto its result so the schema advertises them.
+
 The aggregate is authoritative but no longer request-time. `stats.EndpointObservationReader` is the
 narrow domain port, and bootstrap supplies `CachedEndpointObservationReader` around a
 `PostgresEndpointObservationReader`. Entries are keyed by endpoint id. They are fresh for five

--- a/docs/context/architecture/import-boundaries.md
+++ b/docs/context/architecture/import-boundaries.md
@@ -136,7 +136,9 @@ It reads config and writes only its own tables and ratestore keys, from worker-p
 (`treg-worker`, a separate console script so the light `treg` CLI never gains a DB import). The call
 application imports the capacity domain inward (`resolve` → `view`, `settle` → `signatures`/`marks`);
 the domain never imports back; `application.call.overflow` composes the capacity domain, the
-aggregator envelopes and the money primitives, and the aggregator adapters stay pure envelope code; `application.call.route` composes the pure
+aggregator envelopes and the money primitives, and the aggregator adapters stay pure envelope code;
+`routers.catalog` reads the capacity domain's `routes_view` for the overflow price disclosure (a read
+of the worker-owned table through the same in-process copy the call path uses, never a write); `application.call.route` composes the pure
 `domain.catalog.routing` package (contracts, adapters, ranking) with the call use case itself. The
 aggregator envelopes live under `treg.infra.upstream.aggregators` and inherit the upstream contract
 (no HTTP adapters, no routers); the capacity domain's `verify` module may import them because they are

--- a/docs/context/architecture/mcp-oauth.md
+++ b/docs/context/architecture/mcp-oauth.md
@@ -209,6 +209,16 @@ Optional, and it is the caller's. Pass the same key when repeating a call whose 
 treg replays the stored response, does not reach the provider, and charges nothing, with
 `replayed: true` on the result.
 
+## `call` says when the overflow relay served it
+
+`/call/` discloses a relayed answer in `X-Treg-Served-Via`; an MCP client never sees headers, so
+`_call_impl` lifts it into `served_via` on the result with a one-line `hint` naming the relay and
+the exhausted provider (`cost_usd` is then the relay's real price, not the catalog's direct one).
+Both surfaces share the impl, so `/mcp/` and `/mcp/v2/` say it identically. `catalog_get` carries
+`overflow_price_usd` / `overflow_price_unit` / `overflow_via` for the same reason - the price to
+tell the human BEFORE the call includes the one the relay may bill (`architecture/money.md`
+§ Overflow money).
+
 It exists because the feature was built for agents and MCP is the agent path. Without it the whole
 thing was unreachable from the surface it was for.
 

--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -765,7 +765,31 @@ The overflow child (`application.call.overflow`) is an ordinary metered cycle on
 `observed_override` = the aggregator's in-band charge - the caller pays exactly that, 0% markup -
 and `cost_source: "aggregator"` + `served_via` in the ledger `meta`, so `reconcile` needs no join.
 `OverflowSpend` (per aggregator per UTC day) is updated inside that same settle transaction; it is
-accounting for the $20/day budget, not a balance. Shadow mode places no hold and charges nothing.
+accounting for the per-aggregator daily budget, not a balance. That budget is
+`TREG_OVERFLOW_DAILY_BUDGET_USD`: the code and the public Blueprint default to $20, and production
+runs at $500 set by the private Blueprint in treg-internal (the value is owned there; this repo's
+`render.yaml` is not what production reads). Shadow mode places no hold and charges nothing.
+
+**The relay price is disclosed wherever a price is read.** `/call/` says `X-Treg-Served-Via:
+overflow:<aggregator>` with `X-Treg-Cost-Micro` the child's charge; the MCP `call` result (both
+`/mcp/` and `/mcp/v2/`, one `_call_impl`) lifts that header into `served_via` and a one-line `hint`
+naming the relay and the exhausted provider, because an MCP client never sees headers.
+`GET /catalog/endpoints/{id}` and `catalog_get` carry `overflow_price_usd`, `overflow_price_unit`
+and `overflow_via` on a platform-eligible endpoint the deployment can relay (mode on, a key for the
+aggregator, an enabled route), so a catalog-free endpoint is never silently a paid one: on 2026-09-08
+`apollo.people.search` (cost `free`) billed $0.002 through Orthogonal 8,810 times while treg's
+Apollo account was out, and no read surface said it could. What still is NOT disclosed up front is
+*when* a free endpoint is diverted: the route enables whenever the aggregator's price is at most
+`FREE_ROUTE_MAX_USD` (`domain.capacity.routes`), and a caller learns it was relayed only from the
+answer. That is a design gap, recorded here, not a settled rule.
+
+**An aggregator's own per-request refusal never bills.** Orthogonal's bare 400/422/404 with no vendor
+data (its request validation) parses as `contract`: the child hold is released with reason
+`overflow_contract`, `cost_observed_micro` is 0, no `OverflowSpend` delta beyond the estimate
+reversal, and the aggregator is not marked. Only a non-JSON body, a 5xx or a transport error is
+`malformed` (`AGGREGATOR_SIDE`, a 15-minute mark). One such 400 read as `malformed` on 2026-09-08
+struck `overflow:orthogonal` for every org and turned every Apollo call for a quarter hour into
+`provider_capacity_unavailable`.
 
 ## MillionVerifier credit returns
 

--- a/docs/context/architecture/proxy-model.md
+++ b/docs/context/architecture/proxy-model.md
@@ -376,7 +376,8 @@ maybe_overflow` runs a **child cycle** after the primary's settle released its h
 
 1. Route from the in-process route view (`domain.capacity.routes_view`, Orthogonal first), skipping
    an aggregator marked unhealthy (`overflow:<name>` in the capacity view) or without a key; budget
-   check against `OverflowSpend` (`overflow_daily_budget_usd`, $20/aggregator/day) on a short session.
+   check against `OverflowSpend` (`overflow_daily_budget_usd` per aggregator per day; $20 in code,
+   production's value lives in the private Blueprint) on a short session.
 2. **Child hold**, own id `{call_ref}:overflow`, through the ordinary `_platform_reserve` (tag
    budgets, daily cap, trial allowance apply; an empty balance is the normal 402). Never the parent's
    id: release-by-id is a conditional claim and `_finish_cancelled_call` releases both ids exactly once.
@@ -389,7 +390,10 @@ maybe_overflow` runs a **child cycle** after the primary's settle released its h
    the one allowlisted overflow write (`overflow_spend_in_settle`).
 5. The vendor's body goes back as the answer, `X-Treg-Served-Via: overflow:<name>`, `X-Treg-Cost-Micro`
    the child's charge, `X-Treg-Call-Id` the parent's. Two audit rows share the `call_ref`: the primary
-   attempt with its real status and the child with `credential_tier="platform-overflow"`.
+   attempt with its real status and the child with `credential_tier="platform-overflow"`. The MCP
+   `call` result carries the same disclosure as `served_via` plus a hint (an MCP client never sees
+   headers), and `/catalog/endpoints/{id}` / `catalog_get` show the route's price up front as
+   `overflow_price_usd` - see `architecture/money.md` § Overflow money.
 
 When the resolver already knows the account is out (the exhausted view) **and** a route is on, the
 ladder skips the direct attempt entirely (`MarketplaceCall.skip_direct`): no parent hold, no vendor
@@ -408,8 +412,13 @@ hold and marks `overflow:<name>` unhealthy for everyone; a relayed vendor answer
 reads as that vendor's own out-of-credit or quota dialect (`VENDOR_DRY`: a 402, Apollo's 422 through
 Orthogonal's dry Apollo account, a period 429) releases the child hold and marks
 `overflow:<name>:<provider>` only - one vendor's cap never takes the others offline. Either mark
-lasts 15 minutes, and the caller gets the typed `provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call. Its
-stricter-schema refusal (`contract`) releases the child and lets the vendor's own answer stand.
+lasts 15 minutes, and the caller gets the typed `provider_capacity` 503 with alternatives; a second aggregator is never tried on the same call.
+The aggregator's own per-request refusal (`contract`: its stricter schema, or Orthogonal's bare
+400/422/404 with no vendor data) is request-scoped - it releases the child, charges nothing and marks
+nothing; the vendor's own answer stands, and on the skip-direct ladder, where there is none, the caller
+gets the typed 503 naming the refusal rather than the aggregator's envelope dressed as the vendor's
+answer. `malformed` is reserved for what is not an envelope at all (non-JSON, a 5xx, a transport
+error); one validation 400 read as `malformed` once took Orthogonal offline for every org for 15 minutes.
 
 **Shadow mode** (`TREG_OVERFLOW_MODE=shadow`): the aggregator is called, status / shape / cost logged
 and the probe's cost recorded in `OverflowSpend` (treg pays, budget-bounded) - the caller still gets

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -138,6 +138,12 @@ verified for that), the caller paid the aggregator's real price (`X-Treg-Cost-Mi
 `X-Treg-Call-Id` is the parent call's. Absent on every direct call. Off by default
 (`TREG_OVERFLOW_MODE`). See `architecture/proxy-model.md` § Overflow.
 
+The same fact reaches surfaces that cannot read headers: the MCP `call` result (team and directory
+servers alike) carries `served_via: "overflow:<aggregator>"` and a one-line `hint` naming the relay
+and the exhausted provider, and `GET /catalog/endpoints/{id}` / `catalog_get` carry
+`overflow_price_usd`, `overflow_price_unit` and `overflow_via` on a platform-eligible endpoint the
+deployment can relay - the price a "free" endpoint may actually bill, stated before the call.
+
 ## `X-Treg-Smoothed` - the call waited for treg's own rate limit
 
 On platform calls, including owned free polling: `wait=<ms>` when the call was spaced behind other callers on the
@@ -345,7 +351,7 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   | `GET /catalog/platforms` | Non-empty platforms with capability/endpoint counts and providers, ordered by endpoint count |
   | `GET /catalog/platforms/{slug}` | Capabilities, extended endpoints, dashboard domain rows and provider metadata; unknown slug is 404 |
   | `GET /catalog/search?q=&limit=` | Ranked endpoint views, count/total and hints; default 25, maximum 100 |
-  | `GET /catalog/endpoints/{id}` | Endpoint, provider, capability siblings, call template, inline example and next-step hints |
+  | `GET /catalog/endpoints/{id}` | Endpoint, provider, capability siblings, call template, inline example and next-step hints; `overflow_price_usd` / `overflow_price_unit` / `overflow_via` on the endpoint when the deployment can relay it |
   | `GET /catalog/examples/{id}` | Captured JSON, resolved through the catalog before constructing a file path |
   | `POST /tool-requests` | Open, rate-limited demand report with capped fields and optional caller attribution |
 

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -206,7 +206,10 @@ pays the aggregator's real price, 0% markup, disclosed in-band when it ships (st
   endpoint, input}`), `parse()` unwraps the vendor status + body + the real in-band charge, and
   names who to blame when the aggregator itself refused (`AGGREGATOR_SIDE` = `aggregator_auth`,
   `aggregator_balance`, `malformed` - the call path marks the aggregator unhealthy for everyone, the
-  verifier leaves the route alone; `VENDOR_DRY`, folded in by `with_vendor_verdict` from the
+  verifier leaves the route alone; `contract` - the aggregator's own per-request refusal, including
+  Orthogonal's bare 400/422/404 with no vendor data - is request-scoped: child released, nothing
+  charged, no mark, `malformed` being reserved for non-JSON, 5xx and transport errors;
+  `VENDOR_DRY`, folded in by `with_vendor_verdict` from the
   signature table - the one place a relayed body is read - is the aggregator's account for THIS
   vendor (a relayed 402, Apollo's 422, a period 429): the call path marks
   `overflow:<aggregator>:<provider>` only, so one vendor's cap never takes the others offline.
@@ -279,7 +282,8 @@ the policy table. `rate_pressure` alerting is step C.
 ## Overflow, the child cycle (step E) — off by default
 
 `application/call/overflow.py` is documented in `architecture/proxy-model.md` § Overflow. Operating
-it: `TREG_OVERFLOW_MODE` = `off` (default) | `shadow` | `on`; `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
+it: `TREG_OVERFLOW_MODE` = `off` (default) | `shadow` | `on`; `TREG_OVERFLOW_DAILY_BUDGET_USD` (code
+default 20; production's value is set in treg-internal's Blueprint, $500 at the time of writing)
 per aggregator per UTC day is a hard admission cap backed by `OverflowSpend`. Before either an
 `on` call or a `shadow` probe goes to the network, a conditional atomic upsert reserves the route's
 estimated micro-USD only if the resulting daily total fits under the cap. Completion reconciles the

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -560,7 +560,8 @@ run alone does not enable routes.
 
 Aggregator keys
 (`TREG_OVERFLOW_KEY_ORTHOGONAL` / `_MONID`) are dashboard-managed on the web service and flow the same
-way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (20)
+way. `TREG_OVERFLOW_MODE` (`off` default | `shadow` | `on`) and `TREG_OVERFLOW_DAILY_BUDGET_USD` (code
+default 20; production sets its own value in the private Blueprint)
 govern the overflow child cycle (`ops/capacity.md`); the keys serve nothing while the mode is `off`.
 
 `treg-worker asynctasks settle` is the second cron command. `treg-asynctasks-settle` runs every two

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -151,8 +151,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -154,8 +154,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -135,8 +135,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -149,8 +149,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -133,8 +133,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |
     `{linkedin_url}`); treg runs the best child (own keys first, then cheapest per hit), falls back

--- a/src/treg/application/call/overflow.py
+++ b/src/treg/application/call/overflow.py
@@ -6,7 +6,10 @@ treg-owned aggregator account: reserve a child hold (own id `{call_ref}:overflow
 run, no DB open → settle the child at the aggregator's real price (0% markup) and fold the daily
 spend delta into that settle → return the vendor's body from the aggregator's envelope, disclosed via
 `X-Treg-Served-Via`. One hop: an aggregator that fails is data (child released, aggregator marked
-unhealthy 15 min, typed 503 with alternatives), never a second aggregator.
+unhealthy 15 min, typed 503 with alternatives), never a second aggregator. An aggregator's own
+per-request refusal (`contract`) is request-scoped: child released, nothing charged, no mark; the
+vendor's own answer stands, or - when the ladder skipped the direct attempt - the typed 503 names
+the refusal.
 
 Shadow mode (`overflow_mode=shadow`): everything except the child hold and the answer — the
 aggregator is called, status/shape/cost logged and the spend recorded (treg pays the probe, bounded
@@ -310,8 +313,11 @@ async def _maybe_overflow_attempt(
         return OverflowOutcome(False, None, aggregator=aggregator, note=why_agg,
                                failure=_capacity_503(mk, aggregator, why_agg) if mode == "on" else None)
     if res.failure == "contract" or res.failure == "pending":
-        # The aggregator's stricter schema refused (no vendor call, no charge): this route is wrong for
-        # this call; the vendor's own answer stands. Worth a log line — verify should have caught it.
+        # The aggregator's own per-request refusal (no vendor call, no charge, no strike): this route
+        # is wrong for this call. The vendor's own answer stands when there is one; on the skip-direct
+        # ladder there is none, so the caller gets treg's typed 503 naming the relay's refusal - never
+        # the aggregator's envelope dressed up as the vendor's answer. Worth a log line either way:
+        # verify should have caught it.
         if mode == "on":
             spend_adjustment = _overflow_spend_adjustment(budget)
             await _platform_settle(
@@ -326,7 +332,11 @@ async def _maybe_overflow_attempt(
             await _record_shadow_budget(budget)
         log.warning("overflow via %s refused %s: %s", aggregator, mk.endpoint_id, res.detail)
         _audit_child(mk, child, call_ref, aggregator, res, charged=0, client=audit_client, note=res.failure)
-        return OverflowOutcome(False, None, aggregator=aggregator, note=res.failure)
+        failure = None
+        if mode == "on" and force_trigger is not None:
+            failure = _capacity_503(mk, aggregator, f"{res.failure}: it refused the request itself, "
+                                                    f"{res.detail or 'no detail'}")
+        return OverflowOutcome(False, None, aggregator=aggregator, note=res.failure, failure=failure)
     # The vendor answered through the aggregator.
     if mode == "shadow":
         try:

--- a/src/treg/infra/upstream/aggregators/__init__.py
+++ b/src/treg/infra/upstream/aggregators/__init__.py
@@ -30,7 +30,8 @@ class AggregatorRequest:
 AGGREGATOR_SIDE = ("aggregator_auth", "aggregator_balance", "malformed")
 """The `failure` kinds that blame the aggregator (our key, its account, its host or envelope), never
 the route or the vendor: the call path marks the aggregator unhealthy on them, the verifier leaves
-the route as it is. `contract` is this route's fault; `pending` is nobody's yet."""
+the route as it is. `contract` is request-scoped (this route, this request) and never marks the
+aggregator; `pending` is nobody's yet."""
 
 VENDOR_DRY = "vendor_dry"
 """The aggregator relayed the vendor's own out-of-credit / quota answer (a 402, Apollo's 422, a
@@ -56,12 +57,13 @@ def with_vendor_verdict(res: "AggregatorResult", provider: str) -> "AggregatorRe
 class AggregatorResult:
     """`failure` is None when the aggregator relayed the vendor's answer (whatever its status).
     Otherwise it names who to blame, which is what decides the next rung:
-      aggregator_auth    — our key was rejected → mark the aggregator unhealthy
-      aggregator_balance — the aggregator's own account is empty → unhealthy
-      contract           — the aggregator's stricter input schema refused the request → this
-                           route is wrong for this call; no vendor call happened
-      pending            — async run not finished; poll `poll_url`
-      malformed          — not the envelope we know
+      aggregator_auth    - our key was rejected → mark the aggregator unhealthy
+      aggregator_balance - the aggregator's own account is empty → unhealthy
+      contract           - the aggregator's own per-request refusal (its stricter input schema,
+                           a validation 4xx with no vendor data) → this route is wrong for this
+                           call; no vendor call happened, nothing is charged, nothing is struck
+      pending            - async run not finished; poll `poll_url`
+      malformed          - not an envelope at all: non-JSON, a 5xx, a transport error
     `cost_micro` is the aggregator's in-band charge for this call (0 on a miss), the number the
     caller pays. None when the envelope carried no price."""
     upstream_status: int | None

--- a/src/treg/infra/upstream/aggregators/orthogonal.py
+++ b/src/treg/infra/upstream/aggregators/orthogonal.py
@@ -5,7 +5,9 @@ must be strings — Orthogonal rejects numbers), the vendor's body comes back ve
 and `priceCents` / `billing.chargedPriceCents` is the real charge (a vendor miss is still billed).
 An upstream error is relayed as `success: false` with the vendor's status in `error` and its body
 in `data`; Orthogonal's OWN refusals ride `_orthogonal.error` (`orthogonal_endpoint_contract` =
-its stricter schema said no, no vendor call, no charge).
+its stricter schema said no, no vendor call, no charge). A bare 4xx from Orthogonal with no vendor
+data (its request validation) is the same request-scoped `contract` verdict; only a non-JSON body,
+a 5xx or an envelope with neither `success` nor `data` is `malformed`.
 """
 
 from __future__ import annotations
@@ -69,9 +71,23 @@ def parse(status: int, body: bytes | dict) -> AggregatorResult:
     if own.get("error") == "orthogonal_endpoint_contract" and data is None:
         return AggregatorResult(None, b"", 0, "contract", str(own.get("message", ""))[:160])
     if upstream_status is None:
-        # No vendor body and no vendor status: Orthogonal itself refused. 402 = ITS balance.
-        kind = "aggregator_balance" if status == 402 else "aggregator_auth" if status in (401, 403) else "malformed"
-        return AggregatorResult(None, b"", 0 if kind != "malformed" else cost, kind, err[:120])
+        # No vendor body and no vendor status: Orthogonal itself refused. 402 = ITS balance;
+        # 401/403 = OUR key. Any other 4xx is Orthogonal's own per-request answer (a validation
+        # 400, a 422 on the envelope, a 404 for a slug it no longer lists): request-scoped, no
+        # vendor call, no charge - `contract`, never a strike on the whole aggregator. Found
+        # 2026-09-08: one such 400 read as `malformed` took overflow:orthogonal offline for every
+        # org for 15 minutes. `malformed` is reserved for what is NOT an envelope at all: a
+        # non-JSON body, a 5xx, a 2xx that carries neither success nor data.
+        if status == 402:
+            kind = "aggregator_balance"
+        elif status in (401, 403):
+            kind = "aggregator_auth"
+        elif 400 <= status < 500:
+            kind = "contract"
+        else:
+            kind = "malformed"
+        detail = (str(own.get("message") or "")[:160] if own else "") or err[:160]
+        return AggregatorResult(None, b"", 0 if kind != "malformed" else cost, kind, detail)
     # The vendor answered (an error, but ITS error): relay it as data. An upstream 402 through the
     # aggregator means the AGGREGATOR's vendor account is empty — the caller decides that (E).
     return AggregatorResult(upstream_status, _dump(data) if data is not None else b"", cost or 0, None,

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -242,6 +242,10 @@ class CatalogGetOut(TypedDict, total=False):
                                            # response is a list of records (brightdata datasets)
     hints: list[str] | None
     did_you_mean: list[str] | None         # real ids close to one that missed
+    overflow_price_usd: float | None       # what a call bills when treg's own account is out and the
+                                           # overflow relay serves it instead (absent = never relayed)
+    overflow_price_unit: str | None        # "call" | "result": what one unit of that price buys
+    overflow_via: str | None               # the relay aggregator that price belongs to
     error: str | None
     detail: str | None
 
@@ -253,6 +257,8 @@ class CallOut(TypedDict, total=False):
     replayed: bool | None           # answered from an earlier call with the same idempotency_key
     body: Any                       # the provider's response, verbatim
     cost_usd: float | None
+    served_via: str | None          # "overflow:<aggregator>" when a treg-owned relay account served
+                                    # the call at ITS price (X-Treg-Served-Via); absent on a direct call
     whose_error: str | None         # "treg" or "provider" — who to blame, and whether to retry
     hint: str | None
     did_you_mean: list[str] | None  # real ids close to one that missed
@@ -798,7 +804,16 @@ async def _catalog_get_impl(
                 "hints": [catalog_store.unknown_id_hint(endpoint_id, cat),
                           "or use catalog_search to find the right id"],
                 "did_you_mean": catalog_store.near_ids(endpoint_id, cat)}
-    return _body(r)
+    out = _body(r)
+    # Lifted onto the result so the schema advertises it: the direct price is not the only price
+    # a "free" endpoint can bill (found 2026-09-08 - apollo.people.search, catalog cost free, billed
+    # $0.002 through the overflow relay 8,810 times in a day and nothing on this surface said so).
+    ep = (out.get("endpoint") or {}) if isinstance(out, dict) else {}
+    if isinstance(ep, dict) and ep.get("overflow_price_usd") is not None:
+        out["overflow_price_usd"] = ep["overflow_price_usd"]
+        out["overflow_price_unit"] = ep.get("overflow_price_unit")
+        out["overflow_via"] = ep.get("overflow_via")
+    return out
 
 
 # --------------------------------------------------------------------------------------------
@@ -1015,6 +1030,17 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
             out["cost_usd"] = round(int(spent) / 1_000_000, 6)
         except ValueError:
             pass
+    # The relay disclosure. `/call/` says it in a header; an MCP client never sees headers, so
+    # until this line an agent reading `cost_usd` on a "free" endpoint had no way to explain the
+    # charge to the human (the header exists precisely so the price can be attributed).
+    served_via = r.headers.get("X-Treg-Served-Via")
+    if served_via:
+        out["served_via"] = served_via
+        if served_via.startswith("overflow:") and not out.get("hint"):
+            provider = endpoint_id.split(".", 1)[0]
+            out["hint"] = (f"served through the overflow relay ({served_via.removeprefix('overflow:')}) "
+                           f"at its real price because treg's {provider} account is out; cost_usd is "
+                           f"what the relay billed, not the catalog's direct price")
     if 200 <= r.status_code < 300 and not out.get("hint") and not out.get("replayed"):
         kind = None
         if r.headers.get("X-Treg-Review") == "requested" and out.get("call_id"):

--- a/src/treg/routers/catalog.py
+++ b/src/treg/routers/catalog.py
@@ -10,6 +10,7 @@ from fastapi.responses import Response
 
 from .. import audit, oauth_providers
 from ..config import get_settings
+from ..domain.capacity.routes_view import view as overflow_routes_view
 from ..domain.catalog import store as catalog_store
 from ..domain.catalog import stats as endpoint_stats
 
@@ -156,6 +157,30 @@ def _endpoint_observation_reader(request: Request) -> endpoint_stats.EndpointObs
     return request.app.state.endpoint_observation_reader
 
 
+async def _overflow_disclosure(ep: dict, cat) -> dict:
+    """What a platform-eligible endpoint bills when treg's own account is out and the deployment's
+    overflow relay serves it instead: the enabled route's aggregator price, on the row, so a "free"
+    endpoint is never silently a paid one. Same admission facts as the call path (`application.call.
+    overflow`: mode on, a key for the aggregator, an enabled route, Orthogonal first) minus the
+    per-process health marks, which change by the minute and are not a price. Empty when the
+    deployment cannot relay this endpoint at all; the route view is a 60 s in-process copy."""
+    settings = get_settings()
+    if settings.overflow_mode != "on" or not cat.platform_eligible(ep):
+        return {}
+    try:
+        await overflow_routes_view.load()
+    except Exception:  # noqa: BLE001 - a disclosure must never take the catalog down
+        logging.getLogger("treg.catalog").warning("overflow routes unavailable", exc_info=True)
+        return {}
+    for route in overflow_routes_view.for_endpoint(ep["id"]):
+        if not settings.overflow_key_for(route.aggregator) or route.agg_price_micro is None:
+            continue
+        return {"overflow_price_usd": route.agg_price_micro / 1_000_000,
+                "overflow_price_unit": route.agg_unit or "call",
+                "overflow_via": route.aggregator}
+    return {}
+
+
 async def _observed_or_empty(
     reader: endpoint_stats.EndpointObservationReader, endpoint_ids: list[str],
 ) -> endpoint_stats.ObservationSnapshot:
@@ -300,7 +325,8 @@ async def catalog_endpoint(
     # Attached to the SAME response because the choice is made here; a second round-trip to compare
     # reliability is a round-trip an agent will skip.
     stats = await _observed_or_empty(observations, [endpoint_id] + [s["id"] for s in siblings])
-    view = view | {"observed": stats.get(endpoint_id)}
+    overflow = await _overflow_disclosure(ep, cat)
+    view = view | {"observed": stats.get(endpoint_id)} | overflow
     siblings = [s | {"observed": stats.get(s["id"])} for s in siblings]
 
     routing = None
@@ -342,6 +368,11 @@ async def catalog_endpoint(
         "call_template": catalog_store.call_template(ep),
         "example_response": example,
         "hints": [f"{catalog_store.call_template(ep)}   # run it — key injected server-side"]
+                 + ([f"when treg's own {ep['provider']} account is out this may be served through the "
+                     f"overflow relay ({overflow['overflow_via']}) and bill "
+                     f"${overflow['overflow_price_usd']:g} per {overflow['overflow_price_unit']} instead "
+                     f"of the direct price; the answer says so (X-Treg-Served-Via / served_via)"]
+                    if overflow else [])
                  + ([f"treg catalog get {siblings[0]['id']}   # the same job from {siblings[0]['provider']}"]
                     if siblings else []),
     }

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -209,8 +209,10 @@ treg does **not** choose or fail over **between providers** for you, by design: 
 inputs you hold, and treg relays your request rather than rewriting it. One thing it may do, and
 tells you when it does: if treg's OWN account for the provider is out, it can serve the **same
 endpoint** through a treg-owned relay account — same request, same response shape, the relay's
-real price — with `X-Treg-Served-Via: overflow:<name>` on the response (a team can opt out with
-`treg org overflow off`). Your own keys are never relayed.
+real price — with `X-Treg-Served-Via: overflow:<name>` on the response, or `served_via` plus a hint
+on the MCP `call` result (a team can opt out with `treg org overflow off`). `catalog_get` shows that
+relay price up front as `overflow_price_usd` when the deployment can relay the endpoint: a "free"
+endpoint with one may bill exactly that, so quote it. Your own keys are never relayed.
 
 <!--routed-->
 **Routed endpoints — when you WANT treg to choose.** `treg.<capability>` rows (today:

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -112,8 +112,10 @@ Notes:
   - treg does **not** choose or fail over **between providers** for you. That is deliberate: only
     you know which inputs you hold, and treg relays rather than rewrites your request. If treg's
     own account for a provider is out it may serve the **same endpoint** through a treg-owned relay
-    (`X-Treg-Served-Via: overflow:<name>`, real price, same shape); a team opts out with
-    `treg org overflow off`.
+    (`X-Treg-Served-Via: overflow:<name>`, or `served_via` + a hint on the MCP `call` result; real
+    price, same shape). `catalog_get` shows that price up front as `overflow_price_usd` when the
+    deployment can relay the endpoint - a "free" endpoint with one may bill exactly that, so quote
+    it. A team opts out with `treg org overflow off`.
 <!--routed-->
   - **Routed endpoints** (`treg.<capability>`, e.g. `treg.people.email.find`) are where you can
     ask treg to choose: POST the identity (`{full_name, domain}` | `{first_name, last_name, domain}` |

--- a/tests/test_capacity_overflow.py
+++ b/tests/test_capacity_overflow.py
@@ -843,3 +843,151 @@ async def test_contactout_renewal_budget_includes_direct_cost_and_uses_ephemeral
     result=await main(SimpleNamespace(budget_usd=budget,apply=False))
     assert len(seen)==expected_calls
     assert result==(0 if expected_calls else 1)
+
+
+# ---- an aggregator's OWN per-request 4xx is request-scoped, never a strike --------------------
+# 2026-09-08: one Orthogonal 400 (its request validation, no vendor data) parsed as `malformed`,
+# which is AGGREGATOR_SIDE - overflow:orthogonal was struck for 15 minutes for every org, and every
+# Apollo call for that quarter hour became provider_capacity_unavailable with no route left.
+
+APOLLO_SEARCH_EP = "apollo.people.search"       # POST /mixed_people/api_search, catalog cost FREE
+APOLLO_SEARCH_PATH = "/mixed_people/api_search"
+ORTHOGONAL_OWN_400 = {"success": False, "error": "query.page must be a string"}
+ORTHOGONAL_OWN_422 = {"success": False, "error": "Unprocessable: body.per_page exceeds 100",
+                      "_orthogonal": {"message": "body.per_page exceeds 100"}}
+
+
+def test_orthogonal_parse_reserves_malformed_for_what_is_not_an_envelope():
+    from treg.infra.upstream.aggregators import AGGREGATOR_SIDE, orthogonal
+    own_400 = orthogonal.parse(400, json.dumps(ORTHOGONAL_OWN_400).encode())
+    own_422 = orthogonal.parse(422, json.dumps(ORTHOGONAL_OWN_422).encode())
+    own_404 = orthogonal.parse(404, b'{"success":false,"error":"Unknown api slug"}')
+    for res in (own_400, own_422, own_404):
+        assert res.failure == "contract" and res.failure not in AGGREGATOR_SIDE
+        assert res.cost_micro == 0 and res.upstream_status is None and res.upstream_body == b""
+    assert own_422.detail == "body.per_page exceeds 100", "the aggregator's own message, for the caller"
+    # what still blames the aggregator as a whole
+    assert orthogonal.parse(402, b'{"success":false,"error":"insufficient balance"}').failure == "aggregator_balance"
+    assert orthogonal.parse(401, b'{"error":"invalid key"}').failure == "aggregator_auth"
+    assert orthogonal.parse(500, b'{"success":false,"error":"internal"}').failure == "malformed"
+    assert orthogonal.parse(502, b"<html>bad gateway</html>").failure == "malformed"
+    assert orthogonal.parse(200, b"<html>").failure == "malformed"
+    # a 4xx that DOES carry the vendor's body is the vendor's answer, relayed as before
+    relayed = orthogonal.parse(422, json.dumps({"success": False, "error": "API request failed with status 422",
+                                                "data": {"error": "Please provide at least one of: first_name"}}).encode())
+    assert relayed.failure is None and relayed.upstream_status == 422
+
+
+async def _orthogonal_lock():
+    async with session_maker() as db:
+        raw = await ratestore.kv_get(db, LOCK_NS, "overflow:orthogonal")
+    return Lock.from_json(raw) if raw else None
+
+
+async def test_orthogonals_own_400_is_request_scoped_and_never_strikes_the_aggregator(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    """The old wrong outcome: the vendor 402 became a typed 503, overflow:orthogonal went unhealthy
+    for 15 minutes for every org. Now: the vendor's own answer stands, nothing charged, no mark, and
+    the very next call reaches Orthogonal again."""
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"nope"}'))
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(400, ORTHOGONAL_OWN_400),
+                                                 (200, {"success": True, "data": VENDOR_BODY, "priceCents": 0.3})], seen))
+    before = await _balance(clients)
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 402 and r.text == '{"detail":"nope"}', "the vendor's answer, not the relay's envelope"
+    assert "X-Treg-Served-Via" not in r.headers
+    assert await _balance(clients) == before and await _holds() == []
+    lock = await _orthogonal_lock()
+    assert lock is None or not lock.is_active(), "a request-scoped refusal is not an aggregator outage"
+    r2 = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r2.status_code == 200 and r2.headers["X-Treg-Served-Via"] == "overflow:orthogonal", r2.text
+    assert len(seen) == 2 and before - await _balance(clients) == 3_000
+    await audit.drain()
+    from treg.models import CallRecord
+    async with session_maker() as db:
+        children = (await db.execute(select(CallRecord).where(CallRecord.credential_tier == "platform-overflow"))).scalars().all()
+    refused = [c for c in children if (c.error_response or "").endswith("contract")]
+    assert len(children) == 2 and len(refused) == 1, "both child attempts are on the record"
+    assert refused[0].cost_charged_micro == 0 and refused[0].cost_observed_micro == 0
+
+
+async def test_orthogonals_own_422_on_the_skip_direct_ladder_is_a_typed_503_naming_the_refusal(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    """No vendor answer exists on this ladder, so the caller gets treg's typed 503 that says the
+    relay refused THIS request - never Orthogonal's envelope as if Apollo had answered - and the
+    aggregator stays healthy for the next caller."""
+    await _route(endpoint_id=APOLLO_SEARCH_EP, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH,
+                 price_micro=2_000, ratio=None)
+    now = utcnow_naive()
+    async with session_maker() as db:
+        await ratestore.kv_put(db, STATE_NS, "apollo", LatestState(
+            "apollo", 0.0, "USD", now, "exact", exhausted_until=now + timedelta(hours=1), health="exhausted").to_json(), ttl_s=3600)
+        await db.commit()
+    capacity_view.invalidate()
+
+    async def never(*a, **k):
+        raise AssertionError("the direct relay must not run")
+    monkeypatch.setattr(call_service, "relay", never)
+    seen = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(422, ORTHOGONAL_OWN_422)], seen))
+    before = await _balance(clients)
+    r = await clients.post(f"/call/{APOLLO_SEARCH_EP}", json={"person_titles": ["cto"], "per_page": 500})
+    assert r.status_code == 503 and r.headers["X-Treg-Error"] == "1", r.text
+    detail = r.json()["detail"]
+    assert detail["error"] == "provider_capacity_unavailable" and detail["provider"] == "apollo"
+    assert "contract" in detail["message"] and "body.per_page exceeds 100" in detail["message"]
+    assert "nothing was charged" in detail["message"]
+    assert "success" not in r.json() and r.headers.get("X-Treg-Cost-Micro") in (None, "0")
+    assert await _balance(clients) == before and await _holds() == []
+    lock = await _orthogonal_lock()
+    assert lock is None or not lock.is_active(), "one refused request must not take the relay offline"
+    assert len(seen) == 1
+
+
+async def test_orthogonal_5xx_still_marks_the_aggregator_unhealthy(clients: AsyncClient, overflow_on, monkeypatch):
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"nope"}'))
+    monkeypatch.setattr(O, "_send", _orthogonal([(503, {"success": False, "error": "upstream gateway timeout"})], []))
+    r = await clients.get(f"/call/{EP}?aweme_id=7")
+    assert r.status_code == 503 and r.json()["detail"]["error"] == "provider_capacity_unavailable"
+    lock = await _orthogonal_lock()
+    assert lock is not None and lock.is_active()
+    assert await _holds() == []
+
+
+# ---- the catalog discloses what a relayed call bills -------------------------------------------
+
+async def test_catalog_get_discloses_the_overflow_price_of_a_free_endpoint(clients: AsyncClient, overflow_on):
+    """apollo.people.search is catalog-free and billed $0.002 through Orthogonal 8,810 times on
+    2026-09-08; nothing on the read surface said a free endpoint could bill. The route's price now
+    rides on the endpoint row whenever the deployment can relay it."""
+    await _route(endpoint_id=APOLLO_SEARCH_EP, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH,
+                 price_micro=2_000, ratio=None)
+    r = await clients.get(f"/catalog/endpoints/{APOLLO_SEARCH_EP}")
+    assert r.status_code == 200, r.text
+    ep = r.json()["endpoint"]
+    assert ep["cost"]["usd"] == 0 and ep["platform_eligible"] is True
+    assert ep["overflow_price_usd"] == 0.002 and ep["overflow_via"] == "orthogonal"
+    assert ep["overflow_price_unit"] == "call"
+    assert any("overflow relay (orthogonal)" in h and "$0.002 per call" in h for h in r.json()["hints"])
+
+
+async def test_catalog_get_says_nothing_about_overflow_when_the_deployment_cannot_relay(
+    clients: AsyncClient, overflow_on, monkeypatch,
+):
+    await _route(endpoint_id=APOLLO_SEARCH_EP, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH,
+                 price_micro=2_000, ratio=None)
+    # a disabled route is no route
+    await _route(endpoint_id=EP, price_micro=3_000, enabled=False)
+    r = await clients.get(f"/catalog/endpoints/{EP}")
+    assert "overflow_price_usd" not in r.json()["endpoint"]
+    # mode off: the price is not a price this deployment can bill
+    monkeypatch.setenv("TREG_OVERFLOW_MODE", "off")
+    get_settings.cache_clear()
+    r = await clients.get(f"/catalog/endpoints/{APOLLO_SEARCH_EP}")
+    assert "overflow_price_usd" not in r.json()["endpoint"]
+    assert not any("overflow relay" in h for h in r.json()["hints"])

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1416,3 +1416,83 @@ async def test_the_SEARCH_TOOL_itself_ranks_on_evidence_not_just_the_helper(clie
     good_row = next(r for r in out["results"] if r["endpoint_id"] == good)
     broken_row = next(r for r in out["results"] if r["endpoint_id"] == broken)
     assert good_row["works"] == 0.8 and broken_row["works"] == 0.0
+
+
+# ---- the overflow relay is disclosed on THIS surface, not only in a header ------------------
+# 2026-09-08: apollo.people.search (catalog cost free) was served through Orthogonal 8,810 times
+# at $0.002 while treg's Apollo account was out. `/call/` said so in X-Treg-Served-Via; an MCP
+# client never sees headers, so the agent reported a free call that billed. Six reports.
+
+from test_capacity_overflow import VENDOR_BODY, _orthogonal, _route, overflow_on, platform_on  # noqa: E402,F401
+
+
+async def _overflow_rescued(monkeypatch, price_cents: float = 0.3):
+    """Vendor 402 on treg's own key, Orthogonal answers: the shape of every rescued call."""
+    from treg.application.call import overflow as O
+    from treg.application.call import service as call_service
+    from test_marketplace_call import _fake_relay
+
+    await _route(price_micro=3_000)
+    monkeypatch.setattr(call_service, "relay", _fake_relay(402, b'{"detail":"Insufficient balance"}'))
+    seen: list = []
+    monkeypatch.setattr(O, "_send", _orthogonal([(200, {"success": True, "data": VENDOR_BODY,
+                                                         "priceCents": price_cents})], seen))
+    return seen
+
+
+async def test_a_call_served_by_the_overflow_relay_says_so_and_prices_it(clients, overflow_on, monkeypatch):
+    token = clients.headers["X-Treg-Token"]
+    seen = await _overflow_rescued(monkeypatch)
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {"endpoint_id": "tikhub.tiktok.video.comments",
+                                           "params": {"aweme_id": "7"}}, token=token)
+    assert out.get("status") == 200, out
+    assert out["served_via"] == "overflow:orthogonal" and out["cost_usd"] == 0.003
+    assert out["body"] == VENDOR_BODY, "the vendor's body, verbatim, through the relay"
+    hint = out.get("hint") or ""
+    assert "overflow relay (orthogonal)" in hint and "treg's tikhub account is out" in hint, hint
+    assert "real price" in hint and len(seen) == 1
+
+
+async def test_a_direct_call_carries_no_served_via(clients, platform_on):
+    token = clients.headers["X-Treg-Token"]
+    async with mcp_session(clients) as c:
+        out = await _call_tool(c, "call", {"endpoint_id": "tikhub.tiktok.video.comments",
+                                           "params": {"aweme_id": "7"}}, token=token)
+    assert out.get("status") == 200, out
+    assert "served_via" not in out and "overflow" not in (out.get("hint") or "")
+
+
+async def test_the_directory_surface_discloses_the_relay_the_same_way(clients, overflow_on, monkeypatch):
+    """`/mcp/v2/` builds the same result through `_call_impl`; reviewed against both on purpose."""
+    from test_mcp_directory import _call_tool as _directory_call, directory_session
+
+    token = clients.headers["X-Treg-Token"]
+    await _overflow_rescued(monkeypatch)
+    async with directory_session() as client:
+        out = await _directory_call(client, "catalog_call_read",
+                                    {"endpoint_id": "tikhub.tiktok.video.comments",
+                                     "params": {"aweme_id": "7"}}, token)
+    assert out.get("status") == 200, out
+    assert out["served_via"] == "overflow:orthogonal" and out["cost_usd"] == 0.003
+    assert "overflow relay (orthogonal)" in (out.get("hint") or "")
+
+
+async def test_catalog_get_shows_what_a_FREE_endpoint_bills_through_the_relay(clients, overflow_on):
+    """The price an agent quotes before calling must include the one it may actually pay."""
+    from test_capacity_overflow import APOLLO_SEARCH_EP, APOLLO_SEARCH_PATH
+    from test_mcp_directory import _call_tool as _directory_call, directory_session
+
+    token = clients.headers["X-Treg-Token"]
+    await _route(endpoint_id=APOLLO_SEARCH_EP, provider="apollo", method="POST", path=APOLLO_SEARCH_PATH,
+                 price_micro=2_000, ratio=None)
+    async with mcp_session(clients) as c:
+        team = await _call_tool(c, "catalog_get", {"endpoint_id": APOLLO_SEARCH_EP}, token=token)
+    async with directory_session() as client:
+        directory = await _directory_call(client, "catalog_get", {"endpoint_id": APOLLO_SEARCH_EP}, token)
+    for out in (team, directory):
+        assert out["endpoint"]["cost"]["usd"] == 0, out["endpoint"]["cost"]
+        assert out["overflow_price_usd"] == 0.002 and out["overflow_via"] == "orthogonal"
+        assert out["overflow_price_unit"] == "call"
+        assert out["endpoint"]["overflow_price_usd"] == 0.002
+        assert any("overflow relay (orthogonal)" in h for h in out["hints"])


### PR DESCRIPTION
Split out of #400 because it changes capacity policy for every overflowed call, not one provider's billing rule. Two commits so the policy half can be reviewed and reverted on its own.

## 1. Disclose the relay on the MCP surface (low risk)

When treg's own account for a provider is marked out, a platform-eligible endpoint may be served through the overflow relay at the aggregator's real price with 0% markup. That is the documented contract (AGENTS.md non-negotiable 4, money.md "Overflow money", llms.txt, skill.md, `treg org overflow off`), and `/call/` says so in `X-Treg-Served-Via`. The MCP `call` tool dropped that header and `catalog_get` showed only the direct price, so an agent on apollo.people.search (catalog: free) saw `cost_usd 0.002` with no explanation. Ledger for 2026-09-08: 100,113 Apollo searches, 24,960 through the relay, 8,810 billed $0.002. Six feedback reports from one org.

- MCP `call` result carries `served_via` and a one-line hint when it names an overflow aggregator (shared `_call_impl`, so both `/mcp/` and `/mcp/v2/`).
- `catalog_get` and `GET /catalog/{id}` expose `overflow_price_usd`, `overflow_price_unit`, `overflow_via` for endpoints the deployment can relay, and the run hint says a "free" endpoint may bill that price.
- llms.txt, skill.md and the five installed SKILL.md copies say the same thing.

## 2. Scope an aggregator's own 4xx to the request (policy change)

One Orthogonal validation 400 with no vendor data was classified `malformed`, which is aggregator-side and struck `overflow:orthogonal` for 15 minutes for every org; with the direct tier skipped, every call in that window failed as `provider_capacity_unavailable`. A bare 4xx from the aggregator (400/422 validation, 404 for a slug it no longer lists) is now `contract`: request-scoped, no vendor call, nothing charged, no strike, and on the skip-direct ladder the caller gets treg's typed 503 naming the refusal rather than the aggregator envelope. `malformed` is reserved for non-JSON bodies, 5xx and transport errors. 402 and 401/403 keep their aggregator-side meaning.

Trade-off to weigh: repeated bad requests now reach Orthogonal every time instead of being short-circuited for 15 minutes. Also corrects money.md's stale $20/day aggregator budget (render.yaml sets $500).

Not changed: when a free endpoint is diverted to overflow. Today a zero-cost endpoint is skipped on the same exhausted signal as a paid one, including a credit-balance reading from the capacity sweep; whether a $0 direct call should ever be diverted to a paid relay is a product decision left open.

## Verification

- `uv run --with pytest-xdist pytest -n auto`: 3203 passed, 5 skipped. `test_alembic_head_has_no_model_drift` passes against a private `TREG_TEST_DB_URL`; the shared sqlite files under `$TMPDIR/treg-tests` are contaminated on this machine by other checkouts' runs.
- `lint-imports`: 14 contracts kept. `drift.sh origin/main..HEAD`: every changed source maps to a fragment updated in these commits (the mixed docs, money.md and proxy-model.md, sit in the second commit).
