### PR TITLE
feat(review): per-team hourly invitation budget on a shared key-value store

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -86,6 +86,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/application/call/evidence.py` | architecture/import-boundaries.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/idempotency.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/intake.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
+| `src/treg/application/call/invite.py` | architecture/feedback.md |
 | `src/treg/application/call/overflow.py` | architecture/import-boundaries.md, ops/capacity.md |
 | `src/treg/application/call/reserve.py` | architecture/import-boundaries.md, architecture/money.md, architecture/proxy-model.md, interface/api.md |
 | `src/treg/application/call/resolve.py` | architecture/contactout.md, architecture/import-boundaries.md, architecture/instagram-oauth.md, architecture/money.md, architecture/multi-tenancy.md, architecture/proxy-model.md, interface/api.md |
@@ -259,6 +260,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/infra/__init__.py` | architecture/money.md |
 | `src/treg/infra/catalog_observations.py` | architecture/catalog.md |
 | `src/treg/infra/db.py` | architecture/data-model.md, architecture/multi-tenancy.md, ops/deploy.md |
+| `src/treg/infra/kv.py` | architecture/feedback.md |
 | `src/treg/infra/oauth_exchange.py` | architecture/auth-secrets.md, architecture/instagram-oauth.md, guides/expanding-a-category.md |
 | `src/treg/infra/oauth_refresh.py` | architecture/auth-secrets.md |
 | `src/treg/infra/stripe.py` | architecture/money.md |
@@ -383,6 +385,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_influencersclub_overflow.py` | ops/capacity.md |
 | `tests/test_instagram_oauth_architecture.py` | architecture/instagram-oauth.md |
 | `tests/test_key_providers.py` | architecture/contactout.md |
+| `tests/test_kv.py` | architecture/feedback.md |
 | `tests/test_marketplace_call.py` | architecture/contactout.md, architecture/mcp-oauth.md, architecture/proxy-model.md |
 | `tests/test_mcp.py` | architecture/mcp-oauth.md |
 | `tests/test_mcp_directory.py` | architecture/mcp-oauth.md |
@@ -410,7 +413,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/composition.md` | `bootstrap.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `call_surface.py`, `connect.py`, `mcp_oauth.py`, `session.py`, `admin.py`, `auth.py`, `billing.py`, `call.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `web.py`, `dump_surface.py`, `test_app_roles.py` |
 | `architecture/contactout.md` | `contactout.yaml`, `adapters.yaml`, `contactout.people.email.verify.json`, `test_routing.py`, `contactout.companies.search.json`, `contactout.companies.enrich.json`, `resolve.py`, `contactout.py`, `contactout.svg`, `test_marketplace_call.py`, `test_key_providers.py`, `test_capacity_collectors.py`, `test_catalog_validate.py`, `test_capacity_overflow.py`, `contactout_overflow_verify.py`, `contactout.json` |
 | `architecture/data-model.md` | `alembic.ini`, `env.py`, `0001_baseline_current_schema.py`, `0002_archive_tables.py`, `0003_callrecord_cached.py`, `0004_archivekey_request_shape.py`, `0005_capacity_policy_snapshot.py`, `0006_overflow_route.py`, `0007_overflow_spend.py`, `0008_org_platform_overflow_disabled.py`, `0009_callrecord_hit.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `0020_callrecord_created_at_indexes.py`, `0021_ledgerentry_org_created_at_index.py`, `0022_org_spent_today_counter.py`, `0023_callrecord_org_user_created_at_index.py`, `0024_membership_calls_today_counter.py`, `0027_enrich_arena.py`, `0028_arena_insights.py`, `0029_arena_verification_snapshot.py`, `0011_callrecord_archive_link.py`, `0015_idempotentcall_membership_cascade.py`, `maintenance.py`, `sitetrack.js`, `models.py`, `timeutil.py`, `db.py`, `referrals.py`, `audit.py`, `analytics.py`, `bootstrap_handlers.py`, `ratestore.py`, `auth.py`, `test_postgres_reset.py`, `test_alembic_expand_safety.py` |
-| `architecture/feedback.md` | `feedback_contract.py`, `__init__.py`, `reports.py`, `reviews.py`, `hints.py`, `config.py`, `call.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `0026_callreview.py`, `feedback.md`, `test_feedback.py`, `test_reviews.py`, `test_hints.py` |
+| `architecture/feedback.md` | `feedback_contract.py`, `__init__.py`, `reports.py`, `reviews.py`, `hints.py`, `config.py`, `call.py`, `invite.py`, `kv.py`, `feedback.py`, `feedback.py`, `0025_feedback.py`, `0026_callreview.py`, `feedback.md`, `test_feedback.py`, `test_reviews.py`, `test_hints.py`, `test_kv.py` |
 | `architecture/import-boundaries.md` | `pyproject.toml`, `ci.yml`, `__init__.py`, `__init__.py`, `access.py`, `authorize.py`, `idempotency.py`, `overflow.py`, `route.py`, `__init__.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `client_identity.py`, `__init__.py`, `__init__.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `__init__.py`, `__init__.py`, `authorization.py`, `oauth_flow.py`, `refresh.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `__init__.py`, `injectors.py`, `relay.py`, `__init__.py`, `limiter.py`, `test_call_architecture.py`, `test_import_lightness.py` |
 | `architecture/instagram-oauth.md` | `catalog_ingest.py`, `access.py`, `resolve.py`, `service.py`, `instagram.yaml`, `instagram.extended.yaml`, `cli.py`, `store.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `mcp.py`, `call.py`, `index.html`, `0010_oauth_authorization_method.py`, `test_instagram_oauth_architecture.py` |
 | `architecture/local-proxy.md` | `localproxy.py`, `server.js` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ agents then built against a constitution that was wrong.
 | `routers/` | HTTP and MCP translation in, response shape out | business rules, query orchestration, money |
 | `application/` | use-case sequencing, transaction boundaries, compensation, cross-domain composition | empty wrappers around one-domain CRUD |
 | `domain/` | rules explainable and testable alone: `identity`, `governance`, `connections`, `tools`, `catalog`, `capacity`, `money`, `asynctasks`, `feedback` | routers, application, concrete SDKs |
