### PR TITLE
fix(arena): keep previous stats visible during rebuilds

### DIFF
--- a/docs/context/interface/enrich-arena.md
+++ b/docs/context/interface/enrich-arena.md
@@ -234,9 +234,13 @@ is the median of successful calls (including repeats), displayed only with at le
 a known timing aggregate. Current prices remain estimates for the selected entries, and own-key
 prices retain their no-treg-charge label. Historical stats do not alter dispatch or result awards.
 
-`GET /arena/insights` returns the persisted database aggregate via one primary-key read, with
+`GET /arena/insights` first reads the current version's persisted database aggregate by primary key, with
 `updated_at`, source window, actual first/last observation dates, collection status and only public aggregate fields. The disclosure shows recorded dates when observations exist, so a sparse or historical sample does not appear to span the whole rolling window. No production
-metrics ship in assets or fixtures. A fresh database returns `warming` with no rows. The UI polls
+metrics ship in assets or fixtures. If that version has not published yet, one bounded snapshot query
+serves the latest completed, compatible publication from a previous version, preserving its source
+window and update timestamp. Ordering uses the payload's publication timestamp because the worker
+clears the cursor's `updated_at` during refresh. The current version takes precedence as soon as it
+publishes, including a completed snapshot with no rows. A fresh database returns `warming` with no rows. The UI polls
 every two minutes while visible, preserves the last successful values after a refresh error, and
 shows the last update time. Prices still come from the catalog and team quote.
 
@@ -250,7 +254,8 @@ the global content index for identical responses shared by many requests. Missin
 remains unresolved; newer different answers never substitute for historical evidence. The values
 CTE requires SQLAlchemy 2.0.42 or newer, reflected in the server dependency floor.
 `ArenaInsightState` serializes the cursor across workers and stores the aggregate;
-initial history is withheld until the first pass completes. Steady state refreshes about every two
+partial initial history is withheld until the first pass completes; a previous completed publication
+remains visible during a version-triggered rebuild. Steady state refreshes about every two
 minutes (plus collection time), allowing one minute for audit/archive writes and revisiting ten minutes
 of recent evidence. The first backfill may take longer. Evidence that arrives later than this revisit
 window remains unresolved until a version-triggered rebuild; lossy audit cannot establish complete traffic.

--- a/src/treg/application/arena_insights.py
+++ b/src/treg/application/arena_insights.py
@@ -53,12 +53,24 @@ def _empty(at):
 
 
 async def public_snapshot(session_factory=session_maker):
-    # Two bounded snapshot reads; never scan raw audit evidence on a page request.
+    # Read only saved snapshots; never scan raw audit evidence on a page request.
     from .arena_verification_insights import public_snapshot as verification_snapshot
     _, _, version = _catalog()
     async with session_factory() as db:
         state = await db.get(ArenaInsightState, version)
-        payload = dict(state.payload) if state and state.payload else _empty(now())
+        saved = state.payload if state else None
+        if not saved:
+            # A new catalog version must not blank the page during its first pass.
+            # The cursor's updated_at is cleared on refresh, so order by the
+            # publication timestamp inside the retained payload instead.
+            snapshot = ArenaInsightState.payload
+            saved = (await db.execute(select(snapshot).where(
+                snapshot["version"].as_integer() == 2,
+                snapshot["status"].as_string() == "ready",
+                snapshot["updated_at"].as_string().is_not(None),
+            ).order_by(snapshot["updated_at"].as_string().desc(), ArenaInsightState.id)
+                .limit(1))).scalar_one_or_none()
+        payload = dict(saved) if saved else _empty(now())
         payload["verification"] = await verification_snapshot(db)
         return payload
 

