### PR TITLE
feat(archive): observe changed response paths and honour declared ignore paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ TREG_ARCHIVE_OBJECT_STORE_SECRET_ACCESS_KEY=
 
 # Read timeout defaults to 2 seconds; upload keeps its separate timeout.
 # TREG_ARCHIVE_R2_READ_TIMEOUT_S=
+
+# Optional changed-path reporting (shares archive concurrency and lookup read mode).
+TREG_ARCHIVE_CHANGE_OBSERVATION_ENABLED=true

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -244,7 +244,7 @@ fixed phase-1 guesses.
 **Strict comparison.** Result admission still selects the decisive baseline and controls which
 transitions train TTL. Among found-to-found observations, identical raw hashes count stable and
 differing hashes count changed. The legacy field-noise heuristic is removed; hash comparison
-never fetches an old R2 body.
+does not depend on observation reads.
 
 ## The refresh worker (PR 5)
 
@@ -627,3 +627,70 @@ zero transfer/wait time. Do not interpret these post-fix per-record values as on
 latency, or average duplicate statuses and zero-transfer failed waiters into physical PUT latency. R2 pending accounting spans the
 recording's DB completion too; it is not just the number of active PUTs. Compare existing failure/
 drop reasons, leader timing, and duplicate statuses after rollout before increasing queue budgets.
+
+
+## Change observation
+
+After `_store_locked` commits, `_observe_change` reports a byte-hash change from the immediately
+preceding snapshot for `caller` and `refresh` origins only. Cache hits and async terminal evidence
+never emit `archive_change_observed`. The background task has a separate three-second observation
+budget after the existing 30-second DB stage. Failure cannot undo or prevent the recording.
+`_read_change_body` collects an `archive_bodies.pointer` in a short background session, closes it,
+then calls `archive_bodies.read`. The internal `observation` read path follows published R2
+locations (including R2-only rows), with the normal verified GET and DB fallback. No new DB writes,
+tables, per-key detail or configuration switches are introduced. Process-local `change_outcomes`
+counts `observed`, `body_unavailable` and `observation_failed`; missing bytes skip the event.
+
+`_change_summary` runs off the event loop. JSON differences use dot paths, collapse array indices
+to `[*]`, stop at six levels and retain the first 20 sorted distinct paths. `path_count` counts all
+distinct paths before truncation; `truncated` marks more than 20. Added/removed fields, array length
+and type changes count; a changed container at the depth boundary counts at its boundary path.
+Root changes use `$`. `leaf_count` counts new-body leaves at the same depth boundary (empty
+containers count as one). Byte-only whitespace/key-order changes can have zero changed paths.
+Non-JSON pairs use `changed_paths: [non_json]`, `path_count: 1`, `leaf_count: 0`.
+`sole_path` is the sole path when count is one, otherwise null.
+
+Analytics emits `archive_change_observed` with distinct ID `archive` and only `endpoint_id`,
+`provider`, `changed_paths`, `path_count`, `truncated`, `leaf_count`, `sole_path` and
+`masked_by_ignore` (false until a declared ignore comparison masks a change). No values, body
+snippets, call references or key identities are sent. Paths are structural property names from JSON;
+these reports are not a schema or evidence that a field is safe to ignore. Observation is read-only
+and does not alter admission, learning, stored bytes, deduplication or serving.
+
+### Seven-day HogQL review
+
+Paste into the PostHog SQL editor. One row per endpoint/path; all ratios use that endpoint's
+observed byte changes as denominator. `sole_change_ratio` counts events where that path alone
+changed; `endpoint_sole_ratio` counts any sole-path change. Empty path lists remain in the total.
+Truncation makes per-path ratios lower bounds, so inspect `truncated_ratio` before choosing a
+list. Missing bodies and dropped analytics are not in these denominators. `non_json` is a marker,
+not an ignore candidate. SQL uses PostHog's supported [JSON/array functions](https://posthog.com/docs/sql/clickhouse-functions).
+
+```sql
+WITH observed AS (
+    SELECT properties.endpoint_id AS endpoint_id,
+           properties.sole_path AS sole_path,
+           toInt(properties.path_count) AS path_count,
+           properties.truncated = true AS truncated,
+           JSONExtract(ifNull(toString(properties.changed_paths), '[]'), 'Array(String)') AS paths
+    FROM events
+    WHERE event = 'archive_change_observed'
+      AND timestamp >= now() - INTERVAL 7 DAY
+), totals AS (
+    SELECT endpoint_id, count() AS changes,
+           countIf(path_count = 1) / count() AS endpoint_sole_ratio,
+           countIf(truncated) / count() AS truncated_ratio
+    FROM observed GROUP BY endpoint_id
+), per_path AS (
+    SELECT endpoint_id, path, count() AS path_changes,
+           countIf(sole_path = path) AS sole_changes
+    FROM (SELECT endpoint_id, sole_path, arrayJoin(paths) AS path FROM observed)
+    GROUP BY endpoint_id, path
+)
+SELECT totals.endpoint_id, totals.changes, per_path.path,
+       per_path.path_changes / totals.changes AS path_ratio,
+       per_path.sole_changes / totals.changes AS sole_change_ratio,
+       totals.endpoint_sole_ratio, totals.truncated_ratio
+FROM totals LEFT JOIN per_path ON totals.endpoint_id = per_path.endpoint_id
+ORDER BY totals.changes DESC, path_ratio DESC, per_path.path
+```

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -219,7 +219,7 @@ The pointer is owned by the archive writer and key ownership is checked on reads
 never deleted, so no cyclic foreign key is introduced.
 
 For endpoints with enabled hit/miss rules, only found-to-found observations can count stable.
-Strict mode compares exact raw-byte hashes.
+The default compares exact raw-byte hashes; declared `cache.ignore_paths` can relax only found-to-found equality.
 Found-to-empty counts one change and invalidates serving; repeated empty results neither grow
 nor shrink TTL. Empty-to-found counts a change and restores eligibility. Errors and unknowns add
 history under the existing capture policy but do not replace decisive evidence or update learning.
@@ -241,10 +241,10 @@ by min(30 d, the judged `cache.max_age_s`); changed ⇒ ×0.5, floored at 60 s. 
 until a stable refetch resets it. The lookup prefers the learned timer (`ttl_s > 0`) over the
 fixed phase-1 guesses.
 
-**Strict comparison.** Result admission still selects the decisive baseline and controls which
-transitions train TTL. Among found-to-found observations, identical raw hashes count stable and
-differing hashes count changed. The legacy field-noise heuristic is removed; hash comparison
-does not depend on observation reads.
+**Comparison.** Result admission selects the decisive baseline and controls which transitions
+train TTL. Identical raw hashes count stable; differing hashes count changed unless an explicit
+`cache.ignore_paths` list makes the JSON comparison equal. The default list is empty. The legacy
+field-noise heuristic remains removed; observation reporting never determines TTL.
 
 ## The refresh worker (PR 5)
 
@@ -294,7 +294,7 @@ One licence judgment per PROVIDER, written once at the YAML file header and inhe
 endpoint below it; an endpoint's own `cache:` overrides. `catalog_store` carries the header form
 into `provider_meta["cache"]` (dict, not stringified) and stamps the effective value onto each
 normalized endpoint (`entry["cache"]`, absent ⇒ None ⇒ forbidden). The provenance form is
-`{mode, license_quote, source_url, checked}` plus optional `max_age_s` — a vendor-imposed refresh
+`{mode, license_quote, source_url, checked}` plus optional `ignore_paths` and `max_age_s` — a vendor-imposed refresh
 ceiling the learner (PR 5) must treat as a hard cap. `tests/test_archive.py` validates every
 declared field in the shipped catalog: a judged entry must carry its quote, source and date.
 
@@ -353,8 +353,9 @@ enable. Rollback in production is a dashboard env edit, no deploy.
 ## Conservative comparison and controlled serving (2026-09-08)
 
 The comparison setting and helper are removed. Old `TREG_ARCHIVE_COMPARISON_MODE` environment
-values are ignored, including `legacy_noise`; events and admin props report `strict`. Only exact
-found-to-found hashes count stable.
+values are ignored, including `legacy_noise`; existing events and admin props still report the
+default `strict` mode. Endpoint declarations can now relax found-to-found comparison using
+`cache.ignore_paths`; `archive_change_observed.masked_by_ignore` reports actual rescued decisions.
 
 TTL learning and lookup retain the original behavior: stable observations grow the timer by
 1.5, changed observations halve it, and TTL_NEVER remains respected. The fixed capability timer
@@ -652,7 +653,9 @@ Non-JSON pairs use `changed_paths: [non_json]`, `path_count: 1`, `leaf_count: 0`
 
 Analytics emits `archive_change_observed` with distinct ID `archive` and only `endpoint_id`,
 `provider`, `changed_paths`, `path_count`, `truncated`, `leaf_count`, `sole_path` and
-`masked_by_ignore` (false until a declared ignore comparison masks a change). No values, body
+`masked_by_ignore` (true only when a declared ignore comparison actually rescues a stable TTL
+decision). The path report compares the latest historical snapshot; result-aware TTL can instead
+compare an older decisive found snapshot across intervening unknown/error observations. No values, body
 snippets, call references or key identities are sent. Paths are structural property names from JSON;
 these reports are not a schema or evidence that a field is safe to ignore. Observation is read-only
 and does not alter admission, learning, stored bytes, deduplication or serving.