-| `infra/` | DB engine and sessions, crypto, upstream relay and SSRF, ratestore, email, Stripe | decisions |
+| `infra/` | DB engine and sessions, crypto, upstream relay and SSRF, ratestore, the shared key-value store, email, Stripe | decisions |
 
 - Domains do not import each other, with three sanctioned edges: `governance -> identity`,
   `tools -> connections`, `capacity -> catalog` (read-only). `identity` and `money` are leaves.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Environment variables (prefix `TREG_`, read from `.env`):
 | `TREG_BLOCKED_EMAIL_DOMAINS`              | *(empty)*                       | comma-separated email domains refused at every sign-up/sign-in door and at team creation (subdomains included, case-insensitive). Empty blocks nothing — no list ships in the code |
 | `TREG_ADMIN_TOKEN`                        | *(empty)*                       | cross-tenant **super-admin** bearer; authorizes every `/admin/*` endpoint. Empty disables the env path (only `is_superadmin` users reach `/admin`). Keep it long + secret. |
 | `TREG_EMAIL_DEV_MODE`                     | `false`                         | when true, `/auth/email/start` returns the OTP in its response (no mail sender needed) — **dev/local only**, never in prod.                                                |
+| `TREG_KV_URL`                             | *(empty)*                       | shared key-value store (Redis protocol) for counters every worker must agree on, today the per-team review-invitation budget. Empty = an in-process fallback, fine for one worker |
 
 
 No `.env` is needed for local dev — every setting has a working default (ephemeral key, sqlite).

--- a/docs/context/architecture/feedback.md
+++ b/docs/context/architecture/feedback.md
@@ -9,6 +9,8 @@ sources:
   - src/treg/hints.py
   - src/treg/config.py
   - src/treg/routers/call.py
+  - src/treg/application/call/invite.py
+  - src/treg/infra/kv.py
   - src/treg/application/feedback.py
   - src/treg/routers/feedback.py
   - src/treg/alembic/versions/0025_feedback.py
@@ -17,6 +19,7 @@ sources:
   - tests/test_feedback.py
   - tests/test_reviews.py
   - tests/test_hints.py
+  - tests/test_kv.py
 related:
   - architecture/data-model.md
   - architecture/mcp-oauth.md
@@ -93,6 +96,11 @@ is `domain.feedback.reviews`; the moved `reports` module preserves feedback beha
 `hints.sampled(kind, sample_id)` hashes `kind:sample_id` with SHA-256 into the same 64-bit bucket
 construction for both kinds. `TREG_REVIEW_SAMPLE_RATE` and `TREG_FEEDBACK_HINT_RATE` are bounded
 0..1 floats, default 0. Sampling is local and deterministic under the current configuration.
+Sampling decides which calls *qualify*; a per-team budget decides how many of them a team is
+actually asked about (next section). `invited` on a review row therefore means "sampled, so
+eligible", recomputed at submission; the few eligible calls a full budget withheld are counted as
+invited when their agent volunteers a review. That imprecision is accepted on purpose: it keeps
+the invitation fact stateless, and the true count of invitations sent is the `hint_attached` event.
 
 `POST /reviews` uses `require_member` and returns 201 (`review_id`, `status: received`) on
 insertion or 200 on retry. `ReviewIn` rejects extra fields, requires a bounded `CallReference`
@@ -102,28 +110,55 @@ pagination with optional `endpoint_id`. It is excluded from OpenAPI; there is no
 
 ## Optional review and feedback invitations
 
-`routers.call.call_tool` sets `X-Treg-Review: requested` after constructing the streaming response,
-before streaming starts. Phase 1 invites only direct catalog calls served on treg's own platform
-key (`context.marketplace` exists and its `tier` is `platform`). These calls qualify only with a
-2xx status, no idempotent-replay header, `context.cached == False`, and a sampled call reference.
-The service sets `context.cached` from `served_hit` when the archive answers; the hook does not
-depend on cache response headers. Routed parents and own-key catalog calls can still be reviewed
-uninvited. An own tool never qualifies, even if its name matches a catalog endpoint. The whole hook
-is best-effort, has no database or body access, and does not change call service exits or writes.
-Plain HTTP gets only the header. Both MCP transports retain `call_id` and use their single hint
-slot with priority replay > 402 > review > feedback. Each surface's server `instructions` field
-also tells agents, in one sentence, to rate an invited call with `review(call_id, usefulness,
-reason?)` after using it and then continue, one review per invitation. The MCP server
-description, the `catalog_search` description, `skill.md` and `llms.txt` quote the catalog's size
-through `catalog_store.headline_counts` (`{ENDPOINTS}` / `{PROVIDERS}` filled at serve time, and at
-generation time for plugin copies), never a typed number: six hand-written copies had drifted apart. Feedback remains the existing proactive-friction text. The upstream body is unchanged.
+One decision, server-side: `application.call.invite.invitation(context, status, replayed)` runs
+in `routers.call.call_tool` after the streaming response is constructed and before it streams,
+and returns `review`, `feedback` or nothing. The router writes it as `X-Treg-Hint: review|feedback`
+(plus the older `X-Treg-Review: requested` on a review, which CLI releases up to 0.18 read) and
+emits one `hint_attached` analytics event per invitation actually sent, with `kind`, `call_id`,
+`endpoint_id`, the caller's `X-Treg-Client` and the team group. Every surface only translates the
+header: plain HTTP callers read it themselves, the CLI prints one stderr line per kind next to the
+charge line, and both MCP transports render it into their single hint slot with priority
+replay > 402 > review > feedback. Neither MCP transport samples or records anything of its own.
+
+A **review** invitation needs a direct catalog call served on treg's own platform key
+(`context.marketplace` exists and its `tier` is `platform`), a 2xx status, no idempotent replay,
+`context.cached == False` (the service sets it from `served_hit` when the archive answers), a
+sampled call reference, and **budget**: `kv.store().take("review-budget:<org_id>",
+review_budget_per_hour, 3600)` counts invitations per team in a window that starts at the team's
+first invitation and lasts an hour. `TREG_REVIEW_BUDGET_PER_HOUR` defaults to 5. The budget exists
+because per-call sampling scales with call volume: one team's 2,213 calls in twenty minutes drew
+93 invitations at 5% on launch week, and the agent answered every one. Low-volume teams never
+reach the cap, so the sampling rate alone sets their odds; high-volume teams are asked at most
+`review_budget_per_hour` times however many endpoints they hit. There is deliberately no
+per-endpoint cooldown: five ratings of one endpoint from one team are a phase-2 weighting problem,
+not a collection problem. Routed parents and own-key catalog calls can still be reviewed
+uninvited; an own tool never qualifies, even if its name matches a catalog endpoint.
+
+A **feedback** hint rides any other successful, non-replayed, non-cached call (own tools included)
+that samples in, at `TREG_FEEDBACK_HINT_RATE`. It asks for nothing, so it has no budget; a team
+whose review budget is spent still receives it when sampled.
+
+The whole hook is best-effort: no database or body access, no change to the call service's exits
+or writes, and a fault anywhere (the store included) can only lose the header, never the answer.
+The store is `infra/kv.py`: Render Key Value (Redis protocol) at `TREG_KV_URL`, or a bounded
+in-process dictionary when unset; both answer through one `take(key, limit, ttl_s)` that is one
+atomic `INCR` + `EXPIRE NX`. Reads and writes are capped at 100 ms and **fail closed**: a store
+that cannot answer is a spent budget, so an outage silently withholds review invitations rather
+than flooding a team, and `hint_attached` events dropping to zero is the signal. `/admin/kv`
+(superadmin) reports `configured` and `reachable`; startup logs a warning when the configured
+store does not answer. The store is the invitation budget's tenant only; a new tenant is one
+more narrow method, not a generic get/set surface.
+
+Each surface's server `instructions` field also tells agents, in one sentence, to rate an
+invited call with `review(call_id, usefulness, reason?)` after using it and then continue, one
+review per invitation. The MCP server description, the `catalog_search` description, `skill.md`
+and `llms.txt` quote the catalog's size through `catalog_store.headline_counts` (`{ENDPOINTS}` /
+`{PROVIDERS}` filled at serve time, and at generation time for plugin copies), never a typed
+number: six hand-written copies had drifted apart. The upstream body is unchanged.
 
 The config-driven sampler replaces the PostHog flag poller completely; both MCP lifespans only
