### PR TITLE
feat(hub): 7.1 - the front door for agents

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -274,7 +274,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/routers/auth_helpers.py` | interface/api.md |
 | `src/treg/routers/billing.py` | architecture/composition.md, architecture/money.md, interface/api.md |
 | `src/treg/routers/call.py` | architecture/composition.md, architecture/instagram-oauth.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
-| `src/treg/routers/catalog.py` | architecture/catalog.md, interface/api.md |
+| `src/treg/routers/catalog.py` | architecture/catalog.md, architecture/hub.md, interface/api.md |
 | `src/treg/routers/connections.py` | architecture/auth-secrets.md, architecture/composition.md, guides/expanding-a-category.md, interface/api.md |
 | `src/treg/routers/feedback.py` | architecture/feedback.md |
 | `src/treg/routers/hub.py` | architecture/hub.md |
@@ -283,7 +283,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/routers/referrals.py` | architecture/composition.md, architecture/money.md, interface/api.md |
 | `src/treg/routers/resources.py` | architecture/auth-secrets.md, architecture/composition.md, architecture/multi-tenancy.md, interface/api.md |
 | `src/treg/routers/signup_cookies.py` | interface/api.md |
-| `src/treg/routers/web.py` | architecture/composition.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md, interface/skill.md |
+| `src/treg/routers/web.py` | architecture/composition.md, architecture/hub.md, interface/api.md, interface/dashboard.md, interface/landing-sandbox.md, interface/seo.md, interface/skill.md |
 | `src/treg/runner.py` | interface/api.md |
 | `src/treg/sandbox.py` | interface/landing-sandbox.md |
 | `src/treg/sandbox_identity.py` | architecture/proxy-model.md, interface/landing-sandbox.md |
@@ -302,7 +302,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/index.html` | architecture/instagram-oauth.md, interface/dashboard.md, interface/landing-sandbox.md, interface/onboarding.md, interface/seo.md |
 | `src/treg/web/install.sh` | interface/landing-sandbox.md |
 | `src/treg/web/landing.html` | interface/seo.md |
-| `src/treg/web/llms.txt` | interface/seo.md |
+| `src/treg/web/llms.txt` | architecture/hub.md, interface/seo.md |
 | `src/treg/web/logos/contactout.svg` | architecture/contactout.md |
 | `src/treg/web/media/astra/page.css` | interface/seo.md |
 | `src/treg/web/media/astra/page.js` | interface/seo.md |
@@ -310,7 +310,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/robots.txt` | interface/seo.md |
 | `src/treg/web/selfhost.sh` | ops/deploy.md |
 | `src/treg/web/sitetrack.js` | architecture/data-model.md, interface/api.md, interface/dashboard.md |
-| `src/treg/web/skill.md` | interface/skill.md |
+| `src/treg/web/skill.md` | architecture/hub.md, interface/skill.md |
 | `src/treg/web/support.html` | interface/seo.md |
 | `src/treg/web/tour/index.html` | interface/dashboard.md |
 | `src/treg/web/tour/tour.js` | interface/dashboard.md |
@@ -374,7 +374,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/contactout.md` | `contactout.yaml`, `adapters.yaml`, `contactout.people.email.verify.json`, `test_routing.py`, `contactout.companies.search.json`, `contactout.companies.enrich.json`, `resolve.py`, `contactout.py`, `contactout.svg`, `test_marketplace_call.py`, `test_key_providers.py`, `test_capacity_collectors.py`, `test_catalog_validate.py`, `test_capacity_overflow.py`, `contactout_overflow_verify.py`, `contactout.json` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `0020_callrecord_created_at_indexes.py`, `0021_ledgerentry_org_created_at_index.py`, `0022_org_spent_today_counter.py`, `0023_callrecord_org_user_created_at_index.py`, `0024_membership_calls_today_counter.py`, `0011_callrecord_archive_link.py`, `0015_idempotentcall_membership_cascade.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `bootstrap_handlers.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
 | `architecture/feedback.md` | `feedback_contract.py`, `feedback.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `feedback.md`, `test_feedback.py` |
