### PR TITLE
fix(arena): show Intercom for signed-in users

### DIFF
--- a/docs/context/interface/enrich-arena.md
+++ b/docs/context/interface/enrich-arena.md
@@ -60,6 +60,12 @@ is a button opening `/app?from=enrich-arena#billing` through `topUp`, preserving
 The shared header also links to GitHub ("Open source"), Discord and X using the same icons and
 destinations as the people-search landing page. The links remain visible across Arena, Leaderboard
 and Benchmark, wrapping with account controls on narrow screens.
+Support chat is enabled on these shared pages only after `/auth/me` establishes a signed-in
+user and `/meta` supplies `intercom_app_id`. `syncIntercom` boots once, updates the active team
+on team switches or saved-run restoration, and follows `/app` identity verification: email and
+company are sent only with `intercom_user_hash`; without the hash, chat remains anonymous.
+Logout, an expired session, or an account change shuts down the previous Intercom session.
+Guests and deployments without an Intercom app ID load no widget; widget failures do not block Arena.
 Its visual system follows the treg redesign reference (`https://treg-design.vercel.app/#start`):
 Geist Pixel headings, Google Sans Flex body text, DM Mono for technical values, a cool gray canvas,
 white rounded cards with fine borders, black actions and restrained teal status accents. A static

--- a/src/treg/web/enrich-arena/arena.js
+++ b/src/treg/web/enrich-arena/arena.js
@@ -154,7 +154,7 @@
     components:{ArenaTaskTabs,TregTryItOut:TregAgentSetup.TryItOut,TregAgentPicker:TregAgentSetup.AgentPicker,TregSetupInstructions:TregAgentSetup.SetupInstructions,ArenaFighters,ArenaResultTable:{directives:{stickyHeader:StickyHeader},inject:['arena'],props:{rows:{type:Array,required:true},entryView:Boolean},methods:{resultLabel(r){return this.arena.providerName(r.provider)+(this.entryView?' · '+this.arena.entryLabel(this.arena.runEntries[r.entry_index||0]):'');}},template:'#arena-result-table-template'}},
     provide(){return {arena:this};},
     data:()=>({benchmark:(location.pathname||'').endsWith('/people-search-bench'),benchCategories:[],benchCategory:'',benchLoading:false,benchError:'',leaderboard:(location.pathname||'').endsWith('/leaderboard'),setupStep:1,setupTeamName:'',setupExampleCopied:'',setupAgentId:'claude-code',setupToken:null,setupShowToken:false,setupCopied:false,setupError:'',setupLoading:false,setupSequence:0,tasks:[],taskId:'people.email.find',variant:0,inputs:{},extraInputs:[],showAllEntries:false,selectedEntry:null,selectedVendor:'',resultFilter:'all',mode:'waterfall',autoVerify:true,verificationHintHidden:false,verificationQuotes:{},verificationPending:{},
-      user:null,teams:[],team:'',balance:null,meta:{},busy:false,error:'',run:null,quote:null,history:[],customServices:false,services:[],
+      user:null,teams:[],team:'',balance:null,meta:{},intercomStarted:false,intercomIdentity:'',busy:false,error:'',run:null,quote:null,history:[],customServices:false,services:[],
       insights:null,insightsState:'idle',insightsTimer:null,statsView:'rate',chartFocus:null,metricTooltip:null,requestDone:false,requestBusy:false,vendorPromptCopied:false,vendorPromptError:'',requestError:'',requestQuery:'',requestForm:{capability:'',note:'',contact:''},
       manualQuotes:{},manualPending:{},reporting:'',reportDrafts:{},pricing:false,quoteTimer:null,quoteSequence:0,pricedKey:'',expandedResults:[],email:'',code:'',emailStep:'email',devCode:'',authBusy:false,authError:'',
       newTeamName:'',pendingSubmit:false,pollTimer:null,pollFailures:0,runTeam:'',booted:false,draftRestored:false,historySequence:0,historyLoading:false,historyHasMore:false,linkedRunPending:false,urlPopHandler:null}),
@@ -312,7 +312,7 @@
         if(!this.user){await this.openLogin(false);return true;}
         const team=params.get('team');
         if(team&&!this.teams.some(t=>t.slug===team)){this.error='This saved run is not available to your account or team.';return true;}
-        if(team)this.team=team;
+        if(team){this.team=team;this.syncIntercom();}
         if(!this.team){this.error='This saved run is not available to your account or team.';return true;}
         await this.loadHistory(id,{replace:true});this.linkedRunPending=false;
         await this.loadBalance();await this.refreshHistory();return true;
@@ -484,17 +484,42 @@
       },
       track(event,props={}){window.TregTracking?.capture(event,props);},
       identify(){window.TregTracking?.identify(this.user?.email||'',this.team);},
