### PR TITLE
fix(catalog): align DataForSEO docs with live API constraints

### DIFF
--- a/src/treg/catalog/dataforseo.extended.yaml
+++ b/src/treg/catalog/dataforseo.extended.yaml
@@ -7211,12 +7211,12 @@ endpoints:
       item_types:
         type: array
         required: false
-        note: 'types of items returned optional field to speed up the execution of the request, specify one item at a time; possible values: "google_trends_graph", "google_trends_map", "google_trends_topics_list","google_trends_queries_list" default value: "google_trends_graph" Note: to obtain google_trends_topics'
+        note: 'possible values: "google_trends_graph" (default), "google_trends_map", "google_trends_topics_list", "google_trends_queries_list". IMPORTANT: google_trends_topics_list and google_trends_queries_list require exactly 1 keyword — if you pass multiple keywords with these item_types, the API returns error 40501 (Invalid Field).'
       tag:
         type: string
         required: false
         note: user-defined task identifier optional field the character limit is 255 you can use this parameter to identify the task and match it with the result you will find the specified tag value in the data object of the response
-    note: the POST body is an ARRAY of task objects with these fields — one object per task
+    note: POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)
   test_request:
     body:
     - location_name: United States
@@ -7226,7 +7226,6 @@ endpoints:
       category_code: 3
       keywords:
       - rugby
-      - cricket
     bodyType: json
   expect:
     json_path: tasks.0.status_code

--- a/src/treg/catalog/dataforseo.yaml
+++ b/src/treg/catalog/dataforseo.yaml
@@ -60,7 +60,7 @@ source:
 # ============================================================================================
 
 
-limits: "2000 requests/min; up to 100 tasks per POST array"
+limits: "2000 requests/min. Live endpoints (/live) accept exactly 1 task per POST; async task_post endpoints accept up to 100."
 pricing_url: https://dataforseo.com/pricing  # A billable 'SERP' is 10 results, not a whole page. Credits never expire; pay-as-you-go after the minimum top-up. Live mode is ~3x Standard.; free tier: 1 USD trial credit on si
 endpoints:
   # --- Backlinks (the Moz overlap group) --------------------------------------------------------
@@ -84,7 +84,7 @@ endpoints:
         internal_list_limit: {type: integer, required: false, note: "max elements per internal breakdown array, 10-1000; default 10", example: 10}
         rank_scale: {type: string, required: false, note: "one_hundred | one_thousand; default one_thousand"}
         backlinks_filters: {type: array, required: false, note: "narrow the backlink set the aggregates are computed over"}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", internal_list_limit: 10}
@@ -115,7 +115,7 @@ endpoints:
         exclude_internal_backlinks: {type: boolean, required: false, note: "default true"}
         filters: {type: array, required: false, note: "max 8 conditions"}
         order_by: {type: array, required: false, note: "max 3 rules, e.g. [\"rank,desc\"]"}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", limit: 2, mode: "one_per_domain"}
@@ -146,7 +146,7 @@ endpoints:
         exclude_internal_backlinks: {type: boolean, required: false, note: "default true"}
         filters: {type: array, required: false}
         order_by: {type: array, required: false}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", limit: 2}
@@ -176,7 +176,7 @@ endpoints:
         include_subdomains: {type: boolean, required: false, note: "default true"}
         filters: {type: array, required: false}
         order_by: {type: array, required: false}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", limit: 2}
@@ -205,7 +205,7 @@ endpoints:
       body:
         targets: {type: array, required: true, note: "up to 1000 domains/subdomains (no scheme, no www) or full page URLs", example: ["moz.com"]}
         rank_scale: {type: string, required: false, note: "one_hundred (0-100, comparable to Moz DA) | one_thousand (default)"}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {targets: ["moz.com"], rank_scale: "one_hundred"}
@@ -234,7 +234,7 @@ endpoints:
         main_domain: {type: boolean, required: false, note: "return main domains only; default false"}
         filters: {type: array, required: false}
         order_by: {type: array, required: false}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", limit: 2}
@@ -265,7 +265,7 @@ endpoints:
         device: {type: string, required: false, note: "desktop (default) | mobile"}
         os: {type: string, required: false, note: "windows/macos for desktop, android/ios for mobile"}
       note: |
-        POST body is an array of these task objects; one element = one billable task.
+        POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays).
         `/live/regular` is the cheap variant used here: plain organic + a few SERP feature types.
         `/live/advanced` costs more and adds the full set of SERP features (people_also_ask,
         AI overview, images, videos, …) — switch paths if you need those elements.
@@ -300,7 +300,7 @@ endpoints:
         date_to: {type: string, required: false, note: "yyyy-mm-dd, cannot be later than last month"}
         include_adult_keywords: {type: boolean, required: false, note: "default false"}
         sort_by: {type: string, required: false, note: "relevance (default) | search_volume | competition_index | low_top_of_page_bid | high_top_of_page_bid"}
