### PR TITLE
fix(hub): 8.2 - the security pass

### DIFF
--- a/docs/context/architecture/hub.md
+++ b/docs/context/architecture/hub.md
@@ -82,7 +82,7 @@ serves only its data may leave it empty. Every step's `call` must be in `uses` (
 for an own tool, optional `method`, `allow_fail`). Limits: `steps` ≤ 20, `wall_s` ≤ 120,
 `price_usd` 0–100 with at most six decimals. References must parse and the graph is built at
 publish, so a cycle or an unknown step is refused before anyone pays. `validate_check` pins
-`check.json` to the manifest; `validate_data` checks `data.csv` (≤ 50 MB, a header and one row).
+`check.json` to the manifest; `validate_data` checks `data.csv` (≤ 5 MB, a header and one row; the rows travel into the engine on every run).
 
 ## The reference language and the graph (JSON road)
 
@@ -140,7 +140,7 @@ wall-clock kill, the whole group killed on every exit. Inside, QuickJS (the `qui
 server extra) has no network, no file system, no `require`, no `process`, no timers; the engine's
 heap is capped at 64 MB. The whole surface a script gets: `ctx.inputs`, `ctx.call(target,
 {method, query, body, headers})` → `{status, headers, json, text}`, `ctx.csv(text)` → rows
-keyed by the header (RFC 4180), `ctx.data` → the rows of `data.csv` (parsed once per run in the
+keyed by the header (RFC 4180), `ctx.data` → the rows of `data.csv` (≤ 5 MB, parsed once per run in the
 parent), `ctx.log(text)` (50 lines × 2 KB). `ctx.call` crosses to the parent as one JSON line
 over stdin/stdout; the parent enforces `uses` per call (a call outside the list is refused and
 the run stops), the 20-call cap, the ceiling, and the output (one JSON object ≤ 2 MB carrying
@@ -252,3 +252,25 @@ Templates for more data providers incl. `treg hub init --from <template>`; withd
 listing road (pull request + verification); a private-to-team switch; a platform fee; a script
 editor in the dashboard; live polling of a run; billing compute; Crawl4AI as a built-in; a
 benchmark/auditor; job queue, recipe-calls-recipe, retry, live progress, team sandbox.
+
+## The security pass (8.1, 2026-09-10) and what it changed
+
+Two reviewers plus hostile probes; the findings that matter for launch were fixed in one PR,
+the rest went to the backlog. What is different since: the price hold closes on every path
+(a guard around the whole run: a refusal or a disconnect releases it, a crash becomes 424
+`hub_run_crashed`, never a 500 with an open hold); a step's answer is read into memory up to
+1 MB and the stream is closed beyond it (`truncated` on the script's reply, a failed step on
+the JSON road); the child's cost comes from the call record, never from an upstream
+`X-Treg-Cost-Micro`; a child call never resolves to a hub tool (`CallInput.child_of`) and an
+own tool named with a dot cannot be in `uses` (no nested runs); the caller's trace carries the
+kind of tool and no upstream error body, on the 200 body, the 424 detail and the idempotent
+replay; `GET /hub/tools/{id}` on another team's tool returns the public contract only; the
+public page never prints the check's sample inputs; own-tool steps audit as
+`hub-caller:<org>`; a version under check is visible only to its maker and a crashed check
+leaves it `failed`; the wall clock keeps running during a bridge call and the JSON road has
+one too; publish and the scheduled check hold no database connection during the run; the
+ceiling header, `price_usd`, the run body (depth, `NaN`) and header names are validated to
+4xx; server tracebacks never reach the maker's log; `..` is refused in a call path;
+`data.csv` is capped at 5 MB. Backlog: the platform margin on the seller's price (margin is 0),
+bridge state in writable globals, output-root validation at publish, concurrent publish 409,
+slugs starting with `http`, the shortfall under-pay note, the 402 ceiling path's missing run row.

--- a/src/treg/application/call/service.py
+++ b/src/treg/application/call/service.py
@@ -442,7 +442,8 @@ async def _execute_call(request: _ApplicationRequest, upstream_client: httpx.Asy
             if ep is None:
                 # Third and last: a hub tool (`<team-slug>.<name>`), only when nothing above
                 # claimed the id — an own tool or a catalog id always wins.
-                hub_row = await hub_app.tool_for(db, rest) if exc.status_code == 404 else None
+                hub_row = (await hub_app.tool_for(db, rest, caller_org_id=caller.org_id)
+                                   if request.context.input.child_of is None else None) if exc.status_code == 404 else None
                 if hub_row is None:
                     raise
             elif (isinstance(exc.detail, dict)

--- a/src/treg/application/call/types.py
+++ b/src/treg/application/call/types.py
@@ -215,6 +215,9 @@ class CallInput:
     client_ip: str
     # The reviewed /catalog/call surface accepts only a catalog id — team tools never shadow it.
     catalog_only: bool = False
+    # Set on every child call of a hub run: a child never resolves to a hub tool (no nested
+    # runs, no undisclosed second price; 8.1 review).
+    child_of: str | None = None
 
 
 class FinalizationState(Enum):

--- a/src/treg/application/hub/__init__.py
+++ b/src/treg/application/hub/__init__.py
@@ -49,7 +49,8 @@ def split_id(rest: str) -> tuple[str, int | None]:
 OLD_VERSION_DAYS = 30   # a pinned old version stays callable this long after a newer live one
 
 
-async def tool_for(db: AsyncSession, rest: str, *, live_only: bool = True) -> HubTool | None:
+async def tool_for(db: AsyncSession, rest: str, *, live_only: bool = True,
+                   caller_org_id: int | None = None) -> HubTool | None:
     """The version that serves `rest`: the newest `live` one, or `@N` pinned. A pinned version may
     also be the one UNDER CHECK (the check run pins it: HUB-DECISIONS round 2 q10), and a pinned
     old version stays callable for OLD_VERSION_DAYS after a newer live one exists (round 4 q8)."""
@@ -64,7 +65,8 @@ async def tool_for(db: AsyncSession, rest: str, *, live_only: bool = True) -> Hu
     if row is None:
         return None
     if row.status == "checking":
-        return row
+        # the check run pins it (round 2 q10); anyone else who guesses @N gets nothing (8.1 review)
+        return row if caller_org_id is None or row.org_id == caller_org_id else None
     if live_only and row.status != "live":
         return None
     newer = (await db.execute(
@@ -89,7 +91,7 @@ class Published:
     kind: str
 
 
-MAX_DATA_BYTES = 50_000_000
+MAX_DATA_BYTES = 5_000_000   # the engine holds 64 MB; the rows travel into it on every run (8.1 review)
 
 
 def validate_data(data: Any) -> str | None:
@@ -101,7 +103,7 @@ def validate_data(data: Any) -> str | None:
     if not isinstance(data, str):
         raise ManifestError("data", "the CSV as text (the contents of data.csv)")
     if len(data.encode("utf-8")) > MAX_DATA_BYTES:
-        raise ManifestError("data", "at most 50 MB")
+        raise ManifestError("data", "at most 5 MB")
     try:
         reader = csv.reader(io.StringIO(data))
         header = next(reader, None)
@@ -175,19 +177,28 @@ async def run_check(db: AsyncSession, row: HubTool, *, maker_headers: dict[str, 
     headers = {k: v for k, v in maker_headers.items() if k.lower() in ("x-treg-token", "x-treg-org", "cookie")}
     headers["X-Treg-Client"] = "hub-check"
     headers[hub_runner.RUN_MAX_COST_HEADER] = "5.00"
-    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://treg.internal",
-                                 headers=headers, timeout=200.0) as client:
-        r = await client.post(f"/call/{row.tool_id}@{row.version}", json=row.check.get("inputs", {}))
-    from .health import verdict_from
     try:
-        body = r.json()
-    except ValueError:
-        body = {"text": r.text[:600]}
-    verdict = verdict_from(row, r.status_code, body, dict(r.headers))
-    row.status = "live" if verdict["status"] == "passed" else "failed"
-    row.check_result = verdict
-    db.add(row)
-    return verdict
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://treg.internal",
+                                     headers=headers, timeout=200.0) as client:
+            r = await client.post(f"/call/{row.tool_id}@{row.version}", json=row.check.get("inputs", {}))
+        from .health import verdict_from
+        try:
+            body = r.json()
+        except ValueError:
+            body = {"text": r.text[:600]}
+        verdict = verdict_from(row, r.status_code, body, dict(r.headers))
+        row.status = "live" if verdict["status"] == "passed" else "failed"
+        row.check_result = verdict
+        db.add(row)
+        return verdict
+    except Exception as exc:  # noqa: BLE001 - a crashed check must not leave the version `checking`
+        verdict = {"status": "failed", "checked_at": _utcnow().isoformat(),
+                   "error": {"error": "check_crashed", "kind": type(exc).__name__,
+                             "message": "the check could not finish; publish again"}}
+        row.status = "failed"
+        row.check_result = verdict
+        db.add(row)
+        return verdict
 
 
 def view(row: HubTool) -> dict[str, Any]:

--- a/src/treg/application/hub/health.py
+++ b/src/treg/application/hub/health.py
@@ -114,6 +114,7 @@ async def check_as_maker(db: AsyncSession, row: HubTool, upstream_client) -> dic
     from . import runner as hub_runner
 
     caller = await _maker_caller(db, row)
+    await db.commit()   # non-negotiable 3: the selects above autobegan; nothing stays open during the run
     if caller is None:
         v = {"status": "skipped", "error": {"message": "the maker's team has no member left to run the check as"}}
         row.check_result = {**(row.check_result or {}), **v}
@@ -134,7 +135,8 @@ async def check_as_maker(db: AsyncSession, row: HubTool, upstream_client) -> dic
     context = create_call_context(call_input)
     try:
         response, charged = await hub_runner.run_hub_tool(
-            context, row, payload, lambda _name: None, upstream_client, execute_call, audit_client="hub-check")
+            context, row, payload, lambda name: "5.00" if name == hub_runner.RUN_MAX_COST_HEADER else None,
+            upstream_client, execute_call, audit_client="hub-check")
         raw = b"".join([chunk async for chunk in response.body_stream])
         await response.close()
         body = json.loads(raw) if raw else {}

--- a/src/treg/application/hub/runner.py
+++ b/src/treg/application/hub/runner.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
+import re
 import time
 from dataclasses import dataclass, replace
 from typing import Any, Callable
@@ -115,6 +117,8 @@ def coerce_inputs(specs: dict[str, dict[str, Any]], given: dict[str, Any]) -> di
                 if isinstance(v, bool):
                     raise ValueError
                 v = float(v)
+                if not math.isfinite(v):
+                    raise ValueError
             elif typ == "bool":
                 v = v if isinstance(v, bool) else str(v).lower() in ("1", "true", "yes", "on")
             elif typ == "list":
@@ -147,10 +151,12 @@ async def run_hub_tool(
     run_id = parent.call_ref
     started = time.monotonic()
     try:
-        given = json.loads(body_bytes or b"{}") if body_bytes.strip() else {}
-    except ValueError:
+        given = (json.loads(body_bytes or b"{}", parse_constant=_no_constants)
+                 if body_bytes.strip() else {})
+    except (ValueError, RecursionError):
         raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
-            "error": "hub_input_invalid", "field": "body", "rule": "a JSON object of inputs"})
+            "error": "hub_input_invalid", "field": "body",
+            "rule": "a JSON object of inputs (finite numbers, a sane depth)"}) from None
     if not isinstance(given, dict):
         raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
             "error": "hub_input_invalid", "field": "body", "rule": "a JSON object of inputs"})
@@ -172,175 +178,205 @@ async def run_hub_tool(
             "error": "hub_run_max_cost", "max_cost_micro": ceiling, "price_micro": price_held,
             "run_id": run_id, "charged_micro": 0, "trace": [],
             "message": f"the tool's own price ({price_held} µ$) already passes {RUN_MAX_COST_HEADER}"})
-    if tool.kind == "script":
-        return await _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_tools,
-                                      upstream_client, execute_child, started, audit_client, price_held)
-    g = hub_graph.build(manifest["steps"])
+    async def _after_reserve():
+        if tool.kind == "script":
+            return await _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_tools,
+                                          upstream_client, execute_child, started, audit_client, price_held)
+        g = hub_graph.build(manifest["steps"])
+        wall_deadline = started + manifest["limits"]["wall_s"]
 
-    scope: dict[str, Any] = {"input": inputs}
-    trace: list[dict[str, Any]] = []
-    spent = 0
-    counted = 0
-    stop: RunStopped | None = None
-    done: set[str] = set()
-    sem = asyncio.Semaphore(MAX_PARALLEL)
-    running: dict[asyncio.Task, str] = {}
+        scope: dict[str, Any] = {"input": inputs}
+        trace: list[dict[str, Any]] = []
+        spent = 0
+        counted = 0
+        stop: RunStopped | None = None
+        done: set[str] = set()
+        sem = asyncio.Semaphore(MAX_PARALLEL)
+        running: dict[asyncio.Task, str] = {}
 
-    async def one_call(step: _Step) -> tuple[_Step, dict[str, Any], Any]:
-        """One child call. Returns (step, trace entry, answer)."""
-        async with sem:
-            spec = step.spec
-            item_scope = dict(scope)
-            if step.item is not None:
-                item_scope[spec["as"]] = step.item_value
-            if spec.get("skip_if_empty") and refs.is_empty(
-                    refs.resolve(spec["skip_if_empty"], item_scope, g.positions)):
-                entry = _entry(step, "skipped", None, 0, 0, key=None)
-                return step, entry, None
-            call = spec["call"]
-            target = call.split("/", 1)[0]
-            ep = None if target in own_tools else catalog.by_id.get(call)
-            inp = refs.resolve(spec.get("input", {}), item_scope, g.positions)
-            method = (spec.get("method") or (ep["method"] if ep else "GET")).upper()
-            as_who = maker if target in own_tools else parent.input.caller
-            child = CallContext(input=_child_input(parent, call, method, inp, as_who),
-                                call_ref=step.ref, meta=parent.meta)
-            t0 = time.monotonic()
-            try:
-                response = await execute_child(child, upstream_client)
-            except CallFailure as exc:
+        async def one_call(step: _Step) -> tuple[_Step, dict[str, Any], Any]:
+            """One child call. Returns (step, trace entry, answer)."""
+            async with sem:
+                spec = step.spec
+                item_scope = dict(scope)
+                if step.item is not None:
+                    item_scope[spec["as"]] = step.item_value
+                if spec.get("skip_if_empty") and refs.is_empty(
+                        refs.resolve(spec["skip_if_empty"], item_scope, g.positions)):
+                    entry = _entry(step, "skipped", None, 0, 0, key=None)
+                    return step, entry, None
+                call = spec["call"]
+                target = call.split("/", 1)[0]
+                ep = None if target in own_tools else catalog.by_id.get(call)
+                inp = refs.resolve(spec.get("input", {}), item_scope, g.positions)
+                method = (spec.get("method") or (ep["method"] if ep else "GET")).upper()
+                as_who = maker if target in own_tools else parent.input.caller
+                child = CallContext(input=_child_input(parent, call, method, inp, as_who),
+                                    call_ref=step.ref, meta=parent.meta)
+                t0 = time.monotonic()
+                try:
+                    response = await execute_child(child, upstream_client)
+                except CallFailure as exc:
+                    ms = int((time.monotonic() - t0) * 1000)
+                    entry = _entry(step, "failed", exc.status_code, ms, 0, key=None,
+                                   error=_short(exc.detail))
+                    if exc.kind in _GLOBAL_REFUSALS:
+                        entry["global"] = exc.kind
+                    return step, entry, exc
+                raw, truncated = await _read(response)
                 ms = int((time.monotonic() - t0) * 1000)
-                entry = _entry(step, "failed", exc.status_code, ms, 0, key=None,
-                               error=_short(exc.detail))
-                if exc.kind in _GLOBAL_REFUSALS:
-                    entry["global"] = exc.kind
-                return step, entry, exc
-            raw = await _read(response)
-            ms = int((time.monotonic() - t0) * 1000)
-            charged = int(_header(response, "X-Treg-Cost-Micro") or 0)
-            key = "treg" if _header(response, "X-Treg-Cost-Micro") is not None else "team"
-            ok = 200 <= response.status < 300
-            try:
-                answer = json.loads(raw) if raw else None
-            except ValueError:
-                answer = raw.decode("utf-8", "replace")
-            entry = _entry(step, "ok" if ok else "failed", response.status, ms, charged, key=key,
-                           error=None if ok else _short(answer))
-            return step, entry, answer if ok else _StepFailed(response.status, answer)
+                charged, key = _child_cost(response, catalog_step=target not in own_tools)
+                ok = 200 <= response.status < 300 and not truncated
+                try:
+                    answer = json.loads(raw) if raw else None
+                except ValueError:
+                    answer = raw.decode("utf-8", "replace")
+                if truncated:
+                    answer = {"error": "answer_too_large", "message": f"the step's answer passed {MAX_BODY_BYTES} bytes"}
+                entry = _entry(step, "ok" if ok else "failed", response.status, ms, charged, key=key,
+                               error=None if ok else _short(answer))
+                return step, entry, answer if ok else _StepFailed(response.status, answer)
 
-    def estimate(spec: dict[str, Any]) -> int:
-        target = spec["call"].split("/", 1)[0]
-        if target in own_tools:
-            return 0
-        ep = catalog.by_id.get(spec["call"])
-        cv = catalog.cost_view(ep.get("cost"), ep.get("provider")) if ep else None
-        usd = (cv or {}).get("usd")
-        return int(round(float(usd) * 1_000_000)) if usd else 0
+        def estimate(spec: dict[str, Any]) -> int:
+            target = spec["call"].split("/", 1)[0]
+            if target in own_tools:
+                return 0
+            ep = catalog.by_id.get(spec["call"])
+            cv = catalog.cost_view(ep.get("cost"), ep.get("provider")) if ep else None
+            usd = (cv or {}).get("usd")
+            return int(round(float(usd) * 1_000_000)) if usd else 0
 
-    def units_for(name: str) -> list[_Step]:
-        spec = g.steps[name]
-        wave = g.wave[name]
-        idx = g.order.index(name)
-        if spec.get("for_each"):
-            items = refs.resolve(spec["for_each"], scope, g.positions)
-            items = items if isinstance(items, list) else ([] if items is None else [items])
-            return [_Step(name, spec, f"{run_id}:s{idx}.{i}", wave, i, v) for i, v in enumerate(items)]
-        return [_Step(name, spec, f"{run_id}:s{idx}", wave)]
+        def units_for(name: str) -> list[_Step]:
+            spec = g.steps[name]
+            wave = g.wave[name]
+            idx = g.order.index(name)
+            if spec.get("for_each"):
+                items = refs.resolve(spec["for_each"], scope, g.positions)
+                items = items if isinstance(items, list) else ([] if items is None else [items])
+                return [_Step(name, spec, f"{run_id}:s{idx}.{i}", wave, i, v) for i, v in enumerate(items)]
+            return [_Step(name, spec, f"{run_id}:s{idx}", wave)]
 
-    pending_units: dict[str, list[_Step]] = {}
-    results: dict[str, list[Any]] = {}
-    try:
-        while True:
-            if stop is None:
-                for name in g.order:
-                    if name in done or name in pending_units:
-                        continue
-                    if not g.parents[name] <= done:
-                        continue
-                    units = units_for(name)
-                    pending_units[name] = []
-                    results[name] = [None] * len(units)
-                    if not units:                 # a repeat over nothing: the step is done, empty
+        pending_units: dict[str, list[_Step]] = {}
+        results: dict[str, list[Any]] = {}
+        try:
+            while True:
+                if stop is None:
+                    for name in g.order:
+                        if name in done or name in pending_units:
+                            continue
+                        if not g.parents[name] <= done:
+                            continue
+                        units = units_for(name)
+                        pending_units[name] = []
+                        results[name] = [None] * len(units)
+                        if not units:                 # a repeat over nothing: the step is done, empty
+                            done.add(name)
+                            scope[name] = []
+                            continue
+                        for u in units:
+                            if counted + 1 > manifest["limits"]["steps"]:
+                                stop = RunStopped("hub_step_cap", 424, {
+                                    "error": "hub_step_cap", "step": name,
+                                    "message": f"the run would pass its step cap ({manifest['limits']['steps']})"})
+                                break
+                            est = estimate(u.spec)
+                            if price_held + spent + _reserved(running, pending_units, estimate) + est > ceiling:
+                                stop = RunStopped("hub_run_max_cost", 402, {
+                                    "error": "hub_run_max_cost", "step": name, "max_cost_micro": ceiling,
+                                    "message": f"the next step would pass {RUN_MAX_COST_HEADER}"})
+                                break
+                            counted += 1
+                            task = asyncio.create_task(one_call(u))
+                            running[task] = name
+                            pending_units[name].append(u)
+                        if stop is not None:
+                            break
+                if not running:
+                    break
+                left = wall_deadline - time.monotonic()
+                if left <= 0:
+                    for task in running:
+                        task.cancel()
+                    stop = RunStopped("hub_wall_clock", 424, {
+                        "error": "hub_wall_clock",
+                        "message": f"the run passed its {manifest['limits']['wall_s']} s wall clock"})
+                    break
+                finished, _ = await asyncio.wait(set(running), return_when=asyncio.FIRST_COMPLETED, timeout=left)
+                if not finished:
+                    continue
+                for task in finished:
+                    name = running.pop(task)
+                    step, entry, answer = task.result()
+                    trace.append(entry)
+                    spent += entry["cost_micro"]
+                    failed = isinstance(answer, (_StepFailed, CallFailure))
+                    if failed and not step.spec.get("allow_fail"):
+                        if stop is None:
+                            stop = RunStopped("hub_step_failed", 424, {
+                                "error": "hub_step_failed", "step": step.name, "status": entry.get("status"),
+                                **({"message": "a refusal that applies to every step"} if entry.get("global") else {})})
+                        if isinstance(answer, CallFailure) and entry.get("global"):
+                            stop = RunStopped(answer.kind, answer.status_code, {
+                                "error": answer.kind, "step": step.name, "detail": answer.detail})
+                        answer = None
+                    elif failed:
+                        entry["outcome"] = "failed_allowed"
+                        answer = None
+                    slot = step.item if step.item is not None else 0
+                    results[name][slot] = answer
+                    if len([t for t, n in running.items() if n == name]) == 0:
                         done.add(name)
-                        scope[name] = []
-                        continue
-                    for u in units:
-                        if counted + 1 > manifest["limits"]["steps"]:
-                            stop = RunStopped("hub_step_cap", 424, {
-                                "error": "hub_step_cap", "step": name,
-                                "message": f"the run would pass its step cap ({manifest['limits']['steps']})"})
-                            break
-                        est = estimate(u.spec)
-                        if price_held + spent + _reserved(running, pending_units, estimate) + est > ceiling:
-                            stop = RunStopped("hub_run_max_cost", 402, {
-                                "error": "hub_run_max_cost", "step": name, "max_cost_micro": ceiling,
-                                "message": f"the next step would pass {RUN_MAX_COST_HEADER}"})
-                            break
-                        counted += 1
-                        task = asyncio.create_task(one_call(u))
-                        running[task] = name
-                        pending_units[name].append(u)
-                    if stop is not None:
-                        break
-            if not running:
-                break
-            finished, _ = await asyncio.wait(set(running), return_when=asyncio.FIRST_COMPLETED)
-            for task in finished:
-                name = running.pop(task)
-                step, entry, answer = task.result()
-                trace.append(entry)
-                spent += entry["cost_micro"]
-                failed = isinstance(answer, (_StepFailed, CallFailure))
-                if failed and not step.spec.get("allow_fail"):
-                    if stop is None:
-                        stop = RunStopped("hub_step_failed", 424, {
-                            "error": "hub_step_failed", "step": step.name, "status": entry.get("status"),
-                            **({"message": "a refusal that applies to every step"} if entry.get("global") else {})})
-                    if isinstance(answer, CallFailure) and entry.get("global"):
-                        stop = RunStopped(answer.kind, answer.status_code, {
-                            "error": answer.kind, "step": step.name, "detail": answer.detail})
-                    answer = None
-                elif failed:
-                    entry["outcome"] = "failed_allowed"
-                    answer = None
-                slot = step.item if step.item is not None else 0
-                results[name][slot] = answer
-                if len([t for t, n in running.items() if n == name]) == 0:
-                    done.add(name)
-                    scope[name] = results[name] if step.spec.get("for_each") else results[name][0]
-    except asyncio.CancelledError:
+                        scope[name] = results[name] if step.spec.get("for_each") else results[name][0]
+        except asyncio.CancelledError:
+            raise
+
+        trace.sort(key=lambda e: (e["wave"], e["name"], e.get("item") or 0))
+        ms_total = int((time.monotonic() - started) * 1000)
+        if stop is not None:
+            await _close_price(tool, run_id, price_held, success=False, reason=stop.kind)
+            detail = {**stop.detail, "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}",
+                      "charged_micro": spent, "price_micro": 0, "trace": trace}
+            await _record(tool, parent, run_id, "failed" if stop.kind == "hub_step_failed" else "stopped",
+                          counted, spent, ms_total, masked(manifest["inputs"], inputs), trace, error=detail)
+            _audit_parent(parent, tool, stop.status, spent, audit_client)
+            raise ResolutionFailed("hub_run_failed", status_code=stop.status, detail=_public_detail(detail))
+
+        output = refs.resolve(manifest["output"], scope, g.positions)
+        earned = await _close_price(tool, run_id, price_held, success=True)
+        body_out = {
+            "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}", "output": output,
+            "usage": {"cost_micro": spent + earned, "steps_micro": spent, "price_micro": earned,
+                      "steps": counted, "ms": ms_total},
+            "trace": _public_trace(trace), "log": [],
+        }
+        await _record(tool, parent, run_id, "ok", counted, spent, ms_total,
+                      masked(manifest["inputs"], inputs), trace, price=earned, output=output)
+        _audit_parent(parent, tool, 200, spent + earned, audit_client)
+        return _json(body_out, 200, {"X-Treg-Run-Id": run_id, "X-Treg-Steps": str(counted)}), spent + earned
+
+
+    # ---------------------------------------------------------------------------------------------
+    # The seller's price (docs/HUB-DECISIONS.md round 3): one extra hold `{run}:price` on the CALLER
+    # at run start, settled to the MAKER as `earned` credit on success, released on failure. Not
+    # charged when the caller IS the maker (their own tool, and the publish check run), so the check
+    # never costs the seller their own price.
+
+
+    # Non-negotiable 2: the price hold closes exactly once on EVERY path. The success paths
+    # settle it themselves (a second close is a no-op); anything else releases it here: a
+    # refusal, a client disconnect, and a crash, which becomes a 424 with a plain name instead
+    # of a 500 with an open hold (the 8.1 review found seven such paths).
+    try:
+        return await _after_reserve()
+    except (CallFailure, asyncio.CancelledError):
+        await _close_price(tool, run_id, price_held, success=False, reason="hub_run_stopped")
         raise
-
-    trace.sort(key=lambda e: (e["wave"], e["name"], e.get("item") or 0))
-    ms_total = int((time.monotonic() - started) * 1000)
-    if stop is not None:
-        await _close_price(tool, run_id, price_held, success=False, reason=stop.kind)
-        detail = {**stop.detail, "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}",
-                  "charged_micro": spent, "price_micro": 0, "trace": trace}
-        await _record(tool, parent, run_id, "failed" if stop.kind == "hub_step_failed" else "stopped",
-                      counted, spent, ms_total, masked(manifest["inputs"], inputs), trace, error=detail)
-        _audit_parent(parent, tool, stop.status, spent, audit_client)
-        raise ResolutionFailed("hub_run_failed", status_code=stop.status, detail=detail)
-
-    output = refs.resolve(manifest["output"], scope, g.positions)
-    earned = await _close_price(tool, run_id, price_held, success=True)
-    body_out = {
-        "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}", "output": output,
-        "usage": {"cost_micro": spent + earned, "steps_micro": spent, "price_micro": earned,
-                  "steps": counted, "ms": ms_total},
-        "trace": trace, "log": [],
-    }
-    await _record(tool, parent, run_id, "ok", counted, spent, ms_total,
-                  masked(manifest["inputs"], inputs), trace, price=earned, output=output)
-    _audit_parent(parent, tool, 200, spent + earned, audit_client)
-    return _json(body_out, 200, {"X-Treg-Run-Id": run_id, "X-Treg-Steps": str(counted)}), spent + earned
-
-
-# ---------------------------------------------------------------------------------------------
-# The seller's price (docs/HUB-DECISIONS.md round 3): one extra hold `{run}:price` on the CALLER
-# at run start, settled to the MAKER as `earned` credit on success, released on failure. Not
-# charged when the caller IS the maker (their own tool, and the publish check run), so the check
-# never costs the seller their own price.
+    except Exception as exc:  # noqa: BLE001 - the last line of defence for the caller's money
+        await _close_price(tool, run_id, price_held, success=False, reason="hub_run_crashed")
+        raise ResolutionFailed("hub_run_failed", status_code=424, detail={
+            "error": "hub_run_crashed", "run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}",
+            "kind": type(exc).__name__, "charged_micro": 0, "price_micro": 0, "trace": [],
+            "message": "the run could not finish; the maker's log has the detail"}) from exc
 
 async def _reserve_price(parent: CallContext, tool: HubTool, run_id: str) -> int:
     """Open the price hold. Returns the amount held (0 when nothing is owed). Raises
@@ -396,13 +432,42 @@ def _reserved(running: dict, pending: dict, estimate) -> int:
     return sum(estimate(pending[n][-1].spec) for n in names if pending.get(n)) if names else 0
 
 
+MAX_RUN_MAX_COST_MICRO = 1_000_000_000   # $1,000: above it the header is a mistake, not a budget
+
+
 def _ceiling(raw: str | None) -> int:
     if not raw:
         return DEFAULT_RUN_MAX_COST_MICRO
     try:
-        return max(0, int(round(float(raw) * 1_000_000)))
-    except ValueError:
-        return DEFAULT_RUN_MAX_COST_MICRO
+        value = float(raw)
+        if not math.isfinite(value) or value < 0 or value * 1_000_000 > MAX_RUN_MAX_COST_MICRO:
+            raise ValueError(raw)
+        return int(round(value * 1_000_000))
+    except (ValueError, OverflowError):
+        raise ResolutionFailed("hub_input_invalid", status_code=422, detail={
+            "error": "hub_input_invalid", "field": RUN_MAX_COST_HEADER,
+            "rule": "a dollar amount between 0 and 1000, e.g. 0.50"}) from None
+
+
+def _no_constants(name: str):
+    raise ValueError(f"{name} is not a JSON number")
+
+
+def _public_detail(detail: dict[str, Any]) -> dict[str, Any]:
+    """A failure as the CALLER reads it: the same fields, the trace in its public shape."""
+    return {**detail, "trace": _public_trace(detail.get("trace") or [])}
+
+
+def _public_trace(trace: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """What a CALLER may read of a trace: waves, steps, outcome, status, cost, time, whose key.
+    Not what each step called (the maker's recipe) and not an upstream error body (round 4 q10,
+    round 5 q7). The full trace stays on the run row for the maker."""
+    out = []
+    for e in trace:
+        call = str(e.get("call", ""))
+        kind = "a catalog tool" if "." in call.split("/", 1)[0] else "the maker's own tool"
+        out.append({k: v for k, v in e.items() if k not in ("call", "error")} | {"call": kind})
+    return out
 
 
 def _entry(step: _Step, outcome: str, status: int | None, ms: int, cost: int, *, key: str | None,
@@ -421,6 +486,7 @@ def _short(v: Any) -> Any:
     return s[:300]
 
 
+_HEADER_NAME_RE = re.compile(r"^[A-Za-z0-9!#$%&'*+.^_`|~-]{1,128}$")
 _SCRIPT_HEADER_DENY = frozenset({"authorization", "cookie", "host", "content-length", "transfer-encoding",
                                  "connection", "idempotency-key", "apikey"})
 
