### PR TITLE
feat(catalog): add Vid Kraken — YouTube video, audio and clip download API

### DIFF
--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -100,7 +100,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 ---
 
 ## First, check which treg you have
@@ -103,7 +103,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -84,7 +84,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -98,7 +98,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: treg
-description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
+description: Reach for this first for external or live data. 3,200+ endpoints across 71 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
 version: 0.19.0
 ---
 
@@ -82,7 +82,7 @@ spends nothing: that key belongs to them.
 
 ## Task — the catalog: what treg can do for you (start here)
 
-3,200+ catalogued endpoints across 70 providers, grouped by what they DO: keyword & rank tracking,
+3,200+ catalogued endpoints across 71 providers, grouped by what they DO: keyword & rank tracking,
 backlinks & authority, AI visibility, trending & discovery, publishing to the team's own social
 accounts, people & company enrichment, ads management & creative, measurement, video & image
 generation.

--- a/src/treg/catalog/vidkraken.yaml
+++ b/src/treg/catalog/vidkraken.yaml
@@ -1,0 +1,312 @@
+provider: vidkraken
+source:
+  docs: https://vidkraken.com/docs
+  openapi: https://vidkraken.com/openapi.yaml
+  curated: 2026-09-10
+# Vid Kraken is a server-side YouTube download API: submit a URL, poll a job, receive a CDN URL to
+# an MP4 / audio file (optionally a trimmed clip or a dubbed-language audio track). The listing is
+# deliberately just that surface — downloads and the video-info pre-flight — plus the free account
+# read that serves as the probe; channel listing exists on the API but is better served by the
+# dedicated YouTube data providers already in this catalog. Every job route
+# is asynchronous — the file-level `async` block below is the download protocol; the two metadata
+# rows override it with the /info protocol (different status vocabulary) and every synchronous or
+# utility row opts out with `async: false`.
+#
+# Billing (https://vidkraken.com/#pricing, reconciled live 2026-09-10 against GET /me):
+#   - Downloads are billed in BANDWIDTH only — the delivered file size, with a 20 MB minimum per
+#     download, drawn from the plan's monthly allowance. No per-download fee. The USD figure per GB
+#     is the plan's effective rate: Starter $99/mo for 400 GB = $0.25/GB (listed below as the
+#     documented price), Growth $399 for 2 TB = $0.20/GB, Scale $1,499 for 10 TB = $0.15/GB; overage
+#     $0.50 / $0.40 / $0.30 per GB respectively. Free plan: 10 GB and 10 downloads, lifetime.
+#     OBSERVED 2026-09-10: three downloads of 476 KB, 252 KB and 221 KB each moved
+#     balances.bandwidth_mb.used by exactly 20 (the floor) and download_count.used by 1.
+#   - Metadata lookups (POST /info) draw 1 "info request" from a per-plan quota (2× the download
+#     quota, e.g. 200,000/month on Starter; 50 lifetime on Free) and never bandwidth. Never priced
+#     in USD, no overage — a hard stop at the cap. OBSERVED 2026-09-10: two lookups moved
+#     balances.info.used by exactly 2 (the meter lags the response by a few seconds).
+#   - Polling routes, GET /me, failed jobs, 401/403/429 answers: never charged (observed: no meter
+#     moved on any of them).
+# Job status routes answer only the submitting account: a foreign or expired id is 404 ("Download
+# job not found" / "Job not found or expired"). Info job state lives 1 hour; download jobs persist.
+# The API key rides as `Authorization: Bearer <key>`; the free GET /me is the registry's probe.
+limits: "at most 100 downloads queued or in progress per account (429 beyond); jobs finish in seconds for short videos, minutes for long ones; no published per-minute request limit"
+pricing_url: https://vidkraken.com/#pricing
+
+proposed_capabilities:
+  # The youtube platform has metadata/comments/search/channel capabilities but nothing that yields the
+  # media FILE. These are the download jobs an agent reaches for; the clip and audio variants are
+  # priced and requested differently enough (trim bounds; the cheapest tier) to be separate rows.
+  youtube.video.download: "Download a YouTube video as an MP4 file at a chosen resolution"
+  youtube.audio.download: "Download a YouTube video's audio track as a file"
+  youtube.video.clip: "Download a trimmed clip of a YouTube video by start and end time"
+  youtube.video.audio_tracks: "List a video's available audio tracks and dubbed languages"
+  # Polling plumbing for the two async protocols (kind: utility — hidden from the browse surface).
+  youtube.download.job.status: "Check an async download job and get its file URL"
+  youtube.info.job.status: "Check an async video-info job and get its result"
+
+async:
+  id_from: jobId
+  poll:
+    endpoint: vidkraken.youtube.download.job.status
+    param: {in: pathParams, name: jobId}
+  status:
+    path: status
+    success: [COMPLETED]
+    failure: [FAILED]
+  result:
+    path: downloadUrl
+    ttl_note: "CDN URL; download promptly"
+  interval: 5
+
+endpoints:
+  # --- Downloads (async: POST returns a jobId, poll GET /download/{jobId}) ------------------------
+  - id: vidkraken.youtube.video.download
+    capability: youtube.video.download
+    platform: youtube
+    domain: download
+    scope: any_account
+    method: POST
+    path: /download
+    name: "Download a YouTube video (MP4, 360p-1080p)"
+    summary: "Queue a YouTube video for download. Returns a `jobId` that you poll on `GET /download/{jobId}` until status is `COMPLETED` (or `FAILED`)."
+    input:
+      body:
+        url: {type: string, required: true, note: "youtube.com/watch?v=ID, youtu.be/ID or youtube.com/live/ID", example: "https://youtu.be/dQw4w9WgXcQ"}
+        format: {type: string, required: true, enum: ["1080", "720", "480", "360"], example: "720", note: "vertical resolution in pixels; omitting it downloads AUDIO (the API default) — use vidkraken.youtube.audio.download for that. May be capped down for very long videos to fit the plan's per-file limit; the delivered format is `actualFormat`"}
+        language: {type: string, required: false, example: "en-US", note: "BCP-47 tag of the preferred audio track (dubbed videos); falls back to a prefix match, then the original audio. Discover tracks with vidkraken.youtube.video.audio_tracks"}
+        webhookUrl: {type: string, required: false, example: "https://example.com/hooks/vidkraken", note: "public https URL POSTed the final status instead of polling; signed with HMAC-SHA256 over the raw body using the API key"}
+      bodyType: json
+      note: "Submission answers 200 {jobId, title, duration, status: IN_QUEUE} at once; the file appears on the terminal status as `downloadUrl` with `fileSize` in bytes. Failed jobs carry a machine-readable `errorCode` (AGE_RESTRICTED, PRIVATE_VIDEO, GEO_RESTRICTED, LIVE_STREAM_IN_PROGRESS, …) and are not charged"
+    test_request:
+      body: {url: "https://youtu.be/jNQXAC9IVRw", format: "360"}
+    cost:
+      type: per_success
+      value: 0.25
+      currency: USD
+      per: 1
+      unit: GB
+      display: {unit: "GB delivered (20 MB minimum)", variable: true}
+      source: docs
+      source_url: https://vidkraken.com/#pricing
+      checked: '2026-09-10'
+      confidence: documented
+      note: "Bandwidth at the delivered file size, 20 MB minimum per download — so the smallest possible charge is 0.02 GB ($0.005 at the Starter rate). $0.25/GB is the Starter plan's effective rate ($99/mo, 400 GB); Growth is $0.20/GB, Scale $0.15/GB; overage $0.50/$0.40/$0.30 per GB. Charged when the job COMPLETES; submission and failures are free. The test target ('Me at the zoo', 19 s) delivers ~0.5 MB at 360p and OBSERVED 2026-09-10 moved bandwidth_mb.used by exactly 20."
+    docs_url: https://vidkraken.com/docs/endpoint/submit-download
+
+  - id: vidkraken.youtube.audio.download
+    capability: youtube.audio.download
+    platform: youtube
+    domain: download
+    scope: any_account
+    method: POST
+    path: /download
+    name: "Download a YouTube video's audio track"
+    summary: "Queue a YouTube video for download. Returns a `jobId` that you poll on `GET /download/{jobId}` until status is `COMPLETED` (or `FAILED`)."
+    input:
+      body:
+        url: {type: string, required: true, note: "youtube.com/watch?v=ID, youtu.be/ID or youtube.com/live/ID", example: "https://youtu.be/dQw4w9WgXcQ"}
+        format: {type: string, required: true, enum: [audio], example: "audio", note: "best audio stream YouTube offers (~130-160 kbps Opus/AAC) in its native container — no re-encoding. This is the API's default format and its cheapest tier"}
+        language: {type: string, required: false, example: "es", note: "BCP-47 tag of the preferred (dubbed) audio track; falls back to a prefix match, then the original audio"}
+        webhookUrl: {type: string, required: false, example: "https://example.com/hooks/vidkraken", note: "public https URL POSTed the final status instead of polling"}
+      bodyType: json
+      note: "Same job protocol as the video row; the terminal status carries `downloadUrl` and `fileSize`"
+    test_request:
+      body: {url: "https://youtu.be/jNQXAC9IVRw", format: "audio"}
+    cost:
+      type: per_success
+      value: 0.25
+      currency: USD
+      per: 1
+      unit: GB
+      display: {unit: "GB delivered (20 MB minimum)", variable: true}
+      source: docs
+      source_url: https://vidkraken.com/#pricing
+      checked: '2026-09-10'
+      confidence: documented
+      note: "Bandwidth at the delivered file size with the same 20 MB minimum as video, at the plan's per-GB rate (Starter $0.25/GB listed). Audio files are far smaller than video, so most audio downloads settle at the 20 MB floor. OBSERVED 2026-09-10: a 252 KB audio file moved bandwidth_mb.used by exactly 20."
+    docs_url: https://vidkraken.com/docs/endpoint/submit-download
+
+  - id: vidkraken.youtube.video.clip
+    capability: youtube.video.clip
+    platform: youtube
+    domain: download
+    scope: any_account
+    method: POST
+    path: /download
+    name: "Download a trimmed clip of a YouTube video"
+    summary: "Queue a YouTube video for download. Returns a `jobId` that you poll on `GET /download/{jobId}` until status is `COMPLETED` (or `FAILED`)."
+    input:
+      body:
+        url: {type: string, required: true, note: "youtube.com/watch?v=ID, youtu.be/ID or youtube.com/live/ID", example: "https://youtu.be/dQw4w9WgXcQ"}
+        format: {type: string, required: true, enum: ["1080", "720", "480", "360", audio], example: "1080"}
+        startTime: {type: integer, required: true, min: 0, example: 30, note: "trim start in seconds (inclusive); must be in [0, duration)"}
+        endTime: {type: integer, required: true, min: 1, example: 90, note: "trim end in seconds (exclusive); must be in (0, duration] and greater than startTime"}
+        language: {type: string, required: false, example: "en-US", note: "BCP-47 tag of the preferred audio track"}
+        webhookUrl: {type: string, required: false, example: "https://example.com/hooks/vidkraken"}
+      bodyType: json
+      note: "Cuts are frame-accurate (the clip is re-encoded at the cut points), so the delivered file is just the requested range — the bandwidth charge follows the CLIP size, not the full video. Same job protocol as the other download rows"
+    test_request:
+      body: {url: "https://youtu.be/jNQXAC9IVRw", format: "360", startTime: 0, endTime: 5}
+    cost:
+      type: per_success
+      value: 0.25
+      currency: USD
+      per: 1
+      unit: GB
+      display: {unit: "GB delivered (20 MB minimum)", variable: true}
+      source: docs
+      source_url: https://vidkraken.com/#pricing
+      checked: '2026-09-10'
+      confidence: documented
+      note: "Bandwidth at the delivered CLIP size, 20 MB minimum, at the plan's per-GB rate (Starter $0.25/GB listed). OBSERVED 2026-09-10: a 5-second 360p clip (221 KB) moved bandwidth_mb.used by exactly 20."
+    docs_url: https://vidkraken.com/docs/endpoint/submit-download
+
+  - id: vidkraken.youtube.download.job.status
+    kind: utility
+    capability: youtube.download.job.status
+    platform: youtube
+    domain: download
+    scope: any_account
+    method: GET
+    path: /download/{jobId}
+    name: "Check a download job and get the file URL"
+    summary: "Poll the status of a previously-submitted download job. Once `status` is `COMPLETED`, the response carries a `downloadUrl` you can fetch the file from. If `status` is `FAILED`, an `errorCode` identifies why."
+    resource_ownership:
+      requires: {kind: "poll:vidkraken.youtube.download.job.status", param: jobId}
+    async: false
+    input:
+      pathParams:
+        jobId: {type: string, required: true, example: "69cfc45e8a3b4d2f9c1e0a7b", note: "the jobId returned by POST /download"}
+      note: "Status is IN_QUEUE → IN_PROGRESS → COMPLETED | FAILED. Only the submitting account can read a job; any other or unknown id is 404 {\"error\":\"Download job not found\"}. Download jobs persist, so a completed job stays readable"
+    test_request:
+      # a job from the vendor's own verification run — substitute a jobId from YOUR account (404 otherwise)
+      pathParams: {jobId: "6aa2c8d697daf3fb44bcaa51"}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "Polling is never charged (observed: no meter moved)."}
+    docs_url: https://vidkraken.com/docs/endpoint/get-download-status
+
+  # --- Metadata (async: POST returns a jobId, poll GET /info/{jobId}) ------------------------------
+  - id: vidkraken.youtube.video.detail
+    capability: youtube.video.detail
+    platform: youtube
+    domain: video
+    scope: any_account
+    method: POST
+    path: /info
+    name: "YouTube video title and duration (download pre-flight)"
+    summary: "Queue a job that fetches metadata for a YouTube video — title and duration. Returns a `jobId` that you poll on `GET /info/{jobId}`."
+    async:
+      id_from: jobId
+      poll:
+        endpoint: vidkraken.youtube.info.job.status
+        param: {in: pathParams, name: jobId}
+      status:
+        path: status
+        success: [success]
+        failure: [failed]
+      result:
+        path: result
+        ttl_note: "1h — job state expires from Redis an hour after submission (404 after)"
+      interval: 2
+    input:
+      body:
+        url: {type: string, required: true, note: "youtube.com/watch?v=ID, youtu.be/ID or youtube.com/live/ID", example: "https://youtu.be/dQw4w9WgXcQ"}
+        includeAudioTracks: {type: boolean, required: false, default: false, note: "leave false here; the audio-track listing is vidkraken.youtube.video.audio_tracks"}
+      bodyType: json
+      note: "Returns title, duration (seconds) and the canonical url — NOT view/like/comment counts (use another youtube.video.detail provider for stats). Its job here is sizing a download before paying for it: duration × format ≈ bandwidth. A failed job carries the same `errorCode` vocabulary as downloads (PRIVATE_VIDEO, AGE_RESTRICTED, …), so it doubles as a free-of-bandwidth pre-check of whether a download would succeed. Intermediate status may read `processing` (treat as still pending)"
+    test_request:
+      body: {url: "https://youtu.be/jNQXAC9IVRw"}
+    cost:
+      type: per_success
+      value: 1
+      currency: credit
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://vidkraken.com/openapi.yaml
+      checked: '2026-09-10'
+      confidence: documented
+      note: "1 'info request' from the plan's info quota (Starter 200,000/month; Free 50 lifetime) — a quota counter, never priced in USD and with no overage; no bandwidth. Charged on success only. OBSERVED 2026-09-10: balances.info.used moved by exactly 1 per successful lookup."
+    docs_url: https://vidkraken.com/docs/endpoint/submit-video-info
+
+  - id: vidkraken.youtube.video.audio_tracks
+    capability: youtube.video.audio_tracks
+    platform: youtube
+    domain: video
+    scope: any_account
+    method: POST
+    path: /info
+    name: "List a YouTube video's audio tracks (dubbed languages)"
+    summary: "Set `includeAudioTracks: true` to also resolve the list of available audio tracks (original + dubbed languages, if any). Audio tracks require a full extraction, which is slower and can occasionally fail on hard-to-reach videos."
+    async:
+      id_from: jobId
+      poll:
+        endpoint: vidkraken.youtube.info.job.status
+        param: {in: pathParams, name: jobId}
+      status:
+        path: status
+        success: [success]
+        failure: [failed]
+      result:
+        path: result
+        ttl_note: "1h — job state expires from Redis an hour after submission (404 after)"
+      interval: 3
+    input:
+      body:
+        url: {type: string, required: true, example: "https://www.youtube.com/watch?v=omW5PrTMz-c"}
+        includeAudioTracks: {type: boolean, required: true, enum: [true], example: true}
+      bodyType: json
+      note: "The result's `audio[]` lists {type: original|dubbed, language} — feed a language into a download row's `language` field. Slower than the plain lookup (a few seconds)"
+    test_request:
+      body: {url: "https://www.youtube.com/watch?v=omW5PrTMz-c", includeAudioTracks: true}
+    cost:
+      type: per_success
+      value: 1
+      currency: credit
+      per: 1
+      unit: call
+      source: docs
+      source_url: https://vidkraken.com/openapi.yaml
+      checked: '2026-09-10'
+      confidence: documented
+      note: "Same 1 'info request' as the plain lookup — the audio-track extraction costs no more. OBSERVED 2026-09-10: balances.info.used moved by exactly 1."
+    docs_url: https://vidkraken.com/docs/endpoint/submit-video-info
+
+  - id: vidkraken.youtube.info.job.status
+    kind: utility
+    capability: youtube.info.job.status
+    platform: youtube
+    domain: video
+    scope: any_account
+    method: GET
+    path: /info/{jobId}
+    name: "Check a video-info job and get its result"
+    summary: "Poll the status of a previously-submitted video-info job."
+    resource_ownership:
+      requires: {kind: "poll:vidkraken.youtube.info.job.status", param: jobId}
+    async: false
+    input:
+      pathParams:
+        jobId: {type: string, required: true, example: "6f9c1234-5e8a-4b2f-9c1e-0a7b69cfc45e", note: "the jobId returned by POST /info"}
+      note: "Status is pending (or processing) → success | failed; `result` holds {title, duration, url[, audio]}. Job state expires 1 hour after submission and a foreign id is refused: 404 {\"error\":\"Job not found or expired\"}"
+    test_request:
+      # a job from the vendor's own verification run — expires after 1 h; chain the id from a fresh POST /info
+      pathParams: {jobId: "959763b2-f258-413c-aa30-8d631ba2bec2"}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "Polling is never charged (observed: no meter moved)."}
+    docs_url: https://vidkraken.com/docs/endpoint/get-video-info-status
+
+  # --- Account -----------------------------------------------------------------------------------
+  - id: vidkraken.account.usage
+    kind: account
+    capability: account.usage
+    platform: account
+    scope: own_account
+    method: GET
+    path: /me
+    name: "Get plan and remaining bandwidth, downloads and info quota"
+    summary: "Returns the account behind the API key — name, email, current plan, and the live balance on every metered feature."
+    async: false
+    input:
+      note: "no parameters — the key rides in the Authorization header. `balances` is keyed by feature: download_count, bandwidth_mb (THE billed meter) and info on every account; client_download and channel_list only where the add-on is enabled. Each carries granted / used / remaining / unlimited / resetsAt"
+    test_request: {queryParams: {}}
+    cost: {type: free, value: 0, currency: USD, unit: call, note: "free, no call limit; this is the registry's health probe — a bad key answers 401 {\"error\":\"Invalid API key\"}"}
+    docs_url: https://vidkraken.com/docs/endpoint/get-account