+      shutdownIntercom(){
+        try{if(this.intercomStarted)window.Intercom?.('shutdown');}catch{}
+        this.intercomStarted=false;this.intercomIdentity='';delete window.intercomSettings;
+      },
+      syncIntercom(){
+        const app=this.meta.intercom_app_id,user=this.user;
+        if(!app||!user){this.shutdownIntercom();return;}
+        if(this.intercomStarted&&this.intercomIdentity!==user.email)this.shutdownIntercom();
+        const payload={app_id:app};
+        // Match /app: never identify an email without the server's signed hash.
+        if(user.email&&user.intercom_user_hash){
+          payload.email=user.email;payload.user_hash=user.intercom_user_hash;
+          if(this.team)payload.company={id:this.team,name:this.team};
+        }
+        try{
+          if(!window.Intercom){
+            const intercom=function(){intercom.q.push(arguments);};intercom.q=[];window.Intercom=intercom;
+            const script=document.createElement('script');script.async=true;script.src='https://widget.intercom.io/widget/'+encodeURIComponent(app);
+            document.head.appendChild(script);
+          }
+          window.intercomSettings=payload;
+          window.Intercom(this.intercomStarted?'update':'boot',payload);
+          this.intercomStarted=true;this.intercomIdentity=user.email;
+        }catch{} // Support chat must not block Arena when the widget is unavailable.
+      },
       async loadIdentity(){
-        try{this.user=await this.api('/auth/me',{},'');}catch(e){if(e.status!==401)throw e;this.user=null;this.teams=[];this.team='';this.balance=null;this.history=[];this.historySequence++;this.identify();return;}
+        try{this.user=await this.api('/auth/me',{},'');}catch(e){if(e.status!==401)throw e;this.user=null;this.teams=[];this.team='';this.balance=null;this.history=[];this.historySequence++;this.identify();this.syncIntercom();return;}
         this.identify();
         const orgs=await this.api('/orgs');this.teams=orgs.filter(t=>!t.demo);
         let saved='';try{saved=localStorage.getItem('treg.arena.team')||'';}catch{}
         this.team=this.teams.find(t=>t.slug===this.team)?.slug||this.teams.find(t=>t.slug===saved)?.slug||this.teams[0]?.slug||'';
-        this.identify();
+        this.identify();this.syncIntercom();
         if(this.team){await this.loadBalance();if(!this.leaderboard&&!this.benchmark)await this.refreshHistory();}
       },
       async loadBalance(){const t=this.teams.find(t=>t.slug===this.team);if(!t)return;const b=await this.api('/orgs/'+t.org_id+'/balance?limit=1');this.balance=b.balance_micro;},