@@ -441,7 +507,7 @@ def _child_input(parent: CallContext, call: str, method: str, inp: dict[str, Any
     items = tuple((k, v if isinstance(v, str) else json.dumps(v)) for k, v in q.items() if v is not None)
     return CallInput(method=method, raw_rest=call, raw_headers=tuple(headers), query_items=items,
                      raw_query=urlencode(items), body=_Bytes(payload), caller=as_who,
-                     client_ip=parent.input.client_ip, catalog_only=False)
+                     client_ip=parent.input.client_ip, catalog_only=False, child_of=parent.call_ref)
 
 
 async def _maker_snapshot(parent: CallContext, tool: HubTool):
@@ -453,20 +519,54 @@ async def _maker_snapshot(parent: CallContext, tool: HubTool):
     async with session_maker() as s:
         org = await s.get(Org, tool.org_id)
     if org is None:
-        return caller
+        raise ResolutionFailed("hub_not_runnable", status_code=404, detail={
+            "error": "hub_not_runnable", "message": "the maker's team no longer exists"})
+    from ..call.types import UserSnapshot
+    # The maker's call log must not name the caller (round 3 q10): the own-tool step audits as
+    # "hub-caller:<caller org>", the way the scheduled check audits as "hub-check".
     return replace(caller,
                    membership=replace(caller.membership, org_id=tool.org_id, tool_access=None,
                                       project_access=None),
+                   user=UserSnapshot(id=caller.user.id, email=f"hub-caller:{caller.org_id}"),
                    org=replace(caller.org, id=org.id, slug=org.slug, demo=org.demo,
                                public_demo=org.public_demo))
 
 
-async def _read(response: UpstreamResponse) -> bytes:
-    chunks = []
+MAX_BODY_BYTES = 1_000_000   # a step's answer the runner keeps; beyond it the stream is closed
+
+
+async def _read(response: UpstreamResponse) -> tuple[bytes, bool]:
+    """A step's answer, at most MAX_BODY_BYTES; (bytes, truncated). The runner reads answers
+    into the server's memory, so a maker's own server answering 1 GB must not become 1 GB
+    here (8.1 review)."""
+    chunks: list[bytes] = []
+    size = 0
+    truncated = False
     async for chunk in response.body_stream:
+        if size + len(chunk) > MAX_BODY_BYTES:
+            chunks.append(chunk[:MAX_BODY_BYTES - size])
+            truncated = True
+            break
         chunks.append(chunk)
+        size += len(chunk)
     await response.close()
-    return b"".join(chunks)
+    return b"".join(chunks), truncated
+
+
+def _child_cost(response: UpstreamResponse, *, catalog_step: bool) -> tuple[int, str]:
+    """What treg charged for a child call and whose key served it. The X-Treg-Cost-Micro header
+    is read ONLY on a catalog step, where treg's own code wrote it; on an own-tool step the
+    upstream is the maker's server and could write the header itself (8.1 review), so it is
+    never read: an own-tool step costs the caller nothing, by rule 1."""
+    if not catalog_step:
+        return 0, "team"
+    raw = _header(response, "X-Treg-Cost-Micro")
+    if raw is None:
+        return 0, "team"
+    try:
+        return max(0, int(raw)), "treg"
+    except ValueError:
+        return 0, "treg"
 
 
 def _header(response: UpstreamResponse, name: str) -> str | None:
@@ -566,6 +666,8 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         if call.startswith("http://") or call.startswith("https://"):
             call, url_query = from_url(call)
         target = call.split("/", 1)[0]
+        if any(part in ("..", ".") for part in call.split("?", 1)[0].split("/")):
+            raise sandbox.SandboxError("refused", "a call path may not contain `..` segments")
         if not (call in uses or (target in own_tools and "/" in call) or target in uses and target in own_tools):
             raise sandbox.SandboxError("refused", f"{call!r} is not in the manifest's `uses`")
         if target not in own_tools and call not in catalog.by_id:
@@ -590,6 +692,9 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         # Headers a script sets on ctx.call ride to the upstream (a PostgREST `Accept-Profile`, a
         # vendor's `Accept`), minus the ones that carry identity or framing: those are treg's.
         raw_headers = opts.get("headers") if isinstance(opts.get("headers"), dict) else {}
+        for k in raw_headers:
+            if not _HEADER_NAME_RE.match(str(k)):
+                raise sandbox.SandboxError("refused", f"header {str(k)[:40]!r}: a name of ASCII token characters")
         extra_headers = {str(k): str(v) for k, v in raw_headers.items()
                          if str(k).lower() not in _SCRIPT_HEADER_DENY and not str(k).lower().startswith("x-treg-")}
         child = CallContext(input=_child_input(parent, call, method, inp, as_who,
@@ -606,14 +711,13 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
                 raise sandbox.SandboxError("refused", f"{exc.kind}: a refusal that applies to every call")
             return {"status": exc.status_code, "headers": {}, "json": exc.detail if isinstance(exc.detail, dict) else None,
                     "text": str(exc.detail)[:4000]}
-        raw = await _read(response)
+        raw, truncated = await _read(response)
         ms = int((time.monotonic() - t0) * 1000)
-        charged = int(_header(response, "X-Treg-Cost-Micro") or 0)
+        charged, key = _child_cost(response, catalog_step=target not in own_tools)
         spent += charged
-        key = "treg" if _header(response, "X-Treg-Cost-Micro") is not None else "team"
         ok = 200 <= response.status < 300
         try:
-            doc = json.loads(raw) if raw else None
+            doc = None if truncated else (json.loads(raw) if raw else None)
         except ValueError:
             doc = None
         trace.append(_entry(step, "ok" if ok else "failed", response.status, ms, charged, key=key,
@@ -621,7 +725,7 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         headers = {k.decode("latin-1"): v.decode("latin-1") for k, v in response.raw_headers
                    if not k.lower().startswith(b"x-treg-")}
         return {"status": response.status, "headers": headers, "json": doc,
-                "text": raw[:MAX_TEXT].decode("utf-8", "replace")}
+                "text": raw[:MAX_TEXT].decode("utf-8", "replace"), "truncated": truncated}
 
     data_rows = _csv_rows(tool.data) if getattr(tool, "data", None) else None
     try:
@@ -636,7 +740,7 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         await _record(tool, parent, run_id, "failed", counted, spent, ms_total,
                       masked(manifest["inputs"], inputs), trace, error=detail, log=log)
         _audit_parent(parent, tool, 424, spent, audit_client)
-        raise ResolutionFailed("hub_run_failed", status_code=424, detail=detail)
+        raise ResolutionFailed("hub_run_failed", status_code=424, detail=_public_detail(detail))
     missing = [f for f in fields if f not in output]
     ms_total = int((time.monotonic() - started) * 1000)
     if missing:
@@ -648,11 +752,11 @@ async def _run_script_road(parent, tool, inputs, ceiling, maker, catalog, own_to
         await _record(tool, parent, run_id, "failed", counted, spent, ms_total,
                       masked(manifest["inputs"], inputs), trace, error=detail, log=log)
         _audit_parent(parent, tool, 424, spent, audit_client)
-        raise ResolutionFailed("hub_run_failed", status_code=424, detail=detail)
+        raise ResolutionFailed("hub_run_failed", status_code=424, detail=_public_detail(detail))
     earned = await _close_price(tool, run_id, price_held, success=True)
     body_out = {"run_id": run_id, "recipe": f"{tool.tool_id}@{tool.version}", "output": output,
                 "usage": {"cost_micro": spent + earned, "steps_micro": spent, "price_micro": earned,
-                          "steps": counted, "ms": ms_total}, "trace": trace, "log": log}
+                          "steps": counted, "ms": ms_total}, "trace": _public_trace(trace), "log": log}
     await _record(tool, parent, run_id, "ok", counted, spent, ms_total,
                   masked(manifest["inputs"], inputs), trace, log=log, price=earned, output=output)
     _audit_parent(parent, tool, 200, spent + earned, audit_client)

--- a/src/treg/application/hub/sandbox.py
+++ b/src/treg/application/hub/sandbox.py
@@ -128,8 +128,15 @@ async def run_script(
                 line = await asyncio.wait_for(proc.stdout.readline(), timeout=left)
             except asyncio.TimeoutError:
                 raise SandboxError("timeout", f"the run passed its {wall_s} s wall clock") from None
+            except ValueError:
+                # readline's limit: one bridge line over MAX_LINE_BYTES (a call body or a log the
+                # engine could build but the bridge will not carry)
+                raise SandboxError("protocol", f"the sandbox wrote a line over {MAX_LINE_BYTES // (1024 * 1024)} MiB") from None
             if not line:
                 err = (await proc.stderr.read(4000)).decode("utf-8", "replace").strip()
+                if "Traceback" in err or "MemoryError" in err:
+                    # the maker reads this line; a server traceback with paths is not theirs to read
+                    err = "the sandbox stopped (out of memory, or an internal error)"
                 raise SandboxError("script", err[-600:] or "the sandbox exited without an answer")
             try:
                 msg = json.loads(line)
@@ -141,7 +148,13 @@ async def run_script(
                     log.append(str(msg.get("text", ""))[:MAX_LOG_CHARS])
             elif op == "call":
                 calls += 1
-                req = CallRequest(target=str(msg.get("target", "")), opts=dict(msg.get("opts") or {}))
+                opts = msg.get("opts") or {}
+                if not isinstance(opts, dict):
+                    reply = {"op": "refused", "id": msg.get("id"), "error": "ctx.call's second argument must be an object"}
+                    proc.stdin.write((json.dumps(reply) + "\n").encode())
+                    await proc.stdin.drain()
+                    raise SandboxError("refused", reply["error"])
+                req = CallRequest(target=str(msg.get("target", "")), opts=opts)
                 if calls > MAX_CALLS:
                     reply = {"op": "refused", "id": msg["id"],
                              "error": f"the run passed its cap of {MAX_CALLS} calls"}
@@ -149,7 +162,15 @@ async def run_script(
                     await proc.stdin.drain()
                     raise SandboxError("refused", reply["error"])
                 try:
-                    result = await execute(req)
+                    # the wall clock keeps running while the step is in flight: an upstream that
+                    # answers one byte at a time must not hold the run, the slot and the memory
+                    left = deadline - asyncio.get_running_loop().time()
+                    if left <= 0:
+                        raise SandboxError("timeout", f"the run passed its {wall_s} s wall clock")
+                    try:
+                        result = await asyncio.wait_for(execute(req), timeout=left)
+                    except asyncio.TimeoutError:
+                        raise SandboxError("timeout", f"the run passed its {wall_s} s wall clock during a call") from None
                     reply = {"op": "result", "id": msg["id"], **result}
                 except SandboxError as exc:
                     reply = {"op": "refused", "id": msg["id"], "error": exc.message}

--- a/src/treg/domain/hub/manifest.py
+++ b/src/treg/domain/hub/manifest.py
@@ -200,6 +200,12 @@ def _validate_uses(raw: Any, catalog_ids: set[str], own_tools: set[str],
                    hub_ids: frozenset[str] | set[str], allow_empty: bool = False) -> list[str]:
     if not isinstance(raw, list) or (not raw and not allow_empty):
         raise _fail("uses", "a non-empty list of the tools this recipe may call")
+    # The runner tells an own tool from a catalog id by the dot. An own tool NAMED like a catalog
+    # id would run as the caller and could later resolve to a hub tool of that name: a nested
+    # run with an undisclosed price (8.1 review). Refused here, by name.
+    for i, u in enumerate(raw):
+        if isinstance(u, str) and u in own_tools and "." in u:
+            raise _fail(f"uses[{i}]", f"own tool {u!r} is named like a catalog id; rename it without a dot")
     if len(raw) > MAX_USES:
         raise _fail("uses", f"at most {MAX_USES} entries")
     seen: list[str] = []
@@ -238,6 +244,9 @@ def _validate_limits(raw: Any) -> dict[str, Any]:
 
 
 def _validate_price(raw: Any) -> int:
+    import math
+    if _is_number(raw) and not math.isfinite(float(raw)):
+        raise _fail("price_usd", "a finite number")
     if not _is_number(raw) or raw < 0 or raw > MAX_PRICE_USD:
         raise _fail("price_usd", f"a number from 0 to {MAX_PRICE_USD} (dollars per successful run; 0 = free)")
     micro = round(float(raw) * 1_000_000)

--- a/src/treg/hub_sandbox.py
+++ b/src/treg/hub_sandbox.py
@@ -60,7 +60,7 @@ globalThis.ctx = {
   call: async function (target, opts) {
     const reply = JSON.parse(__bridge_call(JSON.stringify([String(target), opts || {}])));
     if (reply.op === "refused") { throw new Error(reply.error); }
-    return { status: reply.status, headers: reply.headers, json: reply.json, text: reply.text };
+    return { status: reply.status, headers: reply.headers, json: reply.json, text: reply.text, truncated: !!reply.truncated };
   },
   csv: __csv,
   log: function (text) { __bridge_log(String(text)); },
@@ -154,10 +154,14 @@ Promise.resolve().then(() => globalThis.__run(globalThis.ctx))
         _emit({"op": "error", "kind": "script", "message": "run(ctx) never settled (an await that waits on nothing)"})
         return 1
     out = ctx.eval("globalThis.__out")
-    if out is None or len(out.encode("utf-8")) > MAX_OUTPUT_BYTES:
+    try:
+        if not isinstance(out, str) or len(out.encode("utf-8")) > MAX_OUTPUT_BYTES:
+            raise ValueError("not a JSON string")
+        parsed = json.loads(out)
+    except (ValueError, TypeError, AttributeError):
         _emit({"op": "error", "kind": "output", "message": f"the returned object must be JSON under {MAX_OUTPUT_BYTES} bytes"})
         return 1
-    _emit({"op": "done", "output": json.loads(out)})
+    _emit({"op": "done", "output": parsed})
     return 0
 
 

--- a/src/treg/routers/hub.py
+++ b/src/treg/routers/hub.py
@@ -69,6 +69,9 @@ async def _publish(body: PublishIn, request: Request, caller: Caller, db: AsyncS
     await db.commit()
     row = (await db.execute(select(HubTool).where(
         HubTool.tool_id == published.tool_id, HubTool.version == published.version))).scalars().one()
+    # Non-negotiable 3: no database connection is held while the check's upstream calls run.
+    # The select above autobegan a transaction; end it (objects stay usable: expire_on_commit=False).
+    await db.commit()
     verdict = await hub_app.run_check(db, row, maker_headers=dict(request.headers), app=request.app)
     await db.commit()
     out = {"tool_id": published.tool_id, "version": published.version, "status": row.status,
@@ -198,6 +201,13 @@ async def get_hub_tool(
     if row.org_id == caller.org_id:
         out["script"] = row.script
         out["check"] = row.check
+        out["readme"] = row.readme
+    else:
+        # another team reads the public contract only: not the maker's tools, not who
+        # published, not the check's trace (8.1 review)
+        for k in ("uses", "created_by", "check_result"):
+            out.pop(k, None)
+        out["made_of"] = len(row.manifest.get("uses", []))
         out["readme"] = row.readme
     return out
 

--- a/src/treg/routers/web.py
+++ b/src/treg/routers/web.py
@@ -2182,7 +2182,7 @@ curl -X POST {e(base)}/call/{e(row.tool_id)} \\
 
   <h2>The check <span class="muted" style="font-size:12px">(run at publish, for real)</span></h2>
   {('<div class="scroll"><table><tr><th>Wave</th><th>Step</th><th>Called</th><th>Result</th><th>Cost</th><th>ms</th></tr>' + trace_html + '</table></div>') if trace_html else '<p class="muted">no trace recorded</p>'}
-  <p class="muted" style="font-size:12px">inputs <code>{e(json.dumps(row.check.get('inputs', {})))}</code> · {e(chk.get('status') or '-')}{(' at ' + e(checked_at)) if checked_at else ''}</p>
+  <p class="muted" style="font-size:12px">{e(chk.get('status') or '-')}{(' at ' + e(checked_at)) if checked_at else ''}</p>
 
   <h2>Made of</h2>
   <ul class="facts">

--- a/tests/callmatrix/test_hub_run.py
+++ b/tests/callmatrix/test_hub_run.py
@@ -266,7 +266,12 @@ async def test_a_script_runs_a_catalog_call_and_an_own_tool_call(
     assert body["output"] == {"name": "figma.com", "rows": 3, "cost_seen": 200}
     assert body["log"] == ["company status 200"]
     assert body["usage"]["steps"] == 2 and body["usage"]["cost_micro"] == EP_MICRO
-    assert [(e["call"], e["key"], e["cost_micro"]) for e in body["trace"]] == [(EP, "treg", EP_MICRO), ("supabase/rest/v1/leads", "team", 0)]
+    # the caller reads the KIND of tool per step, never the maker's recipe (8.1 review)
+    assert [(e["call"], e["key"], e["cost_micro"]) for e in body["trace"]] == [("a catalog tool", "treg", EP_MICRO), ("the maker's own tool", "team", 0)]
+    assert all("error" not in e for e in body["trace"])
+    # the maker's own run row keeps the real calls
+    mine = (await matrix_clients.get(f"/hub/runs/{body['run_id']}")).json()
+    assert [e["call"] for e in mine["trace"]] == [EP, "supabase/rest/v1/leads"]
     assert r.headers["X-Treg-Cost-Micro"] == str(EP_MICRO)
     hits = fake_provider.hits[before.hit_count:]
     assert len(hits) == 2
@@ -582,3 +587,166 @@ async def test_the_uploaded_csv_recipe_serves_its_own_data_with_no_call(
     # a bad CSV is refused by field and rule; a CSV on a steps recipe too
     bad = await matrix_clients.post("/hub/tools", json={**body, "data": "just one line"})
     assert bad.status_code == 422 and bad.json()["detail"]["field"] == "data"
+
+
+
+# ---------------------------------------------------------------------------------------------
+# 8.2: the security pass. Each test is a finding that was open before it.
+
+async def _no_holds(clients: AsyncClient) -> None:
+    org = (await clients.get("/orgs")).json()[0]["org_id"]
+    assert (await clients.get(f"/orgs/{org}/balance")).json()["holds"] == []
+
+
+async def test_hostile_bodies_and_headers_are_4xx_never_500(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}, price_usd=0.01))
+    buyer = (await matrix_clients.post("/users", json={"email": "hostile@example.com"})).json()["token"]
+    h = {**FAKE, "X-Treg-Token": buyer}
+    bomb = "[" * 100_000 + "]" * 100_000
+    r = await matrix_clients.post(f"/call/{tool_id}", content=bomb, headers={**h, "content-type": "application/json"})
+    assert r.status_code == 422 and r.json()["detail"]["field"] == "body"
+    r = await matrix_clients.post(f"/call/{tool_id}", content=b'{"domain": NaN}', headers={**h, "content-type": "application/json"})
+    assert r.status_code == 422
+    for v in ("1e308", "NaN", "abc", "-5", "5000"):
+        r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "x"}, headers={**h, "X-Treg-Run-Max-Cost": v})
+        assert r.status_code == 422 and r.json()["detail"]["field"] == "X-Treg-Run-Max-Cost", (v, r.text)
+    bal = (await matrix_clients.get(f"/orgs/{(await matrix_clients.get('/orgs', headers={'X-Treg-Token': buyer})).json()[0]['org_id']}/balance", headers={"X-Treg-Token": buyer})).json()
+    assert bal["holds"] == []                                       # nothing was held on any refusal
+
+
+async def test_a_crash_inside_the_run_closes_the_price_hold_and_answers_424(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on, monkeypatch,
+):
+    from treg.application.hub import runner
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}, price_usd=0.05))
+    buyer = (await matrix_clients.post("/users", json={"email": "crash@example.com"})).json()["token"]
+    h = {"X-Treg-Token": buyer}
+    org = (await matrix_clients.get("/orgs", headers=h)).json()[0]["org_id"]
+    before = (await matrix_clients.get(f"/orgs/{org}/balance", headers=h)).json()["balance_micro"]
+
+    def boom(*a, **k):
+        raise RuntimeError("simulated crash after the price hold")
+    monkeypatch.setattr(runner.hub_graph, "build", boom)
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "x"}, headers={**FAKE, **h})
+    assert r.status_code == 424 and r.json()["detail"]["error"] == "hub_run_crashed"
+    after = (await matrix_clients.get(f"/orgs/{org}/balance", headers=h)).json()
+    assert after["balance_micro"] == before and after["holds"] == []       # the price came back at once
+
+
+async def test_a_step_answer_over_the_cap_is_cut_not_buffered(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on, monkeypatch,
+):
+    from treg.application.hub import runner
+
+    class _Resp:
+        def __init__(self, chunks): self._c = chunks; self.status = 200; self.raw_headers = []
+        @property
+        async def body_stream(self):
+            for c in self._c:
+                yield c
+        async def close(self): pass
+
+    # a step's answer is never buffered whole: read up to the cap, then the stream is closed
+    monkeypatch.setattr(runner, "MAX_BODY_BYTES", 16)
+    raw, cut = await runner._read(_Resp([b"a" * 40]))
+    assert raw == b"a" * 16 and cut is True
+    raw, cut = await runner._read(_Resp([b"ab", b"cd"]))
+    assert raw == b"abcd" and cut is False
+    # end to end: a script reads `r.truncated` from every step reply (the prelude passes it)
+    tool_id = await _publish_script(
+        matrix_clients,
+        'export default async function run(ctx) { const r = await ctx.call("' + EP
+        + '", {}); return { x: [("truncated" in r), r.truncated] }; }',
+        [EP], ["x"])
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "x"}, headers=FAKE)
+    assert r.status_code == 200 and r.json()["output"]["x"] == [True, False]
+
+
+async def test_an_own_tool_named_like_a_catalog_id_cannot_be_used_and_a_child_never_reaches_the_hub(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "k3", "value": "K"})).json()["id"]
+    r = await matrix_clients.post("/tools", json={"name": "evil.inner", "base_url": "https://fake-provider.invalid", "secret_id": sid})
+    assert r.status_code in (200, 201)
+    bad = await matrix_clients.post("/hub/tools", json={
+        "manifest": _manifest(steps=[{"name": "a", "call": "evil.inner/x", "input": {}}], output={"x": "$a.data"}, uses=["evil.inner"]),
+        "check": {"inputs": {"domain": "x"}, "fields": ["x"]}, "readme": "x"})
+    assert bad.status_code == 422 and bad.json()["detail"]["field"] == "uses[0]" and "dot" in bad.json()["detail"]["rule"]
+    # a child call carries child_of and is never resolved as a hub id
+    from treg.application.call.types import CallInput
+    assert "child_of" in CallInput.__dataclass_fields__
+
+
+async def test_a_caller_never_reads_the_recipe_or_an_upstream_error_body(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}))
+    buyer = (await matrix_clients.post("/users", json={"email": "reader2@example.com"})).json()["token"]
+    h = {"X-Treg-Token": buyer}
+    r = await matrix_clients.post(f"/call/{tool_id}", json={"domain": "x"},
+                                  headers={**h, "X-Fake-Status": "500", "X-Fake-Body": '{"vendor": "SECRET-UPSTREAM-BODY"}'})
+    assert r.status_code == 424
+    text = r.text
+    assert "SECRET-UPSTREAM-BODY" not in text and "tikhub" not in text and "a catalog tool" in text
+    # the stored 424 detail is the public one, so an idempotent replay leaks nothing either
+    mine = (await matrix_clients.get(f"/hub/runs/{r.json()['detail']['run_id']}")).json()
+    assert "SECRET-UPSTREAM-BODY" in json.dumps(mine)      # the MAKER keeps the whole error
+    # another team's GET /hub/tools/{id}: the public contract only
+    other = (await matrix_clients.get(f"/hub/tools/{tool_id}", headers=h)).json()
+    assert "uses" not in other and "created_by" not in other and "check_result" not in other and other["made_of"] == 1
+    # the maker's call log names no caller: an own-tool step audits as hub-caller:<org>
+    sid = (await matrix_clients.post("/secrets", json={"name": "k5", "value": "K"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "mine3", "base_url": "https://fake-provider.invalid", "secret_id": sid})
+    own = await _publish(matrix_clients, _manifest(name="owned", steps=[{"name": "a", "call": "mine3/x", "input": {}}], output={"x": "$a.data"}, uses=["mine3"]))
+    assert (await matrix_clients.post(f"/call/{own}", json={"domain": "x"}, headers={**h, "X-Fake-Body": '{"data": 1}'})).status_code == 200
+    calls = json.dumps((await matrix_clients.get("/calls", params={"limit": 50})).json())
+    assert "reader2@example.com" not in calls and "hub-caller:" in calls
+
+
+async def test_script_road_refusals_are_clean(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on,
+):
+    sid = (await matrix_clients.post("/secrets", json={"name": "k4", "value": "K"})).json()["id"]
+    await matrix_clients.post("/tools", json={"name": "mine2", "base_url": "https://fake-provider.invalid/api/v1", "secret_id": sid})
+    cases = {
+        "dotdot": ('ctx.call("mine2/../../admin")', "`..`"),
+        "bad header name": ('ctx.call("mine2/x", {headers: {"名": "1"}})', "ASCII token"),
+        "opts not an object": ('__bridge_call(JSON.stringify(["mine2/x", "abc"]))', "must be an object"),
+        "line over 8 MiB": ('ctx.call("mine2/x", {body: {x: "a".repeat(9 << 20)}})', "over 8 MiB"),
+    }
+    for name, (expr, rule) in cases.items():
+        t = await _publish_script(matrix_clients, "export default async function run(ctx){ await " + expr + "; return {x: 1}; }", ["mine2"], ["x"])
+        r = await matrix_clients.post(f"/call/{t}", json={"domain": "x"})
+        assert r.status_code == 424 and rule in r.json()["detail"]["message"], (name, r.text)
+        assert "Traceback" not in r.text and "quickjs" not in r.text
+    await _no_holds(matrix_clients)
+
+
+async def test_a_version_under_check_is_invisible_to_strangers_and_a_crashed_check_ends_failed(
+    matrix_clients: AsyncClient, fake_provider: FakeProvider, platform_on, hub_on, monkeypatch,
+):
+    from sqlalchemy import update
+    from treg.infra.db import session_maker
+    from treg.models import HubTool
+    tool_id = await _publish(matrix_clients, _manifest(
+        steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}))
+    async with session_maker() as s:
+        await s.execute(update(HubTool).where(HubTool.tool_id == tool_id).values(status="checking"))
+        await s.commit()
+    buyer = (await matrix_clients.post("/users", json={"email": "guess@example.com"})).json()["token"]
+    assert (await matrix_clients.post(f"/call/{tool_id}@1", json={"domain": "x"}, headers={**FAKE, "X-Treg-Token": buyer})).status_code == 404
+    assert (await matrix_clients.post(f"/call/{tool_id}@1", json={"domain": "x"}, headers=FAKE)).status_code == 200   # the maker's own check pins it
+    # a crashed check: the version ends `failed`, never `checking` forever
+    from treg.application.hub import health as hub_health
+    def boom(*a, **k):
+        raise RuntimeError("simulated crash inside the check")
+    monkeypatch.setattr(hub_health, "verdict_from", boom)
+    r = await matrix_clients.post("/hub/tools", json={
+        "manifest": _manifest(name="crashy", steps=[{"name": "a", "call": EP, "input": {"aweme_id": "x"}}], output={"x": "$a.data"}),
+        "check": {"inputs": {"domain": "x"}, "fields": ["x"]}, "readme": "x"})
+    assert r.status_code == 201 and r.json()["status"] == "failed" and r.json()["check"]["error"]["error"] == "check_crashed"

--- a/tests/test_call_application_contract.py
+++ b/tests/test_call_application_contract.py
@@ -40,6 +40,7 @@ class CallInputContract:
     caller: object
     client_ip: str
     catalog_only: bool = False
+    child_of: str | None = None
 
 
 @dataclass
@@ -55,6 +56,7 @@ def test_call_dto_and_port_shapes_are_frozen() -> None:
         "method", "raw_rest", "raw_headers", "query_items", "raw_query", "body", "caller",
         "client_ip",
         "catalog_only",
+        "child_of",
     ]
     assert [field.name for field in fields(UpstreamResponseContract)] == [
         "status", "raw_headers", "body_stream", "close",


### PR DESCRIPTION
Phase 8.2 of the tool hub: the security pass. The launch-blocking findings from the 8.1 review, one PR: the price hold closes on every path (crashes become 424, never a 500 with an open hold), a step's answer is capped at 1 MB, no nested hub runs, the caller never reads the recipe or an upstream error body, another team's GET returns the public shape, the wall clock runs during bridge calls, publish holds no DB connection during the check. 8 regression tests; suite 2948.

