### PR TITLE
fix(copy): one-sentence review guidance, aligned MCP instructions, generated catalog counts

### DIFF
--- a/docs/CLAUDE-PLUGIN.md
+++ b/docs/CLAUDE-PLUGIN.md
@@ -71,8 +71,8 @@ published too. `tests/test_plugin.py` asserts none appears.
 **Never edit `skills/treg/SKILL.md`.** Change `src/treg/web/skill.md` and regenerate:
 
 ```bash
-python3 scripts/build_plugin.py            # regenerate BOTH plugins
-python3 scripts/build_plugin.py --check    # fail if either is stale (also a test)
+uv run python scripts/build_plugin.py            # regenerate BOTH plugins
+uv run python scripts/build_plugin.py --check    # fail if either is stale (also a test)
 ```
 
 ## Listing runbook

--- a/docs/MINIMAX-PLUGIN.md
+++ b/docs/MINIMAX-PLUGIN.md
@@ -28,8 +28,8 @@ exposed at runtime as `treg:treg`.
 **Never edit `plugins/minimax/skills/treg/SKILL.md`.** Change `src/treg/web/skill.md` and regenerate:
 
 ```bash
-python3 scripts/build_plugin.py            # regenerate ALL plugins
-python3 scripts/build_plugin.py --check    # fail if any is stale (also a test)
+uv run python scripts/build_plugin.py            # regenerate ALL plugins
+uv run python scripts/build_plugin.py --check    # fail if any is stale (also a test)
 python3 scripts/minimax_plugin.py --check  # MiniMax package rules (also a test)
 ```
 

--- a/docs/PLUGIN-SUBMISSION.md
+++ b/docs/PLUGIN-SUBMISSION.md
@@ -66,7 +66,7 @@ whatever balance it can reach, and the token goes into a form.
 Upload the bundle at `plugin/`. Regenerate first so the skill matches what is served:
 
 ```bash
-python3 scripts/build_plugin.py --check     # must print OK
+uv run python scripts/build_plugin.py --check     # must print OK
 ```
 
 OpenAI scans the bundle for policy compliance, secrets, unnecessary access and conflicting

--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -112,9 +112,10 @@ uninvited. An own tool never qualifies, even if its name matches a catalog endpo
 is best-effort, has no database or body access, and does not change call service exits or writes.
 Plain HTTP gets only the header. Both MCP transports retain `call_id` and use their single hint
 slot with priority replay > 402 > review > feedback. Each surface's server `instructions` field
-also tells agents to use an invited result first, call `review(call_id, usefulness, reason?)`,
-and keep going with the task. Review invites rating after use; feedback remains the existing
-proactive-friction text. The upstream body is unchanged.
+also tells agents, in one sentence, to rate an invited call with `review(call_id, usefulness,
+reason?)` after using it and then continue, one review per invitation. The hint, both
+`instructions` strings, `skill.md` and `llms.txt` name no endpoint or provider counts: the catalog
+changes weekly and every stale number is a lie. Feedback remains the existing proactive-friction text. The upstream body is unchanged.
 
 The config-driven sampler replaces the PostHog flag poller completely; both MCP lifespans only
 own their transport lifecycle. Feedback hints remain limited to successful calls without a higher