-      async changeTeam(){this.quote=null;this.run=null;this.history=[];this.historySequence++;clearTimeout(this.pollTimer);remove(ACTIVE);this.linkedRunPending=false;this.syncUrl();try{localStorage.setItem('treg.arena.team',this.team);this.identify();await this.loadBalance();await this.refreshHistory();}catch(e){this.error=e.message;}},
+      async changeTeam(){this.quote=null;this.run=null;this.history=[];this.historySequence++;clearTimeout(this.pollTimer);remove(ACTIVE);this.linkedRunPending=false;this.syncUrl();this.syncIntercom();try{localStorage.setItem('treg.arena.team',this.team);this.identify();await this.loadBalance();await this.refreshHistory();}catch(e){this.error=e.message;}},
       setupIcon(icon){return TregAgentSetup.iconUrl(icon);},
       async openSetup(){
         this.setupStep=this.user&&!this.team?0:1;this.setupTeamName='';this.setupToken=null;this.setupShowToken=false;this.setupCopied=false;this.setupError='';this.setupLoading=false;this.setupSequence++;
@@ -718,7 +743,7 @@
       async newQuery(){this.manualQuotes={};this.reporting='';this.expandedResults=[];this.run=null;this.quote=null;this.linkedRunPending=false;clearTimeout(this.pollTimer);remove(ACTIVE);this.syncUrl();this.scheduleQuote();await this.$nextTick();document.querySelector('#composer')?.scrollIntoView({behavior:'smooth'});},
       tryWaterfall(){const previous=this.run;this.taskId=previous.capability;this.inputs={...previous.identity};this.extraInputs=(previous.identities||[]).slice(1).map(r=>({...r}));this.variant=Math.max(0,this.currentTask.variants.findIndex(v=>v.every(k=>k in previous.identity)));this.mode='waterfall';this.customServices=false;this.services=[];this.newQuery();},
       exportResult(){const b=new Blob([JSON.stringify(this.run,null,2)],{type:'application/json'});const url=URL.createObjectURL(b);const a=document.createElement('a');a.href=url;a.download='enrich-arena-'+this.run.id+'.json';a.click();setTimeout(()=>URL.revokeObjectURL(url),1000);},
-      async logout(){try{await this.api('/auth/logout',{method:'POST'});this.user=null;this.teams=[];this.team='';this.balance=null;this.run=null;this.quote=null;this.history=[];this.historySequence++;remove(ACTIVE);remove(DRAFT);}catch(e){this.error=e.message;}}
+      async logout(){try{await this.api('/auth/logout',{method:'POST'});this.shutdownIntercom();this.user=null;this.teams=[];this.team='';this.balance=null;this.run=null;this.quote=null;this.history=[];this.historySequence++;remove(ACTIVE);remove(DRAFT);}catch(e){this.error=e.message;}}
     },
     async mounted(){
       this.track('arena_page_viewed');

--- a/tests/js/enrich-arena.test.cjs
+++ b/tests/js/enrich-arena.test.cjs
@@ -19,6 +19,37 @@ function setup(location={}){
   const price=(extra={})=>{app.quote=quote(extra);app.pricedKey=app.quoteKey;};
   return {app,quote,price,stored,destinations,components:options.components,directives:options.directives,runtime,mounted:options.mounted};
 }
+test('Intercom loads only for authenticated users on opted-in deployments and reuses its loader',()=>{
+ const {app,runtime}=setup(),scripts=[];
+ runtime.document.createElement=()=>({});runtime.document.head={appendChild:s=>scripts.push(s)};
+ app.meta={intercom_app_id:'test-app'};app.user=null;app.syncIntercom();assert.equal(scripts.length,0);
+ app.user={email:'test@example.com',intercom_user_hash:'signed-test-hash'};app.meta={};app.syncIntercom();assert.equal(scripts.length,0);
+ app.meta={intercom_app_id:'test-app'};app.syncIntercom();app.syncIntercom();
+ assert.equal(scripts.length,1);assert.equal(scripts[0].src,'https://widget.intercom.io/widget/test-app');
+ const calls=runtime.window.Intercom.q;
+ assert.equal(calls[0][0],'boot');assert.equal(calls[1][0],'update');assert.equal(calls[0][1].user_hash,'signed-test-hash');
+ assert.equal(calls[0][1].email,'test@example.com');assert.equal(calls[0][1].company.id,'test-team');
+});
+test('Intercom does not send unhashed identity and clears conversations between accounts',async()=>{
+ const {app,runtime}=setup(),calls=[];runtime.window.Intercom=(...args)=>calls.push(args);
+ app.meta={intercom_app_id:'test-app'};app.user={email:'first@example.com'};app.syncIntercom();
+ assert.deepEqual(Object.keys(calls[0][1]),['app_id']);
+ app.user={email:'second@example.com',intercom_user_hash:'second-hash'};app.syncIntercom();
+ assert.deepEqual(calls.map(c=>c[0]),['boot','shutdown','boot']);
+ app.api=async()=>({});await app.logout();assert.equal(calls.at(-1)[0],'shutdown');assert.equal(runtime.window.intercomSettings,undefined);
+ app.syncIntercom();assert.equal(calls.length,4);
+ app.user={email:'first@example.com',intercom_user_hash:'first-hash'};app.syncIntercom();assert.equal(calls.at(-1)[0],'boot');
+ app.api=async()=>{throw {status:401};};await app.loadIdentity();assert.equal(calls.at(-1)[0],'shutdown');assert.equal(app.intercomStarted,false);
+});
+test('Identity loading boots Intercom with the selected team, and team changes update it',async()=>{
+ const {app,runtime,stored}=setup(),calls=[];runtime.window.Intercom=(...args)=>calls.push(args);
+ app.meta={intercom_app_id:'test-app'};stored.set('treg.arena.team','second-team');
+ app.api=async path=>{if(path==='/auth/me')return {email:'test@example.com',intercom_user_hash:'signed-test-hash'};if(path==='/orgs')return [{slug:'first-team'},{slug:'second-team'}];throw Error(path);};
+ app.loadBalance=async()=>{};app.refreshHistory=async()=>{};
+ await app.loadIdentity();assert.equal(calls.length,1);assert.equal(calls[0][0],'boot');assert.equal(calls[0][1].company.id,'second-team');
+ app.team='first-team';await app.changeTeam();assert.equal(calls.at(-1)[0],'update');assert.equal(calls.at(-1)[1].company.id,'first-team');
+ runtime.window.Intercom=()=>{throw Error('Widget blocked');};await app.changeTeam();assert.equal(app.error,'');
+});
 test('Page-scrolling headers stop at table bounds, offset nested headers, and clean up listeners',()=>{
  const {directives,runtime}=setup(),listeners=new Map();let pending,offset,disconnected=false;
  runtime.requestAnimationFrame=fn=>{pending=fn;return 1;};runtime.cancelAnimationFrame=()=>{pending=null;};


### PR DESCRIPTION
Arena never initialized Intercom, so signed-in users could not access support chat even when the deployment had it configured. The shared Arena, Leaderboard and Benchmark app now boots chat after loading the signed-in account and selected team, updates it on team changes, and shuts it down on logout, session expiry or account changes.

Matches the dashboard identity rule: email and company are sent only alongside the server-signed Intercom hash. Guests and deployments without an Intercom app ID load no widget. Chat errors do not block Arena.

Validation: 112 JavaScript/template tests passed. Browser checks passed for authenticated/guest Arena and Leaderboard visits and logout cleanup, with Intercom requests mocked to avoid sending test identities. Production `/meta` confirms Intercom is already configured. Updated `docs/context/interface/enrich-arena.md`.