-| `architecture/hub.md` | `__init__.py`, `manifest.py`, `refs.py`, `graph.py`, `__init__.py`, `runner.py`, `sandbox.py`, `limits.py`, `__init__.py`, `0028_hubtool_check_result.py`, `mcp.py`, `cli.py`, `hub_sandbox.py`, `hub.py`, `0026_hub_tools.py`, `0027_hub_runs.py`, `test_hub.py`, `test_hub_run.py`, `test_hub_sandbox.py` |
+| `architecture/hub.md` | `__init__.py`, `manifest.py`, `refs.py`, `graph.py`, `__init__.py`, `runner.py`, `sandbox.py`, `limits.py`, `__init__.py`, `catalog.py`, `web.py`, `skill.md`, `llms.txt`, `0028_hubtool_check_result.py`, `mcp.py`, `cli.py`, `hub_sandbox.py`, `hub.py`, `0026_hub_tools.py`, `0027_hub_runs.py`, `test_hub.py`, `test_hub_run.py`, `test_hub_sandbox.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `feedback.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -24,7 +24,7 @@ covers (frontmatter `sources:`). Regenerate this index with
 | [ContactOut — LinkedIn enrichment, Starter billing and independent credit pools](architecture/contactout.md) | implemented; live connect and core surface verified, informational capacity monitoring | contactout.yaml, adapters.yaml, contactout.people.email.verify.json, test_routing.py, … |
 | [Data model — the registry tables, async DB, audit writer](architecture/data-model.md) | shipped | alembic.ini, env.py, 0001_baseline_current_schema.py, 0002_archive_tables.py, … |
 | [Feedback - private intake for problems and suggestions](architecture/feedback.md) | shipped | feedback_contract.py, feedback.py, feedback.py, feedback.py, … |
-| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 6 of 8: the seller's money; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
+| [The tool hub — tools a maker publishes, made of other tools](architecture/hub.md) | in-progress (phase 7 of 8: the surfaces; behind TREG_HUB_ENABLED, off) | __init__.py, manifest.py, refs.py, graph.py, … |
 | [Enforced import boundaries](architecture/import-boundaries.md) | shipped | pyproject.toml, ci.yml, __init__.py, __init__.py, … |
 | [Instagram OAuth — direct Login and optional Facebook Page tools](architecture/instagram-oauth.md) | built; Meta configuration and live verification pending | catalog_ingest.py, access.py, resolve.py, service.py, … |
 | [Local proxy — catch a program's own outgoing calls (`treg <command>`)](architecture/local-proxy.md) | shipped | localproxy.py, server.js |

--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -1,6 +1,6 @@
 ---
 title: The tool hub — tools a maker publishes, made of other tools
-status: in-progress (phase 6 of 8: the seller's money; behind TREG_HUB_ENABLED, off)
+status: in-progress (phase 7 of 8: the surfaces; behind TREG_HUB_ENABLED, off)
 sources:
   - src/treg/domain/hub/__init__.py
   - src/treg/domain/hub/manifest.py
@@ -11,6 +11,10 @@ sources:
   - src/treg/application/hub/sandbox.py
   - src/treg/application/hub/limits.py
   - src/treg/domain/money/__init__.py
+  - src/treg/routers/catalog.py
+  - src/treg/routers/web.py
+  - src/treg/web/skill.md
+  - src/treg/web/llms.txt
   - src/treg/alembic/versions/0028_hubtool_check_result.py
   - src/treg/mcp.py
   - src/treg/cli.py
@@ -231,3 +235,18 @@ The seller's view: `GET /hub/tools/{id}/earnings?days=90[&format=csv]` and `treg
 <id> [--days N] [--csv]`: per day, runs, successes, failures and what was earned, for a tool the
 team owns. Sales only (the maker's own runs are excluded), counts and amounts only, never who
 called.
+
+## The front door for agents (phase 7.1)
+
+`skill.md` and `llms.txt` carry a hub section (the four files, `ctx.call`, the check, publish,
+price, the share page, and the owner's rule: never paste a credential into a script, register it
+first) inside `<!--hub-->…<!--/hub-->` blocks. `routers/web.py` strips those blocks when
+`hub_enabled` is off, exactly as it strips the routed-discovery blocks, so a deployment never
+documents what it has not switched on. The generated plugin SKILL.md files are regenerated only
+at the final merge, when the flag flips.
+
+`GET /catalog/endpoints/<id>` (behind `catalog_get` and `treg catalog get`) answers for a hub id
+too: `endpoint.kind == "hub"`, with summary, inputs, output, the price line, health, version,
+`call_template`, the page URL and the readme; never the script, the maker's tools or a key.
+Search never returns a hub tool (unlisted by design); an unknown hub-shaped id stays a 404 with
+the usual near-miss hints.

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -51,6 +51,7 @@ Usage:  python3 scripts/build_plugin.py [--check]
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -307,7 +308,18 @@ def render(variant: str) -> str:
     #    setting, so it keeps the content — but the markers themselves must never ship, or the
     #    product's most-read page starts with visible HTML comments.
     out = out.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
+    # 5. `<!--hub-->` / `<!--/hub-->` delimit the tool-hub section, which the SERVER strips while
+    #    `hub_enabled` is off. A plugin is a static file: it ships the hub text only once production
+    #    has switched the hub on — `--with-hub` at that merge; until then the block is dropped, so
+    #    the plugin never teaches what a reader cannot use (AGENTS.md: do not document what is not built).
+    if WITH_HUB:
+        out = out.replace("<!--hub-->\n", "").replace("\n<!--/hub-->", "")
+    else:
+        out = re.sub(r"<!--hub-->.*?<!--/hub-->\n?", "", out, flags=re.S)
     return out.replace("{BASE}", PUBLIC_BASE)
+
+
+WITH_HUB = "--with-hub" in sys.argv
 
 
 def main() -> int:

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -5254,6 +5254,34 @@ def _catalog_request(text: str, cfg) -> None:
     _dim("requests steer which provider gets added next — the most-asked-for tools land first")
 
 
+def _catalog_get_hub(e: dict) -> None:
+    """A hub tool's contract: what a caller needs, nothing the maker hides."""
+    def _line(k: str, v: str) -> None:
+        if v:
+            print(f"  {_M}{k:<10}{_R}{v}")
+    _line("maker", f"{e.get('provider')}  (a hub tool made of {e.get('made_of')} tool{'s' if e.get('made_of') != 1 else ''}; {e.get('recipe')} recipe, v{e.get('version')})")
+    _line("price", f"{e.get('price_line')}   (${(e.get('cost') or {}).get('usd', 0):.6g} per successful run to the maker; metered steps on top)")
+    chk = e.get("check") or {}
+    _line("health", f"{e.get('status')} · check {chk.get('status') or '-'} {('at ' + str(chk.get('checked_at'))[:16]) if chk.get('checked_at') else ''}")
+    inputs = e.get("inputs") or {}
+    if inputs:
+        print(f"  {_M}{'inputs':<10}{_R}")
+        for k, v in inputs.items():
+            req = "" if "default" in v else "  (required)"
+            dflt = f"  default {json.dumps(v['default'])}" if "default" in v else ""
+            mx = f"  max {v['max']}" if "max" in v else ""
+            note = f"  — {v['note']}" if v.get("note") else ""
+            print(f"    {k:<12}{v.get('type', ''):<8}{dflt}{mx}{req}{note}")
+    out = e.get("output") or {}
+    fields = out.get("fields") if isinstance(out, dict) and "fields" in out else list(out)
+    _line("output", ", ".join(fields))
+    ct = e.get("call_template") or {}
+    print(f"\n  {_M}{'call':<10}{_R}{ct.get('cli', '')}")
+    print(f"  {_M}{'':<10}{_R}{ct.get('http', '')}   X-Treg-Token · JSON body of inputs")
+    if e.get("page"):
+        print(f"  {_M}{'page':<10}{_R}{e['page']}")
+
+
 def _catalog_get(endpoint_id: str, cfg) -> None:
     """One endpoint, everything about it — the last stop before `treg call`."""
     with _client(cfg, auth=False) as c:
@@ -5290,6 +5318,9 @@ def _catalog_get(endpoint_id: str, cfg) -> None:
     print(f"\n{_B}{e['id']}{_R}")
     if e.get("summary"):
         print(f"{e['summary']}\n")
+    if e.get("kind") == "hub":
+        _catalog_get_hub(e)
+        return
 
     def _line(k: str, v: str) -> None:
         if v:

--- a/src/treg/routers/catalog.py
+++ b/src/treg/routers/catalog.py
@@ -9,7 +9,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import Response
 
 from .. import audit, oauth_providers
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from ..config import get_settings
+from ..infra.db import get_session
 from ..domain.catalog import store as catalog_store
 from ..domain.catalog import stats as endpoint_stats
 
@@ -265,6 +268,7 @@ async def catalog_endpoint(
     endpoint_id: str,
     observations: endpoint_stats.EndpointObservationReader = Depends(
         _endpoint_observation_reader),
+    db: AsyncSession = Depends(get_session),
 ) -> dict:
     """Open: everything about ONE endpoint — the INSPECT half of the loop.
 
@@ -275,6 +279,12 @@ async def catalog_endpoint(
     cat = catalog_store.load()
     ep = cat.by_id.get(endpoint_id)
     if ep is None:
+        # A hub tool (a maker's tool made of tools) answers here too, so an agent that holds the
+        # id reads its contract the same way it reads a catalog endpoint. Unlisted: never in
+        # search, only by id. Flag off ⇒ the branch does not exist.
+        hub_view = await _hub_endpoint_view(endpoint_id, db)
+        if hub_view is not None:
+            return hub_view
         # Name the near misses. An id that is one segment off is the common miss, and a bare 404
         # ends the search → get → call loop at its first step with nothing to try next.
         raise HTTPException(status_code=404, detail={
@@ -357,3 +367,51 @@ async def catalog_example(endpoint_id: str) -> Response:
     if path is None or not path.is_file():
         raise HTTPException(status_code=404, detail=f"no example response for {endpoint_id!r}")
     return Response(content=path.read_bytes(), media_type="application/json")
+
+
+async def _hub_endpoint_view(endpoint_id: str, db: AsyncSession) -> dict | None:
+    """The public contract of one hub tool, in the shape `treg catalog get` and `catalog_get`
+    already print: `endpoint` (with `kind: "hub"`), `provider` (the maker's team). Hides the
+    script, the maker's tools and every key (docs/HUB-DECISIONS.md round 4 q4, round 5 q7)."""
+    from ..application import hub as hub_app
+    from ..models import Org
+    if not hub_app.enabled() or not hub_app.is_hub_id_shape(endpoint_id):
+        return None
+    row = await hub_app.tool_for(db, endpoint_id)
+    if row is None:
+        return None
+    org = await db.get(Org, row.org_id)
+    base = get_settings().public_url.rstrip("/")
+    m = row.manifest
+    inputs = m.get("inputs", {})
+    example = {k: v.get("example", v.get("default")) for k, v in inputs.items()
+               if "example" in v or "default" in v}
+    example = {k: v for k, v in example.items() if v not in ("", None, 0)}
+    return {
+        "endpoint": {
+            "id": row.tool_id, "kind": "hub", "hub": True, "version": row.version,
+            "name": row.name, "summary": row.summary, "provider": org.slug if org else "",
+            "provider_display": org.slug if org else "", "method": "POST",
+            "path": f"/call/{row.tool_id}",
+            "inputs": inputs, "output": m.get("output", {}), "writes": row.writes,
+            "recipe": "script" if row.kind == "script" else "steps",
+            "limits": m.get("limits", {}),
+            "cost": {"type": "per_success", "usd": row.price_micro / 1_000_000, "currency": "USD",
+                     "unit": "run", "note": "the maker's price per successful run; metered steps are billed on top, one trace line each"},
+            "price_line": f"seller ${row.price_micro / 1e6:.6g} + steps",
+            "made_of": len(m.get("uses", [])),
+            "status": row.status,
+            "check": {"status": (row.check_result or {}).get("status"),
+                      "checked_at": (row.check_result or {}).get("checked_at")},
+            "call_template": {
+                "cli": f"treg call {row.tool_id} --data '{json.dumps(example)}'",
+                "http": f"POST {base}/call/{row.tool_id}",
+                "body": example,
+                "headers": {"X-Treg-Token": "<your token>", "Content-Type": "application/json"},
+            },
+            "page": f"{base}/hub/{row.tool_id}",
+            "readme": row.readme,
+        },
+        "provider": {"display_name": org.slug if org else "", "kind": "hub maker"},
+        "siblings": [],
+    }

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2858,10 +2858,17 @@ def routed_discovery_on() -> bool:
 
 
 def _strip_routed(text: str) -> str:
-    """Remove the `<!--routed-->…<!--/routed-->` blocks (and, when kept, just the markers)."""
+    """Remove the `<!--routed-->…<!--/routed-->` blocks (and, when kept, just the markers), and the
+    `<!--hub-->…<!--/hub-->` blocks the same way behind `hub_enabled`: an agent-facing file must
+    never describe what this deployment has not switched on (AGENTS.md: do not document what is
+    not built)."""
     if routed_discovery_on():
-        return text.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
-    return re.sub(r"<!--routed-->.*?<!--/routed-->\n?", "", text, flags=re.S)
+        text = text.replace("<!--routed-->\n", "").replace("\n<!--/routed-->", "")
+    else:
+        text = re.sub(r"<!--routed-->.*?<!--/routed-->\n?", "", text, flags=re.S)
+    if get_settings().hub_enabled:
+        return text.replace("<!--hub-->\n", "").replace("\n<!--/hub-->", "")
+    return re.sub(r"<!--hub-->.*?<!--/hub-->\n?", "", text, flags=re.S)
 
 
 def _serve_md(name: str) -> PlainTextResponse:

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -352,6 +352,30 @@ find it — never a vendor key, but a file on disk the subshell version does not
 A recipe-only skill that's just CLI instructions (e.g. `stripe-cli`) auto-becomes runnable — `treg upload`
 recognizes the catalog CLI and wires the credential, so `treg run` works with no `treg.json`.
 
+<!--hub-->
+## The hub — tools your team publishes, made of other tools
+
+A hub tool is one your team publishes for other people's agents: a JSON steps recipe, or a script in
+a sandbox. Every step runs through the team's own tools and keys; a caller pays the metered steps
+plus the price the maker set (`price_usd`), and the price lands on the maker's balance as `earned`
+credit, spendable at once. Callable the moment it is published, by id `<team-slug>.<name>`:
+`POST {BASE}/call/<id>` with the inputs as a JSON body → `{run_id, output, usage, trace}`. Not
+listed in search; the maker shares the id or the page `{BASE}/hub/<id>` (`.md` for agents).
+
+- Make one: `treg hub init <name> [--script]` writes four files (recipe.json, run.js, check.json,
+  README.md); `treg hub run . --input k=v` runs the folder for real, nothing stored; `treg hub
+  publish .` validates, runs check.json once on your balance, and the tool is live on pass. Over
+  MCP: `hub_create`, `hub_update`, `hub_mine`.
+- A script gets `ctx.inputs`, `ctx.call(target, {method, query, body, headers})` and `ctx.log`;
+  no network, no files, no `require`. `target` must be in the manifest's `uses`: a catalog id or one
+  of the team's own tools as `<tool>/<path>`. Caps: 120 s, 20 calls, 64 MB, four runs at a time.
+- **Never paste a credential into a script.** Register it first (`treg secret add`, `treg tool
+  add`), list the tool in `uses`, name it in `ctx.call`. The script never sees the key.
+- Read any hub tool's contract with `GET {BASE}/catalog/endpoints/<id>` (`catalog_get`,
+  `treg catalog get`): inputs, output, price line, health, the call line.
+- Versions: the newest live one serves; `<id>@N` pins one for 30 days after a newer lands.
+  `treg hub earnings <id>` shows runs and credit per day.
+<!--/hub-->
 ## Install the CLI
 
     curl -fsSL {BASE}/install.sh | sh
@@ -406,7 +430,9 @@ A small tool set, the same for every client:
     my_tools         what your team registered that you can call without the key
     catalog_request  request a missing capability
     feedback         share a problem or suggestion (omit private information)
-
+<!--hub-->
+- `hub_create` · `hub_update` · `hub_mine` — publish a tool made of tools (the four files as fields; the check runs once on your balance; live on pass).
+<!--/hub-->
 All need a credential, and the challenge comes EARLY: every id-bearing JSON-RPC request,
 `initialize` included, is answered with **401** and a `WWW-Authenticate` header naming
 `{BASE}/.well-known/oauth-protected-resource`. That header is how a client discovers where to
@@ -442,6 +468,12 @@ are both supported; you do not need to pre-arrange anything with us.
     treg logout
     treg onboard [--mode guided|quick]            guided first-run tutorial (seeds a demo team)
 
+<!--hub-->
+    treg hub init <name> [--script]               four files for a new hub tool (a tool made of tools)
+    treg hub run <dir> --input k=v                run the folder for real on your token; nothing stored
+    treg hub publish <dir>                        validate, run check.json once, live on pass (a new version)
+    treg hub ls | earnings <id> [--days N] [--csv]   your hub tools; what one earned, per day
+<!--/hub-->
     treg org create "Name"                        make a team, become owner
     treg org ls | org use <slug>                  list / switch the active org
     treg org invite <email> --role viewer|member|admin

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -200,6 +200,55 @@ it. Works for GET/POST/PUT/PATCH/DELETE.
 
 Only tools this org has registered resolve. Discover them with `treg tool ls` · `treg skill ls`.
 
+<!--hub-->
+## Task — publish a tool made of tools (the hub)
+
+**A hub tool is a tool your team publishes, made of other tools:** a JSON steps recipe, or a script
+that runs in a sandbox. Every step runs through the team's own tools and keys; a caller pays the
+metered steps plus the price you set, and the price lands on your balance as credit. The tool is
+callable at once by id, `<team-slug>.<name>`, from any agent with a treg token. Nothing is listed in
+search: you share the id or the page `{BASE}/hub/<id>`.
+
+**One folder, four files** — `treg hub init <name> --script` writes a neutral skeleton:
+
+```
+recipe.json   the manifest: name, summary, inputs, uses, output, price_usd; steps OR "script": "run.js"
+run.js        export default async function run(ctx) { ... }   (script recipes only)
+check.json    sample inputs + the output fields the check must find; run once for real at publish
+README.md     what it does, for a human
+```
+
+**The rule before you write a line of script: never paste a credential into it.** A key the team
+does not hold yet is registered FIRST, then named. The script only ever sees a tool's NAME:
+
+```
+treg secret add SUPABASE_SERVICE_KEY --value <the key>
+treg tool add supabase --base-url https://<ref>.supabase.co \
+  --bind "secret=<ID>,name=Authorization,format=Bearer {secret}"     # then list "supabase" in `uses`
+```
+
+**What a script gets — the whole surface:** `ctx.inputs` (checked against the manifest),
+`ctx.call(target, {method, query, body, headers})` → `{status, headers, json, text}`, and
+`ctx.log(text)`. No network, no files, no `require`; `ctx.call` is the only road out, and `target`
+must be in the manifest's `uses`: a catalog id, or one of the team's own tools as `<tool>/<path>`.
+Caps: 120 s, 20 calls, 64 MB, four runs at a time per team. A steps recipe instead names its calls in
+`steps` and reads earlier answers with references (`$input.x`, `$step.path`, `$step[]`,
+`$step.length`); steps that do not depend on each other run four at a time.
+
+**The road:**
+
+```
+treg hub run . --input domain=figma.com   # a real run on your own token; nothing stored; read the trace
+treg hub publish .                        # validate, run check.json once on your balance, live on pass
+treg hub ls · treg hub earnings <id>      # your tools; what one earned, per day
+```
+
+A refusal names the exact field and rule to fix (`uses[0]: 'supabase' is not one of your team's
+tools`). Over MCP the same three moves are `hub_create`, `hub_update`, `hub_mine`; calling stays
+`call`. A caller runs it with `treg call <team>.<name> --data '{...}'` or `POST {BASE}/call/<id>`;
+the reply carries `output`, `usage` (steps cost + your price), and the `trace`. Read a tool's
+contract, yours or anyone's, with `treg catalog get <id>` / `catalog_get`.
+<!--/hub-->
 ## Task — share your keys & skills so teammates' agents can use them
 **Bulk (the fast path):** run it in the directory the human names. It lists the provider keys it
 recognises in that `.env` and the skills in its subdirs, and registers only the ones they tick:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,3 +958,20 @@ def test_hub_is_in_the_help_and_parses():
         assert a.hub_cmd == "run" and a.input == ["domain=figma.com", "limit=3"]
         e = parser.parse_args(["hub", "earnings", "acme.leads-db", "--days", "30", "--csv"])
         assert e.hub_cmd == "earnings" and e.days == 30 and e.csv
+
+
+
+def test_catalog_get_prints_a_hub_tool_contract(capsys):
+    from treg import cli
+    e = {"id": "acme.leads-db", "kind": "hub", "version": 2, "provider": "acme", "made_of": 2, "recipe": "script",
+         "price_line": "seller $0.01 + steps", "cost": {"usd": 0.01}, "status": "live",
+         "check": {"status": "passed", "checked_at": "2026-09-09T20:11:00"},
+         "inputs": {"domain": {"type": "string", "example": "figma.com", "note": "one domain"},
+                    "limit": {"type": "int", "default": 20, "max": 100}},
+         "output": {"fields": ["rows", "count"]},
+         "call_template": {"cli": "treg call acme.leads-db --data '{\"domain\": \"figma.com\"}'", "http": "POST https://treg.to/call/acme.leads-db"},
+         "page": "https://treg.to/hub/acme.leads-db"}
+    cli._catalog_get_hub(e)
+    out = capsys.readouterr().out
+    assert "seller $0.01 + steps" in out and "domain" in out and "(required)" in out and "rows, count" in out
+    assert "treg call acme.leads-db" in out and "https://treg.to/hub/acme.leads-db" in out

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -507,3 +507,53 @@ async def test_the_fifth_concurrent_run_is_refused_with_a_retry_time(clients: As
     done = await asyncio.gather(*tasks)
     assert all(r.status_code in (200, 424) for r in done)
     assert not limits._active                         # every slot given back
+
+
+# ---------------------------------------------------------------------------------------------
+# Phase 7.1: the agent-facing files and catalog_get on a hub id
+
+async def test_catalog_get_answers_for_a_hub_id_and_hides_what_the_maker_hides(clients: AsyncClient, hub_on, platform_on, monkeypatch):
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"data": {"domain": "figma.com"}, "body": [1]}'))
+    await _own_supabase(clients)
+    m = _steps_manifest(steps=[{"name": "people", "call": EP, "input": {"aweme_id": "$input.domain"}}],
+                        output={"leads": "$people.data"}, price_usd=0.02)
+    tool_id = (await clients.post("/hub/tools", json={"manifest": m, "check": CHECK, "readme": "About it."})).json()["tool_id"]
+    r = await clients.get(f"/catalog/endpoints/{tool_id}")
+    assert r.status_code == 200, r.text
+    e = r.json()["endpoint"]
+    assert e["kind"] == "hub" and e["id"] == tool_id and e["version"] == 1 and e["status"] == "live"
+    assert e["cost"]["usd"] == 0.02 and e["price_line"].startswith("seller $0.02")
+    assert e["inputs"]["domain"]["example"] == "figma.com" and e["output"] == {"leads": "$people.data"}
+    assert e["call_template"]["cli"].startswith(f"treg call {tool_id} --data")
+    assert e["page"].endswith(f"/hub/{tool_id}") and e["readme"] == "About it."
+    text = r.text
+    assert "supabase" not in text and "tikhub" not in text          # the maker's tools are not on the contract
+    assert "script" not in e or e.get("script") is None
+    # not in search, only by id
+    s = await clients.get("/catalog/search", params={"q": "leads-db"})
+    assert tool_id not in s.text
+    # the same through the MCP-shaped miss path: an unknown hub-shaped id is still a 404 with hints
+    assert (await clients.get("/catalog/endpoints/nobody.nothing")).status_code == 404
+
+
+async def test_catalog_get_on_a_hub_id_with_the_flag_off_is_a_plain_404(clients: AsyncClient, hub_on, platform_on, monkeypatch):
+    tool_id = await _publish_live(clients)
+    monkeypatch.setenv("TREG_HUB_ENABLED", "0")
+    get_settings.cache_clear()
+    r = await clients.get(f"/catalog/endpoints/{tool_id}")
+    assert r.status_code == 404 and "hub" not in r.text
+
+
+async def test_the_agent_files_mention_the_hub_only_when_it_is_on(clients: AsyncClient, monkeypatch):
+    for on in ("1", "0"):
+        monkeypatch.setenv("TREG_HUB_ENABLED", on)
+        get_settings.cache_clear()
+        llms = (await clients.get("/llms.txt")).text
+        skill = (await clients.get("/skill.md")).text
+        for body in (llms, skill):
+            assert "<!--hub-->" not in body and "<!--/hub-->" not in body     # markers never leak
+            assert ("treg hub init" in body) is (on == "1")
+            assert ("hub_create" in body) is (on == "1")
+        if on == "1":
+            assert "never paste a credential" in llms.lower() or "never paste a credential" in skill.lower()
+    get_settings.cache_clear()


### PR DESCRIPTION
Phase 7.1 of the tool hub: the front door for agents. Hub sections in skill.md and llms.txt gated by the flag (stripped when off, also in the plugin builder), catalog_get / treg catalog get / the HTTP route answer for a hub id with the public contract only. Suite 2923.