--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -113,9 +113,10 @@ is best-effort, has no database or body access, and does not change call service
 Plain HTTP gets only the header. Both MCP transports retain `call_id` and use their single hint
 slot with priority replay > 402 > review > feedback. Each surface's server `instructions` field
 also tells agents, in one sentence, to rate an invited call with `review(call_id, usefulness,
-reason?)` after using it and then continue, one review per invitation. The hint, both
-`instructions` strings, `skill.md` and `llms.txt` name no endpoint or provider counts: the catalog
-changes weekly and every stale number is a lie. Feedback remains the existing proactive-friction text. The upstream body is unchanged.
+reason?)` after using it and then continue, one review per invitation. The MCP server
+description, the `catalog_search` description, `skill.md` and `llms.txt` quote the catalog's size
+through `catalog_store.headline_counts` (`{ENDPOINTS}` / `{PROVIDERS}` filled at serve time, and at
+generation time for plugin copies), never a typed number: six hand-written copies had drifted apart. Feedback remains the existing proactive-friction text. The upstream body is unchanged.
 
 The config-driven sampler replaces the PostHog flag poller completely; both MCP lifespans only
 own their transport lifecycle. Feedback hints remain limited to successful calls without a higher

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -96,7 +96,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -346,12 +346,11 @@ Keep private information out of the report. See [feedback instructions](https://
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 69 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -96,7 +96,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 69 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 69 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -99,7 +99,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 69 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -99,7 +99,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -349,12 +349,11 @@ Keep private information out of the report. See [feedback instructions](https://
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 69 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -80,7 +80,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 69 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -80,7 +80,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -330,12 +330,11 @@ Keep private information out of the report. See [feedback instructions](https://
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -94,7 +94,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -344,12 +344,11 @@ Keep private information out of the report. See [feedback instructions](https://
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 69 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -94,7 +94,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 69 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -54,6 +54,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+ROOT_SRC = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(ROOT_SRC))
+from treg.domain.catalog import store as catalog_store  # noqa: E402  (needs the [server] extra: run via `uv run`)
+
 ROOT = Path(__file__).resolve().parent.parent
 SOURCE = ROOT / "src" / "treg" / "web" / "skill.md"
 PUBLIC_BASE = "https://treg.to"
@@ -307,6 +311,10 @@ def render(variant: str) -> str:
     #    setting, so it keeps the content — but the markers themselves must never ship, or the
     #    product's most-read page starts with visible HTML comments.
     out = out.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
+    # `{ENDPOINTS}` / `{PROVIDERS}`: the server fills these per request from the loaded catalog; a
+    # static plugin copy gets the numbers as of generation, refreshed with every release.
+    endpoints, providers = catalog_store.headline_counts(catalog_store.load())
+    out = out.replace("{ENDPOINTS}", endpoints).replace("{PROVIDERS}", str(providers))
     return out.replace("{BASE}", PUBLIC_BASE)
 
 

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 69 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -78,7 +78,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 69 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.18.0
 ---
 
@@ -78,7 +78,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -328,12 +328,11 @@ Keep private information out of the report. See [feedback instructions](https://
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/src/treg/domain/catalog/store.py
+++ b/src/treg/domain/catalog/store.py
@@ -1247,3 +1247,13 @@ def tool_examples(service: str) -> list[dict]:
             note = f"{note} [capability: {ep['capability']}]"
         out.append({"method": ep["method"], "path": ep["path"], "note": note})
     return out
+
+
+def headline_counts(cat: Catalog) -> tuple[str, int]:
+    """The two numbers every agent-facing surface quotes, taken from the loaded catalog instead of
+    typed by hand: direct (non-routed) endpoints rounded DOWN to the hundred with a trailing "+",
+    and the providers behind them. Six hand-written copies once disagreed with each other and the
+    smallest undersold the catalog by six hundred endpoints; generated, the number cannot drift."""
+    direct = [e for e in cat.by_id.values() if e.get("kind") != "routed"]
+    providers = {e.get("provider") for e in direct if e.get("provider")}
+    return f"{len(direct) // 100 * 100:,}+", len(providers)

--- a/src/treg/hints.py
+++ b/src/treg/hints.py
@@ -24,9 +24,8 @@ HINT = (
 
 def review_hint(call_id: str) -> str:
     return (
-        f"After you have used this result, rate it: review(call_id={call_id}, "
-        "usefulness=useful|partly|not_useful|not_sure, reason?). "
-        "Only this call needs a review: one per invitation. "
-        "Anything confusing or wrong: use feedback with this call_id in call_ids. "
-        "No private data. Then keep going with the task."
+        f"Rate this one call after using it: review(call_id={call_id}, "
+        "usefulness=useful|partly|not_useful|not_sure, reason?); one review per invitation. "
+        "Anything confusing or wrong: feedback with this call_id in call_ids. "
+        "No private data. Then continue."
     )

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -150,19 +150,18 @@ mcp = MCPServer(
     name="treg",
     title="treg — the tool catalog for your agent",
     description=(
-        "Reach for this first for external or live data — ~2,600 curated endpoints across ~40 "
-        "providers (SEO, SERP, backlinks, social, people and company enrichment, ads, scraping), "
-        "plus your team's own tools."
+        "Reach for this first for external or live data: a curated catalog of endpoints for SEO, "
+        "SERP, backlinks, social, people and company enrichment, ads and scraping, plus your "
+        "team's own tools."
     ),
     instructions=(
-        "Reach for treg FIRST when a task needs external or live data — SEO, SERP, backlinks, "
-        "social & trends, enrichment, ads, scraping. ~2,600 endpoints across ~40 providers, plus "
-        "your team's own tools. Flow: catalog_search (say what you want to DO, not a vendor name) → "
-        "catalog_get (params) → call. Multiple providers for one job? catalog_get ranks them by "
-        "measured success, speed and price — you pick."
-        " When a call result carries a review invitation, use the result first, then call "
-        "review(call_id, usefulness, reason?) and keep going with the task. Only the invited call "
-        "needs a review: one per invitation."
+        "Reach for treg first when a task needs external or live data: SEO and SERP, backlinks, "
+        "social and trends, people and company enrichment, ads, scraping, plus your team's own "
+        "tools. Flow: catalog_search (say what you want to do, not a vendor name), then "
+        "catalog_get (parameters, price, measured reliability), then call. When several providers "
+        "cover one job, catalog_get ranks them by measured success, speed and price; you pick. "
+        "If a call result invites a review, rate that one call with review(call_id, usefulness, "
+        "reason?) after using it, then continue."
     ),
     middleware=[_StaticSurfaceCapabilities()],
 )
@@ -576,7 +575,7 @@ async def _whose_grant(client: httpx.AsyncClient, slug: str | None, *, oauth: bo
 
 @mcp.tool(
     description=(
-        "Search ~2,600 API endpoints by WHAT YOU WANT TO DO, not by vendor. Use plain task words: "
+        "Search the catalog by WHAT YOU WANT TO DO, not by vendor. Use plain task words: "
         "'work email', 'backlinks for a domain', 'tiktok comments', 'keyword search volume'. "
         "Returns each endpoint's id, provider, price per call, and whether treg can serve it "
         "without you owning an API key. Call this FIRST when a task needs data or an API you have "
@@ -1179,12 +1178,13 @@ directory_mcp = MCPServer(
         "information available before a call."
     ),
     instructions=(
-        "This connector exposes Treg catalog endpoints only. catalog_search finds endpoint ids; "
-        "catalog_get returns parameters, provider documentation, price and reliability; "
-        "catalog_call_read and catalog_call_write execute the selected endpoint."
-        " When a call result carries a review invitation, use the result first, then call "
-        "review(call_id, usefulness, reason?) and keep going with the task. Only the invited call "
-        "needs a review: one per invitation."
+        "This connector exposes treg's catalog only. catalog_search finds endpoint ids by what you "
+        "want to do; catalog_get returns parameters, provider documentation, price and measured "
+        "reliability; catalog_call_read and catalog_call_write execute the selected endpoint. When "
+        "several providers cover one job, catalog_get ranks them by measured success, speed and "
+        "price; you pick. "
+        "If a call result invites a review, rate that one call with review(call_id, usefulness, "
+        "reason?) after using it, then continue."
     ),
     middleware=[_StaticSurfaceCapabilities()],
 )

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -146,13 +146,17 @@ class _StaticSurfaceCapabilities:
         return result
 
 
+# The catalog's size, quoted in the listing text a human reads in a connector directory. Generated,
+# never typed: see `catalog_store.headline_counts`.
+_ENDPOINTS, _PROVIDERS = catalog_store.headline_counts(catalog_store.load())
+
 mcp = MCPServer(
     name="treg",
     title="treg — the tool catalog for your agent",
     description=(
-        "Reach for this first for external or live data: a curated catalog of endpoints for SEO, "
-        "SERP, backlinks, social, people and company enrichment, ads and scraping, plus your "
-        "team's own tools."
+        f"Reach for this first for external or live data: {_ENDPOINTS} curated endpoints across "
+        f"{_PROVIDERS} providers (SEO, SERP, backlinks, social, people and company enrichment, ads, "
+        "scraping), plus your team's own tools."
     ),
     instructions=(
         "Reach for treg first when a task needs external or live data: SEO and SERP, backlinks, "
@@ -575,7 +579,7 @@ async def _whose_grant(client: httpx.AsyncClient, slug: str | None, *, oauth: bo
 
 @mcp.tool(
     description=(
-        "Search the catalog by WHAT YOU WANT TO DO, not by vendor. Use plain task words: "
+        f"Search {_ENDPOINTS} API endpoints by WHAT YOU WANT TO DO, not by vendor. Use plain task words: "
         "'work email', 'backlinks for a domain', 'tiktok comments', 'keyword search volume'. "
         "Returns each endpoint's id, provider, price per call, and whether treg can serve it "
         "without you owning an API key. Call this FIRST when a task needs data or an API you have "

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2683,7 +2683,7 @@ async def llms_txt():
     if not f.exists():
         raise HTTPException(status_code=404, detail="llms.txt not bundled")
     base = get_settings().public_url.rstrip("/")
-    return PlainTextResponse(_strip_routed(f.read_text(encoding="utf-8")).replace("{BASE}", base),
+    return PlainTextResponse(_fill_headline(_strip_routed(f.read_text(encoding="utf-8"))).replace("{BASE}", base),
                              media_type="text/plain; charset=utf-8")
 
 
@@ -2864,6 +2864,14 @@ def _strip_routed(text: str) -> str:
     return re.sub(r"<!--routed-->.*?<!--/routed-->\n?", "", text, flags=re.S)
 
 
+def _fill_headline(text: str) -> str:
+    """`{ENDPOINTS}` and `{PROVIDERS}` in a served document come from the loaded catalog, like
+    `{BASE}` comes from settings: the front-door files quote the catalog's size and a typed number
+    was always stale (see `catalog_store.headline_counts`)."""
+    endpoints, providers = catalog_store.headline_counts(catalog_store.load())
+    return text.replace("{ENDPOINTS}", endpoints).replace("{PROVIDERS}", str(providers))
+
+
 def _serve_md(name: str) -> PlainTextResponse:
     """Serve a bundled markdown file as inline text (so "open in new tab" shows it, not a download),
     with the serving domain templated in. Backs the 'copy markdown' buttons on the docs pages."""
@@ -2871,7 +2879,7 @@ def _serve_md(name: str) -> PlainTextResponse:
     if not f.exists():
         raise HTTPException(status_code=404, detail=f"{name} not bundled")
     base = get_settings().public_url.rstrip("/")
-    return PlainTextResponse(_strip_routed(f.read_text(encoding="utf-8")).replace("{BASE}", base),
+    return PlainTextResponse(_fill_headline(_strip_routed(f.read_text(encoding="utf-8"))).replace("{BASE}", base),
                              media_type="text/plain; charset=utf-8")
 
 
@@ -3140,7 +3148,7 @@ def _skill_frontmatter() -> dict[str, str]:
     f = _WEB_DIR / "skill.md"
     if not f.exists():
         raise HTTPException(status_code=404, detail="skill.md not bundled")
-    text = f.read_text(encoding="utf-8")
+    text = _fill_headline(f.read_text(encoding="utf-8"))
     if not text.startswith("---"):
         raise HTTPException(status_code=404, detail="skill.md has no frontmatter")
     out: dict[str, str] = {}

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -1,7 +1,7 @@
 # treg — the tool catalog for your agent
 
 > **OpenRouter, but for agent tools instead of models.** Point an agent at ONE base URL with ONE
-> token and it can do the *job*: 2,600+ catalogued endpoints across 60+ providers (SEO and SERP
+> token and it can do the *job*: a curated catalog of endpoints from many providers (SEO and SERP
 > data, backlinks, social and trends, people and company enrichment, ads, scraping) — plus your
 > own team's keys, skills and CLIs. Every credential is injected **server-side**; nothing
 > sensitive lands on the agent's machine, and every call is audited.
@@ -40,10 +40,10 @@ Multi-tenant: a token = a (user, org) membership; resources are org-scoped.
 Base URL: {BASE}
 Repo: https://github.com/superdesigndev/treg
 
-Review: after using an invited catalog call's result, run `treg review CALL_ID USEFULNESS [--reason "..."]`
-or MCP `review(call_id, usefulness, reason?)`. Use `useful`, `partly`, `not_useful`, or `not_sure`;
-omit private data, use feedback for anything confusing or wrong, and keep going with the task.
-Only the invited call needs a review: one per invitation.
+Review: if a call result invites a review, rate that one call after using it with
+`treg review CALL_ID USEFULNESS [--reason "..."]` or MCP `review(call_id, usefulness, reason?)`.
+Use `useful`, `partly`, `not_useful`, or `not_sure`; one review per invitation; omit private data;
+use feedback for anything confusing or wrong, then continue.
 
 Feedback: `treg feedback submit <quality|pricing|friction|other> "message"`, or the MCP `feedback` tool.
 Include call IDs when available and omit private information. Instructions: `{BASE}/feedback.md`.
@@ -143,7 +143,7 @@ ledger.
 
 ## The catalog — tools you do not have a key for
 
-Curated endpoints across 60+ providers, grouped by what they DO: keyword and rank tracking,
+Curated endpoints from many providers, grouped by what they DO: keyword and rank tracking,
 backlinks and authority, AI visibility, trending and discovery, publishing to socials, people and
 company enrichment, ads management and creative, measurement, video and image generation. Ask for the task; the catalog tells
 you which endpoints serve it, what each costs, and how you would be served. Exact live counts:
@@ -593,7 +593,7 @@ skills` restrict it (`--dir` sets the location).
 8. **Report the outcome as a doorway, not an install log.** Nobody signed up to read which
    Python version uv picked. Open with ONE line about what they just gained, e.g.:
 