--- a/src/treg/oauth_providers.py
+++ b/src/treg/oauth_providers.py
@@ -1594,6 +1594,33 @@ SCRAPECREATORS = OAuthProvider(
     token_verify_field="creditCount",
 )
 
+VIDKRAKEN = OAuthProvider(
+    service="vidkraken",
+    display_name="Vid Kraken",
+    auth_kind="key",
+    token_label="API key",
+    token_placeholder="your Vid Kraken API key",
+    token_header="Authorization",
+    token_format="Bearer {secret}",
+    setup_url="https://vidkraken.com/dashboard",
+    setup_action_label="Get your Vid Kraken API key",
+    setup_steps=(
+        "Sign in to Vid Kraken with Google and open the Dashboard.",
+        "Copy the API key shown at the top of the dashboard.",
+    ),
+    setup_note="Downloads are billed by bandwidth (delivered file size, 20 MB minimum); metadata lookups draw from a per-plan quota; polling and the account check are free.",
+    auth_uri="", token_uri="",
+    scopes={},
+    client_id_setting="", client_secret_setting="",
+    category="Social media",
+    summary="Download YouTube videos, audio tracks and trimmed clips to a CDN file URL, and look up a video's title, duration and audio languages.",
+    base_url="https://vidkraken.com/api/v2",
+    docs_url="https://vidkraken.com/docs",
+    # Free account/balances read. Live 2026-09-10: bogus Bearer -> 401 {"error":"Invalid API key"};
+    # missing header -> 401 {"error":"Missing API key. Provide it as 'Bearer YOUR_API_KEY'"}.
+    probe_path="/me",
+)
+
 # ---- SEO API-key providers -------------------------------------------------------------------
 
 DATAFORSEO = OAuthProvider(
@@ -2815,7 +2842,7 @@ REGISTRY: dict[str, OAuthProvider] = {
         # API-key providers
         APOLLO, PDL, AKTA, HUNTER, SUMBLE, QUICKENRICH, TRYKITT, CONTACTOUT, MILLIONVERIFIER, CRUNCHBASE, MINIMAX, OPENROUTER, REPLICATE,
         TIKHUB, BRIGHTDATA, SEMRUSH, JUSTONEAPI,
-        SCRAPECREATORS,
+        SCRAPECREATORS, VIDKRAKEN,
         # SEO API-key providers
         DATAFORSEO, SERANKING, MOZ, MAJESTIC, SERPSTAT, EXA, CLORO,
         # more Enrichment API-key providers

--- a/src/treg/web/logos/vidkraken.svg
+++ b/src/treg/web/logos/vidkraken.svg
@@ -1,0 +1,5 @@
+<svg width="65" height="65" viewBox="0 0 65 65" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="vidkraken">
+  <rect x="0.75" y="0.988281" width="64" height="64" rx="12.8" fill="#0F172A"/>
+  <text x="32.75" y="43" text-anchor="middle" font-family="Inter, -apple-system, Helvetica, Arial, sans-serif" font-size="30" font-weight="700" fill="#FFFFFF">V</text>
+  <rect x="1.25" y="1.48828" width="63" height="63" rx="12.3" stroke="#ECECEC"/>
+</svg>

--- a/tests/test_key_providers.py
+++ b/tests/test_key_providers.py
@@ -23,7 +23,7 @@ def test_key_providers_are_offerable_without_deployment_credentials():
     """The user brings the key, so treg holds no app of its own — a key provider must be offerable,
     not shown as 'not configured' the way an unset OAuth provider is."""
     for svc in ("apollo", "pdl", "akta", "hunter", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush",
-                "justoneapi", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
+                "justoneapi", "vidkraken", "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
                 "cloro",
                 "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",
                 "companyenrich", "oceanio", "tomba", "predictleads", "findymail", "branddev",

--- a/tests/test_oauth_providers_m3.py
+++ b/tests/test_oauth_providers_m3.py
@@ -48,7 +48,7 @@ def test_every_provider_is_registered():
         "facebook", "instagram", "meta-ads",
         # API-key providers (auth_kind="key")
         "apollo", "pdl", "akta", "hunter", "sumble", "quickenrich", "contactout", "millionverifier", "trykitt", "crunchbase", "tikhub", "brightdata", "semrush", "justoneapi",
-        "scrapecreators",
+        "scrapecreators", "vidkraken",
         "dataforseo", "seranking", "moz", "majestic", "serpstat", "exa",
         "cloro",
         "lusha", "coresignal", "diffbot", "thecompaniesapi", "leadmagic", "fiber-ai",


### PR DESCRIPTION
## What this does

Adds **Vid Kraken** (https://vidkraken.com) as a self-serve API-key provider and catalogs its 8 core operations: server-side YouTube **video / audio / trimmed-clip downloads** delivered as a CDN file URL (async job protocol, wired with `async:` descriptors), the video title/duration and audio-track (dubbed language) lookups that pre-flight a download, and the free account/balances read that serves as the probe. The listing is deliberately scoped to downloads and video info.

Files: registry entry (`src/treg/oauth_providers.py`), `src/treg/catalog/vidkraken.yaml`, neutral lettermark `src/treg/web/logos/vidkraken.svg`, the two test-list additions, and the five generated `SKILL.md` copies regenerated by `scripts/build_plugin.py` (provider count 70 → 71; `test_the_plugin_skill_is_not_stale` fails otherwise). No `verified:` stamps, no example responses, no credential values anywhere in the diff.

**Contact: hello@vidkraken.com**

Please reach us there to arrange the test credential for live verification. We will hand over a dedicated key with a bandwidth grant large enough for repeated sweeps (a stock free-plan key is capped at 10 lifetime downloads / 50 info lookups / 10 GB).

## Eligibility and integration facts

- **Self-serve key:** sign in with Google at https://vidkraken.com/dashboard; the API key is shown on the dashboard. No sales call.
- **Base URL:** `https://vidkraken.com/api/v2` (the two legacy hostnames in the spec's `servers` list are aliases of it).
- **Auth:** `Authorization: Bearer <key>` header.
- **Probe:** `GET /me` — free, no call limit, returns plan + live balances.
- **Docs:** https://vidkraken.com/docs (per-endpoint pages linked from each row's `docs_url`).
- **Stable OpenAPI 3.1 spec:** https://vidkraken.com/openapi.yaml — yes, published; happy to have an extended tier generated from it (the core file already covers every documented path, see the surface map).
- **Pricing:** https://vidkraken.com/#pricing. No machine-readable rate-card endpoint; `GET /me` returns balances, not prices.
- **Limits:** at most 100 downloads queued or in progress per account (429 beyond, not charged). No published per-minute request limit.

### Pricing and billing model

Downloads are billed in **bandwidth only**: the delivered file size, with a **20 MB minimum per download**, drawn from the plan's monthly allowance. There is no per-download fee and failures are never charged. The USD figure in the cost blocks is the plan's effective per-GB rate; the catalog lists the Starter rate as the documented price:

| plan | monthly | included | effective | overage |
|---|---:|---:|---:|---:|
| Free | $0 | 10 GB + 10 downloads, lifetime | — | none (hard stop) |
| Starter | $99 | 400 GB | **$0.25/GB** (listed) | $0.50/GB |
| Growth | $399 | 2 TB | $0.20/GB | $0.40/GB |
| Scale | $1,499 | 10 TB | $0.15/GB | $0.30/GB |

- `POST /info` (both rows) draws **1 "info request"** from a per-plan quota (2× the download quota, e.g. 200,000/month on Starter; 50 lifetime on Free). It is a quota counter that is never priced in USD and has no overage, so it is recorded as `1 credit per call` with a note. `settle` semantics: charged on success only.
- Polling routes and `GET /me`: free.

## Bogus-key probe — observed from the wire, 2026-09-10 15:12:47 UTC

```text
GET https://vidkraken.com/api/v2/me   Authorization: Bearer treg-bogus-key-<timestamp>
HTTP 401
{"error":"Invalid API key"}
```

Also observed (15:08 UTC): no `Authorization` header → `401 {"error":"Missing API key. Provide it as 'Bearer YOUR_API_KEY'"}`; the same bogus key on `POST /info` → `401 {"error":"Invalid API key"}`. A valid key on `GET /me` → `200` with `plan` and `balances`. I did not run treg's `POST /connections/token` flow locally; the registry entry relies on the default "any ≥400 rejects" rule, which this behavior satisfies.

## Vendor self-verification ledger — 2026-09-10 (15:12 UTC sweep)

Every `test_request` was run live against production on our own Scale-plan account, reading `GET /me` balances immediately after each call. The meter is `balances.bandwidth_mb.used` (bandwidth, THE billed meter), `balances.info.used` (info quota) and `balances.download_count.used`.

| endpoint | HTTP | test target | catalog price | metered | matches? | evidence |
|---|---:|---|---|---|:---:|---|
| `vidkraken.youtube.video.download` | 200 → `COMPLETED` in 5 s | `jNQXAC9IVRw` ("Me at the zoo", 19 s), format 360 | $0.25/GB, 20 MB min ⇒ 0.02 GB | +20 MB, +1 download | ✅ | `fileSize` 475,958 B billed at the 20 MB floor; bandwidth_mb.used 1,123,936 → 1,123,956 |
| `vidkraken.youtube.audio.download` | 200 → `COMPLETED` in 5 s | same video, format audio | same | +20 MB, +1 download | ✅ | `fileSize` 252,182 B; 1,123,956 → 1,123,976 |
| `vidkraken.youtube.video.clip` | 200 → `COMPLETED` in 5 s | same video, 0–5 s, 360 | same | +20 MB, +1 download | ✅ | `fileSize` 220,975 B; 1,123,976 → 1,123,996 |
| `vidkraken.youtube.download.job.status` | 200 | jobId from the row above | free | no meter moved | ✅ | polled 2× per job, balances unchanged |
| `vidkraken.youtube.video.detail` | 200 → `success` in 0 s | `jNQXAC9IVRw` | 1 info request | +1 info | ✅ | info.used 11,339 → 11,341 across the two info rows (meter lags the response by a few seconds) |
| `vidkraken.youtube.video.audio_tracks` | 200 → `success` in 6 s | `omW5PrTMz-c` (has dubbed tracks), `includeAudioTracks: true` | 1 info request | +1 info | ✅ | same +2 total for the two info rows |
| `vidkraken.youtube.info.job.status` | 200 | jobId from the row above | free | no meter moved | ✅ | balances unchanged |
| `vidkraken.account.usage` | 200 | — | free | no meter moved | ✅ | this is the probe |

**Reconciliation of the sweep:** bandwidth_mb.used 1,123,936 → 1,123,996 = **60 MB = 3 × 20 MB floor** ✓; download_count 5,966 → 5,969 = 3 ✓; info 11,339 → 11,341 = 2 ✓ (the sweep also called `POST /list-channel` once, moving channel_list.used 1,180 → 1,181; that route was subsequently dropped from the listing). The account's `client_download` meter moved during the run (281,870 → 281,886) from unrelated concurrent traffic on this production account; no listed route touches that meter.

Notes on price observation: all three download test targets are tiny on purpose (sub-MB files) and therefore settle at the 20 MB floor — the floor is the observed charge. A download larger than 20 MB was not run in this sweep; the "actual file size" half of the rule is documented (OpenAPI `info.description`, pricing page), not observed here. There are no deliberate-miss targets. Expired/foreign job ids answer `404 {"error":"Download job not found"}` and `404 {"error":"Job not found or expired"}` respectively (observed 15:12:46 UTC).

**Second sweep, 15:15 UTC, via `scripts/catalog_verify.py vidkraken`: PASS on every row** (http 200; the run predates dropping the channel row, so it covered 9 rows of which the listed 8 are a subset). Its account-level deltas are not reported as meter evidence because the same account was serving unrelated traffic at the time (download_count moved by 5 where the sweep submitted 3).

Validation:

```text
$ uv run --frozen python scripts/catalog_validate.py
OK — 97 provider file(s), 3256 endpoint(s), 0 error(s), 0 warning(s)
$ uv run --with pytest-xdist pytest -n auto -q
3612 passed, 6 skipped, 1 failed (run 1: test_the_plugin_skill_is_not_stale — fixed by regenerating the SKILL.md copies;
run 2: tests/test_maintenance.py::test_real_serve_path_can_query_database_after_pre_serve_maintenance —
passes when run alone: `pytest tests/test_maintenance.py tests/test_plugin.py` → 50 passed; flaky under -n auto, unrelated to this change)
```

## Full documented surface map

The source of truth is the 6-path OpenAPI 3.1 document at https://vidkraken.com/openapi.yaml (plus one outbound webhook).

| documented operation | decision |
|---|---|
| `POST /download` | **Catalogued** as three rows — `youtube.video.download` (360p–1080p MP4), `youtube.audio.download` (format `audio`: the API default and the cheapest tier), `youtube.video.clip` (`startTime`/`endTime` trim). The `language` (dubbed audio track) and `webhookUrl` options are inputs on those rows rather than separate rows. |
| `GET /download/{jobId}` | **Catalogued** — `kind: utility` poll target of the file-level `async` descriptor. |
| `POST /info` | **Catalogued** as two rows — `youtube.video.detail` (title + duration, the free-of-bandwidth pre-flight) and `youtube.video.audio_tracks` (`includeAudioTracks: true`). |
| `GET /info/{jobId}` | **Catalogued** — `kind: utility` poll target of the /info `async` override. |
| `POST /list-channel` | Excluded — channel video listing is better served by the dedicated YouTube data providers already on `youtube.channel.videos`. |
| `GET /me` | **Catalogued** — `account.usage`, the probe. |
| webhook `download.finished` | Excluded — an outbound callback, not a callable route; surfaced as the `webhookUrl` input. |
| `POST /client-download` (named in the spec's billing table; no published path) | Excluded — account add-on, not self-serve. |

## Capability mapping

- Reused: `youtube.video.detail` (POST /info — note it returns title + duration only, no stats; the row's summary and note say so. If reviewers would rather keep that id for stat-bearing providers, a narrower proposed id such as `youtube.video.preflight` is fine by us) and `account.usage`.
- Proposed (nothing on the `youtube` platform yields the media file today): `youtube.video.download`, `youtube.audio.download`, `youtube.video.clip`, `youtube.video.audio_tracks`, plus the two utility ids `youtube.download.job.status` / `youtube.info.job.status`.
- We are not aware of another provider in the catalog with an unmapped endpoint doing these download jobs.

## How it was tested

Live sweep with our own key as above; `scripts/catalog_verify.py vidkraken` PASS on every row; `scripts/catalog_validate.py` exit 0 over the whole catalog; full pytest suite (result above).

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change (provider added to `test_every_provider_is_registered` and the key-provider offerable loop)
- [ ] Updated the relevant `docs/context/` fragment — data-only vendor listing; left to the maintainer half per `docs/VENDORS.md`
- [x] No secrets in the diff (keys, tokens, `.env` values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoRYeRXZeWQWWjdmFzBdhM