@@ -694,3 +697,33 @@ SELECT totals.endpoint_id, totals.changes, per_path.path,
 FROM totals LEFT JOIN per_path ON totals.endpoint_id = per_path.endpoint_id
 ORDER BY totals.changes DESC, path_ratio DESC, per_path.path
 ```
+
+
+## Declared ignore comparison
+
+`cache.ignore_paths` is an optional list in the same catalog block as `max_age_s`, empty by default.
+No endpoint has a list in this delivery. Only human-reviewed declarations can enable it; there is
+no automatic learning of ignore paths and `ArchiveKey.volatile_paths` remains unused.
+
+`_normalized_hash` parses a private JSON copy, deletes the declared paths, then hashes JSON with
+sorted object keys and compact separators. Array order, length and all unignored values remain
+significant; ignoring `items[*].request_id` preserves array elements, while `items[*]` deliberately
+removes all elements. Missing paths and type mismatches are no-ops. Normalization also disregards
+whitespace and object-key order whenever a nonempty list is declared. Non-JSON or unreadable
+baselines fall back to the original byte hashes. Ignore matching has no six-level observation
+limit. It never uses reported/truncated paths to make a decision.
+
+`_ignored_matches` preloads at most the latest and decisive snapshot bodies via `archive_bodies`
+in the background recorder, before the DB write stage. Pointer sessions close before object I/O.
+This optional pre-read has its own three-second budget, leaving the DB stage's 30 seconds intact.
+It returns matching snapshot IDs only. `_store_locked` still locks and selects the actual baseline;
+if another recording advances it beyond those IDs, that recording conservatively uses raw hashes.
+No cross-process lock is held during object I/O, and no retry/reconciliation write is introduced.
+`ignore_body_unavailable` and `ignore_comparison_failed` process counters expose read failures.
+
+The only relaxed decision is stable/changed TTL learning, including its existing counters and
+TTL_NEVER recovery. Found/empty transitions, hit/miss classification, decisive evidence, admission,
+raw body storage, `content_hash`, deduplication and response bytes are untouched. A cache hit still
+returns exactly the retained answer; the learned expiration can change only for an opted-in endpoint.
+Read/analysis failures preserve strict comparison. No schema migration, new DB write, serving
+allowlist change, production configuration, field selection UI or automated ignore proposal ships.

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -637,12 +637,22 @@ preceding snapshot for `caller` and `refresh` origins only. Cache hits and async
 never emit `archive_change_observed`. The background task has a separate three-second observation
 budget after the existing 30-second DB stage. Failure cannot undo or prevent the recording.
 `_read_change_body` collects an `archive_bodies.pointer` in a short background session, closes it,
-then calls `archive_bodies.read`. The internal `observation` read path follows published R2
-locations (including R2-only rows), with the normal verified GET and DB fallback. No new DB writes,
-tables, per-key detail or configuration switches are introduced. Process-local `change_outcomes`
-counts `observed`, `body_unavailable` and `observation_failed`; missing bytes skip the event.
+then calls `archive_bodies.read`. Observation follows `TREG_ARCHIVE_BODY_READ_LOOKUP`: default
+`db` makes no R2 requests; `r2-first` uses verified GET and falls back exclusively to the background
+pool. It cannot enable R2 independently of the existing startup checks or rollback switches.
+`TREG_ARCHIVE_CHANGE_OBSERVATION_ENABLED=false` disables change reporting and its reads/CPU work
+(default true). Declared ignore-path TTL comparison remains a separate decision mechanism.
+Both ignore comparison and change reporting share the recorder/touch semaphore budget of two,
+including fallback sessions and CPU work. No DB connection is held during object I/O. New bodies
+not retained by policy/size/storage and known hash-only previous snapshots skip observation.
+Process-local `change_outcomes` counts `observed`, `body_unavailable`, `observation_failed`,
+`ignore_body_unavailable` and `ignore_comparison_failed`. `/admin/archive` exposes this mapping and
+`body_outcomes` (archive_bodies.outcomes), including on cached report responses; counters reset on
+restart and are per process, not durable or fleet-wide totals.
 
-`_change_summary` runs off the event loop. JSON differences use dot paths, collapse array indices
+`_change_summary` runs off the event loop. Structure comparison visits each subtree once without
+repeated JSON serialization, retaining type-sensitive comparisons. Cancellation keeps the semaphore
+slot occupied until the bounded-size CPU job finishes; asyncio timeout does not stop a Python thread. JSON differences use dot paths, collapse array indices
 to `[*]`, stop at six levels and retain the first 20 sorted distinct paths. `path_count` counts all
 distinct paths before truncation; `truncated` marks more than 20. Added/removed fields, array length
 and type changes count; a changed container at the depth boundary counts at its boundary path.
@@ -715,7 +725,8 @@ limit. It never uses reported/truncated paths to make a decision.
 
 `_ignored_matches` preloads at most the latest and decisive snapshot bodies via `archive_bodies`
 in the background recorder, before the DB write stage. Pointer sessions close before object I/O.
-This optional pre-read has its own three-second budget, leaving the DB stage's 30 seconds intact.
+This optional pre-read holds the shared archive semaphore and has its own three-second budget,
+leaving the DB stage's 30 seconds intact. Hash-only baselines and unstored new bodies are skipped.
 It returns matching snapshot IDs only. `_store_locked` still locks and selects the actual baseline;
 if another recording advances it beyond those IDs, that recording conservatively uses raw hashes.
 No cross-process lock is held during object I/O, and no retry/reconciliation write is introduced.
@@ -727,3 +738,10 @@ raw body storage, `content_hash`, deduplication and response bytes are untouched
 returns exactly the retained answer; the learned expiration can change only for an opted-in endpoint.
 Read/analysis failures preserve strict comparison. No schema migration, new DB write, serving
 allowlist change, production configuration, field selection UI or automated ignore proposal ships.
+
+Known deferred limitation: `changed_paths` compares the immediately previous snapshot, while
+`masked_by_ignore` can refer to a different decisive baseline. No endpoint currently declares
+ignore paths, so the latter is always false. **This must be fixed before the first ignore list
+is introduced.** This delivery only documents the mismatch; it does not change snapshot pairing.
+
+Ignore-path segments may begin with digits, e.g. `2fa_enabled` or `data.123status`.

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1759,9 +1759,9 @@ an empty list. Provider-header inheritance and whole-block endpoint override fol
 cache policy rules. `store._validate_cache` rejects an invalid list or path during catalog loading,
 including provider-header declarations even when endpoint blocks override them.
 
-Paths are case-sensitive dot-separated property names matching `[A-Za-z_][A-Za-z0-9_-]*`, with
+Paths are case-sensitive dot-separated property names matching `[A-Za-z0-9_][A-Za-z0-9_-]*`, with
 `[*]` suffixes for arbitrary array elements: `request_id`, `data.items[*].updated_at`, or
-`matrix[*][*].request-id`. A root array can use `[*].request_id`. Empty lists are valid; null,
+`matrix[*][*].request-id`. Leading digits are allowed, e.g. `2fa_enabled`. A root array can use `[*].request_id`. Empty lists are valid; null,
 non-lists, non-string members, empty paths, numeric indices, plain `*`, `$` prefixes, spaces,
 empty segments, escaping and recursive wildcards are rejected. Keys containing literal dots or
 brackets are deliberately not addressable in this first grammar. Missing paths are harmless.

--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1752,6 +1752,27 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   Leadsforge and Fiber contact lookup success flags no longer populate `verified`: neither
   flag is an explicit mailbox deliverability verdict. The field remains absent when unknown.
 
+## Archive comparison declarations
+
+The effective `cache:` block accepts `ignore_paths: [...]` alongside `max_age_s`. The default is
+an empty list. Provider-header inheritance and whole-block endpoint override follow the existing
+cache policy rules. `store._validate_cache` rejects an invalid list or path during catalog loading,
+including provider-header declarations even when endpoint blocks override them.
+
+Paths are case-sensitive dot-separated property names matching `[A-Za-z_][A-Za-z0-9_-]*`, with
+`[*]` suffixes for arbitrary array elements: `request_id`, `data.items[*].updated_at`, or
+`matrix[*][*].request-id`. A root array can use `[*].request_id`. Empty lists are valid; null,
+non-lists, non-string members, empty paths, numeric indices, plain `*`, `$` prefixes, spaces,
+empty segments, escaping and recursive wildcards are rejected. Keys containing literal dots or
+brackets are deliberately not addressable in this first grammar. Missing paths are harmless.
+
+`archive._normalized_hash` removes only these paths from a parsed copy for TTL equality. It never
+changes archived or served data, raw hashes, deduplication or hit/miss classification. Without a
+nonempty list, exact byte comparison remains authoritative. No shipped endpoint has an ignore
+list; use the bounded `archive_change_observed` reports and HogQL in [archive](archive.md) as
+human review input, then add a justified declaration in a separate PR.
+
+
 ## Security
 
 PII IS THE HARD RULE. This repo is public, and every captured example ships in it. Three checks

--- a/docs/context/ops/deploy.md
+++ b/docs/context/ops/deploy.md
@@ -640,3 +640,9 @@ Its public snapshot endpoint makes a single primary-key read on the API pool; ag
 on the background worker. The default per-process budget is now 27 slots; with two workers and
 two instances a rolling deployment can reach 108. Existing deployment overrides remain necessary
 for the 103-connection plan; this merge does not alter production overrides.
+
+Archive change observation and declared ignore comparisons share the existing two-slot archive
+semaphore, including background-only fallback reads and CPU work. No extra pool consumer is added.
+`tests/test_db_pool_isolation.py` inventories each background-maker reference by function and count,
+so a new site in an already registered module must name its concurrency budget. Observation follows
+`TREG_ARCHIVE_BODY_READ_LOOKUP`; `TREG_ARCHIVE_CHANGE_OBSERVATION_ENABLED=false` stops change reporting.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 from typing import Any
+from collections import Counter
 from urllib.parse import parse_qsl
 
 from .config import get_settings
@@ -261,6 +262,8 @@ def _get_key_lock(key_hash: str) -> asyncio.Lock:
 # or a shutdown hostage. CI's serial Postgres job hung exactly that way three times before this
 # bound existed, at whichever drain() happened to gather the stuck task.
 _STORE_TIMEOUT_S = 30
+_CHANGE_TIMEOUT_S = 3
+change_outcomes: Counter[str] = Counter()
 
 
 def _utcnow() -> datetime:
@@ -536,17 +539,19 @@ async def _store(
                 # first-key race and multi-process SQLite, where SELECT FOR UPDATE is ignored.
                 for attempt in range(4):
                     try:
-                        await _store_locked(
+                        previous_id = await _store_locked(
                             method=method, endpoint_id=endpoint_id, provider=provider, url=url,
                             caller_body=caller_body, headers=headers, status_code=status_code,
                             media_type=media_type, body=body, origin=origin,
                             key_hash=kh, body_hash=ch, plan=plan)
                         stored, reason = plan.storage, plan.reason
-                        return
+                        break
                     except IntegrityError:
                         if attempt == 3:
                             raise
                         await asyncio.sleep(0.01 * (attempt + 1))
+        if previous_id is not None:
+            await _observe_change(previous_id, body, endpoint_id, provider)
     except asyncio.CancelledError:
         reason = "cancelled"
         raise
@@ -558,6 +563,77 @@ async def _store(
         _log.error("archive recording dropped for %s", endpoint_id, exc_info=True)
     finally:
         observation.finish(storage=stored, reason=reason)
+
+
+def _change_summary(old_body: bytes, new_body: bytes) -> dict:
+    """Report structure only; array indices collapse, containers stop at depth six."""
+    try:
+        old, new = json.loads(old_body), json.loads(new_body)
+    except (ValueError, UnicodeError, RecursionError):
+        return dict(changed_paths=["non_json"], path_count=1, truncated=False,
+                    leaf_count=0, sole_path="non_json", masked_by_ignore=False)
+
+    paths: set[str] = set()
+    missing = object()
+
+    def walk(left, right, path, depth):
+        if (type(left) is type(right)
+                and json.dumps(left, sort_keys=True) == json.dumps(right, sort_keys=True)):
+            return
+        if depth >= 6:
+            paths.add(path or "$")
+        elif isinstance(left, dict) and isinstance(right, dict):
+            for key in left.keys() | right.keys():
+                walk(left.get(key, missing), right.get(key, missing),
+                     f"{path}.{key}" if path else key, depth + 1)
+        elif isinstance(left, list) and isinstance(right, list):
+            for i in range(max(len(left), len(right))):
+                walk(left[i] if i < len(left) else missing,
+                     right[i] if i < len(right) else missing, path + "[*]", depth + 1)
+        else:
+            paths.add(path or "$")
+
+    def leaves(value, depth=0):
+        if depth >= 6 or not isinstance(value, (dict, list)) or not value:
+            return 1
+        return sum(leaves(v, depth + 1) for v in
+                   (value.values() if isinstance(value, dict) else value))
+
+    walk(old, new, "", 0)
+    ordered = sorted(paths)
+    return dict(changed_paths=ordered[:20], path_count=len(paths), truncated=len(paths) > 20,
+                leaf_count=leaves(new), sole_path=ordered[0] if len(paths) == 1 else None,
+                masked_by_ignore=False)
+
+
+async def _read_change_body(snapshot_id: int) -> bytes | None:
+    from sqlalchemy import select
+    from .infra.db import background_session_maker
+    from .models import ArchiveSnapshot
+
+    async with background_session_maker() as s:
+        row = (await s.execute(select(ArchiveSnapshot).where(ArchiveSnapshot.id == snapshot_id)
+                              .options(*archive_bodies.read_options("observation")))).scalar_one_or_none()
+        pointer = await archive_bodies.pointer(s, row, "observation") if row is not None else None
+    return await archive_bodies.read(pointer, "observation") if pointer is not None else None
+
+
+async def _observe_change(previous_id: int, body: bytes, endpoint_id: str, provider: str) -> None:
+    from . import analytics
+
+    try:
+        async with asyncio.timeout(_CHANGE_TIMEOUT_S):
+            previous = await _read_change_body(previous_id)
+            if previous is None:
+                change_outcomes["body_unavailable"] += 1
+                return
+            props = await asyncio.to_thread(_change_summary, previous, body)
+            analytics.capture("archive", "archive_change_observed",
+                              dict(endpoint_id=endpoint_id, provider=provider, **props))
+            change_outcomes["observed"] += 1
+    except Exception:
+        # Observation is optional and happens after commit. Never log provider bytes/errors.
+        change_outcomes["observation_failed"] += 1
 
 
 async def _lock_archive_key(s, key_id: int):
@@ -598,7 +674,7 @@ async def _store_locked(
     key_hash: str | None = None,
     body_hash: str | None = None,
     plan: archive_bodies.WritePlan,
-) -> None:
+) -> int | None:
     from sqlalchemy import select
     from sqlalchemy.exc import IntegrityError
 
@@ -715,6 +791,8 @@ async def _store_locked(
             stable_d=key.stable_seen - seen_before[0], changed_d=key.change_seen - seen_before[1],
             kept=plan.storage is not None, size=len(body), now=now)
         await s.commit()
+        return (newest.id if newest is not None and newest.content_hash != ch
+                and origin in ("caller", "refresh") else None)
 
 
 

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -430,8 +430,8 @@ async def load_terminal_responses(tasks: list[tuple[str, str]]) -> dict[str, byt
 
 
 async def drain() -> None:
-    """Flush in-flight recordings — shutdown and tests. Bounded: every task carries its own
-    _STORE_TIMEOUT_S, so this cannot wait longer than the slowest permitted recording."""
+    """Flush in-flight recordings for shutdown and tests. Each task carries bounded upload,
+    write and optional change-analysis stages."""
     await archive_bodies.drain()
     while _pending:
         tasks = list(_pending)
@@ -531,6 +531,12 @@ async def _store(
             else:
                 plan = await archive_bodies.prepare(body, ch, mode=plan.storage, observation=observation)
 
+        from .domain.catalog import store as catalog_store
+        cache = (catalog_store.load().by_id.get(endpoint_id) or {}).get("cache")
+        ignore_paths = cache.get("ignore_paths", []) if isinstance(cache, dict) else []
+        ignored_matches = (await _ignored_matches(kh, body, ignore_paths)
+                           if ignore_paths and origin in ("caller", "refresh") else set())
+
         # Same-key waiters must queue before taking a scarce database-write slot. Otherwise four
         # duplicate recordings can occupy the whole semaphore while only one touches the database.
         async with asyncio.timeout(_TERMINAL_DB_S if origin == "async_terminal" else _STORE_TIMEOUT_S), _get_key_lock(kh):
@@ -539,19 +545,20 @@ async def _store(
                 # first-key race and multi-process SQLite, where SELECT FOR UPDATE is ignored.
                 for attempt in range(4):
                     try:
-                        previous_id = await _store_locked(
+                        change = await _store_locked(
                             method=method, endpoint_id=endpoint_id, provider=provider, url=url,
                             caller_body=caller_body, headers=headers, status_code=status_code,
                             media_type=media_type, body=body, origin=origin,
-                            key_hash=kh, body_hash=ch, plan=plan)
+                            key_hash=kh, body_hash=ch, plan=plan, ignored_matches=ignored_matches)
                         stored, reason = plan.storage, plan.reason
                         break
                     except IntegrityError:
                         if attempt == 3:
                             raise
                         await asyncio.sleep(0.01 * (attempt + 1))
-        if previous_id is not None:
-            await _observe_change(previous_id, body, endpoint_id, provider)
+        if change is not None:
+            previous_id, masked_by_ignore = change
+            await _observe_change(previous_id, body, endpoint_id, provider, masked_by_ignore)
     except asyncio.CancelledError:
         reason = "cancelled"
         raise
@@ -565,10 +572,87 @@ async def _store(
         observation.finish(storage=stored, reason=reason)
 
 
+def _change_json(body: bytes):
+    def invalid_constant(_value):
+        raise ValueError("non-JSON numeric constant")
+    return json.loads(body, parse_constant=invalid_constant)
+
+
+def _normalized_hash(body: bytes, paths: list[str]) -> str | None:
+    """Delete only declared paths in a parsed copy; raw bytes and their identity never change."""
+    try:
+        value = _change_json(body)
+
+        def remove(node, parts):
+            part, *rest = parts
+            if part == "[*]":
+                if isinstance(node, list):
+                    if rest:
+                        for child in node:
+                            remove(child, rest)
+                    else:
+                        node.clear()
+            elif isinstance(node, dict) and part in node:
+                if rest:
+                    remove(node[part], rest)
+                else:
+                    del node[part]
+
+        for path in paths:
+            # The catalog validates the grammar; keeping [*] as a token also supports root arrays.
+            parts = path.replace("[*]", ".[*]").lstrip(".").split(".")
+            remove(value, parts)
+        canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+                               allow_nan=False).encode()
+        return content_hash(canonical)
+    except (ValueError, UnicodeError, RecursionError):
+        return None
+
+
+async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[int]:
+    """Pre-read at most latest/decisive bodies; the writer accepts only its actual baseline ID.
+
+    A concurrent writer can invalidate this sample. That observation falls back to raw hashes,
+    without keeping a DB connection/row lock across object I/O or adding a second write.
+    """
+    from sqlalchemy import select
+    from .infra.db import background_session_maker
+    from .models import ArchiveKey, ArchiveSnapshot
+
+    matches = set()
+    try:
+        async with asyncio.timeout(_CHANGE_TIMEOUT_S):
+            new_hash = await asyncio.to_thread(_normalized_hash, body, paths)
+            if new_hash is None:
+                return matches
+            async with background_session_maker() as s:
+                key = (await s.execute(select(ArchiveKey).where(
+                    ArchiveKey.key_hash == key_hash))).scalar_one_or_none()
+                if key is None:
+                    return matches
+                latest = (await s.execute(select(ArchiveSnapshot.id).where(
+                    ArchiveSnapshot.key_id == key.id).order_by(ArchiveSnapshot.version.desc())
+                    .limit(1))).scalar_one_or_none()
+                ids = {i for i in (latest, key.result_snapshot_id) if i is not None}
+                rows = (await s.execute(select(ArchiveSnapshot).where(
+                    ArchiveSnapshot.key_id == key.id, ArchiveSnapshot.id.in_(ids))
+                    .options(*archive_bodies.read_options("observation")))).scalars().all()
+                pointers = [(row.id, await archive_bodies.pointer(s, row, "observation")) for row in rows]
+            for snapshot_id, pointer in pointers:
+                previous = await archive_bodies.read(pointer, "observation")
+                if previous is None:
+                    change_outcomes["ignore_body_unavailable"] += 1
+                elif await asyncio.to_thread(_normalized_hash, previous, paths) == new_hash:
+                    matches.add(snapshot_id)
+    except Exception:
+        change_outcomes["ignore_comparison_failed"] += 1
+    return matches
+
+
 def _change_summary(old_body: bytes, new_body: bytes) -> dict:
     """Report structure only; array indices collapse, containers stop at depth six."""
     try:
-        old, new = json.loads(old_body), json.loads(new_body)
+        old, new = _change_json(old_body), _change_json(new_body)
     except (ValueError, UnicodeError, RecursionError):
         return dict(changed_paths=["non_json"], path_count=1, truncated=False,
                     leaf_count=0, sole_path="non_json", masked_by_ignore=False)
@@ -618,7 +702,8 @@ async def _read_change_body(snapshot_id: int) -> bytes | None:
     return await archive_bodies.read(pointer, "observation") if pointer is not None else None
 
 
-async def _observe_change(previous_id: int, body: bytes, endpoint_id: str, provider: str) -> None:
+async def _observe_change(previous_id: int, body: bytes, endpoint_id: str, provider: str,
+                          masked_by_ignore: bool = False) -> None:
     from . import analytics
 
     try:
@@ -628,6 +713,7 @@ async def _observe_change(previous_id: int, body: bytes, endpoint_id: str, provi
                 change_outcomes["body_unavailable"] += 1
                 return
             props = await asyncio.to_thread(_change_summary, previous, body)
+            props["masked_by_ignore"] = masked_by_ignore
             analytics.capture("archive", "archive_change_observed",
                               dict(endpoint_id=endpoint_id, provider=provider, **props))
             change_outcomes["observed"] += 1
@@ -674,7 +760,8 @@ async def _store_locked(
     key_hash: str | None = None,
     body_hash: str | None = None,
     plan: archive_bodies.WritePlan,
-) -> int | None:
+    ignored_matches: set[int] | None = None,
+) -> tuple[int, bool] | None:
     from sqlalchemy import select
     from sqlalchemy.exc import IntegrityError
 
@@ -764,9 +851,12 @@ async def _store_locked(
 
         previous_state = key.result_state if result_aware else "found"
         next_state = result.state if result_aware else "found"
+        masked_by_ignore = False
         decisive = next_state in ("found", "empty") and origin != "async_terminal"
         if decisive and baseline is not None and (previous_state, next_state) != ("empty", "empty"):
-            stable = previous_state == next_state == "found" and baseline.content_hash == ch
+            stable = previous_state == next_state == "found" and (
+                baseline.content_hash == ch or baseline.id in (ignored_matches or ()))
+            masked_by_ignore = stable and baseline.content_hash != ch
             if stable:
                 key.stable_seen += 1
             else:
@@ -791,7 +881,7 @@ async def _store_locked(
             stable_d=key.stable_seen - seen_before[0], changed_d=key.change_seen - seen_before[1],
             kept=plan.storage is not None, size=len(body), now=now)
         await s.commit()
-        return (newest.id if newest is not None and newest.content_hash != ch
+        return ((newest.id, masked_by_ignore) if newest is not None and newest.content_hash != ch
                 and origin in ("caller", "refresh") else None)
 
 

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -534,8 +534,10 @@ async def _store(
         from .domain.catalog import store as catalog_store
         cache = (catalog_store.load().by_id.get(endpoint_id) or {}).get("cache")
         ignore_paths = cache.get("ignore_paths", []) if isinstance(cache, dict) else []
-        ignored_matches = (await _ignored_matches(kh, body, ignore_paths)
-                           if ignore_paths and origin in ("caller", "refresh") else set())
+        ignored_matches = set()
+        if ignore_paths and plan.storage is not None and origin in ("caller", "refresh"):
+            async with _get_sem():
+                ignored_matches = await _ignored_matches(kh, body, ignore_paths)
 
         # Same-key waiters must queue before taking a scarce database-write slot. Otherwise four
         # duplicate recordings can occupy the whole semaphore while only one touches the database.
@@ -556,9 +558,10 @@ async def _store(
                         if attempt == 3:
                             raise
                         await asyncio.sleep(0.01 * (attempt + 1))
-        if change is not None:
+        if change is not None and get_settings().archive_change_observation_enabled:
             previous_id, masked_by_ignore = change
-            await _observe_change(previous_id, body, endpoint_id, provider, masked_by_ignore)
+            async with _get_sem():
+                await _observe_change(previous_id, body, endpoint_id, provider, masked_by_ignore)
     except asyncio.CancelledError:
         reason = "cancelled"
         raise
@@ -609,6 +612,24 @@ def _normalized_hash(body: bytes, paths: list[str]) -> str | None:
         return None
 
 
+async def _change_compute(fn, *args):
+    """Keep the caller's semaphore slot until its CPU job really finishes on cancellation."""
+    task = asyncio.create_task(asyncio.to_thread(fn, *args))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+def _has_change_body(snapshot) -> bool:
+    # Legacy rows may have a deferred body and no location marker: preserve their fallback.
+    # A loaded NULL with no carrier/location is known hash-only and needs no read.
+    return (snapshot.body_storage in ("both", "r2")
+            or snapshot.body_of is not None
+            or snapshot.__dict__.get("body", True) is not None)
+
+
 async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[int]:
     """Pre-read at most latest/decisive bodies; the writer accepts only its actual baseline ID.
 
@@ -622,7 +643,7 @@ async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[
     matches = set()
     try:
         async with asyncio.timeout(_CHANGE_TIMEOUT_S):
-            new_hash = await asyncio.to_thread(_normalized_hash, body, paths)
+            new_hash = await _change_compute(_normalized_hash, body, paths)
             if new_hash is None:
                 return matches
             async with background_session_maker() as s:
@@ -637,12 +658,13 @@ async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[
                 rows = (await s.execute(select(ArchiveSnapshot).where(
                     ArchiveSnapshot.key_id == key.id, ArchiveSnapshot.id.in_(ids))
                     .options(*archive_bodies.read_options("observation")))).scalars().all()
-                pointers = [(row.id, await archive_bodies.pointer(s, row, "observation")) for row in rows]
+                pointers = [(row.id, await archive_bodies.pointer(s, row, "observation"))
+                            for row in rows if _has_change_body(row)]
             for snapshot_id, pointer in pointers:
                 previous = await archive_bodies.read(pointer, "observation")
                 if previous is None:
                     change_outcomes["ignore_body_unavailable"] += 1
-                elif await asyncio.to_thread(_normalized_hash, previous, paths) == new_hash:
+                elif await _change_compute(_normalized_hash, previous, paths) == new_hash:
                     matches.add(snapshot_id)
     except Exception:
         change_outcomes["ignore_comparison_failed"] += 1
@@ -660,12 +682,19 @@ def _change_summary(old_body: bytes, new_body: bytes) -> dict:
     paths: set[str] = set()
     missing = object()
 
+    def equal(left, right):
+        if type(left) is not type(right):
+            return False
+        if isinstance(left, dict):
+            return left.keys() == right.keys() and all(equal(v, right[k]) for k, v in left.items())
+        if isinstance(left, list):
+            return len(left) == len(right) and all(equal(a, b) for a, b in zip(left, right))
+        return left == right
+
     def walk(left, right, path, depth):
-        if (type(left) is type(right)
-                and json.dumps(left, sort_keys=True) == json.dumps(right, sort_keys=True)):
-            return
         if depth >= 6:
-            paths.add(path or "$")
+            if not equal(left, right):
+                paths.add(path or "$")
         elif isinstance(left, dict) and isinstance(right, dict):
             for key in left.keys() | right.keys():
                 walk(left.get(key, missing), right.get(key, missing),
@@ -674,7 +703,7 @@ def _change_summary(old_body: bytes, new_body: bytes) -> dict:
             for i in range(max(len(left), len(right))):
                 walk(left[i] if i < len(left) else missing,
                      right[i] if i < len(right) else missing, path + "[*]", depth + 1)
-        else:
+        elif not equal(left, right):
             paths.add(path or "$")
 
     def leaves(value, depth=0):
@@ -698,7 +727,8 @@ async def _read_change_body(snapshot_id: int) -> bytes | None:
     async with background_session_maker() as s:
         row = (await s.execute(select(ArchiveSnapshot).where(ArchiveSnapshot.id == snapshot_id)
                               .options(*archive_bodies.read_options("observation")))).scalar_one_or_none()
-        pointer = await archive_bodies.pointer(s, row, "observation") if row is not None else None
+        pointer = (await archive_bodies.pointer(s, row, "observation")
+                   if row is not None and _has_change_body(row) else None)
     return await archive_bodies.read(pointer, "observation") if pointer is not None else None
 
 
@@ -712,7 +742,7 @@ async def _observe_change(previous_id: int, body: bytes, endpoint_id: str, provi
             if previous is None:
                 change_outcomes["body_unavailable"] += 1
                 return
-            props = await asyncio.to_thread(_change_summary, previous, body)
+            props = await _change_compute(_change_summary, previous, body)
             props["masked_by_ignore"] = masked_by_ignore
             analytics.capture("archive", "archive_change_observed",
                               dict(endpoint_id=endpoint_id, provider=provider, **props))
@@ -882,6 +912,8 @@ async def _store_locked(
             kept=plan.storage is not None, size=len(body), now=now)
         await s.commit()
         return ((newest.id, masked_by_ignore) if newest is not None and newest.content_hash != ch
+                and plan.storage is not None and _has_change_body(newest)
+                and get_settings().archive_change_observation_enabled
                 and origin in ("caller", "refresh") else None)
 
 

--- a/src/treg/archive_bodies.py
+++ b/src/treg/archive_bodies.py
@@ -219,8 +219,9 @@ class BodyPointer:
 
 
 def _r2_first(path: str) -> bool:
-    # Background change analysis follows the published location, including R2-only history.
-    return path == "observation" or getattr(get_settings(), "archive_body_read_" + path) == "r2-first"
+    # Observation shares lookup's rollout/rollback switch; it never enables R2 independently.
+    path = "lookup" if path == "observation" else path
+    return getattr(get_settings(), "archive_body_read_" + path) == "r2-first"
 
 
 def read_options(path):
@@ -238,13 +239,14 @@ async def pointer(session, snapshot, path):
     return BodyPointer(snapshot.content_hash, snapshot.body_storage, body, None)
 
 
-async def _db_fallback(pointer):
-    from .infra.db import session_maker
+async def _db_fallback(pointer, path):
+    from .infra.db import session_maker, background_session_maker
     from .models import ArchiveSnapshot
     from .archive import _snapshot_body, _unpack
     if pointer.snapshot_id is None:
         return _unpack(pointer.body, pointer.enc)
-    async with session_maker() as session:
+    maker = background_session_maker if path == "observation" else session_maker
+    async with maker() as session:
         row = await session.get(ArchiveSnapshot, pointer.snapshot_id)
         return await _snapshot_body(session, row) if row is not None else None
 
@@ -281,5 +283,5 @@ async def read(pointer: BodyPointer, path: str, *, diagnostics: dict | None = No
         level = logging.ERROR if reason in {"permission_denied", "hash_mismatch", "too_large"} else logging.WARNING
         _log.log(level, "archive R2 read fallback path=%s reason=%s elapsed_ms=%s exception_type=%s",
                  path, reason, elapsed, error_type)
-    body = await _db_fallback(pointer)
+    body = await _db_fallback(pointer, path)
     return observed(body, "db" if body is not None else "none")

--- a/src/treg/archive_bodies.py
+++ b/src/treg/archive_bodies.py
@@ -218,15 +218,20 @@ class BodyPointer:
     snapshot_id: int | None = None
 
 
+def _r2_first(path: str) -> bool:
+    # Background change analysis follows the published location, including R2-only history.
+    return path == "observation" or getattr(get_settings(), "archive_body_read_" + path) == "r2-first"
+
+
 def read_options(path):
     from sqlalchemy.orm import defer
     from .models import ArchiveSnapshot
-    return (defer(ArchiveSnapshot.body),) if getattr(get_settings(), "archive_body_read_" + path) == "r2-first" else ()
+    return (defer(ArchiveSnapshot.body),) if _r2_first(path) else ()
 
 
 async def pointer(session, snapshot, path):
     """Capture metadata only for R2-first; DB fallback is loaded in a later short session."""
-    if getattr(get_settings(), "archive_body_read_" + path) == "r2-first":
+    if _r2_first(path):
         return BodyPointer(snapshot.content_hash, snapshot.body_storage, None, None, snapshot.id)
     from .archive import _snapshot_body
     body = await _snapshot_body(session, snapshot)
@@ -253,7 +258,7 @@ async def read(pointer: BodyPointer, path: str, *, diagnostics: dict | None = No
                                cache_r2_read_ms=elapsed)
         return body
 
-    if (getattr(get_settings(), f"archive_body_read_{path}") == "r2-first"
+    if (_r2_first(path)
             and pointer.storage in ("both", "r2")):
         started = time.monotonic()
         try:

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -309,6 +309,7 @@ class Settings(BaseSettings):
     # enable. Staged deliberately so production can sit in "shadow" while phase 0 measures.
     archive_mode: str = "off"
     archive_body_write: Literal["db", "both", "r2"] = "db"
+    archive_change_observation_enabled: bool = True
     archive_body_read_lookup: Literal["db", "r2-first"] = "db"
     archive_body_read_result: Literal["db", "r2-first"] = "db"
     archive_body_read_terminal: Literal["db", "r2-first"] = "db"

--- a/src/treg/domain/catalog/store.py
+++ b/src/treg/domain/catalog/store.py
@@ -320,6 +320,7 @@ def _parse(directory: Path) -> Catalog:
         # The provider's cache policy (docs/context/architecture/archive.md): one licence judgment
         # at the file header covers every endpoint below it; an endpoint's own `cache:` overrides.
         # Kept as the dict/provenance form, not stringified — archive.policy reads `mode` from it.
+        _validate_cache(doc.get("cache"))
         if doc.get("cache") and not meta.get("cache"):
             meta["cache"] = doc["cache"]
         for raw in doc.get("endpoints") or []:
@@ -519,7 +520,20 @@ def _effective_cost(raw: dict):
             "note": "price observed at live verification (provider-reported charge)"}
 
 
+_IGNORE_PATH = re.compile(r"(?:[A-Za-z_][A-Za-z0-9_-]*|\[\*\])(?:\[\*\])*(?:\.[A-Za-z_][A-Za-z0-9_-]*(?:\[\*\])*)*")
+
+
+def _validate_cache(cache) -> None:
+    if not isinstance(cache, dict) or "ignore_paths" not in cache:
+        return
+    paths = cache["ignore_paths"]
+    if (not isinstance(paths, list) or
+            any(not isinstance(path, str) or not _IGNORE_PATH.fullmatch(path) for path in paths)):
+        raise ValueError("cache.ignore_paths must be a list of dot paths with optional [*] array wildcards")
+
+
 def _normalize(raw: dict, provider: str, directory: Path) -> dict:
+    _validate_cache(raw.get("cache"))
     capability = raw.get("capability") or ""
     platform = raw.get("platform") or (capability.split(".")[0] if capability else "other")
     verified = raw.get("verified")

--- a/src/treg/domain/catalog/store.py
+++ b/src/treg/domain/catalog/store.py
@@ -520,7 +520,7 @@ def _effective_cost(raw: dict):
             "note": "price observed at live verification (provider-reported charge)"}
 
 
-_IGNORE_PATH = re.compile(r"(?:[A-Za-z_][A-Za-z0-9_-]*|\[\*\])(?:\[\*\])*(?:\.[A-Za-z_][A-Za-z0-9_-]*(?:\[\*\])*)*")
+_IGNORE_PATH = re.compile(r"(?:[A-Za-z0-9_][A-Za-z0-9_-]*|\[\*\])(?:\[\*\])*(?:\.[A-Za-z0-9_][A-Za-z0-9_-]*(?:\[\*\])*)*")
 
 
 def _validate_cache(cache) -> None:

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -381,7 +381,8 @@ async def admin_archive(
     import time as _time
     hit = _archive_report_cache.get(top)
     if hit and _time.monotonic() - hit[0] < _ARCHIVE_REPORT_TTL_S:
-        return hit[1]
+        return hit[1] | {"change_outcomes": dict(archive_mod.change_outcomes),
+                         "body_outcomes": dict(archive_mod.archive_bodies.outcomes)}
 
     stats = (await db.execute(
         select(ArchiveEndpointStat)
@@ -420,6 +421,8 @@ async def admin_archive(
             "kept_bytes": st.kept_bytes,
         })
     report = {"mode": archive_mod.mode(),
+              "change_outcomes": dict(archive_mod.change_outcomes),
+              "body_outcomes": dict(archive_mod.archive_bodies.outcomes),
               "comparison_mode": "strict",
               "ttl_policy": "adaptive",
               "serve_endpoints": sorted(archive_mod.serve_endpoints()),

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -700,6 +700,11 @@ async def test_admin_archive_keys_endpoint(clients: AsyncClient, serve, monkeypa
 
         rep = (await clients.get("/admin/archive", headers={"X-Treg-Token": "ADM-TOKEN"})).json()
         assert rep["hits_today"] == 1 and "worker_on" in rep and "refresh_daily_cap" in rep
+        assert rep["change_outcomes"] == dict(archive.change_outcomes)
+        assert rep["body_outcomes"] == dict(archive.archive_bodies.outcomes)
+        monkeypatch.setitem(archive.change_outcomes, "observation_failed", 123)
+        cached = (await clients.get("/admin/archive", headers={"X-Treg-Token": "ADM-TOKEN"})).json()
+        assert cached["change_outcomes"]["observation_failed"] == 123
         row = next(x for x in rep["endpoints"] if x["endpoint_id"] == EP)
         assert row["hits"] == 1 and row["kept_bytes"] > 0
     finally:
@@ -1392,7 +1397,7 @@ def test_catalog_rejects_invalid_ignore_paths(tmp_path, paths, at_header):
 
 def test_catalog_preserves_ignore_paths_and_defaults(tmp_path):
     import yaml
-    paths = ['request_id', 'data[*].updated_at', '[*].id', 'matrix[*][*].meta.request-id']
+    paths = ['2fa_enabled', 'data.123status', 'request_id', 'data[*].updated_at', '[*].id', 'matrix[*][*].meta.request-id']
     doc = {'provider': 'test', 'cache': {'mode': 'transient', 'ignore_paths': paths},
            'endpoints': [{'id': 'test.inherit'}, {'id': 'test.override', 'cache': {'mode': 'transient'}}]}
     (tmp_path / 'test.yaml').write_text(yaml.safe_dump(doc))
@@ -1516,3 +1521,83 @@ async def test_refresh_observation_and_terminal_exclusion(clients, shadow, monke
     assert len(snaps) == 3 and (keys[0].stable_seen, keys[0].change_seen) == (1, 0)
     observed = [p for name, p in events if name == 'archive_change_observed']
     assert len(observed) == 1 and observed[0]['masked_by_ignore'] is True
+
+
+async def test_observation_and_ignore_reads_share_archive_budget(clients, shadow, monkeypatch):
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setitem(catalog_store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['request_id']})
+    seen = []
+    for name in ('_ignored_matches', '_read_change_body'):
+        original = getattr(archive, name)
+        async def checked(*args, _original=original, _name=name):
+            assert archive._get_sem()._value < archive._MAX_CONCURRENT_WRITES
+            seen.append(_name)
+            return await _original(*args)
+        monkeypatch.setattr(archive, name, checked)
+    for value in (1, 2):
+        monkeypatch.setattr(call_service, 'relay', _fake_relay(200, json.dumps({'value': value}).encode()))
+        assert (await clients.get(f'/call/{EP}?aweme_id=7')).status_code == 200
+        await archive.drain()
+    assert '_ignored_matches' in seen and '_read_change_body' in seen
+
+
+@pytest.mark.parametrize('skip', ['disabled', 'old_hash_only', 'oversize', 'action'])
+async def test_change_skips_unavailable_or_disabled_without_io(clients, shadow, monkeypatch, skip):
+    from tests.test_marketplace_call import _fake_relay
+    settings = get_settings()
+    if skip == 'old_hash_only':
+        monkeypatch.setattr(settings, 'archive_max_body_bytes', 0)
+    if skip == 'action':
+        monkeypatch.setitem(catalog_store.load().by_id[EP], 'kind', 'action')
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, b'{"value":1}'))
+    await clients.get(f'/call/{EP}?aweme_id=7')
+    await archive.drain()
+    if skip == 'old_hash_only':
+        monkeypatch.setattr(settings, 'archive_max_body_bytes', 2_000_000)
+    if skip == 'oversize':
+        monkeypatch.setattr(settings, 'archive_max_body_bytes', 0)
+    if skip == 'disabled':
+        monkeypatch.setattr(settings, 'archive_change_observation_enabled', False)
+    async def forbidden(*args):
+        pytest.fail('skipped observation must not start any read/compute')
+    monkeypatch.setattr(archive, '_read_change_body', forbidden)
+    monkeypatch.setattr(archive, '_change_compute', forbidden)
+    before = archive.change_outcomes.copy()
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, b'{"value":2}'))
+    await clients.get(f'/call/{EP}?aweme_id=7')
+    await archive.drain()
+    assert archive.change_outcomes == before
+    assert len((await _rows())[1]) == 2
+
+
+async def test_cancelled_change_compute_keeps_slot_until_thread_finishes():
+    import asyncio
+    import threading
+    started, release = threading.Event(), threading.Event()
+    def compute():
+        started.set()
+        release.wait(2)
+    async def run():
+        async with archive._get_sem():
+            await archive._change_compute(compute)
+    task = asyncio.create_task(run())
+    try:
+        while not started.is_set():
+            await asyncio.sleep(0.001)
+        task.cancel()
+        await asyncio.sleep(0.01)
+        assert not task.done()
+        assert archive._get_sem()._value == archive._MAX_CONCURRENT_WRITES - 1
+    finally:
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert archive._get_sem()._value == archive._MAX_CONCURRENT_WRITES
+
+
+def test_change_summary_never_reserializes_subtrees(monkeypatch):
+    def forbidden(*args, **kwargs):
+        pytest.fail('structure comparison must not reserialize JSON')
+    monkeypatch.setattr(archive.json, 'dumps', forbidden)
+    assert archive._change_summary(b'{"a":[{"b":1}]}', b'{"a":[{"b":2}]}')['changed_paths'] == ['a[*].b']

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1306,3 +1306,72 @@ async def test_strict_comparison_preserves_existing_ttl(clients, serve, monkeypa
     assert props["cache_outcome"] == outcome
     if timer > 0:
         assert props["cache_window_s"] == timer
+
+
+@pytest.mark.parametrize("old,new,paths", [
+    ({"items": [{"id": 1}, {"id": 2}]}, {"items": [{"id": 3}, {"id": 4}]}, ["items[*].id"]),
+    ({"a": 1}, {"b": 2}, ["a", "b"]),
+    ({"a": True}, {"a": 1}, ["a"]),
+    ({"a": {"b": {"c": {"d": {"e": {"f": {"g": 1}}}}}}},
+     {"a": {"b": {"c": {"d": {"e": {"f": {"g": 2}}}}}}}, ["a.b.c.d.e.f"]),
+    ([1], [1, 2], ["[*]"]),
+    ({}, {}, []),
+])
+def test_change_summary_paths(old, new, paths):
+    props = archive._change_summary(json.dumps(old).encode(), json.dumps(new).encode())
+    assert props["changed_paths"] == paths
+    assert props["path_count"] == len(paths)
+    assert props["sole_path"] == (paths[0] if len(paths) == 1 else None)
+
+
+def test_change_summary_bounds_and_non_json():
+    props = archive._change_summary(b'{}', json.dumps({f"p{i}": i for i in range(25)}).encode())
+    assert len(props["changed_paths"]) == 20
+    assert props["path_count"] == props["leaf_count"] == 25
+    assert props["truncated"] and props["sole_path"] is None
+    assert archive._change_summary(b'not json', b'{}')["changed_paths"] == ["non_json"]
+
+
+async def test_change_observation_is_read_only(clients, shadow, monkeypatch):
+    from treg import analytics
+    from tests.test_marketplace_call import _fake_relay
+    events = []
+    monkeypatch.setattr(analytics, "capture", lambda who, name, props, **kw: events.append((name, props)))
+    bodies = [b'{"request_id":"secret-one","value":42}',
+              b'{"request_id":"secret-two","value":42}']
+    for body in bodies + [bodies[-1]]:
+        monkeypatch.setattr(call_service, "relay", _fake_relay(200, body))
+        response = await clients.get(f"/call/{EP}?aweme_id=7")
+        assert response.content == body
+        await archive.drain()
+    keys, snaps = await _rows()
+    assert (keys[0].change_seen, keys[0].stable_seen, keys[0].ttl_s) == (1, 1, 2700)
+    assert snaps[2].body_of == snaps[1].id
+    props = [p for name, p in events if name == "archive_change_observed"]
+    assert props == [dict(endpoint_id=EP, provider="tikhub", changed_paths=["request_id"],
+                          path_count=1, leaf_count=2, sole_path="request_id", truncated=False,
+                          masked_by_ignore=False)]
+    assert "secret" not in json.dumps(props) and "call_ref" not in props[0]
+
+
+@pytest.mark.parametrize("failure", ["missing", "exception", "timeout"])
+async def test_change_observation_failure_preserves_record(clients, shadow, monkeypatch, failure):
+    import asyncio
+    from tests.test_marketplace_call import _fake_relay
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    async def unavailable(*args):
+        if failure == "exception":
+            raise RuntimeError("must not leak")
+        if failure == "timeout":
+            await asyncio.Event().wait()
+        return None
+    monkeypatch.setattr(archive, "_read_change_body", unavailable)
+    monkeypatch.setattr(archive, "_CHANGE_TIMEOUT_S", 0.05)
+    before = archive.change_outcomes.copy()
+    monkeypatch.setattr(call_service, "relay", _fake_relay(200, b'{"new":42}'))
+    assert (await clients.get(f"/call/{EP}?aweme_id=7")).status_code == 200
+    keys, snaps = await _rows()
+    assert len(snaps) == 2 and keys[0].change_seen == 1
+    counter = "body_unavailable" if failure == "missing" else "observation_failed"
+    assert archive.change_outcomes[counter] == before[counter] + 1

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1375,3 +1375,144 @@ async def test_change_observation_failure_preserves_record(clients, shadow, monk
     assert len(snaps) == 2 and keys[0].change_seen == 1
     counter = "body_unavailable" if failure == "missing" else "observation_failed"
     assert archive.change_outcomes[counter] == before[counter] + 1
+
+
+@pytest.mark.parametrize('paths', [None, 'request_id', [1], [''], ['a..b'], ['a[0]'],
+                                  ['a.*.b'], ['$.a'], ['a.[*]'], ['a '], ['a\\.b']])
+@pytest.mark.parametrize('at_header', [False, True])
+def test_catalog_rejects_invalid_ignore_paths(tmp_path, paths, at_header):
+    import yaml
+    doc = {'provider': 'test', 'endpoints': [{'id': 'test.read', 'kind': 'read'}]}
+    target = doc if at_header else doc['endpoints'][0]
+    target['cache'] = {'mode': 'transient', 'ignore_paths': paths}
+    (tmp_path / 'test.yaml').write_text(yaml.safe_dump(doc))
+    with pytest.raises(ValueError, match='cache.ignore_paths'):
+        catalog_store.load(directory=tmp_path)
+
+
+def test_catalog_preserves_ignore_paths_and_defaults(tmp_path):
+    import yaml
+    paths = ['request_id', 'data[*].updated_at', '[*].id', 'matrix[*][*].meta.request-id']
+    doc = {'provider': 'test', 'cache': {'mode': 'transient', 'ignore_paths': paths},
+           'endpoints': [{'id': 'test.inherit'}, {'id': 'test.override', 'cache': {'mode': 'transient'}}]}
+    (tmp_path / 'test.yaml').write_text(yaml.safe_dump(doc))
+    cat = catalog_store.load(directory=tmp_path)
+    assert cat.by_id['test.inherit']['cache']['ignore_paths'] == paths
+    assert cat.by_id['test.override']['cache'].get('ignore_paths', []) == []
+    assert all(not (ep.get('cache') or {}).get('ignore_paths')
+               for ep in catalog_store.load().endpoints if isinstance(ep.get('cache'), dict))
+
+
+@pytest.mark.parametrize('old,new,paths,equal', [
+    ({'id': 1, 'a': 2}, {'a': 2, 'id': 3}, ['id'], True),
+    ({'a': 2}, {'a': 2, 'id': 3}, ['id'], True),
+    ({'a': 2}, {'a': 3}, ['missing'], False),
+    ({'rows': [{'id': 1, 'value': 2}]}, {'rows': [{'id': 3, 'value': 2}]}, ['rows[*].id'], True),
+    ({'rows': [{'id': 1}]}, {'rows': [{'id': 3}, {'id': 4}]}, ['rows[*].id'], False),
+    ({'rows': [1]}, {'rows': [2, 3]}, ['rows[*]'], True),
+    ([{'id': 1}], [{'id': 2}], ['[*].id'], True),
+    ([[{'id': 1}]], [[{'id': 2}]], ['[*][*].id'], True),
+    ({'a': True}, {'a': 1}, ['missing'], False),
+    ({'x': {'id': 1}}, {'x': {'id': 2}}, ['x', 'x.id'], True),
+])
+def test_ignore_normalization(old, new, paths, equal):
+    before, after = json.dumps(old).encode(), json.dumps(new).encode()
+    assert (archive._normalized_hash(before, paths) == archive._normalized_hash(after, paths)) is equal
+    assert json.loads(before) == old and json.loads(after) == new
+
+
+@pytest.mark.parametrize('raw', [b'not JSON', b'\xff', b'{"x":NaN}'])
+def test_ignore_non_json_uses_raw_comparison(raw):
+    assert archive._normalized_hash(raw, ['id']) is None
+    assert archive._normalized_hash(raw, ['x']) is None
+    assert archive._change_summary(raw, b'{}')['changed_paths'] == ['non_json']
+
+
+@pytest.mark.parametrize('paths,expected', [([], (0, 1, 1800)), (['request_id'], (1, 0, 5400))])
+async def test_ignore_only_changes_learning(clients, serve, monkeypatch, paths, expected):
+    from treg import analytics
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setitem(catalog_store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': paths})
+    events = []
+    monkeypatch.setattr(analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    bodies = [b'{"request_id":1,"value":42}', b'{ "value":42, "request_id":2 }']
+    for raw in bodies:
+        monkeypatch.setattr(call_service, 'relay', _fake_relay(200, raw))
+        r = await clients.get(f'/call/{EP}?aweme_id=7', headers={'Cache-Control': 'no-cache'})
+        assert r.content == raw and 'x-treg-cache' not in r.headers
+        await archive.drain()
+    keys, snaps = await _rows()
+    assert (keys[0].stable_seen, keys[0].change_seen, keys[0].ttl_s) == expected
+    assert [snap.content_hash for snap in snaps] == [archive.content_hash(b) for b in bodies]
+    assert all(snap.body_of is None for snap in snaps)
+    for raw in bodies:
+        result = await archive.resolve_result(keys[0].key_hash, archive.content_hash(raw))
+        assert result['response']['body_text'] == raw.decode()
+    hit = await clients.get(f'/call/{EP}?aweme_id=7')
+    assert hit.headers['x-treg-cache'] == 'hit' and hit.content == bodies[-1]
+    await archive.drain()
+    observed = [p for name, p in events if name == 'archive_change_observed']
+    assert len(observed) == 1 and observed[0]['masked_by_ignore'] is bool(paths)
+
+
+async def test_missing_ignore_baseline_falls_back_to_bytes(clients, shadow, monkeypatch):
+    from treg import archive_bodies
+    from tests.test_marketplace_call import _fake_relay
+    monkeypatch.setitem(catalog_store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['request_id']})
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, b'{"request_id":1}'))
+    await clients.get(f'/call/{EP}?aweme_id=7')
+    await archive.drain()
+    async def missing(*args, **kwargs):
+        return None
+    monkeypatch.setattr(archive_bodies, 'read', missing)
+    monkeypatch.setattr(call_service, 'relay', _fake_relay(200, b'{"request_id":2}'))
+    await clients.get(f'/call/{EP}?aweme_id=7')
+    keys, snaps = await _rows()
+    assert len(snaps) == 2 and (keys[0].stable_seen, keys[0].change_seen) == (0, 1)
+
+
+async def test_ignore_rechecks_baseline_after_concurrent_recording(clients, shadow, monkeypatch):
+    import asyncio
+    monkeypatch.setitem(catalog_store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['id']})
+    common = dict(method='GET', endpoint_id=EP, provider='tikhub', url='https://example.com/race',
+                  caller_body=b'', headers={}, status_code=200, media_type='application/json')
+    await archive._store(**common, body=b'{"id":1,"value":1}')
+    second = b'{"id":2,"value":1}'
+    entered, release = asyncio.Event(), asyncio.Event()
+    real = archive._ignored_matches
+    async def paused(kh, body, paths):
+        matches = await real(kh, body, paths)
+        if body == second:
+            assert matches
+            entered.set()
+            await release.wait()
+        return matches
+    monkeypatch.setattr(archive, '_ignored_matches', paused)
+    task = asyncio.create_task(archive._store(**common, body=second))
+    try:
+        await asyncio.wait_for(entered.wait(), 2)
+        await archive._store(**common, body=b'{"id":3,"value":9}')
+    finally:
+        release.set()
+        await task
+    keys, snaps = await _rows()
+    assert len(snaps) == 3 and (keys[0].stable_seen, keys[0].change_seen) == (0, 2)
+
+
+async def test_refresh_observation_and_terminal_exclusion(clients, shadow, monkeypatch):
+    from treg import analytics
+    events = []
+    monkeypatch.setattr(analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    monkeypatch.setitem(catalog_store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['id']})
+    common = dict(method='GET', endpoint_id=EP, provider='tikhub', url='https://example.com/origins',
+                  caller_body=b'', headers={}, status_code=200, media_type='application/json')
+    for i, origin in enumerate(('caller', 'refresh', 'async_terminal')):
+        await archive._store(**common, body=json.dumps({'id': i}).encode(), origin=origin)
+    keys, snaps = await _rows()
+    assert len(snaps) == 3 and (keys[0].stable_seen, keys[0].change_seen) == (1, 0)
+    observed = [p for name, p in events if name == 'archive_change_observed']
+    assert len(observed) == 1 and observed[0]['masked_by_ignore'] is True

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -911,3 +911,19 @@ async def test_singleflight_shares_exhausted_retry_result(r2, monkeypatch):
     assert all(plan.storage == 'db' and plan.reason == 'rate_limited' for plan in plans)
     assert r2.put_calls == 2 and not archive_bodies._uploaded and not archive_bodies._inflight
     assert (await put()).storage == 'both' and r2.put_calls == 3
+
+
+async def test_change_observation_reads_r2_only_without_db_connection(clients, r2, monkeypatch):
+    monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
+    monkeypatch.setattr(get_settings(), 'archive_mode', 'shadow')
+    events = []
+    monkeypatch.setattr(service.analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    for body in (RAW, RAW.replace(b'hello', b'world')):
+        monkeypatch.setattr(service, 'relay', _fake_relay(200, body))
+        assert (await clients.get(URL)).content == body
+        await archive.drain()
+    rows = await snapshots()
+    assert all(row.body is None and row.body_storage == 'r2' for row in rows)
+    observed = [p for name, p in events if name == 'archive_change_observed']
+    assert len(observed) == 1
+    assert observed[0]['changed_paths'] == ['data.comments[*].text']

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -914,6 +914,7 @@ async def test_singleflight_shares_exhausted_retry_result(r2, monkeypatch):
 
 
 async def test_change_observation_reads_r2_only_without_db_connection(clients, r2, monkeypatch):
+    monkeypatch.setattr(get_settings(), 'archive_body_read_lookup', 'r2-first')
     monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
     monkeypatch.setattr(get_settings(), 'archive_mode', 'shadow')
     events = []
@@ -930,6 +931,7 @@ async def test_change_observation_reads_r2_only_without_db_connection(clients, r
 
 
 async def test_ignore_learning_reads_r2_only_without_db_connection(clients, r2, monkeypatch):
+    monkeypatch.setattr(get_settings(), 'archive_body_read_lookup', 'r2-first')
     from treg.domain.catalog import store
     monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
     monkeypatch.setattr(get_settings(), 'archive_mode', 'shadow')
@@ -943,3 +945,30 @@ async def test_ignore_learning_reads_r2_only_without_db_connection(clients, r2, 
         key = (await s.execute(select(ArchiveKey))).scalar_one()
         assert (key.stable_seen, key.change_seen) == (1, 0)
     assert all(row.body is None for row in await snapshots())
+
+
+@pytest.mark.parametrize('read_mode', ['db', 'r2-first'])
+async def test_observation_uses_background_fallback_and_lookup_switch(clients, r2, monkeypatch, read_mode):
+    from contextlib import asynccontextmanager
+    monkeypatch.setattr(get_settings(), 'archive_body_read_lookup', read_mode)
+    calls = []
+    @asynccontextmanager
+    async def background():
+        calls.append('background')
+        class Session:
+            async def get(self, *args):
+                return None
+        yield Session()
+    def api():
+        pytest.fail('observation must never use API pool')
+    class Store:
+        async def get(self, *args):
+            calls.append('r2')
+            return None
+    monkeypatch.setattr(db, 'background_session_maker', background)
+    monkeypatch.setattr(db, 'session_maker', api)
+    monkeypatch.setattr(archive_bodies, '_store', Store())
+    pointer = archive_bodies.BodyPointer(archive.content_hash(RAW), 'both', None, None, 1)
+    assert await archive_bodies.read(pointer, 'observation') is None
+    assert calls == (['r2', 'background'] if read_mode == 'r2-first' else ['background'])
+    assert archive_bodies._r2_first('observation') == (read_mode == 'r2-first')

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -927,3 +927,19 @@ async def test_change_observation_reads_r2_only_without_db_connection(clients, r
     observed = [p for name, p in events if name == 'archive_change_observed']
     assert len(observed) == 1
     assert observed[0]['changed_paths'] == ['data.comments[*].text']
+
+
+async def test_ignore_learning_reads_r2_only_without_db_connection(clients, r2, monkeypatch):
+    from treg.domain.catalog import store
+    monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
+    monkeypatch.setattr(get_settings(), 'archive_mode', 'shadow')
+    monkeypatch.setitem(store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['data.comments[*].text']})
+    for body in (RAW, RAW.replace(b'hello', b'world')):
+        monkeypatch.setattr(service, 'relay', _fake_relay(200, body))
+        assert (await clients.get(URL)).content == body
+        await archive.drain()
+    async with db.session_maker() as s:
+        key = (await s.execute(select(ArchiveKey))).scalar_one()
+        assert (key.stable_seen, key.change_seen) == (1, 0)
+    assert all(row.body is None for row in await snapshots())

--- a/tests/test_cache_result_admission.py
+++ b/tests/test_cache_result_admission.py
@@ -313,3 +313,27 @@ def test_verified_adapter_positive_fixture_is_admissible(ep):
     body = (Path(__file__).parents[1] / 'src/treg/catalog/examples' / (ep + '.json')).read_bytes()
     result = classify(ep, 200, body)
     assert result.state == 'found' and result.reason == 'adapter_hit'
+
+
+async def test_ignore_cannot_mask_result_transitions_and_uses_decisive_baseline(clients, cache_on, monkeypatch):
+    from treg.domain.catalog import store
+    monkeypatch.setitem(store.load().by_id[EP], 'cache',
+                        {'mode': 'transient', 'ignore_paths': ['meta', 'data']})
+    events = []
+    monkeypatch.setattr(service.analytics, 'capture',
+                        lambda who, event, props, **kw: events.append((event, props)))
+    await _call(clients, monkeypatch, FOUND)
+    await _call(clients, monkeypatch, b'{}', live=True)  # unknown, retain found baseline
+    changed = FOUND.replace(b'hello@', b'other@')
+    await _call(clients, monkeypatch, changed, live=True)
+    assert (await _key()).stable_seen == 1
+    await _call(clients, monkeypatch, EMPTY, live=True)
+    k = await _key()
+    assert (k.stable_seen, k.change_seen, k.result_state) == (1, 1, 'empty')
+    observed = [p for name, p in events if name == 'archive_change_observed']
+    assert [p['masked_by_ignore'] for p in observed] == [False, True, False]
+    await _call(clients, monkeypatch, EMPTY)
+    assert (await _key()).change_seen == 1
+    response = await _call(clients, monkeypatch, changed)
+    assert response.content == changed and 'x-treg-cache' not in response.headers
+    assert (await _key()).change_seen == 2

--- a/tests/test_db_pool_isolation.py
+++ b/tests/test_db_pool_isolation.py
@@ -60,8 +60,8 @@ EXPECTED_MAKERS: dict[str, set[str]] = {
     "bootstrap.py": {BACKGROUND},
     # `lookup` is on the API pool inside a caller's /call/; every write here is background.
     "archive.py": {API, BACKGROUND},
-    # On-request fallback reads only, opened after R2 I/O has finished. No body writes.
-    "archive_bodies.py": {API},
+    # Request fallbacks use API; observation fallbacks share archive's background budget.
+    "archive_bodies.py": {API, BACKGROUND},
 }
 
 
@@ -132,15 +132,57 @@ def test_the_background_pool_fits_every_consumer_not_just_the_throttled_ones():
     assert infra_db.POOL_SPECS["background"]["pool_size"] >= sum(consumers.values())
 
 
+def _background_sites(tree):
+    from collections import Counter
+    class Sites(ast.NodeVisitor):
+        def __init__(self):
+            self.functions = []
+            self.sites = Counter()
+        def visit_AsyncFunctionDef(self, node):
+            self.functions.append(node.name)
+            self.generic_visit(node)
+            self.functions.pop()
+        visit_FunctionDef = visit_AsyncFunctionDef
+        def visit_Name(self, node):
+            if node.id == BACKGROUND and self.functions:
+                self.sites[".".join(self.functions)] += 1
+        def visit_Attribute(self, node):
+            if node.attr == BACKGROUND and self.functions:
+                self.sites[".".join(self.functions)] += 1
+            self.generic_visit(node)
+    visitor = Sites()
+    visitor.visit(tree)
+    return visitor.sites
+
+
+BACKGROUND_SITES = {
+    "bootstrap.py:_lifespan.lifespan": "adsconv.worker",
+    "bootstrap.py:create_app": "catalog observation refresh",
+    "audit.py:_write_batch": "audit._flush",
+    "archive.py:_store_locked": "archive._store/_touch",
+    "archive.py:_touch_write": "archive._store/_touch",
+    "archive.py:_ignored_matches": "archive._store/_touch",
+    "archive.py:_read_change_body": "archive._store/_touch",
+    "archive_bodies.py:_db_fallback": "archive._store/_touch",
+    "archive.py:prune_once": "archive.prune_worker",
+    "archive.py:refresh_once": "archive.refresh_worker",
+    "routers/admin.py:_purge_expired_error_evidence": "admin evidence sweep",
+    "application/arena_insights.py:collect_batch": "arena_insights.worker",
+}
+
+
 def test_every_background_session_site_is_named_in_the_consumer_list():
-    """The list sizes the pool, so a consumer missing from it is a row silently dropped under load.
-    Cross-checked against the modules classified above rather than trusted."""
-    background_modules = {m for m, pools in EXPECTED_MAKERS.items() if BACKGROUND in pools}
-    named = " ".join(infra_db.BACKGROUND_CONSUMERS)
-    for module in background_modules:
-        stem = pathlib.Path(module).stem
-        assert stem in named or stem in {"bootstrap", "admin"}, (
-            f"{module} opens background sessions but names no entry in BACKGROUND_CONSUMERS")
+    actual = {f"{module}:{function}": count
+              for module, tree in _modules_opening_sessions().items()
+              for function, count in _background_sites(tree).items()}
+    assert actual == {site: 1 for site in BACKGROUND_SITES}
+    assert set(BACKGROUND_SITES.values()) <= infra_db.BACKGROUND_CONSUMERS.keys()
+
+
+def test_background_guard_detects_another_site_in_an_existing_module():
+    tree = ast.parse("async def added():\n async with background_session_maker(): pass")
+    assert _background_sites(tree) == {"added": 1}
+    assert "archive.py:added" not in BACKGROUND_SITES
 
 
 def test_the_spec_is_what_the_engines_were_actually_built_with():


### PR DESCRIPTION
Two commits, both zero behaviour change by default.

1. Change observation. When a real refetch (caller or refresh origin) lands a body whose hash differs from the previous version, the recorder reads the previous body through archive_bodies (following the published location, so it keeps working once bodies are R2-only), computes the changed JSON paths (depth 6, array indices collapsed to [*], 20 paths max, NaN/Infinity rejected) and emits one PostHog event archive_change_observed with endpoint, provider, changed_paths, path_count, truncated, leaf_count, sole_path and masked_by_ignore. No body fragments, no call ref, no new DB writes. Runs after commit, outside any DB session, bounded by its own timeout; failures only bump an in-process counter. A seven-day HogQL for ranking endpoints by change volume and per-path share is in archive.md.

2. Declared ignore paths. A catalog entry may list cache.ignore_paths (dot paths with optional [*] wildcards, validated at load). For such endpoints the TTL comparison hashes the canonical JSON with those paths removed; everything else is untouched: stored bytes, content_hash, dedup, result classification and what a cache hit returns. When the ignore list masks all differences the observation is counted stable and the event carries masked_by_ignore=true. Bodies that cannot be read, non-JSON bodies and analysis timeouts fall back to the byte comparison. No endpoint declares a list yet; lists are proposed from the observation data and land through reviewed catalog PRs.

Fragments updated: archive.md, catalog.md. Full regression 3668 passed, 6 skipped; import-linter 14 kept; test_call_architecture allowlist unchanged.