-      note: "POST body is an array of these task objects; one task is billed as one call regardless of keyword count, so batch keywords rather than looping"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays); the task is billed as one call regardless of keyword count, so batch keywords within a single task"
     test_request:
       body:
         - {keywords: ["coffee"], location_code: 2840, language_code: "en"}
@@ -334,7 +334,7 @@ endpoints:
         ignore_synonyms: {type: boolean, required: false, note: "drop near-duplicate keywords; default false"}
         filters: {type: array, required: false, note: "max 8 conditions"}
         order_by: {type: array, required: false, note: "max 3 rules"}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {keyword: "coffee", location_code: 2840, language_code: "en", depth: 1, limit: 2}
@@ -366,7 +366,7 @@ endpoints:
         load_rank_absolute: {type: boolean, required: false, note: "include absolute SERP position; default false"}
         filters: {type: array, required: false, note: "max 8 conditions"}
         order_by: {type: array, required: false, note: "max 3 rules"}
-      note: "POST body is an array of these task objects; one element = one billable task"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays)"
     test_request:
       body:
         - {target: "moz.com", location_code: 2840, language_code: "en", limit: 2}
@@ -396,7 +396,7 @@ endpoints:
         enable_browser_rendering: {type: boolean, required: false, note: "measure Core Web Vitals; implies enable_javascript; costs more; default false"}
         accept_language: {type: string, required: false}
         check_spell: {type: boolean, required: false, note: "default false"}
-      note: "POST body is an array of these task objects; one element = one billable task (one page crawled)"
+      note: "POST body is an array with exactly 1 task object (Live endpoints do not support multi-task arrays; one page crawled per task)"
     test_request:
       body:
         - {url: "https://moz.com/"}

