### PR TITLE
fix(arena): finish cancellation polling before saving runs

### DIFF
--- a/docs/context/interface/enrich-arena.md
+++ b/docs/context/interface/enrich-arena.md
@@ -452,6 +452,13 @@ Automatic price previews do not count toward that limit. Quote creation retires 
 quotes to retain at most 100 per user, preserving completed/running sessions. Start admission
 serializes on the user row across drafts and teams; hitting the execution limit still allows pricing.
 
+Run completion signals the cancellation poll to stop and waits for its current read/session to
+close before the final save. It never cancels that poll inside database I/O: under SQLite's
+rollback journal, cancellation during cursor execution can retain a read lock, blocking the
+final commit and subsequent test schema resets. `test_run_finishes_while_cancel_poll_is_reading`
+forces that overlap through a real Arena run; repeated xdist tests with CPU pressure cover the
+original intermittent failure. Audit/archive drains alone cannot release this reader's lock.
+
 Waterfall uses ascending quoted prices, retaining planner order for ties, and the bounded error fallback policy. It stops
 at the first structural hit: the adapter supplies the contract's required fields. Found work email
 does not mean verified deliverability; phone found does not mean a live line. A negative mailbox

--- a/src/treg/application/arena.py
+++ b/src/treg/application/arena.py
@@ -748,9 +748,15 @@ async def _run(run_id, mode, capability, payload, caller, client, client_ip, onl
                 payload["stop_reason"] = (stopped.get(0, "No remaining service within the run budget returned the required data.") if count == 1 else
                     f"{hits} of {count} entries found. Each entry stops at its first result; later vendors receive unresolved entries.")
 
+    stop_watching = asyncio.Event()
+
     async def watch_cancel():
         while True:
-            await asyncio.sleep(0.75)
+            try:
+                await asyncio.wait_for(stop_watching.wait(), 0.75)
+                return
+            except TimeoutError:
+                pass
             async with session_maker() as db:
                 row = await db.get(ArenaRun, run_id)
                 if row is None or row.cancel_requested:
@@ -774,7 +780,9 @@ async def _run(run_id, mode, capability, payload, caller, client, client_ip, onl
         log.exception("Arena run failed: %s", run_id)
     finally:
         worker.cancel()
-        watcher.cancel()
+        # Finish an in-flight poll before saving. Cancelling SQLite cursor execution can leave
+        # a read lock alive after session cleanup, blocking this commit and later schema resets.
+        stop_watching.set()
         await asyncio.gather(worker, watcher, return_exceptions=True)
         for a in payload["attempts"]:
             v = a.get("verification")

--- a/tests/test_enrich_arena.py
+++ b/tests/test_enrich_arena.py
@@ -1429,3 +1429,51 @@ def test_phone_verification_context_does_not_override_explicit_calling_code():
     assert rules.validate_identity('people.phone.verify', {'phone':'020 7946 0958','country_code':'gb'}) == {'phone':'02079460958','country_code':'GB'}
     with pytest.raises(rules.ArenaError):
         rules.validate_identity('people.phone.verify', {'phone':'4155550100','country_code':'USA'})
+
+
+async def test_run_finishes_while_cancel_poll_is_reading(clients, enrichment_on, monkeypatch):
+    """Finish a real run while the cancellation poll is materializing a SQLite SELECT."""
+    from aiosqlite import Cursor
+    from treg.infra import db as database
+
+    if not database._is_sqlite:
+        pytest.skip("SQLite cursor cancellation regression")
+    queried = asyncio.Event()
+    release = asyncio.Event()
+    interrupted = []
+    execute = Cursor.execute
+    save = arena._save
+
+    async def slow_poll(cursor, sql, parameters=None):
+        result = await execute(cursor, sql, parameters)
+        if ("watch_cancel" in asyncio.current_task().get_coro().__qualname__
+                and sql.startswith("SELECT") and not queried.is_set()):
+            queried.set()
+            asyncio.get_running_loop().call_later(0.05, release.set)
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                interrupted.append(True)
+                raise
+        return result
+
+    async def last_save(run_id, payload, state=None, **kwargs):
+        await save(run_id, payload, state, **kwargs)
+        if state is None and all(a["state"] in {"hit", "miss"} for a in payload["attempts"]):
+            await asyncio.wait_for(queried.wait(), 5)
+
+    monkeypatch.setattr(Cursor, "execute", slow_poll)
+    monkeypatch.setattr(arena, "_save", last_save)
+    monkeypatch.setattr(service, "relay", _relay_by_provider({
+        "hunter": [(200, HUNTER_HIT)], "tomba": [(200, TOMBA_HIT)]}, []))
+    try:
+        result = await finish(clients, await plan(clients))
+        assert result["state"] == "completed"
+        assert not interrupted, "run completion cancelled the poll inside SQLite cursor execution"
+        # Match the next fixture boundary: drain the writes, then rebuild the schema.
+        from treg import archive, audit
+        await audit.drain()
+        await archive.drain()
+        await database.reset_db()
+    finally:
+        release.set()


### PR DESCRIPTION
Arena run completion could fail with SQLite `database is locked`, followed by cascading lock errors in subsequent tests' `reset_db()`. Cancelling `watch_cancel` while its SELECT cursor was still being materialized interrupted cursor cleanup and left a read lock alive. The final save failed first; audit/archive drains could not release the cancellation poll's reader lock.

Signal the poll to stop, then wait for its current query and session to finish before the final save. The change does not add retry loops or change SQLite busy_timeout/journal mode. A controlled HTTP Arena regression test forces completion to overlap cursor execution and verifies the following schema reset succeeds.

Validation used an isolated TMPDIR with 16 xdist workers, each using its own SQLite file, plus four CPU load processes. Both affected test files ran with `--count=10`:

- Before: 2 failed, 1710 passed, 28 setup errors.
- After: 1750 passed, including ten executions of the new regression test.
- Controlled regression repeated separately: 10 passed after the fix; the original code reproduced the lock failure.
- Two complete `uv run --with pytest-xdist pytest -n auto -q` runs: each 3492 passed, 6 skipped.
- Import contracts: 14 kept. Context drift checked; updated `docs/context/interface/enrich-arena.md`.

Rebased onto main at `49b80733` after the R2 merge. The rebased branch also passes all 175 tests in `test_enrich_arena.py` and `test_error_capture.py`, plus all 14 import contracts. No deployment is included.