--- a/tests/test_arena_insights.py
+++ b/tests/test_arena_insights.py
@@ -80,6 +80,60 @@ async def test_initial_backlog_hidden_and_incremental_refresh(clients, monkeypat
     assert (await service.public_snapshot(session_maker))["rows"][0]["unique_requests"]==2
 
 
+async def test_catalog_rebuild_serves_previous_snapshot_until_new_one_is_complete(clients, monkeypatch):
+    await record("first", response={"data": {"email": "found@example.test"}}, duration=100)
+    await service.collect_batch(session_maker)
+    initial = await service.public_snapshot(session_maker)
+    cat, endpoints, _ = service._catalog()
+    monkeypatch.setattr(service, "_catalog", lambda: (cat, endpoints, "next-catalog"))
+    monkeypatch.setattr(service, "BATCH_SIZE", 1)
+
+    # A fresh process can use the database snapshot before its worker starts.
+    assert await service.public_snapshot(session_maker) == initial
+    await record("second", response={"data": {"email": "other@example.test"}}, duration=300)
+    for _ in range(2):
+        assert await service.collect_batch(session_maker)
+        assert await service.public_snapshot(session_maker) == initial
+
+    assert not await service.collect_batch(session_maker)
+    refreshed = await service.public_snapshot(session_maker)
+    assert refreshed["status"] == "ready"
+    assert refreshed["rows"][0]["unique_requests"] == 2
+    assert refreshed["rows"][0]["median_hit_ms"] == 200
+    async with session_maker() as db:
+        state = await db.get(ArenaInsightState, "next-catalog")
+        assert refreshed["updated_at"] == state.payload["updated_at"]
+
+
+async def test_fallback_uses_latest_compatible_publication_even_during_refresh(clients):
+    await record("first", response={"data": {"email": "found@example.test"}})
+    await service.collect_batch(session_maker)
+    initial = await service.public_snapshot(session_maker)
+    _, _, version = service._catalog()
+    async with session_maker() as db:
+        current = await db.get(ArenaInsightState, version)
+        original = dict(current.payload)
+        current.payload = {}
+        current.updated_at = None
+        # Newest completed publication is retained even when its cursor is busy.
+        db.add(ArenaInsightState(id="prior", scan_until=now(), payload=original))
+        db.add(ArenaInsightState(id="older", scan_until=now(), updated_at=now(),
+            payload={**original, "updated_at": "2000-01-01T00:00:00Z", "rows": []}))
+        db.add(ArenaInsightState(id="incompatible", scan_until=now(), updated_at=now(),
+            payload={**original, "version": 1, "updated_at": "2099-01-01T00:00:00Z"}))
+        db.add(ArenaInsightState(id="unfinished", scan_until=now(),
+            payload=service._empty(now())))
+        await db.commit()
+    assert await service.public_snapshot(session_maker) == initial
+
+    # A completed current snapshot wins even if it legitimately has no rows.
+    async with session_maker() as db:
+        current = await db.get(ArenaInsightState, version)
+        current.payload = {**original, "rows": []}
+        await db.commit()
+    assert (await service.public_snapshot(session_maker))["rows"] == []
+
+
 async def test_missing_archive_is_revisited_and_old_window_removed(clients):
     ident=await record("late",ago=180)
     await record("expired",response={"data":{"email":"old@example.test"}},ago=31*86400)


### PR DESCRIPTION
When a catalog change starts a new Arena stats version, hit rate and response time disappear until its initial backfill completes. Serve the latest completed compatible database snapshot while the new version is warming, then prefer the new publication on subsequent reads. Preserve the original source window and timestamp; an empty completed current snapshot still takes precedence.

The fallback reads only the small snapshot table and orders by the payload's publication timestamp, since the worker clears its cursor timestamp during refresh. No migration, production data fixture, worker restart, or frontend change is needed. Updated context fragment: `docs/context/interface/enrich-arena.md`.

Validation: 25 Arena insights and verification tests; 117 frontend tests; diff and documentation drift checks passed. Regression coverage includes pre-worker reads, partial rebuilds, automatic replacement, compatible/latest publication selection, and empty current snapshots.