-own their transport lifecycle. Feedback hints remain limited to successful calls without a higher
-priority hint; missing call references use a fresh sampling ID without inventing a public call ID.
-`mcp_hint_attached` is a best-effort analytics event with `kind`, `surface` and available `call_id`,
-never upstream contents or credentials. Attachment does not prove display or reading. No session
-reminder cap or adaptive sampling is implemented.
+own their transport lifecycle. Attachment does not prove display or reading. No session reminder
+cap or adaptive sampling is implemented.
 
 ## Known biases
 
@@ -133,6 +168,12 @@ endpoints of one capability. Phase 1 collects only: no aggregation, catalog scor
 team-side read route, dashboard, or adaptive per-endpoint sampling.
 
 ## Response-rate query
+
+The denominator that counts is the `hint_attached` event with `kind = review`: one per invitation
+sent, on every surface, after the budget. The SQL below replays sampling over `callrecord` instead
+and therefore counts *eligible* calls; for a team that hit its budget it overstates invitations
+and understates the response rate. Use it when PostHog is unavailable or for a window before the
+budget shipped, and read its result as a floor.
 
 For PostgreSQL, bind `:window_start`, `:window_end`, `:as_of` as naive UTC timestamps and
 `:review_rate` to the configured rate for that window. Split windows when the rate changes:

--- a/docs/context/interface/cli.md
+++ b/docs/context/interface/cli.md
@@ -30,8 +30,9 @@ failures report an unconfirmed outcome, not a definite failure. Bare `treg feedb
 `cmd_review` implements `treg review <call_id> <usefulness> [--reason TEXT]`, sharing the light
 contract's enum and description with MCP. It validates the reference and trimmed reason locally,
 posts to `/reviews`, prints a receipt, and emits structured errors without echoing rejected input.
-A transport failure explicitly leaves the outcome unconfirmed. `_show_review_line`, beside the
-charge line, prints the sampled `X-Treg-Review: requested` invitation only on stderr. Call responses
+A transport failure explicitly leaves the outcome unconfirmed. `_show_hint_line`, beside the
+charge line, prints the server's invitation (`X-Treg-Hint: review|feedback`; the older
+`X-Treg-Review: requested` still means review) as one stderr line per kind. Call responses
 retain the existing `_show` formatting on stdout, including pretty-printed JSON.
 
 ## Instagram grants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ server = [
     "stripe>=12",  # balance top-ups (src/treg/infra/stripe.py) — the payment rail, server-side only
     "mcp>=2",      # the MCP front door (src/treg/mcp.py) — server-side only; pulls httpx2 ALONGSIDE
                    # httpx (they coexist), so the light CLI's dependency set is untouched
+    "redis>=5",    # the shared key-value store (src/treg/infra/kv.py) — server-side only
 ]
 # The LOCAL PROXY (`treg shell` catching the agent's own outgoing calls). It needs to generate a
 # certificate authority on the machine, and `cryptography` is a compiled package — putting it in the
@@ -112,6 +113,7 @@ forbidden_modules = [
     "pydantic",
     "pydantic_core",
     "pydantic_settings",
+    "redis",
     "sqlalchemy",
     "sqlmodel",
     "starlette",

--- a/src/treg/application/call/invite.py
+++ b/src/treg/application/call/invite.py
@@ -1,0 +1,41 @@
+"""Which optional hint, if any, rides on a successful call's answer.
+
+Decided once, server-side, after the upstream has answered and before the body streams; every
+surface (plain HTTP, CLI, both MCP transports) only translates the resulting `X-Treg-Hint` header.
+A review invitation asks the agent for work, so it is rationed twice: `hints.sampled` picks WHICH
+calls qualify (deterministic, so `POST /reviews` can recompute eligibility), and a per-team hourly
+budget in the shared store caps HOW MANY a team is asked about, whatever its call volume. A team
+hammering one endpoint 2,000 times in an hour is asked `review_budget_per_hour` times, not 100.
+The feedback hint asks for nothing and stays purely sampled.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from ... import hints
+from ...config import get_settings
+from ...infra import kv
+from .types import CallContext
+
+Kind = Literal["review", "feedback"]
+BUDGET_WINDOW_S = 3600
+
+
+def budget_key(org_id: int) -> str:
+    return f"review-budget:{org_id}"
+
+
+async def invitation(context: CallContext, status: int, *, replayed: bool) -> Kind | None:
+    """No database, no body access. Phase 1 invites reviews only on direct catalog calls served
+    on treg's platform key; an own tool never qualifies even when its name matches an endpoint."""
+    if not (200 <= status < 300) or replayed or context.cached:
+        return None
+    marketplace = context.marketplace
+    platform = marketplace is not None and getattr(marketplace, "tier", None) == "platform"
+    if platform and hints.sampled("review", context.call_ref):
+        if await kv.store().take(budget_key(context.input.caller.org_id),
+                                 get_settings().review_budget_per_hour, BUDGET_WINDOW_S):
+            return "review"
+    if hints.sampled("feedback", context.call_ref):
+        return "feedback"
+    return None

--- a/src/treg/bootstrap.py
+++ b/src/treg/bootstrap.py
@@ -28,6 +28,7 @@ from .bootstrap_http import (
     _SecurityHeadersMiddleware,
 )
 from .config import get_settings
+from .infra import kv
 from .infra.db import background_session_maker, verify_db
 from .infra.catalog_observations import (
     CachedEndpointObservationReader,
@@ -272,6 +273,7 @@ _CONTROL_ROUTE_KEYS: frozenset[RouteKey] = frozenset({
     ('/admin/calls', ('GET',), 'admin_calls'),
     ('/admin/errors', ('GET',), 'admin_errors'),
     ('/admin/health', ('GET',), 'admin_health'),
+    ('/admin/kv', ('GET',), 'admin_kv'),
     ('/admin/users/{user_id}/superadmin', ('POST',), 'admin_set_superadmin'),
     ('/admin/users/{user_id}/suspend', ('POST',), 'admin_suspend_user'),
     ('/admin/users/{user_id}', ('DELETE',), 'admin_delete_user'),
@@ -486,6 +488,10 @@ def _lifespan(role: AppRole):
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         await verify_db()
+        if kv.configured() and not await kv.store().ping():
+            # Not fatal: the store's tenants fail closed (infra/kv.py). Loud, because until it
+            # answers no team receives a review invitation. /admin/kv shows the live state.
+            logging.getLogger("treg").warning("kv configured but unreachable at startup")
 
         limits = httpx.Limits(max_keepalive_connections=100, max_connections=200)
         app.state.http = httpx.AsyncClient(
@@ -551,6 +557,7 @@ def _lifespan(role: AppRole):
                 await archive.drain()
                 await analytics.drain()
                 await app.state.http.aclose()
+                await kv.close()
             finally:
                 analytics.remove_fault_handler(fault_handler)
 

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -289,7 +289,7 @@ def _show(resp: httpx.Response) -> None:
         print(resp.text)
     if resp.status_code < 400:
         _show_charge_line(resp)
-        _show_review_line(resp)
+        _show_hint_line(resp)
     if resp.status_code >= 400:
         _show_failure_diagnostics(resp)
         # 402 = the team balance can't cover a call on treg's key. The JSON above already carries the
@@ -326,13 +326,26 @@ def _show_charge_line(resp: httpx.Response) -> None:
     print(line, file=sys.stderr)
 
 
-def _show_review_line(resp: httpx.Response) -> None:
+def _show_hint_line(resp: httpx.Response) -> None:
+    """The server's optional invitation (`X-Treg-Hint: review|feedback`), one stderr line beside the
+    charge line. `X-Treg-Review: requested` is the older review-only header a pre-0.19 registry
+    still sends. stdout stays the exact body."""
     headers = getattr(resp, "headers", {}) or {}
     call_id = headers.get("X-Treg-Call-Id")
-    if headers.get("X-Treg-Review") == "requested" and call_id:
+    kind = headers.get("X-Treg-Hint")
+    if kind is None and headers.get("X-Treg-Review") == "requested":
+        kind = "review"
+    if not call_id:
+        return
+    if kind == "review":
         print(f'treg: after using this result, run treg review {call_id} '
               '<useful|partly|not_useful|not_sure> [--reason "..."]; '
               'omit private data, then keep going with the task.', file=sys.stderr)
+    elif kind == "feedback":
+        print('treg: anything confusing or wrong about this call, even if it worked? '
+              'treg feedback submit <quality|pricing|friction|other> "what you saw" '
+              f'--call-id {call_id}; omit private data, then keep going with the task.',
+              file=sys.stderr)
 
 
 def _show_failure_diagnostics(resp: httpx.Response) -> None:
@@ -2441,7 +2454,7 @@ def _show_call_response(response: httpx.Response) -> None:
             _show_failure_diagnostics(response)
             raise SystemExit(1)
         _show_charge_line(response)
-        _show_review_line(response)
+        _show_hint_line(response)
         return
     _show(response)
 

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
 
     review_sample_rate: float = Field(default=0, ge=0, le=1)
     feedback_hint_rate: float = Field(default=0, ge=0, le=1)
+    # Review invitations a team can receive per hour, whatever its call volume. Sampling decides
+    # WHICH calls qualify; this decides how many of them a team is actually asked about.
+    review_budget_per_hour: int = Field(default=5, ge=1)
+    # The shared key-value store (Redis protocol). Empty = an in-process fallback; see infra/kv.py.
+    kv_url: str = ""
 
     # SQLite locally, Postgres on Render — same code path, just swap the URL.
     database_url: str = "sqlite+aiosqlite:///./treg.db"

--- a/src/treg/infra/kv.py
+++ b/src/treg/infra/kv.py
@@ -1,0 +1,130 @@
+"""The shared key-value store: small, expiring counters that several workers must agree on.
+
+Render Key Value (Redis protocol) in production, an in-process dictionary when `TREG_KV_URL` is
+unset (local development, tests, self-hosters without one). The store holds nothing that must
+survive: every key expires, and every caller treats "unavailable" as a safe answer. Reads and
+writes are bounded by `_TIMEOUT_S` so a slow store can never hold a call open.
+
+The first tenant is the review-invitation budget (`application/call/invite.py`). Nothing else may
+depend on this module until it has proved itself there; the pattern for a new tenant is one more
+narrow method here, not a generic get/set surface.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Protocol
+
+from ..config import get_settings
+
+_TIMEOUT_S = 0.1
+_LOCAL_MAX_KEYS = 10_000
+log = logging.getLogger("treg.kv")
+
+
+class Store(Protocol):
+    async def take(self, key: str, limit: int, ttl_s: int) -> bool:
+        """Count one use of `key` inside a window that starts at its first use and lasts `ttl_s`.
+        True while the window holds `limit` or fewer uses, False past it OR when the store cannot
+        answer: a budget that cannot be checked is spent, never free."""
+
+    async def ping(self) -> bool: ...
+
+    async def aclose(self) -> None: ...
+
+
+class LocalStore:
+    """Per-process fallback with the same contract. Bounded so a flood of keys cannot grow it."""
+
+    def __init__(self) -> None:
+        self._windows: dict[str, tuple[float, int]] = {}
+
+    async def take(self, key: str, limit: int, ttl_s: int) -> bool:
+        now = time.monotonic()
+        expires, count = self._windows.get(key, (0.0, 0))
+        if expires <= now:
+            if len(self._windows) >= _LOCAL_MAX_KEYS:
+                self._evict(now)
+            expires, count = now + ttl_s, 0
+        count += 1
+        self._windows[key] = (expires, count)
+        return count <= limit
+
+    def _evict(self, now: float) -> None:
+        live = {k: v for k, v in self._windows.items() if v[0] > now}
+        if len(live) >= _LOCAL_MAX_KEYS:
+            live = dict(sorted(live.items(), key=lambda kv: kv[1][0])[_LOCAL_MAX_KEYS // 2:])
+        self._windows = live
+
+    async def ping(self) -> bool:
+        return True
+
+    async def aclose(self) -> None:
+        self._windows.clear()
+
+
+class RedisStore:
+    def __init__(self, url: str) -> None:
+        import redis.asyncio as redis  # server extra; imported here so the light CLI never loads it
+
+        self._client = redis.Redis.from_url(
+            url, socket_timeout=_TIMEOUT_S, socket_connect_timeout=_TIMEOUT_S,
+            decode_responses=True,
+        )
+
+    async def take(self, key: str, limit: int, ttl_s: int) -> bool:
+        try:
+            async with asyncio.timeout(_TIMEOUT_S * 2):
+                async with self._client.pipeline(transaction=True) as pipe:
+                    pipe.incr(key)
+                    pipe.expire(key, ttl_s, nx=True)  # the window starts at the first use
+                    count, _ = await pipe.execute()
+            return int(count) <= limit
+        except Exception as exc:  # noqa: BLE001 — a store fault is a spent budget, never a call fault
+            _note_fault(exc)
+            return False
+
+    async def ping(self) -> bool:
+        try:
+            async with asyncio.timeout(_TIMEOUT_S * 2):
+                return bool(await self._client.ping())
+        except Exception as exc:  # noqa: BLE001
+            _note_fault(exc)
+            return False
+
+    async def aclose(self) -> None:
+        try:
+            await self._client.aclose()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _note_fault(exc: BaseException) -> None:
+    from .. import analytics  # lazy: analytics imports config, and this module is imported early
+
+    log.warning("kv unavailable: %s: %s", type(exc).__name__, exc)
+    analytics.capture_fault(exc, component="kv")
+
+
+_store: Store | None = None
+
+
+def store() -> Store:
+    """The process-wide store, built on first use from `TREG_KV_URL`."""
+    global _store
+    if _store is None:
+        url = get_settings().kv_url
+        _store = RedisStore(url) if url else LocalStore()
+    return _store
+
+
+def configured() -> bool:
+    return bool(get_settings().kv_url)
+
+
+async def close() -> None:
+    global _store
+    if _store is not None:
+        await _store.aclose()
+        _store = None

--- a/src/treg/mcp.py
+++ b/src/treg/mcp.py
@@ -42,7 +42,6 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, TypedDict
 from urllib.parse import parse_qsl, urlsplit
-from uuid import uuid4
 
 import httpx
 from mcp.server import MCPServer
@@ -52,7 +51,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 from mcp.shared.exceptions import MCPError
 from mcp.types import METHOD_NOT_FOUND, ToolAnnotations
 
-from . import analytics, audit, hints
+from . import audit, hints
 from .domain.catalog import store as catalog_store
 from .config import PUBLIC_HOST_ALIASES, get_settings
 from .feedback_contract import FeedbackCategory, FEEDBACK_DESCRIPTION, ReviewUsefulness, REVIEW_DESCRIPTION
@@ -1045,17 +1044,13 @@ async def _call_impl(endpoint_id: str, params: dict | list | None = None,
                            f"at its real price because treg's {provider} account is out; cost_usd is "
                            f"what the relay billed, not the catalog's direct price")
     if 200 <= r.status_code < 300 and not out.get("hint") and not out.get("replayed"):
-        kind = None
-        if r.headers.get("X-Treg-Review") == "requested" and out.get("call_id"):
+        # /call/ decides whether to invite (application/call/invite.py) and records that it did;
+        # this surface only renders the header into the single hint slot.
+        kind = r.headers.get("X-Treg-Hint")
+        if kind == "review" and out.get("call_id"):
             out["hint"] = hints.review_hint(out["call_id"])
-            kind = "review"
-        elif hints.sampled("feedback", out.get("call_id") or uuid4().hex):
+        elif kind == "feedback":
             out["hint"] = hints.HINT
-            kind = "feedback"
-        if kind:
-            analytics.capture(analytics.SERVER_DISTINCT_ID, "mcp_hint_attached", {
-                "call_id": out.get("call_id"), "surface": surface.client_name, "kind": kind,
-            })
     if r.status_code == 402:
         # States the fact and stops. No link, and `topup_url` is stripped from the relayed body, so
         # nothing on this path points a user at a payment page.

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -17,6 +17,7 @@ from sqlmodel import select
 
 from .. import reconcile
 from ..config import get_settings
+from ..infra import kv
 from ..infra.db import background_session_maker, get_admin_session
 from ..domain import money
 from ..models import ArchiveEndpointStat, ArchiveKey, ArchiveSnapshot, Bundle, CallRecord, LedgerEntry, Membership, Org, Referral, Secret, Tool, User
@@ -296,6 +297,14 @@ async def admin_health(_: str = Depends(require_superadmin), db: AsyncSession = 
         out.append({"secret_id": s.id, "name": s.name, "org": org.slug if org else None,
                     "kind": s.kind, "status": s.health_status, "detail": s.health_detail})
     return out
+
+
+@app.get("/admin/kv", include_in_schema=False)
+async def admin_kv(_: str = Depends(require_superadmin)) -> dict:
+    """Is the shared key-value store reachable? `configured` false means the in-process fallback
+    (no `TREG_KV_URL`); `reachable` false with it configured means every budgeted invitation is
+    currently withheld (infra/kv.py fails closed)."""
+    return {"configured": kv.configured(), "reachable": await kv.store().ping()}
 
 
 # Rebind app so the second block keeps its decorator text and remains a separate attach point.

--- a/src/treg/routers/call.py
+++ b/src/treg/routers/call.py
@@ -12,7 +12,7 @@ from sqlalchemy.exc import TimeoutError as PoolTimeoutError
 from starlette.background import BackgroundTask
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from .. import analytics, hints
+from .. import analytics
 from .. import audit
 from .. import sandbox as demo_sandbox
 from ..application.call.access import catalog_endpoint_access as get_catalog_endpoint_access
@@ -29,6 +29,7 @@ from ..application.call.service import (
     create_call_context,
     execute_call,
 )
+from ..application.call.invite import invitation
 from ..application.call.intake import (
     META_HEADER,
     CallMeta,
@@ -265,6 +266,17 @@ async def catalog_endpoint_access(
     except CallFailure as exc:
         raise _translate_call_failure(exc) from exc
 
+def _capture_hint(request: Request, context, kind: str) -> None:
+    """One event per invitation actually sent, on every surface: the response-rate denominator.
+    Attachment is not display; the surface's `X-Treg-Client` says who was asked."""
+    marketplace = context.marketplace
+    slug = context.input.caller.org.slug
+    analytics.capture(analytics.SERVER_DISTINCT_ID, "hint_attached", {
+        "kind": kind, "call_id": context.call_ref, "client": _client_of(request),
+        "endpoint_id": marketplace.endpoint_id if marketplace is not None else None,
+    }, groups={"team": slug} if slug else None)
+
+
 @app.api_route(
     "/call/{rest:path}",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
@@ -311,15 +323,16 @@ async def call_tool(
         _attach_async_descriptor(upstream, context, rest)
         response = _http_upstream_response(upstream)
         try:
-            # Phase 1 invites only direct catalog calls served on treg's platform key.
-            if (context.marketplace is not None and context.marketplace.tier == "platform"
-                    and 200 <= response.status_code < 300
-                    and not response.headers.get("X-Treg-Idempotent-Replay")
-                    and not context.cached
-                    and hints.sampled("review", context.call_ref)):
-                response.headers["X-Treg-Review"] = "requested"
+            # Optional invitation, decided before the body streams (application/call/invite.py).
+            kind = await invitation(context, response.status_code,
+                                    replayed=bool(response.headers.get("X-Treg-Idempotent-Replay")))
+            if kind is not None:
+                response.headers["X-Treg-Hint"] = kind
+                if kind == "review":
+                    response.headers["X-Treg-Review"] = "requested"  # read by CLI <= 0.18
+                _capture_hint(request, context, kind)
         except Exception:
-            pass  # Optional invitation: a fault can only lose the header.
+            pass  # A fault here can only lose the header; the answer is already built.
         return response
     except CallFailure as exc:
         raise _translate_call_failure(exc) from exc

--- a/src/treg/web/feedback.md
+++ b/src/treg/web/feedback.md
@@ -65,7 +65,9 @@ anything confusing or wrong. Keep going with your task after rating.
 Phase 1 invites only direct catalog calls served on treg's own platform key. Routed and own-key
 catalog calls can still be reviewed uninvited.
 
-CLI invitations appear on stderr; plain HTTP invitations use `X-Treg-Review: requested`.
+CLI invitations appear on stderr; plain HTTP invitations use `X-Treg-Hint: review` (with
+`X-Treg-Review: requested` alongside for older clients). A sampled `X-Treg-Hint: feedback` is a
+lighter nudge to report friction and asks for nothing.
 MCP invitations appear in the call result's hint. Use the call ID in the response:
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,6 +341,10 @@ def _reset_call_path_caches():
             limiter.reset()
         except ImportError:
             pass
+        # The shared store's in-process fallback (the review-invitation budget): org ids restart
+        # with every reset_db(), so a counter left over would ration the NEXT test's team.
+        from treg.infra import kv
+        kv._store = None
     _clear()
     yield
     _clear()

--- a/tests/snapshots/routes.json
+++ b/tests/snapshots/routes.json
@@ -1897,6 +1897,15 @@
   {
     "kind": "APIRoute",
     "methods": [
+      "GET",
+      "HEAD"
+    ],
+    "name": "admin_kv",
+    "path": "/admin/kv"
+  },
+  {
+    "kind": "APIRoute",
+    "methods": [
       "POST"
     ],
     "name": "admin_set_superadmin",

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -424,11 +424,12 @@ async def test_archive_hit_never_invites_review(clients: AsyncClient, serve, mon
 
     monkeypatch.setattr(call_service, "_served_response", stored_response)
     live = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
+    assert live.headers["X-Treg-Hint"] == "review"
     assert live.headers["X-Treg-Review"] == "requested"
     await archive.drain()
     hit = await clients.get(f"/call/{EP}?aweme_id=7&count=5")
     assert hit.status_code == 200 and hit.content == live.content
-    assert "X-Treg-Review" not in hit.headers
+    assert "X-Treg-Hint" not in hit.headers and "X-Treg-Review" not in hit.headers
     await audit.drain()
     assert (await clients.get("/calls")).json()[0]["cached"] is True
 

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -63,15 +63,24 @@ def test_cli_review_rejects_invalid_fields_locally(monkeypatch, capsys, args):
     assert json.loads(capsys.readouterr().out)['error'].startswith('invalid_')
 
 
-@pytest.mark.parametrize('requested', [True, False])
-def test_invitation_only_on_stderr(capsys, requested):
-    response = httpx.Response(200, content=b'raw upstream text', headers={
-        'X-Treg-Call-Id': 'call-id', **({'X-Treg-Review': 'requested'} if requested else {}),
-    })
+@pytest.mark.parametrize('headers,expect', [
+    ({'X-Treg-Hint': 'review'}, 'treg review call-id'),
+    ({'X-Treg-Review': 'requested'}, 'treg review call-id'),  # a pre-0.19 registry
+    ({'X-Treg-Hint': 'feedback'}, 'treg feedback submit <quality|pricing|friction|other> "what you saw" --call-id call-id'),
+    ({'X-Treg-Hint': 'unknown-kind'}, None),
+    ({}, None),
+])
+def test_invitation_only_on_stderr(capsys, headers, expect):
+    response = httpx.Response(200, content=b'raw upstream text', headers={'X-Treg-Call-Id': 'call-id', **headers})
     cli._show_call_response(response)
     output = capsys.readouterr()
     assert output.out == 'raw upstream text\n'
-    assert ('treg review call-id' in output.err) is requested
+    assert (expect in output.err) if expect else (output.err == '')
+
+
+def test_invitation_needs_a_call_id(capsys):
+    cli._show_call_response(httpx.Response(200, content=b'x', headers={'X-Treg-Hint': 'feedback'}))
+    assert capsys.readouterr().err == ''
 
 
 def test_cli_review_help_shares_description():

--- a/tests/test_hints.py
+++ b/tests/test_hints.py
@@ -65,16 +65,102 @@ async def test_header_before_stream_without_changing_response(
         return UpstreamResponse(status, tuple((k.lower().encode(), v.encode()) for k, v in headers.items()),
                                 stream(), close)
     def sampled(kind, ref):
-        assert consumed == []
-        assert kind == 'review' and ref
+        assert consumed == []  # decided before the body streams
+        assert ref
         if sample == 'exception':
             raise RuntimeError('optional hook broke')
-        return sample
+        return sample if kind == 'review' else False
     monkeypatch.setattr(call, 'execute_call', execute)
     monkeypatch.setattr(call.catalog_store, 'load', lambda: SimpleNamespace(by_id={'example.search': {}}))
     monkeypatch.setattr(hints, 'sampled', sampled)
     response = await clients.get('/call/example.search')
     assert response.status_code == status
     assert response.content == b'exact upstream bytes'
-    assert (response.headers.get('X-Treg-Review') == 'requested') is expected
+    assert (response.headers.get('X-Treg-Hint') == 'review') is expected
+    assert (response.headers.get('X-Treg-Review') == 'requested') is expected  # CLI <= 0.18
     assert consumed == ['body', 'close']
+
+
+def _platform_call(monkeypatch, *, tier='platform', own=False):
+    """A stubbed 2xx call on treg's platform key (or an own tool) with a static body."""
+    from treg.routers import call
+    from treg.application.call.types import UpstreamResponse
+
+    async def stream():
+        yield b'{}'
+    async def close():
+        pass
+    async def execute(context, client):
+        if own:
+            context.target = SimpleNamespace(tool=SimpleNamespace(name='example.search'))
+        else:
+            context.marketplace = SimpleNamespace(endpoint_id='example.search', tier=tier)
+        return UpstreamResponse(200, (), stream(), close)
+    monkeypatch.setattr(call, 'execute_call', execute)
+    monkeypatch.setattr(call.catalog_store, 'load', lambda: SimpleNamespace(by_id={'example.search': {}}))
+
+
+async def test_review_budget_caps_a_team_per_hour_and_every_invitation_is_an_event(clients, monkeypatch):
+    from treg import analytics
+
+    _platform_call(monkeypatch)
+    monkeypatch.setattr(get_settings(), 'review_sample_rate', 1)
+    monkeypatch.setattr(get_settings(), 'feedback_hint_rate', 0)
+    monkeypatch.setattr(get_settings(), 'review_budget_per_hour', 2)
+    events = []
+    monkeypatch.setattr(analytics, 'capture', lambda *args, **kw: events.append((args, kw)))
+    kinds = []
+    for _ in range(4):
+        response = await clients.get('/call/example.search', headers={'X-Treg-Client': 'claude-code'})
+        assert response.status_code == 200
+        kinds.append(response.headers.get('X-Treg-Hint'))
+    assert kinds == ['review', 'review', None, None]
+    sent = [(a[2], kw) for a, kw in events if a[1] == 'hint_attached']
+    assert [p['kind'] for p, _ in sent] == ['review', 'review']
+    assert all(p['client'] == 'claude-code' and p['endpoint_id'] == 'example.search' and p['call_id']
+               for p, _ in sent)
+    assert all(kw['groups']['team'] for _, kw in sent)
+    assert not [a for a, _ in events if a[1] == 'mcp_hint_attached']
+
+
+async def test_budget_is_per_team(clients, monkeypatch):
+    from treg.application.call import invite
+    from treg.infra import kv
+
+    _platform_call(monkeypatch)
+    monkeypatch.setattr(get_settings(), 'review_sample_rate', 1)
+    monkeypatch.setattr(get_settings(), 'review_budget_per_hour', 1)
+    assert (await clients.get('/call/example.search')).headers.get('X-Treg-Hint') == 'review'
+    assert (await clients.get('/call/example.search')).headers.get('X-Treg-Hint') is None
+    # Another team's budget is untouched: its key has never been taken.
+    assert await kv.store().take(invite.budget_key(999), 1, 60)
+
+
+async def test_unavailable_store_withholds_the_review_but_not_the_answer(clients, monkeypatch):
+    from treg.infra import kv
+
+    class Down:
+        async def take(self, key, limit, ttl_s):
+            return False  # what RedisStore returns on any fault: a budget that cannot be checked is spent
+        async def ping(self):
+            return False
+        async def aclose(self):
+            pass
+    _platform_call(monkeypatch)
+    monkeypatch.setattr(kv, '_store', Down())
+    monkeypatch.setattr(get_settings(), 'review_sample_rate', 1)
+    monkeypatch.setattr(get_settings(), 'feedback_hint_rate', 1)
+    response = await clients.get('/call/example.search')
+    assert response.status_code == 200 and response.content == b'{}'
+    assert response.headers.get('X-Treg-Hint') == 'feedback'  # the lighter hint still rides along
+    assert 'X-Treg-Review' not in response.headers
+
+
+@pytest.mark.parametrize('own', [True, False])
+async def test_feedback_hint_rides_plain_http_on_any_successful_call(clients, monkeypatch, own):
+    _platform_call(monkeypatch, own=own)
+    monkeypatch.setattr(get_settings(), 'review_sample_rate', 0)
+    monkeypatch.setattr(get_settings(), 'feedback_hint_rate', 1)
+    response = await clients.get('/call/example.search')
+    assert response.headers.get('X-Treg-Hint') == 'feedback'
+    assert 'X-Treg-Review' not in response.headers

--- a/tests/test_kv.py
+++ b/tests/test_kv.py
@@ -1,0 +1,75 @@
+"""The shared key-value store: windowed counters that fail closed."""
+import os
+import time
+
+import pytest
+
+from treg.config import get_settings
+from treg.infra import kv
+
+
+async def test_local_window_counts_then_expires(monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(time, 'monotonic', lambda: clock[0])
+    store = kv.LocalStore()
+    assert [await store.take('k', 2, 60) for _ in range(3)] == [True, True, False]
+    assert await store.take('other', 2, 60)  # keys are independent
+    clock[0] += 59
+    assert not await store.take('k', 2, 60)
+    clock[0] += 2  # the window started at the first take and is now over
+    assert await store.take('k', 2, 60)
+
+
+async def test_local_store_is_bounded(monkeypatch):
+    monkeypatch.setattr(kv, '_LOCAL_MAX_KEYS', 4)
+    clock = [0.0]
+    monkeypatch.setattr(time, 'monotonic', lambda: clock[0])
+    store = kv.LocalStore()
+    for i in range(4):
+        await store.take(f'old{i}', 1, 10)
+    clock[0] += 11  # all expired: eviction drops them instead of growing
+    await store.take('new', 1, 10)
+    assert set(store._windows) == {'new'}
+    for i in range(4):
+        await store.take(f'live{i}', 1, 100)
+    assert len(store._windows) <= 4  # live keys past the bound: the oldest windows go
+
+
+async def test_unreachable_redis_fails_closed_and_fast():
+    store = kv.RedisStore('redis://127.0.0.1:1')
+    started = time.monotonic()
+    assert await store.take('k', 5, 60) is False
+    assert await store.ping() is False
+    assert time.monotonic() - started < 2
+    await store.aclose()
+
+
+def test_store_follows_configuration(monkeypatch):
+    monkeypatch.setattr(kv, '_store', None)
+    monkeypatch.setattr(get_settings(), 'kv_url', '')
+    assert isinstance(kv.store(), kv.LocalStore) and not kv.configured()
+    monkeypatch.setattr(kv, '_store', None)
+    monkeypatch.setattr(get_settings(), 'kv_url', 'redis://127.0.0.1:1')
+    assert isinstance(kv.store(), kv.RedisStore) and kv.configured()
+    monkeypatch.setattr(kv, '_store', None)
+
+
+async def test_admin_kv_reports_the_fallback(clients, monkeypatch):
+    assert (await clients.get('/admin/kv')).status_code in (401, 403)
+    monkeypatch.setattr(get_settings(), 'admin_token', 'kv-admin')
+    response = await clients.get('/admin/kv', headers={'X-Treg-Token': 'kv-admin'})
+    assert response.json() == {'configured': False, 'reachable': True}
+
+
+@pytest.mark.skipif(not os.environ.get('TREG_TEST_KV_URL'), reason='set TREG_TEST_KV_URL to a scratch Redis')
+async def test_real_redis_window():
+    store = kv.RedisStore(os.environ['TREG_TEST_KV_URL'])
+    key = f'treg-test:{time.time_ns()}'
+    try:
+        assert await store.ping()
+        assert [await store.take(key, 2, 5) for _ in range(3)] == [True, True, False]
+        ttl = await store._client.ttl(key)
+        assert 0 < ttl <= 5
+    finally:
+        await store._client.delete(key)
+        await store.aclose()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -186,7 +186,12 @@ def _free_port() -> int:
 def _boot_raw_asgi(env: dict[str, str], tmp_path: Path) -> tuple[bool, str]:
     port = _free_port()
     base_url = f"http://127.0.0.1:{port}"
-    env = {**env, "PORT": str(port), "TREG_PUBLIC_URL": base_url}
+    env = {**env, "PORT": str(port), "TREG_PUBLIC_URL": base_url, "NO_COLOR": "1"}
+    # The assertions read the server's log text. Rich honours FORCE_COLOR even into a file and
+    # then highlights numbers with escape codes ("Database revision \x1b[1;36m9999"), so a shell
+    # that forces colour (agent harnesses do) would fail the revision checks for no reason.
+    for forcing in ("FORCE_COLOR", "CLICOLOR_FORCE", "TTY_COMPATIBLE"):
+        env.pop(forcing, None)
     stdout_path = tmp_path / "raw-asgi.stdout"
     stderr_path = tmp_path / "raw-asgi.stderr"
     ready = False

--- a/tests/test_mcp_directory.py
+++ b/tests/test_mcp_directory.py
@@ -657,7 +657,7 @@ async def test_feedback_hint_only_wraps_successful_sampled_calls(clients, monkey
         assert replay['call_id'] == first['call_id']
         assert failed['status'] == 503
         assert failed.get('hint') != hints.HINT
-        exposures = [a for a, _ in events if a[1] == 'mcp_hint_attached']
+        exposures = [a for a, _ in events if a[1] == 'hint_attached']
         assert len(exposures) == int(sampled)
         if sampled:
             assert exposures[0][2]['call_id'] == first['call_id']

--- a/uv.lock
+++ b/uv.lock
@@ -886,6 +886,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1073,6 +1082,7 @@ server = [
     { name = "mcp" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "sqlmodel" },
     { name = "stripe" },
@@ -1104,6 +1114,7 @@ requires-dist = [
     { name = "pydantic-settings", marker = "extra == 'server'", specifier = ">=2.5" },
     { name = "pyyaml", marker = "extra == 'server'", specifier = ">=6" },
     { name = "questionary", specifier = ">=2.0" },
+    { name = "redis", marker = "extra == 'server'", specifier = ">=5" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'server'", specifier = ">=2.0" },
     { name = "sqlmodel", marker = "extra == 'server'", specifier = ">=0.0.22" },
     { name = "stripe", marker = "extra == 'server'", specifier = ">=12" },


### PR DESCRIPTION
## What

Review invitations are now rationed **per team, per hour**, and every surface reads one server-side header.

- **Why.** Per-call sampling scales with call volume. On launch week one team made 2,213 calls in twenty minutes and drew 93 review invitations at 5%; its agent answered every one. Those 93 rows say almost nothing new about the endpoint, and the agent was interrupted 93 times.
- **Budget.** `application/call/invite.py` decides once, after the upstream answered and before the body streams: sampling picks *which* calls qualify (unchanged, still deterministic), then `kv.store().take("review-budget:<org_id>", TREG_REVIEW_BUDGET_PER_HOUR, 3600)` caps *how many* a team is asked about. Default 5 per hour. Low-volume teams never reach the cap, so the sampling rate alone sets their odds. There is deliberately no per-endpoint cooldown: five ratings of one endpoint from one team are a phase-2 weighting problem.
- **One header.** `/call/` writes `X-Treg-Hint: review|feedback`. Both MCP transports (kept separate) and the CLI only translate it; neither samples or records anything of its own any more. `X-Treg-Review: requested` stays alongside a review for CLI releases up to 0.18. The CLI gains the feedback line it never had.
- **One event.** `hint_attached` (`kind`, `call_id`, `endpoint_id`, `client`, team group) is emitted by the router per invitation actually sent, on every surface. It replaces `mcp_hint_attached` and is the response-rate denominator; the SQL replay in the fragment is now documented as a floor.
- **`invited` stays a recompute.** With a budget, "sampled" no longer equals "invited"; the few eligible calls a full budget withheld are counted as invited if their agent volunteers a review. Accepted imprecision, documented, keeps the invitation fact stateless.

## The store

`infra/kv.py`: Render Key Value (Redis protocol) at `TREG_KV_URL`, or a bounded in-process dictionary when unset. One narrow method, `take(key, limit, ttl_s)`, one atomic `INCR` + `EXPIRE NX`. 100 ms cap, **fails closed**: a store that cannot answer is a spent budget, so an outage withholds invitations rather than flooding a team, and `hint_attached` dropping to zero is the signal. `/admin/kv` (superadmin) reports `configured` / `reachable`; startup warns when the configured store is silent. `redis` joins the `[server]` extra and the light-CLI forbidden list. The budget is the store's only tenant on purpose.

## Evidence

- Full suite green (3,236 passed), `lint-imports` 14/14, `drift.sh` run and the fragments updated in the same commits.
- Real Redis: `tests/test_kv.py::test_real_redis_window` against a scratch `redis:7-alpine` (set `TREG_TEST_KV_URL`), and the budget hook tests run through `RedisStore` end to end: four takes left `review-budget:1 = 4` with a 3,597 s TTL.
- Also fixed on the way: `test_maintenance` failed in any shell that forces colour (`FORCE_COLOR`), because Rich highlighted the revision number with escape codes. The raw ASGI helper now boots the server with a plain log.

## Rollout

1. Create a Render Key Value instance and set `TREG_KV_URL` (treg-internal, its own PR). Until then the in-process fallback runs, which on several workers means each worker keeps its own budget: still a hard improvement over today.
2. Optionally lower `TREG_REVIEW_BUDGET_PER_HOUR`; default 5.
3. A CLI release (0.19) later carries the feedback line; older CLIs keep working on the legacy header.

## Docs moved with the code

`docs/context/architecture/feedback.md` (invitation decision, budget, store, `invited` semantics, denominator), `interface/cli.md`, `src/treg/web/feedback.md`, README config table, `AGENTS.md` infra row, regenerated `docs/context/README.md` and `MAP.md`.