-       treg is live — your agent can now call 2,800+ tools across 60 providers (market data, SEO &
+       treg is live — your agent can now call the whole catalog (market data, SEO &
        keywords, social & trends, people/company enrichment, ads, scraping), with $1.00
        of free credit to spend.
 

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -1,7 +1,7 @@
 # treg — the tool catalog for your agent
 
 > **OpenRouter, but for agent tools instead of models.** Point an agent at ONE base URL with ONE
-> token and it can do the *job*: a curated catalog of endpoints from many providers (SEO and SERP
+> token and it can do the *job*: {ENDPOINTS} catalogued endpoints across {PROVIDERS} providers (SEO and SERP
 > data, backlinks, social and trends, people and company enrichment, ads, scraping) — plus your
 > own team's keys, skills and CLIs. Every credential is injected **server-side**; nothing
 > sensitive lands on the agent's machine, and every call is audited.
@@ -143,7 +143,7 @@ ledger.
 
 ## The catalog — tools you do not have a key for
 
-Curated endpoints from many providers, grouped by what they DO: keyword and rank tracking,
+{ENDPOINTS} curated endpoints across {PROVIDERS} providers, grouped by what they DO: keyword and rank tracking,
 backlinks and authority, AI visibility, trending and discovery, publishing to socials, people and
 company enrichment, ads management and creative, measurement, video and image generation. Ask for the task; the catalog tells
 you which endpoints serve it, what each costs, and how you would be served. Exact live counts:
@@ -593,7 +593,7 @@ skills` restrict it (`--dir` sets the location).
 8. **Report the outcome as a doorway, not an install log.** Nobody signed up to read which
    Python version uv picked. Open with ONE line about what they just gained, e.g.:
 
-       treg is live — your agent can now call the whole catalog (market data, SEO &
+       treg is live — your agent can now call {ENDPOINTS} tools across {PROVIDERS} providers (market data, SEO &
        keywords, social & trends, people/company enrichment, ads, scraping), with $1.00
        of free credit to spend.
 

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. {ENDPOINTS} endpoints across {PROVIDERS} providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 # treg — the tool catalog for your agent
@@ -57,7 +57,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
+{ENDPOINTS} catalogued endpoints across {PROVIDERS} providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 2,600+ endpoints across 60+ providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. A curated catalog of endpoints - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 # treg — the tool catalog for your agent
@@ -57,7 +57,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-2,600+ catalogued endpoints across 60+ providers, grouped by what they DO: keyword & rank tracking,
+Catalogued endpoints from many providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.
@@ -309,12 +309,11 @@ Keep private information out of the report. See [feedback instructions]({BASE}/f
 
 ## Review
 
-When invited to review a catalog call, use its result first, then call
+If a call result invites a review, rate that one call after using it:
 `review(call_id, usefulness, reason?)` over MCP or `treg review CALL_ID USEFULNESS [--reason "..."]`.
-Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. Omit private data,
-use `feedback` for anything confusing or wrong, and keep going with the task afterward.
-Only the invited call needs a review: one per invitation. Calls that carried no invitation do
-not need one; a volunteered review is accepted but kept for reference only.
+Choose `useful`, `partly`, `not_useful`, or `not_sure`; uncertainty is fine. One review per
+invitation; a review of an uninvited call is accepted but kept for reference only. Omit private
+data, use `feedback` for anything confusing or wrong, then continue.
 
 ## Rules
 - Secrets are **write-only** — the API never returns a stored value, to you or to anyone.

--- a/tests/test_headline_counts.py
+++ b/tests/test_headline_counts.py
@@ -1,0 +1,21 @@
+"""The catalog's size on the front door is generated, never typed (`catalog_store.headline_counts`)."""
+from treg.domain.catalog import store as catalog_store
+
+
+def test_headline_counts_round_down_and_skip_routed():
+    cat = catalog_store.Catalog()
+    for i in range(3218):
+        cat.by_id[f"p{i % 69}.e{i}"] = {"id": f"p{i % 69}.e{i}", "provider": f"p{i % 69}"}
+    for i in range(75):
+        cat.by_id[f"treg.r{i}"] = {"id": f"treg.r{i}", "provider": "treg", "kind": "routed"}
+    assert catalog_store.headline_counts(cat) == ("3,200+", 69)
+
+
+async def test_served_front_door_fills_the_counts(clients):
+    endpoints, providers = catalog_store.headline_counts(catalog_store.load())
+    for path in ("/skill.md", "/llms.txt"):
+        text = (await clients.get(path)).text
+        assert "{ENDPOINTS}" not in text and "{PROVIDERS}" not in text, path
+        assert f"{endpoints} " in text and f"across {providers} providers" in text, path
+    listing = (await clients.get("/.well-known/skill.md")).text
+    assert "{ENDPOINTS}" not in listing

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -721,7 +721,5 @@ async def test_server_instructions_explain_review_invitations(clients, path):
         }, clients.headers['X-Treg-Token'], path=path)
     assert response.status_code == 200
     assert response.json()['result']['instructions'].endswith(
-        'When a call result carries a review invitation, use the result first, then call '
-        'review(call_id, usefulness, reason?) and keep going with the task. Only the invited call '
-        'needs a review: one per invitation.'
+        'If a call result invites a review, rate that one call with review(call_id, usefulness, reason?) after using it, then continue.'
     )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -113,7 +113,7 @@ def test_the_plugin_skill_is_not_stale():
     r = subprocess.run([sys.executable, str(ROOT / "scripts" / "build_plugin.py"), "--check"],
                        capture_output=True, text=True)
     assert r.returncode == 0, (
-        f"plugin SKILL.md is stale — regenerate with `python3 scripts/build_plugin.py`\n"
+        f"plugin SKILL.md is stale — regenerate with `uv run python scripts/build_plugin.py`\n"
         f"{r.stdout}{r.stderr}")
 
 


### PR DESCRIPTION
Three copy changes to the agent-facing surfaces, no call-path behaviour change:

- **Review guidance is one sentence** in the server hint, both MCP `instructions`, skill.md and llms.txt: "If a call result invites a review, rate that one call with review(call_id, usefulness, reason?) after using it, then continue." It was two sentences and a third of the instructions text for a 5% side path.
- **Both MCP surfaces follow the same four-part structure** (what treg is, this surface's flow, how to choose among providers, the review sentence) while keeping their different tool sets; `/mcp/` and `/mcp/v2/` stay separate code. The `instructions` strings carry no counts: a model following the flow does not need them.
- **The catalog's size is generated, never typed.** Six hand-written copies disagreed (~2,600/~40, 2,600+/60+, 2,800+/60 ...) and the smallest undersold the live catalog (3,218 direct endpoints, 69 providers) by six hundred. New `catalog_store.headline_counts` rounds endpoints down to the hundred ("3,200+") and counts providers; the MCP server description and `catalog_search` description use it at import, `skill.md` / `llms.txt` / the well-known skill listing fill `{ENDPOINTS}` and `{PROVIDERS}` at serve time, and `build_plugin.py` fills them at generation time (so run it with `uv run python scripts/build_plugin.py`; docs updated). README and the landing page still carry typed counts; separate decision.

Tests: `tests/test_headline_counts.py` (rounding, routed exclusion, served files carry no placeholder), instructions test updated, plugin check regenerated. Fragment `docs/context/architecture/feedback.md` records the rule. Full suite 3196 passed; import contracts kept.