--- a/tests/test_dataforseo_constraints.py
+++ b/tests/test_dataforseo_constraints.py
@@ -1,0 +1,176 @@
+"""Validate DataForSEO catalog entries match upstream API constraints.
+
+DataForSEO has provider-specific rules that generic catalog validation can't catch:
+
+1. Live endpoints (/live) accept exactly 1 task per POST body array — multi-task
+   arrays are only supported by async task_post endpoints.
+
+2. Google Trends item_types google_trends_topics_list and google_trends_queries_list
+   require exactly 1 keyword — multiple keywords with these item_types cause error 40501.
+
+These tests ensure catalog test_requests and documentation stay aligned with live behavior.
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+
+
+CATALOG = Path("src/treg/catalog")
+
+
+def load_dataforseo_endpoints():
+    """Load all DataForSEO endpoints from core and extended catalogs."""
+    endpoints = []
+
+    core_path = CATALOG / "dataforseo.yaml"
+    if core_path.exists():
+        data = yaml.safe_load(core_path.read_text())
+        for ep in data.get("endpoints", []):
+            ep["_source"] = "dataforseo.yaml"
+            endpoints.append(ep)
+
+    extended_path = CATALOG / "dataforseo.extended.yaml"
+    if extended_path.exists():
+        data = yaml.safe_load(extended_path.read_text())
+        if isinstance(data, list):
+            for ep in data:
+                ep["_source"] = "dataforseo.extended.yaml"
+                endpoints.append(ep)
+
+    return endpoints
+
+
+def test_live_endpoints_have_single_task_test_requests():
+    """DataForSEO Live endpoints accept exactly 1 task per POST array.
+
+    The upstream API documentation states: "each Live API call can contain only
+    one task". Async task_post endpoints support up to 100 tasks, but /live
+    endpoints reject multi-task arrays.
+
+    Ref: https://docs.dataforseo.com/v3/backlinks/summary/live/
+    """
+    endpoints = load_dataforseo_endpoints()
+    violations = []
+
+    for ep in endpoints:
+        path = ep.get("path", "")
+        method = ep.get("method", "")
+
+        if "/live" not in path or method != "POST":
+            continue
+
+        test_req = ep.get("test_request", {})
+        body = test_req.get("body")
+
+        if body is None:
+            continue
+
+        if not isinstance(body, list):
+            violations.append(f"{ep['id']}: test_request.body is not a list")
+            continue
+
+        if len(body) != 1:
+            violations.append(
+                f"{ep['id']}: Live endpoint test_request.body has {len(body)} tasks, "
+                f"expected exactly 1 (Live endpoints do not support multi-task arrays)"
+            )
+
+    assert not violations, "DataForSEO Live endpoints must have exactly 1 task:\n" + "\n".join(violations)
+
+
+def test_google_trends_topics_queries_require_single_keyword():
+    """Google Trends topics_list/queries_list item_types require exactly 1 keyword.
+
+    The upstream API documentation states: "to obtain google_trends_topics_list
+    and google_trends_queries_list items, specify no more than 1 keyword".
+    Sending multiple keywords with these item_types causes error 40501 (Invalid Field).
+
+    Ref: https://docs.dataforseo.com/v3/keywords_data/google_trends/explore/live/
+    """
+    endpoints = load_dataforseo_endpoints()
+    restricted_item_types = {"google_trends_topics_list", "google_trends_queries_list"}
+    violations = []
+
+    for ep in endpoints:
+        path = ep.get("path", "")
+
+        if "google_trends" not in path:
+            continue
+
+        test_req = ep.get("test_request", {})
+        body = test_req.get("body")
+
+        if not isinstance(body, list) or not body:
+            continue
+
+        for i, task in enumerate(body):
+            if not isinstance(task, dict):
+                continue
+
+            item_types = task.get("item_types", [])
+            if not isinstance(item_types, list):
+                item_types = [item_types] if item_types else []
+
+            uses_restricted = bool(set(item_types) & restricted_item_types)
+
+            if not uses_restricted:
+                continue
+
+            keywords = task.get("keywords", [])
+            if not isinstance(keywords, list):
+                keywords = [keywords] if keywords else []
+
+            if len(keywords) > 1:
+                violations.append(
+                    f"{ep['id']}: task[{i}] uses {set(item_types) & restricted_item_types} "
+                    f"with {len(keywords)} keywords, but these item_types require exactly 1 keyword"
+                )
+
+    assert not violations, "Google Trends constraint violated:\n" + "\n".join(violations)
+
+
+def test_limits_doc_mentions_single_task_for_live():
+    """The provider limits string must clarify Live endpoints accept only 1 task."""
+    core_path = CATALOG / "dataforseo.yaml"
+    data = yaml.safe_load(core_path.read_text())
+    limits = data.get("limits", "")
+
+    assert "Live" in limits, "limits should mention Live endpoint behavior"
+    assert "1 task" in limits or "exactly 1" in limits, (
+        "limits should state that Live endpoints accept exactly 1 task per POST"
+    )
+
+
+@pytest.mark.parametrize("endpoint_id", [
+    "dataforseo.web.backlinks.summary",
+    "dataforseo.web.backlinks.list",
+    "dataforseo.web.linking_domains.list",
+    "dataforseo.web.anchors.list",
+    "dataforseo.web.url.metrics",
+    "dataforseo.web.backlinks.competitors",
+    "dataforseo.google.serp.organic",
+    "dataforseo.google.keywords.volume",
+    "dataforseo.google.keywords.ideas",
+    "dataforseo.google.domain.ranked_keywords",
+    "dataforseo.web.page.audit",
+])
+def test_core_live_endpoints_document_single_task_constraint(endpoint_id):
+    """Each core Live endpoint's input.note must mention the single-task constraint."""
+    core_path = CATALOG / "dataforseo.yaml"
+    data = yaml.safe_load(core_path.read_text())
+
+    endpoint = None
+    for ep in data.get("endpoints", []):
+        if ep.get("id") == endpoint_id:
+            endpoint = ep
+            break
+
+    assert endpoint is not None, f"Endpoint {endpoint_id} not found"
+
+    input_spec = endpoint.get("input", {})
+    note = input_spec.get("note", "")
+
+    assert "exactly 1" in note.lower() or "do not support multi-task" in note.lower(), (
+        f"{endpoint_id}: input.note should clarify Live endpoints accept exactly 1 task"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes two catalog/docs vs. live-API mismatches in the DataForSEO provider:

**Problem A — Multi-task arrays (Feedback #102/#103, org 4759)**
The catalog claimed "up to 100 tasks per POST array" but DataForSEO **Live** endpoints (`/live`) accept exactly 1 task per call. Multi-task arrays are only supported by **async** task_post endpoints.

**Problem B — Google Trends item_types (Feedback #125/#127, org 11273)**  
The catalog documented `google_trends_queries_list` and `google_trends_topics_list` as valid item_types but didn't note they require exactly 1 keyword. Passing multiple keywords with these item_types causes error 40501 (Invalid Field).

### Changes

- **dataforseo.yaml**: Clarify `limits` to distinguish Live (1 task) from async (up to 100)
- **dataforseo.yaml**: Update all `input.note` fields on Live endpoints to state the single-task constraint
- **dataforseo.extended.yaml**: Fix Google Trends `item_types` documentation and test_request (use 1 keyword)
- **tests/test_dataforseo_constraints.py**: Add CI tests to prevent regression

### New test coverage

The new tests verify:
1. All DataForSEO Live endpoint `test_request`s have exactly 1 task in the array
2. Google Trends `test_request`s with `topics_list`/`queries_list` have ≤1 keyword
3. Provider `limits` string mentions the single-task constraint
4. Each core Live endpoint's `input.note` explains the constraint

## How it was tested

```bash
uv run python -m pytest tests/test_dataforseo_constraints.py -v  # 14 passed
uv run --with pytest-xdist pytest -n auto -q tests/ -k "catalog"  # 251 passed, 2 skipped
```

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [ ] Updated the relevant `docs/context/` fragment (if a subsystem changed) — N/A: catalog docs changes only
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b23a2b3-9011-43fc-8f51-360c2ab97c27?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b23a2b3-9011-43fc-8f51-360c2ab97c27&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

