### PR TITLE
feat(importyeti): draft trade-data catalog with paid access blocked

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -184,6 +184,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/catalog/google-search-console.yaml` | architecture/catalog.md |
 | `src/treg/catalog/google-tag-manager.extended.yaml` | architecture/catalog.md |
 | `src/treg/catalog/google-tag-manager.yaml` | architecture/catalog.md |
+| `src/treg/catalog/importyeti.yaml` | guides/importyeti-validation.md |
 | `src/treg/catalog/instagram.extended.yaml` | architecture/catalog.md, architecture/instagram-oauth.md |
 | `src/treg/catalog/instagram.yaml` | architecture/catalog.md, architecture/instagram-oauth.md |
 | `src/treg/catalog/justoneapi.extended.yaml` | architecture/catalog.md |
@@ -336,6 +337,7 @@ Regenerate via `scripts/build-map.py`.
 | `src/treg/web/logos/findymail.svg` | interface/enrich-arena.md |
 | `src/treg/web/logos/hunter.svg` | interface/enrich-arena.md |
 | `src/treg/web/logos/icypeas.svg` | interface/enrich-arena.md |
+| `src/treg/web/logos/importyeti.svg` | guides/importyeti-validation.md |
 | `src/treg/web/logos/leadmagic.svg` | interface/enrich-arena.md |
 | `src/treg/web/logos/leadsforge.svg` | interface/enrich-arena.md |
 | `src/treg/web/logos/lusha.svg` | interface/enrich-arena.md |
@@ -389,6 +391,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_feedback_handling_schema.py` | architecture/feedback.md |
 | `tests/test_hints.py` | architecture/feedback.md |
 | `tests/test_import_lightness.py` | architecture/import-boundaries.md |
+| `tests/test_importyeti.py` | guides/importyeti-validation.md |
 | `tests/test_influencersclub_overflow.py` | ops/capacity.md |
 | `tests/test_instagram_oauth_architecture.py` | architecture/instagram-oauth.md |
 | `tests/test_key_providers.py` | architecture/contactout.md |
@@ -434,6 +437,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/super-admin.md` | `api.py`, `admin.py`, `access.py`, `config.py` |
 | `foundation/charter.md` | `2026-06-30-jason-tools-registry.md`, `README.md` |
 | `guides/expanding-a-category.md` | `oauth_providers.py`, `authorization.py`, `oauth_flow.py`, `oauth_exchange.py`, `connect.py`, `connections.py`, `config.py` |
+| `guides/importyeti-validation.md` | `importyeti.yaml`, `importyeti.svg`, `test_importyeti.py` |
 | `interface/api.md` | `sitetrack.js`, `api.py`, `bootstrap_handlers.py`, `bootstrap_http.py`, `call_surface.py`, `caller_metadata.py`, `client_identity.py`, `auth.py`, `access.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `relay.py`, `connect.py`, `onboard.py`, `referrals.py`, `signup.py`, `__init__.py`, `admin.py`, `auth.py`, `auth_helpers.py`, `billing.py`, `call.py`, `catalog.py`, `connections.py`, `onboard.py`, `orgs.py`, `resources.py`, `referrals.py`, `signup_cookies.py`, `web.py`, `access.py`, `teams.py`, `access.py`, `budgets.py`, `publicdemo.py`, `usage.py`, `mcp_oauth.py`, `session.py`, `timeutil.py`, `store.py`, `email.py`, `runner.py`, `ratestore.py` |
 | `interface/catalog-review-proposal.md` | `store.py`, `capabilities.yaml` |
 | `interface/cli.md` | `cli.py`, `cli_analytics.py`, `convert.py`, `agents.py` |

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -69,4 +69,5 @@ covers (frontmatter `sources:`). Regenerate this index with
 | Fragment | Status | Covers |
 |---|---|---|
 | [Expanding a catalog category — the add-a-provider playbook](guides/expanding-a-category.md) | guide | oauth_providers.py, authorization.py, oauth_flow.py, oauth_exchange.py, … |
+| [ImportYeti trade-data pilot — validation and release gates](guides/importyeti-validation.md) | draft; no valid-key or paid verification | importyeti.yaml, importyeti.svg, test_importyeti.py |
 

--- a/docs/context/architecture/auth-secrets.md
+++ b/docs/context/architecture/auth-secrets.md
@@ -394,3 +394,12 @@ platform-provider allow-list is also required. Own keys always take precedence.
 `oauth_providers.CONTACTOUT` verifies against `/v1/stats` and requires `status_code: 200` as well
 as HTTP success. Its binding injects the raw `token` header. Both garbage rejection and valid
 connection creation were tested live; see [ContactOut](contactout.md).
+
+## ImportYeti draft key provider
+
+ImportYeti uses a plain `IYApiKey` header at `https://data.importyeti.com`.
+The documented free `/v1.0/database-updated` probe rejected a real bogus key
+with HTTP 401 on 2026-09-10; treg returned 422 without creating a tool. Valid-key
+success remains unverified. Registry metadata supplies the binding through the
+existing connect flow; no provider-specific relay behavior is added. See the
+[validation gates](../guides/importyeti-validation.md) before claiming readiness.

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1847,3 +1847,13 @@ through `queryParams.phone`. The adapter reads `data.valid`, `data.e164_format`,
 line type and carrier. A boolean false is a returned invalid verdict; a missing verdict is a
 miss. This validates numbering-plan/format details, not line activity or subscriber ownership.
 The single verified adapter is usable by Arena; the two-provider public routing gate stays intact.
+
+## ImportYeti draft trade surface
+
+`importyeti.yaml` introduces the `trade` platform with 15 importer, supplier,
+shipment, product-counterparty, Mexico-declaration and freshness operations.
+Parameters come from the official embedded OpenAPI; all valid-key verification
+is pending. Every row blocks platform calls independently of the unset credit
+rate, including the free freshness utility. Conditional discovery searches have
+unknown prices. See [validation and full surface map](../guides/importyeti-validation.md)
+for observed evidence, deferred operations and requirements to remove the blocks.

--- a/docs/context/guides/importyeti-validation.md
+++ b/docs/context/guides/importyeti-validation.md
@@ -1,0 +1,118 @@
+---
+title: ImportYeti trade-data pilot — validation and release gates
+status: draft; no valid-key or paid verification
+sources:
+  - src/treg/catalog/importyeti.yaml
+  - src/treg/web/logos/importyeti.svg
+  - tests/test_importyeti.py
+related:
+  - architecture/catalog.md
+  - architecture/auth-secrets.md
+  - guides/expanding-a-category.md
+---
+
+# ImportYeti trade-data pilot
+
+This draft lists 15 operations from the vendor's 26-operation OpenAPI surface. No
+valid credential or dollar/credit quote is available. Every endpoint carries an
+explicit `platform_blocked` reason; the platform-key slot is preparatory only.
+No paid response, target-industry coverage or production availability is claimed.
+
+## Sources and auth evidence
+
+- [Official reference](https://docs.importyeti.com/docs/reference).
+- [Embedded OpenAPI](https://data.importyeti.com/swagger/swagger-ui-init.js): extract
+  the `swaggerDoc` object. `/openapi.json` is not a working spec URL. The catalog
+  preserves the native path/query schemas; its date note explains the dynamic
+  previous-month-end default instead of freezing the fetched snapshot's date.
+- [API credits](https://docs.importyeti.com/docs/credits): profile 1 credit,
+  BOL detail 0.1 credit, lists 0.1 per returned record. Search is conditionally
+  free when followed by full-data access; standalone search costs credits and
+  may need account configuration. Its catalog price stays unknown, never free.
+- [Data use](https://www.importyeti.com/policies/data-use) describes purchased-data
+  reuse; free website data and bulk/continuous feeds have separate conditions.
+
+On 2026-09-10 a real bogus `IYApiKey` sent to
+`GET https://data.importyeti.com/v1.0/database-updated` returned HTTP 401 with
+`{"message":"Unauthorized","statusCode":401}`. The same real upstream probe
+through isolated treg `POST /connections/token` returned 422 and created no tool.
+A public Walmart sample returned 200 without debit fields. It is demo evidence,
+not a valid-key success or a paid sample. The automated success fixture is
+synthetic and proves only treg's generic binding behavior.
+
+## Full surface disposition
+
+All paths below use GET. Deferred operations need entitlement, target-data and
+billing checks before promotion; they are not catalog entries in this draft.
+
+| Path | Disposition |
+|---|---|
+| `/v1.0/bol/{number}` | Core draft; valid-key and charge pending |
+| `/v1.0/company/search` | Core draft; valid-key and charge pending |
+| `/v1.0/company/{company}` | Core draft; valid-key and charge pending |
+| `/v1.0/company/{company}/bols` | Core draft; valid-key and charge pending |
+| `/v1.0/supplier/search` | Core draft; valid-key and charge pending |
+| `/v1.0/supplier/{supplier}` | Core draft; valid-key and charge pending |
+| `/v1.0/supplier/{supplier}/bols` | Core draft; valid-key and charge pending |
+| `/v1.0/product/{product}/suppliers` | Core draft; valid-key and charge pending |
+| `/v1.0/product/{product}/companies` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/us-import/bols` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/us-import/companies` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/us-import/suppliers` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/us-export/bols` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/us-export/bols/{bolNumber}` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/us-export/companies` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-import/declarations` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/mx-import/declarations/{declarationId}` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-import/companies` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-import/suppliers` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-import/brokers` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-export/declarations` | Core draft; valid-key and charge pending |
+| `/v1.0/powerquery/mx-export/declarations/{declarationId}` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-export/companies` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-export/suppliers` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/powerquery/mx-export/brokers` | Deferred: US export / additional Mexico detail and aggregates |
+| `/v1.0/database-updated` | Core draft; valid-key and charge pending |
+
+## Live validation required before merge or paid enablement
+
+Obtain an API credential without putting it in code, a purchase receipt or API
+quote (USD/credit, minimum top-up, expiry), an authorized test budget and written
+clarity on shared-account search billing. No subscription or purchase is implied.
+
+For each of the 15 core operations record: resolved target and exact parameters,
+retrieval date, HTTP status, substantive response, expected credits, `requestCost`,
+`creditsRemaining` and an independently observable serial balance delta. Test a
+multi-row response and an empty result. Populate scrubbed examples and replayable
+`test_request`s only with real identifiers harvested from those calls. Do not use
+public demo meter values or mocked fixtures as evidence of actual billing.
+
+Before removing `platform_blocked`, implement and validate reserve/settlement
+against those actual responses, including fractional charges, default pagination,
+zero hits, and JSON versus TOON. `fields`/`exclude` do not change billing. Leave FX
+null until the dollar rate is evidenced; simply adding a key or rate does not
+satisfy the gate. Rerun the validator, full test suite and plugin consistency check.
+
+## News investigation acceptance
+
+Compare at least three correctly identified relevant companies and one ambiguous
+or negative control against a web-search baseline. Record legal entity, country,
+operational address, parent relationship and source IDs before enriching contacts.
+Keep event date, publication date, shipment date, database update and retrieval
+separate. Explicit MM/DD/YYYY windows are essential: defaults start in 2021 and
+end at the previous month end. PowerQuery defaults space-separated terms to OR.
+
+US ocean records exclude air/land and can omit confidential or aliased entities.
+Mexico declarations have a different coverage model. A shipper can be a forwarding
+intermediary. Shipment counts or weights are not inventory, orders, revenue or a
+product-specific design win. No current Apple supplier claim is established by
+this draft. If target queries add little beyond public search, switch sources;
+do not promote the provider just because the integration compiles.
+
+The content deliverable is a real finding with traceable evidence, a recorded
+through-treg call sequence and cost, and English X copy plus a reproducible demo.
+Only enrich business contacts after entity resolution; do not publish personal
+contact details. Measure views, qualified visits and first successful tool use
+after publication. Code tested, PR merged, production enabled, case verified and
+content published are separate states. Traffic is an outcome to measure, not a
+promise this integration can validate in advance.

--- a/docs/context/ops/capacity.md
+++ b/docs/context/ops/capacity.md
@@ -62,6 +62,12 @@ endpoint using query auth `api`. Both the balance script and sweep use this coll
 not add `bulk_credits` to the balance. No overflow route is claimed. Verify the funded
 account's empty-credit response before adding a signature or enabling overflow.
 
+ImportYeti's draft platform slot also has an acknowledged unrecorded signature.
+Its documentation describes HTTP 403 `Not enough credits`, but no funded key or
+live exhaustion sample is available. No balance collector or overflow route is
+claimed; all catalog rows block platform use pending the
+[live validation gates](../guides/importyeti-validation.md).
+
 ## QuickEnrich subscriptions
 
 `collectors._quickenrich` reads `meta.remaining_credits` from a free Contact Finder miss;

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -631,3 +631,11 @@ Its public snapshot endpoint makes a single primary-key read on the API pool; ag
 on the background worker. The default per-process budget is now 27 slots; with two workers and
 two instances a rolling deployment can reach 108. Existing deployment overrides remain necessary
 for the 103-connection plan; this merge does not alter production overrides.
+
+## ImportYeti reserved platform slot
+
+`TREG_PLATFORM_KEY_IMPORTYETI` is declared on the web service and inherited by the
+worker. It has no configured value in this change. API dollar/credit pricing and
+paid settlement remain unverified; FX stays null and all catalog rows explicitly
+block platform calls. Setting a key or allow-list entry alone does not enable this
+provider. Complete the [validation gates](../guides/importyeti-validation.md) first.

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -96,7 +96,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -99,7 +99,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -80,7 +80,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -94,7 +94,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/render.yaml
+++ b/render.yaml
@@ -103,6 +103,8 @@ services:
         sync: false
       - key: TREG_PLATFORM_KEY_SUMBLE
         sync: false
+      - key: TREG_PLATFORM_KEY_IMPORTYETI  # Reserved; catalog blocks shared-key calls pending validation
+        sync: false
       - key: TREG_PLATFORM_KEY_QUICKENRICH
         sync: false
       - key: TREG_PLATFORM_KEY_TRYKITT
@@ -260,6 +262,11 @@ services:
           type: web
           name: treg
           envVarName: TREG_PLATFORM_KEY_SUMBLE
+      - key: TREG_PLATFORM_KEY_IMPORTYETI
+        fromService:
+          type: web
+          name: treg
+          envVarName: TREG_PLATFORM_KEY_IMPORTYETI
       - key: TREG_PLATFORM_KEY_QUICKENRICH
         fromService:
           type: web

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -78,7 +78,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/src/treg/catalog/capabilities.yaml
+++ b/src/treg/catalog/capabilities.yaml
@@ -10,6 +10,7 @@
 # `account` that should not appear as a browsable tab tile.
 
 platforms:
+  trade: {label: "Trade & supply chains", category: "Market data", summary: "Find importers, suppliers and shipment records to investigate trade relationships."}
   # --- SEO: search engines & the open web ------------------------------------------------------
   google: {label: "Google Keyword Data", category: "SEO/AEO", featured: 1, summary: "Organic rankings, keyword volume and full SERP data from Google."}
   web: {label: "Backlinks, authority & domain metrics", category: "SEO/AEO", featured: 2, summary: "Backlinks, referring domains, anchors and authority metrics for any site."}

--- a/src/treg/catalog/fx.yaml
+++ b/src/treg/catalog/fx.yaml
@@ -28,6 +28,7 @@
 # NOTE: this block must stay ABOVE `rates_to_usd:` -- catalog_fx_update.py rewrites the file
 # from the text before that key, so anything below it is discarded on the next FX refresh.
 credit_rates_usd:
+  importyeti: {usd: null, basis: "API credits: no verified USD/credit quote or purchase receipt. Website subscription prices are not API credit rates.", source: "https://docs.importyeti.com/docs/credits", checked: "2026-09-10"}
   sumble: {usd: 0.01, basis: "Pro monthly subscription: $99 / 9900 credits = $0.01 per credit, before configured platform margin. Retain this list rate when negotiating a custom plan.", source: "https://sumble.com/pricing", checked: "2026-09-09"}
   quickenrich: {usd: 0.004834, basis: "Starter monthly subscription: $29 / 6000 credits = $0.004833333 per credit, rounded up to 4834 micro-USD. treg base list rate before configured platform margin, assuming all monthly credits are used; unused credits increase effective cost. Free, Starter and Growth use subscription allowances. Unlimited-plan API status is not yet verified", source: "https://quickenrich.io/", checked: "2026-09-09"}
   cloro: {usd: 0.0008, basis: "Lite $30/mo / 37,500 credits = $0.0008/credit — the cheapest paid tier, so the upper bound. Higher tiers are cheaper (Hobby $100/250,000 = $0.0004, Business $1,000/2,800,000 = $0.00036). The free plan grants 500 credits/month, which is not a sustainable rate. Credits are charged only on a successful extraction", source: "https://cloro.dev/pricing", checked: "2026-09-05"}

--- a/src/treg/catalog/importyeti.yaml
+++ b/src/treg/catalog/importyeti.yaml
@@ -1,0 +1,1640 @@
+# DRAFT — no valid-key or paid verification. No public examples are represented as live evidence.
+# Full 26-operation disposition and release gates: docs/context/guides/importyeti-validation.md.
+# US ocean trade coverage excludes air/land and may omit confidential or aliased entities.
+# Shipments are evidence of historical trade, not inventory, revenue, a BOM or a new design win.
+provider: importyeti
+source:
+  docs: https://docs.importyeti.com/docs/reference
+  openapi: null
+  spec_urls:
+  - https://data.importyeti.com/swagger/swagger-ui-init.js
+  curated: '2026-09-10'
+  note: OpenAPI is embedded as swaggerDoc in the Swagger UI initialization script; /openapi.json is not available.
+pricing_url: https://docs.importyeti.com/docs/credits
+proposed_capabilities:
+  trade.shipments.get: Get a bill of lading by number
+  trade.importers.search: Find US importers by name, website or phone
+  trade.importers.profile: Get a US importer profile by resolved slug
+  trade.importers.shipments: List an importer’s shipment records
+  trade.suppliers.search: Find suppliers by name, website or phone
+  trade.suppliers.profile: Get a supplier profile by resolved slug
+  trade.suppliers.shipments: List a supplier’s shipment records
+  trade.products.suppliers: Find suppliers shipping a product
+  trade.products.buyers: Find importers buying a product
+  trade.us_import.shipments.search: Search US import shipment records
+  trade.us_import.buyers.rank: Rank US import buyers by trade filters
+  trade.us_import.suppliers.rank: Rank US import suppliers by trade filters
+  trade.mx_import.declarations.search: Search Mexican import declarations
+  trade.mx_export.declarations.search: Search Mexican export declarations
+  trade.database.updated: Check the database update date
+endpoints:
+- id: importyeti.trade.shipments.get
+  platform: trade
+  domain: shipments
+  scope: any_account
+  method: GET
+  path: /v1.0/bol/{number}
+  name: Get a bill of lading by number
+  summary: Get bill of lading by number
+  capability: trade.shipments.get
+  input:
+    pathParams:
+      number:
+        type: string
+        required: true
+    queryParams:
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_success
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'BOL detail: 0.1 API credit per record. Dollar conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.importers.search
+  platform: trade
+  domain: importers
+  scope: any_account
+  method: GET
+  path: /v1.0/company/search
+  name: Find US importers by name, website or phone
+  summary: Search a US company by name
+  capability: trade.importers.search
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      name:
+        type: string
+        required: false
+      phone:
+        type: string
+        required: false
+      website:
+        type: string
+        required: false
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: null
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: unknown
+    note: Search is conditionally free as a gateway to full-data endpoints; standalone use costs 0.1 credit/result
+      and may require account configuration. Shared-account billing must be confirmed.
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.importers.profile
+  platform: trade
+  domain: importers
+  scope: any_account
+  method: GET
+  path: /v1.0/company/{company}
+  name: Get a US importer profile by resolved slug
+  summary: Get US company information by ID
+  capability: trade.importers.profile
+  input:
+    pathParams:
+      company:
+        example: ikea-supply
+        type: string
+        required: true
+        description: ImportYeti **company URL slug** — the hyphenated segment from the website path `/company/...`
+          (e.g. `ikea-supply`), **not** the company display or legal name. To resolve a name to a slug, use
+          `GET /company/search`. Slugs use lowercase letters, digits, and hyphens; letter casing in this parameter
+          is normalized. Underscores are accepted in place of hyphens.
+    queryParams:
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_success
+    value: 1
+    currency: credit
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Profile lookup: 1 API credit. Dollar conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.importers.shipments
+  platform: trade
+  domain: importers
+  scope: any_account
+  method: GET
+  path: /v1.0/company/{company}/bols
+  name: List an importer’s shipment records
+  summary: Get a list of US company BOLs
+  capability: trade.importers.shipments
+  input:
+    pathParams:
+      company:
+        example: ikea-supply
+        type: string
+        required: true
+        description: ImportYeti **company URL slug** — the hyphenated segment from the website path `/company/...`
+          (e.g. `ikea-supply`), **not** the company display or legal name. To resolve a name to a slug, use
+          `GET /company/search`. Slugs use lowercase letters, digits, and hyphens; letter casing in this parameter
+          is normalized. Underscores are accepted in place of hyphens.
+    queryParams:
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.suppliers.search
+  platform: trade
+  domain: suppliers
+  scope: any_account
+  method: GET
+  path: /v1.0/supplier/search
+  name: Find suppliers by name, website or phone
+  summary: Search overseas supplier by name
+  capability: trade.suppliers.search
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      name:
+        type: string
+        required: false
+      phone:
+        type: string
+        required: false
+      website:
+        type: string
+        required: false
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: null
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: unknown
+    note: Search is conditionally free as a gateway to full-data endpoints; standalone use costs 0.1 credit/result
+      and may require account configuration. Shared-account billing must be confirmed.
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.suppliers.profile
+  platform: trade
+  domain: suppliers
+  scope: any_account
+  method: GET
+  path: /v1.0/supplier/{supplier}
+  name: Get a supplier profile by resolved slug
+  summary: Get overseas supplier information by ID
+  capability: trade.suppliers.profile
+  input:
+    pathParams:
+      supplier:
+        example: yiwu-yida-import-and-export-co-ltd
+        type: string
+        required: true
+        description: ImportYeti **supplier URL slug** — the hyphenated segment from the website path `/supplier/...`
+          (e.g. `yiwu-yida-import-and-export-co-ltd`), **not** the supplier display or legal name. To resolve
+          a name to a slug, use `GET /supplier/search`. Slugs use lowercase letters, digits, and hyphens; letter
+          casing in this parameter is normalized. Underscores are accepted in place of hyphens.
+    queryParams:
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_success
+    value: 1
+    currency: credit
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Profile lookup: 1 API credit. Dollar conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.suppliers.shipments
+  platform: trade
+  domain: suppliers
+  scope: any_account
+  method: GET
+  path: /v1.0/supplier/{supplier}/bols
+  name: List a supplier’s shipment records
+  summary: Get a list of BOLs of an overseas supplier
+  capability: trade.suppliers.shipments
+  input:
+    pathParams:
+      supplier:
+        example: yiwu-yida-import-and-export-co-ltd
+        type: string
+        required: true
+        description: ImportYeti **supplier URL slug** — the hyphenated segment from the website path `/supplier/...`
+          (e.g. `yiwu-yida-import-and-export-co-ltd`), **not** the supplier display or legal name. To resolve
+          a name to a slug, use `GET /supplier/search`. Slugs use lowercase letters, digits, and hyphens; letter
+          casing in this parameter is normalized. Underscores are accepted in place of hyphens.
+    queryParams:
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.products.suppliers
+  platform: trade
+  domain: products
+  scope: any_account
+  method: GET
+  path: /v1.0/product/{product}/suppliers
+  name: Find suppliers shipping a product
+  summary: Search a supplier by product name
+  capability: trade.products.suppliers
+  input:
+    pathParams:
+      product:
+        type: string
+        required: true
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      countries:
+        example: china,india,brazil
+        type: string
+        required: false
+        description: Comma-separated list of supplier countries
+      exclude_countries:
+        example: china,india,brazil
+        type: string
+        required: false
+        description: Comma-separated list of supplier countries to exclude
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.products.buyers
+  platform: trade
+  domain: products
+  scope: any_account
+  method: GET
+  path: /v1.0/product/{product}/companies
+  name: Find importers buying a product
+  summary: Search a US buyer by product name
+  capability: trade.products.buyers
+  input:
+    pathParams:
+      product:
+        type: string
+        required: true
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      countries:
+        example: china,india,brazil
+        type: string
+        required: false
+        description: Comma-separated list of supplier countries
+      exclude_countries:
+        example: china,india,brazil
+        type: string
+        required: false
+        description: Comma-separated list of supplier countries to exclude
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.us_import.shipments.search
+  platform: trade
+  domain: us_import
+  scope: any_account
+  method: GET
+  path: /v1.0/powerquery/us-import/bols
+  name: Search US import shipment records
+  summary: Search US import documents (bills of lading)
+  capability: trade.us_import.shipments.search
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page:
+        example: 1
+        type: number
+        required: false
+        description: Page number (1-indexed). Takes precedence over offset.
+      company:
+        example: ikea-supply
+        type: string
+        required: false
+        description: Company identifier
+      supplier:
+        example: damco-india
+        type: string
+        required: false
+        description: Supplier identifier
+      product_description:
+        example: '"cat toys" OR ("dog toys" AND NOT "dog bowls")'
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      weight:
+        example: 0 TO 15000
+        type: string
+        required: false
+        description: Supports ranges
+      teu:
+        example: '* TO 2'
+        type: string
+        required: false
+        description: Supports ranges
+      company_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      supplier_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      hs_code:
+        example: 7013* AND NOT (701391 OR 701341)
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      entry_port:
+        example: Houston, Tx
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      exit_port:
+        example: Pusan
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      internal_supplier:
+        default: 'false'
+        type: string
+        required: false
+      supplier_country:
+        example: Republic of Korea
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      notify_party:
+        example: Kukdo Chemical America Inc
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      last_visited_foreign_port:
+        example: Vancouver, BC
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      vessel_name:
+        example: Seaspan Yangtze
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      carrier_scac_code:
+        type: string
+        required: false
+        description: 'Example: Oney'
+      container_id:
+        example: DFSU4370223
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      bol_type:
+        example: R
+        type: string
+        required: false
+      company_phone:
+        example: '19058212111'
+        type: string
+        required: false
+        description: Supports wildcards
+      company_email:
+        example: company@example.com
+        type: string
+        required: false
+        description: Supports wildcards
+      include_omitted_data:
+        example: false
+        type: string
+        required: false
+        description: Include records with empty consignee and/or shipper. false by default.
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end. Space-separated terms default to OR; quote phrases and use explicit AND. page
+      takes precedence over offset.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.us_import.buyers.rank
+  platform: trade
+  domain: us_import
+  scope: any_account
+  method: GET
+  path: /v1.0/powerquery/us-import/companies
+  name: Rank US import buyers by trade filters
+  summary: Search companies aggregated from bills of lading
+  capability: trade.us_import.buyers.rank
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page:
+        example: 1
+        type: number
+        required: false
+        description: Page number (1-indexed). Takes precedence over offset.
+      company:
+        example: ikea-supply
+        type: string
+        required: false
+        description: Company identifier
+      supplier:
+        example: damco-india
+        type: string
+        required: false
+        description: Supplier identifier
+      product_description:
+        example: '"cat toys" OR ("dog toys" AND NOT "dog bowls")'
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      weight:
+        example: 0 TO 15000
+        type: string
+        required: false
+        description: Supports ranges
+      teu:
+        example: '* TO 2'
+        type: string
+        required: false
+        description: Supports ranges
+      company_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      supplier_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      hs_code:
+        example: 7013* AND NOT (701391 OR 701341)
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      entry_port:
+        example: Houston, Tx
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      exit_port:
+        example: Pusan
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      internal_supplier:
+        default: 'false'
+        type: string
+        required: false
+      supplier_country:
+        example: Republic of Korea
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      notify_party:
+        example: Kukdo Chemical America Inc
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      last_visited_foreign_port:
+        example: Vancouver, BC
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      vessel_name:
+        example: Seaspan Yangtze
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      carrier_scac_code:
+        type: string
+        required: false
+        description: 'Example: Oney'
+      container_id:
+        example: DFSU4370223
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      bol_type:
+        example: R
+        type: string
+        required: false
+      company_phone:
+        example: '19058212111'
+        type: string
+        required: false
+        description: Supports wildcards
+      company_email:
+        example: company@example.com
+        type: string
+        required: false
+        description: Supports wildcards
+      include_omitted_data:
+        example: false
+        type: string
+        required: false
+        description: Include records with empty consignee and/or shipper. false by default.
+      sort_by:
+        example: weight
+        type: string
+        required: false
+        description: Sort aggregation buckets by this sub-aggregation (descending)
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end. Space-separated terms default to OR; quote phrases and use explicit AND. page
+      takes precedence over offset.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.us_import.suppliers.rank
+  platform: trade
+  domain: us_import
+  scope: any_account
+  method: GET
+  path: /v1.0/powerquery/us-import/suppliers
+  name: Rank US import suppliers by trade filters
+  summary: Search suppliers aggregated from bills of lading
+  capability: trade.us_import.suppliers.rank
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page:
+        example: 1
+        type: number
+        required: false
+        description: Page number (1-indexed). Takes precedence over offset.
+      company:
+        example: ikea-supply
+        type: string
+        required: false
+        description: Company identifier
+      supplier:
+        example: damco-india
+        type: string
+        required: false
+        description: Supplier identifier
+      product_description:
+        example: '"cat toys" OR ("dog toys" AND NOT "dog bowls")'
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      weight:
+        example: 0 TO 15000
+        type: string
+        required: false
+        description: Supports ranges
+      teu:
+        example: '* TO 2'
+        type: string
+        required: false
+        description: Supports ranges
+      company_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      supplier_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      hs_code:
+        example: 7013* AND NOT (701391 OR 701341)
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      entry_port:
+        example: Houston, Tx
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      exit_port:
+        example: Pusan
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      internal_supplier:
+        default: 'false'
+        type: string
+        required: false
+      supplier_country:
+        example: Republic of Korea
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      notify_party:
+        example: Kukdo Chemical America Inc
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      last_visited_foreign_port:
+        example: Vancouver, BC
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      vessel_name:
+        example: Seaspan Yangtze
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      carrier_scac_code:
+        type: string
+        required: false
+        description: 'Example: Oney'
+      container_id:
+        example: DFSU4370223
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      bol_type:
+        example: R
+        type: string
+        required: false
+      company_phone:
+        example: '19058212111'
+        type: string
+        required: false
+        description: Supports wildcards
+      company_email:
+        example: company@example.com
+        type: string
+        required: false
+        description: Supports wildcards
+      include_omitted_data:
+        example: false
+        type: string
+        required: false
+        description: Include records with empty consignee and/or shipper. false by default.
+      sort_by:
+        example: weight
+        type: string
+        required: false
+        description: Sort aggregation buckets by this sub-aggregation (descending)
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end. Space-separated terms default to OR; quote phrases and use explicit AND. page
+      takes precedence over offset.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.mx_import.declarations.search
+  platform: trade
+  domain: mx_import
+  scope: any_account
+  method: GET
+  path: /v1.0/powerquery/mx-import/declarations
+  name: Search Mexican import declarations
+  summary: Search Mexico import customs declaration documents
+  capability: trade.mx_import.declarations.search
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page:
+        example: 1
+        type: number
+        required: false
+        description: Page number (1-indexed). Takes precedence over offset.
+      company_name:
+        example: Samsung
+        type: string
+        required: false
+      supplier_name:
+        example: Foxconn
+        type: string
+        required: false
+      product_description:
+        example: Aluminio
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      weight:
+        example: 500 TO 1000
+        type: string
+        required: false
+        description: Supports ranges
+      company_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      supplier_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      who_pays_freight:
+        default: Foreign entity
+        example: Foreign entity
+        type: string
+        enum:
+        - Foreign entity
+        - Mexico entity
+        required: false
+        description: Foreign entity / Mexico entity
+      hs_code:
+        example: 8471*
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      pedimento_number:
+        example: 26_17_TME840710TR4_6002927
+        type: string
+        required: false
+        description: Line-level pedimento identifier
+      declaration_number:
+        example: '6002927'
+        type: string
+        required: false
+      rfc_number:
+        example: TME840710TR4
+        type: string
+        required: false
+      customs_office:
+        example: Manzanillo
+        type: string
+        required: false
+        description: Destination port / aduana (customs office)
+      transport_type:
+        example: Truck
+        type: string
+        required: false
+      incoterm:
+        example: DAP
+        type: string
+        required: false
+      custom_broker:
+        example: Elsa Castaneda Trevino
+        type: string
+        required: false
+      custom_regime:
+        example: A1
+        type: string
+        required: false
+      supplier_country:
+        example: Estados Unidos De America
+        type: string
+        required: false
+      company_state:
+        example: Coahuila
+        type: string
+        required: false
+      mx_value:
+        example: 1000 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end. Space-separated terms default to OR; quote phrases and use explicit AND. page
+      takes precedence over offset.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.mx_export.declarations.search
+  platform: trade
+  domain: mx_export
+  scope: any_account
+  method: GET
+  path: /v1.0/powerquery/mx-export/declarations
+  name: Search Mexican export declarations
+  summary: Search Mexico export customs declaration documents
+  capability: trade.mx_export.declarations.search
+  input:
+    queryParams:
+      page_size:
+        default: 10
+        type: number
+        required: false
+        description: Number of returned results
+      offset:
+        default: 0
+        type: number
+        required: false
+        description: Results starting position
+      start_date:
+        format: mm/dd/yyyy
+        default: 01/01/2021
+        type: string
+        required: false
+      end_date:
+        format: mm/dd/yyyy
+        type: string
+        required: false
+        note: Upstream defaults to the previous month end. Always supply an explicit MM/DD/YYYY end date for
+          news investigations.
+      page:
+        example: 1
+        type: number
+        required: false
+        description: Page number (1-indexed). Takes precedence over offset.
+      company_name:
+        example: Cemex
+        type: string
+        required: false
+      supplier_name:
+        example: Caterpillar
+        type: string
+        required: false
+      product_description:
+        example: Partes
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      weight:
+        example: 500 TO 1000
+        type: string
+        required: false
+        description: Supports ranges
+      company_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      supplier_total_shipments:
+        example: 500 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      who_pays_freight:
+        default: Foreign entity
+        example: Foreign entity
+        type: string
+        enum:
+        - Foreign entity
+        - Mexico entity
+        required: false
+        description: Foreign entity / Mexico entity
+      hs_code:
+        example: 8471*
+        type: string
+        required: false
+        description: Supports boolean operators and wildcards
+      pedimento_number:
+        example: 26_44_EAA731217A14_6001438
+        type: string
+        required: false
+        description: Line-level pedimento identifier
+      declaration_number:
+        example: '6001438'
+        type: string
+        required: false
+      rfc_number:
+        example: EAA731217A14
+        type: string
+        required: false
+      customs_office:
+        example: 440 - Ciudad Acuna, Coahuila
+        type: string
+        required: false
+        description: Departure port / aduana (customs office)
+      transport_type:
+        example: Truck
+        type: string
+        required: false
+      incoterm:
+        example: CFR
+        type: string
+        required: false
+      custom_broker:
+        example: Jose Baltazar Ramon Losoya
+        type: string
+        required: false
+      custom_regime:
+        example: RT - Retorno De Mercancias (Immex)
+        type: string
+        required: false
+      supplier_state:
+        example: PUEBLA
+        type: string
+        required: false
+      company_country:
+        example: Estados Unidos De America
+        type: string
+        required: false
+      mx_value:
+        example: 1000 TO *
+        type: string
+        required: false
+        description: Supports ranges
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits. Set explicit MM/DD/YYYY start_date and end_date; the default window starts in 2021 and ends
+      at the previous month end. Space-separated terms default to OR; quote phrases and use explicit AND. page
+      takes precedence over offset.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: per_result
+    value: 0.1
+    currency: credit
+    per: 1
+    unit: record
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: 'Documented list pricing: 1 API credit per 10 returned records (fractional 0.1 per record). Dollar
+      conversion and actual charge unverified.'
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'
+- id: importyeti.trade.database.updated
+  platform: trade
+  domain: database
+  scope: any_account
+  method: GET
+  path: /v1.0/database-updated
+  name: Check the database update date
+  summary: Get the database last updated date
+  capability: trade.database.updated
+  input:
+    queryParams:
+      fields:
+        type: string
+        required: false
+        description: Comma-separated list of fields to keep on each returned record, e.g. `bol_number,arrival_date,supplier_name`.
+          Everything else is omitted. Names that the record does not carry are ignored. The envelope (`requestCost`,
+          `creditsRemaining`, `executionTime`, `totalCount`) is always returned in full. Cannot be combined
+          with `exclude`. Omit for the full record.
+        example: bol_number,arrival_date,supplier_name
+      exclude:
+        type: string
+        required: false
+        description: Comma-separated list of fields to drop from each returned record, e.g. `containers,shipping_rate`.
+          Every other field is kept. Cannot be combined with `fields`. Omit for the full record.
+        example: containers,shipping_rate
+      format:
+        type: string
+        enum:
+        - json
+        - toon
+        default: json
+        required: false
+        description: Response encoding. Defaults to `json`. Pass `toon` to receive [TOON](https://github.com/toon-format/toon)
+          — the same data in a compact, token-efficient text form intended for LLM prompts. Error responses
+          are always JSON.
+    note: Unverified with a valid key. Resolve company/supplier slugs from search before lookup; a name match
+      alone does not establish the legal entity. fields and exclude are mutually exclusive and do not reduce
+      credits.
+  docs_url: https://data.importyeti.com/swagger
+  cost:
+    type: free
+    value: 0
+    currency: USD
+    per: 1
+    unit: call
+    source: docs
+    source_url: https://docs.importyeti.com/docs/credits
+    checked: '2026-09-10'
+    confidence: documented
+    note: Documented free authenticated utility; valid-key success not yet observed.
+  platform_blocked: 'Draft: valid-key access, target coverage, USD/credit rate and requestCost settlement have
+    not been verified. Connect your own key; treg-funded calls remain disabled, including TOON responses.'
+  unverified: 'No valid credential: authenticated success, target data and balance delta pending.'

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -178,6 +178,7 @@ class Settings(BaseSettings):
     platform_key_contactout: str = ""  # raw API token; injected into the token header
     platform_key_millionverifier: str = ""  # raw key; injected as ?api=…
     platform_key_hunter: str = ""
+    platform_key_importyeti: str = ""  # IYApiKey; API credits, USD rate and paid validation pending
     platform_key_sumble: str = ""  # Bearer; Pro monthly credits, optional vendor auto-top-up
     platform_key_quickenrich: str = ""  # Bearer; monthly subscription credits, not auto-top-up
     platform_key_leadmagic: str = ""

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1256,6 +1256,23 @@ HUNTER = OAuthProvider(
     probe_path="/account",  # free — consumes no search/verification/enrichment credits
 )
 
+IMPORTYETI = OAuthProvider(
+    service="importyeti", display_name="ImportYeti", auth_kind="key",
+    token_label="API key", token_placeholder="your ImportYeti API key",
+    token_header="IYApiKey", token_format="{secret}",
+    setup_url="https://docs.importyeti.com/docs/authentication",
+    setup_action_label="Get your ImportYeti API key",
+    setup_steps=("Sign in to ImportYeti and obtain an API key using its API authentication guide.",),
+    setup_note="API credit pricing is separate from website subscriptions. Connect your own key; treg-funded calls are not enabled. Connection verification uses the documented free database update endpoint.",
+    auth_uri="", token_uri="", scopes={}, client_id_setting="", client_secret_setting="",
+    category="Market data",
+    summary="Find importers, suppliers and shipment records to investigate trade relationships.",
+    base_url="https://data.importyeti.com", docs_url="https://docs.importyeti.com/docs/reference",
+    probe_path="/v1.0/database-updated",
+    # Live 2026-09-10: bogus IYApiKey returns 401 (treg connect rejects with 422).
+    # Valid-key acceptance and paid data remain unverified; listing is a draft.
+)
+
 SUMBLE = OAuthProvider(
     service="sumble", display_name="Sumble", auth_kind="key",
     token_label="API key", token_placeholder="your Sumble API key",
@@ -2813,7 +2830,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         GOOGLE_ADS, YOUTUBE,
         LINKEDIN, SLACK, X, TIKTOK, FACEBOOK, INSTAGRAM, META_ADS,
         # API-key providers
-        APOLLO, PDL, AKTA, HUNTER, SUMBLE, QUICKENRICH, TRYKITT, CONTACTOUT, MILLIONVERIFIER, CRUNCHBASE, MINIMAX, OPENROUTER, REPLICATE,
+        APOLLO, PDL, AKTA, HUNTER, IMPORTYETI, SUMBLE, QUICKENRICH, TRYKITT, CONTACTOUT, MILLIONVERIFIER, CRUNCHBASE, MINIMAX, OPENROUTER, REPLICATE,
         TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
         SCRAPECREATORS,
         # SEO API-key providers

--- a/src/treg/web/logos/importyeti.svg
+++ b/src/treg/web/logos/importyeti.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#155e75"/><text x="32" y="42" text-anchor="middle" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#fff">IY</text></svg>

--- a/tests/test_capacity_overflow_routes.py
+++ b/tests/test_capacity_overflow_routes.py
@@ -252,6 +252,7 @@ _UNRECORDED_SIGNATURE = {
     "apify", "aviato", "branddev", "brightdata", "coingecko", "coresignal", "crustdata", "dataforseo",
     "diffbot", "exa", "fiber-ai", "finnhub", "icypeas", "justoneapi", "marketstack",
     "sumble",  # exhaustion not forced; no overflow route claimed
+    "importyeti",  # draft: no funded credential; documented 403 not observed live
     "quickenrich",  # subscription exhaustion not observed; do not spend the trial to force it
     "millionverifier",  # funded-account exhaustion not observed; trial still has credits
     "minimax", "oceanio", "openrouter", "replicate", "scrapecreators", "seranking",

--- a/tests/test_importyeti.py
+++ b/tests/test_importyeti.py
@@ -1,0 +1,71 @@
+"""Draft listing contracts; fixtures do not stand in for paid upstream verification."""
+
+import httpx
+
+from treg import oauth_providers as providers
+from treg.api import app
+from treg.config import Settings
+from treg.domain.catalog import store
+
+
+async def test_importyeti_rejects_bad_key_and_binds_verified_key(clients, monkeypatch):
+    def upstream_reply(request):
+        assert request.url.host == "data.importyeti.com"
+        assert request.url.path == "/v1.0/database-updated"
+        assert "authorization" not in request.headers
+        if request.headers["IYApiKey"] == "bad-key":
+            # Observed live on 2026-09-10.
+            return httpx.Response(401, json={"message": "Unauthorized", "statusCode": 401})
+        assert request.headers["IYApiKey"] == "test-importyeti-key"
+        # Synthetic success: connect must not require a positive paid credit balance.
+        return httpx.Response(200, headers={"content-type": "application/json"},
+                              stream=httpx.ByteStream(b'{"data": {}, "creditsRemaining": 0}'))
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(upstream_reply)) as upstream:
+        monkeypatch.setattr(app.state, "http", upstream)
+        rejected = await clients.post("/connections/token", json={
+            "provider": "importyeti", "token": "bad-key"})
+        assert rejected.status_code == 422
+        assert "HTTP 401" in rejected.text
+        assert not (await clients.get("/tools")).json()
+
+        accepted = await clients.post("/connections/token", json={
+            "provider": "importyeti", "token": "test-importyeti-key"})
+        assert accepted.status_code == 200, accepted.text
+        tool = next(t for t in (await clients.get("/tools")).json() if t["name"] == "importyeti")
+        binding = tool["bindings"][0]
+        assert binding["location"] == "header"
+        assert binding["name"] == "IYApiKey"
+        assert binding["format"] == "{secret}"
+        called = await clients.get("/call/importyeti/v1.0/database-updated", headers={
+            "IYApiKey": "caller-supplied-key"})
+        assert called.status_code == 200, called.text
+
+
+def test_importyeti_platform_slot_cannot_enable_unvalidated_spend(monkeypatch):
+    monkeypatch.setenv("TREG_PLATFORM_KEY_IMPORTYETI", "test-platform-key")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "importyeti")
+    assert Settings(_env_file=None).platform_key_for("importyeti") == "test-platform-key"
+    assert providers.platform_bindings(providers.get("importyeti")) == [
+        {"platform_setting": "platform_key_importyeti", "injector": "env",
+         "location": "header", "name": "IYApiKey", "format": "{secret}"}]
+    cat = store.load()
+    endpoints = [ep for ep in cat.endpoints if ep["provider"] == "importyeti"]
+    assert len(endpoints) == 15
+    assert cat.credit_rates["importyeti"] is None
+    for ep in endpoints:
+        assert not ep["verified"]
+        assert not cat.platform_eligible(ep)
+    # Even entering a rate later must not bypass the remaining live/billing gates.
+    monkeypatch.setitem(cat.credit_rates, "importyeti", 0.01)
+    assert all(not cat.platform_eligible(ep) for ep in endpoints)
+
+
+def test_supplier_discovery_does_not_advertise_conditional_search_as_free():
+    cat = store.load()
+    for role in ("suppliers", "importers"):
+        ep = cat.by_id[f"importyeti.trade.{role}.search"]
+        assert ep["cost"]["value"] is None
+        assert cat.cost_view(ep["cost"], "importyeti")["usd"] is None
+    results, _ = store.search("suppliers shipment", cat)
+    assert any(ep["provider"] == "importyeti" for ep, _ in results)

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -22,7 +22,7 @@ from treg import oauth_providers as P
 def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
-    for svc in ("apollo", "pdl", "akta", "hunter", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush",
+    for svc in ("apollo", "pdl", "akta", "hunter", "importyeti", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush",
                 "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "cloro",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -47,7 +47,7 @@ def test_every_provider_is_registered():
         "google-ads", "youtube", "linkedin", "slack", "x", "tiktok",
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
-        "apollo", "pdl", "akta", "hunter", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
+        "apollo", "pdl", "akta", "hunter", "importyeti", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
         "scrapecreators",
         "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "cloro",


### PR DESCRIPTION
Withdrawn after author re-review: this integration was proposed before a valid-key target-data and billing pilot established its value for the requested news-to-opportunity use case.

The 15 catalog operations have no real success samples, replay requests or observed charges. Shared-key calls are blocked, but merging would still expose a provider, catalog entries and increased capability counts. Passing local regression tests establishes compatibility, not source quality or paid readiness.

Commit `f8c41dce` and the feature branch are retained for experiments. No production change or purchase occurred. Reconsider a minimal listing only after target coverage, incremental evidence and actual pricing are validated. No replacement PR is being proposed now.

---

Original draft description, retained as an audit trail:

## Problem and result

Agents can already discover news and people in treg, but lack a dedicated trade-record surface to investigate importer/supplier relationships. This draft adds ImportYeti key connection metadata and 15 trade operations covering discovery, profiles, bills of lading, product counterparties, US import filtering, Mexico declarations and database freshness.

**Draft — do not merge or enable platform spend yet.** Valid-key success, target-industry quality and dollar pricing are unverified. This is an integration candidate, not evidence that ImportYeti can identify current Apple design wins or generate investment returns.

- Plain `IYApiKey` binding; documented free `/v1.0/database-updated` auth probe.
- Parameters extracted from the official embedded OpenAPI; all path/query names, required flags and schema constraints compared against it. The dynamic end-date default is explained instead of freezing the fetched month.
- Platform key slot on web/worker, null USD/credit rate and explicit `platform_blocked` on every route. Adding a key or rate alone cannot enable paid serving. Conditional discovery searches are not advertised as free. No relay or billing arithmetic changes.
- Neutral lettermark, connection and spending-gate tests, regenerated plugin provider counts.

## Evidence and validation

- Base: main `1061db3f`, pulled with fast-forward only.
- Baseline: `uv run pytest -q` — 3468 passed, 6 skipped.
- Focused provider/auth/catalog tests: 57 passed.
- Catalog validator: 97 provider files / 3263 endpoints, zero errors or warnings.
- Initial full serial suite: 3470 passed, 6 skipped; one guard identified the missing acknowledged capacity-signature gap. Added the explicit unverified entry and capacity documentation.
- Full suite after that correction: `uv run --with pytest-xdist pytest -n 4 -q` — **3471 passed, 6 skipped**, 25 warnings, 206.67s.
- Plugin consistency check and `git diff --check`: passed.
- Import boundary lint: 14 contracts kept, 0 broken.
- Live bogus-key preflight (repeated using the newly registered provider): upstream 401 `{ "message": "Unauthorized", "statusCode": 401 }`; isolated treg connect 422 and no tool created (one test passed). No localhost stack or production state was changed.
- A public Walmart example returned 200 without actual debit evidence. No public demo is stamped verified or committed as a paid response. The good-key unit-test response is explicitly synthetic.

## Per-endpoint evidence ledger

| Operation | Documented charge | Live evidence | Status |
| --- | --- | --- | --- |
| GET `/v1.0/bol/{number}` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/company/search` | Conditional: free discovery followed by full retrieval; standalone search 0.1 credit/result | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/company/{company}` | 1 credit/profile | Walmart no-key example 200, no debit fields; excludes paid validation | Paid/valid-key test pending |
| GET `/v1.0/company/{company}/bols` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/supplier/search` | Conditional: free discovery followed by full retrieval; standalone search 0.1 credit/result | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/supplier/{supplier}` | 1 credit/profile | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/supplier/{supplier}/bols` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/product/{product}/suppliers` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/product/{product}/companies` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/powerquery/us-import/bols` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/powerquery/us-import/companies` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/powerquery/us-import/suppliers` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/powerquery/mx-import/declarations` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/powerquery/mx-export/declarations` | 0.1 credit/returned record | Not called with authenticated target | Paid/valid-key test pending |
| GET `/v1.0/database-updated` | Free; authentication required | Direct bogus key 401; through isolated treg POST /connections/token 422; no tool created | Paid/valid-key test pending |


## Before ready for review / enablement

- Supply a test credential through an environment variable, an API credit quote/receipt (USD rate, minimum top-up, expiry), and an authorized validation budget. Confirm shared-account search billing.
- Run every selected endpoint through treg with real resolved targets; record substantive responses, requestCost and independent balance deltas, including multi-row and empty hits. Add scrubbed response examples and replay requests.
- Prove incremental target coverage against web search for three relevant entities and an ambiguous/negative control. Abandon this candidate if quality is insufficient; historical shipping does not establish a new order, inventory, revenue or product BOM.
- Implement and verify reserve/settlement, including JSON/TOON, before removing platform blocks. Do not infer billing from synthetic tests.

The full 26-operation disposition and investigation acceptance criteria are in `docs/context/guides/importyeti-validation.md`. Updated fragments: catalog, auth-secrets, deploy, capacity; added importyeti-validation and regenerated context index/map. No credential, purchase, production configuration or public content publication is included.

Vendor contact: https://www.importyeti.com/contact (Core Team, API/data questions). Public business contact: theyeti@importyeti.com, supplied by DaveMApplegate in [this API question response](https://www.reddit.com/r/ImportYeti/comments/1pfq5nn/can_we_connect_importyeti_data_to_container_ships/). Delivery has not been tested; no vendor message has been sent.
Official sources: https://docs.importyeti.com/docs/reference, https://docs.importyeti.com/docs/credits, https://data.importyeti.com/swagger/swagger-ui-init.js, https://www.importyeti.com/policies/data-use.

