### PR TITLE
fix(route): add capped signal when max-cost truncates waterfall

### DIFF
--- a/docs/context/architecture/catalog.md
+++ b/docs/context/architecture/catalog.md
@@ -1601,9 +1601,12 @@ to choose (`docs/CAPABILITY-ROUTING-PLAN.md`). Everything else in the catalog st
   the advisory quote was too low or the child uses overflow. A budget refusal skips that candidate
   without using the provider-error retry allowance; if every candidate is skipped, return 402
   `route_max_cost`. A retained weak answer keeps its own outcome when later candidates are skipped.
+  When the waterfall ends with some candidates skipped due to max-cost, the response includes
+  `_treg.capped: true` and `X-Treg-Route-Capped: true` — a partial miss is distinguishable from an
+  exhaustive one, so callers can raise their budget if needed (feedback #131, 2026-09).
   Response: `{output, raw, _treg: {served_by, provider, tier,
-  outcome, tried[], charged_micro}}`, `X-Treg-Served-By`, `X-Treg-Providers-Tried`,
-  `X-Treg-Route-Outcome`, `X-Treg-Cost-Micro` = the sum, one `X-Treg-Call-Id`. The parent owns
+  outcome, tried[], charged_micro, capped?}}`, `X-Treg-Served-By`, `X-Treg-Providers-Tried`,
+  `X-Treg-Route-Outcome`, `X-Treg-Route-Capped?`, `X-Treg-Cost-Micro` = the sum, one `X-Treg-Call-Id`. The parent owns
   the idempotency label (a success, or a terminal failure after a paid child, replays without
   touching a provider) and writes one audit row
   (`credential_tier: routed`) beside the children's.

--- a/src/treg/application/call/route.py
+++ b/src/treg/application/call/route.py
@@ -389,9 +389,11 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
     answers: list[tuple] = []      # every attempt that returned rows, for X-Treg-Route-Merge
     weak_hits = 0
     best: tuple[int, tuple[Candidate, dict, dict, bytes]] | None = None   # best WEAK answer seen
+    cost_capped = False            # true when any candidate was skipped due to max-cost ceiling
     for n, cand in enumerate(plan.candidates):
         if options.max_cost_micro is not None and spent + (cand.price_micro or 0) > options.max_cost_micro:
             tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "skipped", None, 0, "would exceed max cost"))
+            cost_capped = True
             continue
         if rejected_by and (cand.endpoint["provider"] in rejected_by or not _free_on_failure(cand)):
             tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "skipped", None, 0,
@@ -412,6 +414,7 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
             if exc.kind == "route_max_cost":
                 tried.append(Attempt(cand.endpoint["id"], cand.endpoint["provider"], "skipped", None, 0,
                                      "would exceed max cost"))
+                cost_capped = True
                 continue
             if exc.kind in _GLOBAL_REFUSALS or (
                 exc.status_code in _CALLER_FAULT and exc.kind not in _CANDIDATE_LOCAL_FAILURES
@@ -523,9 +526,12 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
             last = next(t for t in reversed(tried) if t.outcome == "miss")
             body_out = {"output": {k: None for k in plan.contract.output}, "raw": None,
                         "_treg": {"served_by": None, "outcome": "miss", "tried": [t.view() for t in tried], "charged_micro": spent,
+                                  **({"capped": True} if cost_capped else {}),
                                   **({"dropped": plan.dropped} if plan.dropped else {})}}
             _audit_parent(parent, ep, 200, spent, audit_client)
-            return _json(body_out, 200, {"X-Treg-Providers-Tried": ",".join(t.provider for t in tried), "X-Treg-Route-Outcome": "miss"}), spent
+            headers = {"X-Treg-Providers-Tried": ",".join(t.provider for t in tried), "X-Treg-Route-Outcome": "miss",
+                       **({"X-Treg-Route-Capped": "true"} if cost_capped else {})}
+            return _json(body_out, 200, headers), spent
         _audit_parent(parent, ep, 502, spent, audit_client)
         raise GatewayFailed("route_failed", status_code=502, detail={
             "error": "route_failed", "endpoint_id": ep["id"], "tried": [t.view() for t in tried], "charged_micro": spent,
@@ -563,12 +569,14 @@ async def run_routed(parent: CallContext, ep: dict, body_bytes: bytes, get_heade
                           **({"merged_from": merged_from} if merged_from else {}),
                           **({"advice": advice} if advice else {}),
                           "outcome": winner_outcome, "tried": [t.view() for t in tried], "charged_micro": spent,
+                          **({"capped": True} if cost_capped else {}),
                           **({"ignored_filters": list(cand.ignored)} if cand.ignored else {}),
                           **({"dropped": plan.dropped} if plan.dropped else {})}}
     _audit_parent(parent, ep, 200, spent, audit_client)
     return _json(body_out, 200, {"X-Treg-Served-By": served, "X-Treg-Providers-Tried": ",".join(t.provider for t in tried),
                                  **({"X-Treg-Merged-From": ",".join(merged_from)} if merged_from else {}),
                                  **({"X-Treg-Ignored-Filters": ",".join(cand.ignored)} if cand.ignored else {}),
+                                 **({"X-Treg-Route-Capped": "true"} if cost_capped else {}),
                                  "X-Treg-Route-Outcome": winner_outcome}), spent
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -40,6 +40,18 @@ def enrichment_on(monkeypatch, platform_on):
     get_settings.cache_clear()
 
 
+@pytest.fixture
+def enrichment_with_quickenrich_on(monkeypatch, platform_on):
+    """Like enrichment_on but includes QuickEnrich - the cheapest provider for phone/email lookups."""
+    for p in ("HUNTER", "TOMBA", "LEADMAGIC", "LEADSFORGE", "FINDYMAIL", "AVIATO", "FIBER_AI", "QUICKENRICH"):
+        monkeypatch.setenv(f"TREG_PLATFORM_KEY_{p}", f"PLATFORM-{p}-KEY")
+    monkeypatch.setenv("TREG_PLATFORM_KEY_TOMBA_SECRET", "PLATFORM-TOMBA-SECRET")
+    monkeypatch.setenv("TREG_PLATFORM_PROVIDERS", "hunter,tomba,leadmagic,leadsforge,findymail,aviato,fiber-ai,quickenrich")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 def _relay_by_provider(answers: dict[str, list[tuple[int, dict]]], seen: list):
     """A fake upstream keyed by the vendor host: each provider answers its scripted list in order."""
     async def _relay(request, upstream_url, tool, secrets, client, drop_params=None, force_identity=False):
@@ -1179,6 +1191,67 @@ async def test_lusha_is_the_last_rung_of_the_phone_waterfall_and_settles_on_its_
     assert r.status_code == 200 and r.headers["X-Treg-Route-Outcome"] == "miss" and r.json()["output"]["phone"] is None, r.text
     assert before - await _balance(clients) == int(1 * rate * 1_000_000 + 0.5)
     get_settings.cache_clear()
+
+
+async def test_quickenrich_is_cheapest_phone_provider_and_respects_max_cost(clients: AsyncClient, enrichment_with_quickenrich_on, monkeypatch):
+    """QuickEnrich is the cheapest phone provider (~$0.0048) and must be considered when max-cost is
+    set above its price. Regression for feedback #136/#128: customers got 402s because the router
+    was treating a more expensive provider as cheapest when QuickEnrich was not in PLATFORM_PROVIDERS."""
+    routed = "treg.people.phone.find"
+    plan = (await clients.get(f"/catalog/endpoints/{routed}")).json()["routing"]["plan"]
+    prices = [(c["endpoint_id"], c["usd"]) for c in plan]
+    quickenrich_entry = next((p for p in prices if "quickenrich" in p[0]), None)
+    assert quickenrich_entry is not None, f"QuickEnrich must be in the phone waterfall: {prices}"
+    assert quickenrich_entry[1] == min(p[1] for p in prices if p[1]), f"QuickEnrich must be the cheapest: {prices}"
+
+    seen = []
+    hit = {'success': True, 'data': {'employee_phone': '+15550100100', 'employee_phone_type': 'mobile'},
+           'meta': {'credits_used': 1}}
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({'quickenrich': [(200, hit)]}, seen))
+
+    before = await _balance(clients)
+    # max_cost=$0.01 is above QuickEnrich (~$0.0048) but below every other provider
+    r = await clients.post(f"/call/{routed}", json={"linkedin_url": "https://www.linkedin.com/in/example"},
+                           headers={"X-Treg-Route-Max-Cost": "0.01"})
+    assert r.status_code == 200, f"Should succeed with QuickEnrich: {r.text}"
+    assert r.json()["_treg"]["served_by"] == "quickenrich.people.phone.find"
+    assert r.json()["output"]["phone"] == "+15550100100"
+    assert [p for p, *_ in seen] == ["quickenrich"], "Only QuickEnrich should be called"
+    charged = before - await _balance(clients)
+    assert charged == 4834, f"QuickEnrich should charge 1 credit = $0.004834 = 4834 micro: got {charged}"
+
+
+async def test_max_cost_below_cheapest_refuses_before_any_call_for_phone(clients: AsyncClient, enrichment_with_quickenrich_on, monkeypatch):
+    """When max-cost is below even the cheapest provider (QuickEnrich), the call is refused with
+    route_max_cost error before any provider is asked, naming the cheapest candidate."""
+    routed = "treg.people.phone.find"
+    seen = []
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({}, seen))
+    r = await clients.post(f"/call/{routed}", json={"linkedin_url": "https://www.linkedin.com/in/example"},
+                           headers={"X-Treg-Route-Max-Cost": "0.001"})  # $0.001 < QuickEnrich's $0.0048
+    assert r.status_code == 402, r.text
+    d = r.json()["detail"]
+    assert d["error"] == "route_max_cost"
+    assert "quickenrich" in d["message"], f"Error should name QuickEnrich as cheapest: {d['message']}"
+    assert seen == [], "No provider should be called when max-cost is below the cheapest"
+
+
+async def test_capped_signal_when_max_cost_truncates_waterfall(clients: AsyncClient, enrichment_with_quickenrich_on, monkeypatch):
+    """Feedback #131: When max-cost stops the waterfall early, the result should indicate that more
+    expensive providers were skipped (capped=true). This lets callers distinguish an exhaustive miss
+    from one truncated by budget - they can raise their ceiling if they need to try all providers."""
+    routed = "treg.people.phone.find"
+    miss = {'success': False, 'message': 'No data found for this profile'}
+    monkeypatch.setattr(call_service, "relay", _relay_by_provider({'quickenrich': [(200, miss)]}, []))
+    r = await clients.post(f"/call/{routed}", json={"linkedin_url": "https://www.linkedin.com/in/example"},
+                           headers={"X-Treg-Route-Max-Cost": "0.01"})  # ~$0.01 allows QuickEnrich only
+    assert r.status_code == 200, r.text
+    treg = r.json()["_treg"]
+    assert treg["outcome"] == "miss"
+    assert treg.get("capped") is True, f"Expected capped=true when waterfall truncated: {treg}"
+    assert r.headers.get("X-Treg-Route-Capped") == "true", "Expected X-Treg-Route-Capped header"
+    skipped = [t for t in treg["tried"] if t["outcome"] == "skipped" and "would exceed" in t.get("detail", "")]
+    assert skipped, f"Expected some providers skipped due to cost: {treg['tried']}"
 
 
 async def test_strict_filters_refuses_a_looser_answer_instead_of_billing_it(clients: AsyncClient, enrichment_on, monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Fixes the issue where callers using `X-Treg-Route-Max-Cost` couldn't tell whether a miss was exhaustive or truncated by their budget (feedback #131). Also adds test coverage for the QuickEnrich routing scenario (feedback #136 jacob@jkcbrands.com, #128 adam@betaacid.co).

**Code changes:**
- Track when any candidate is skipped due to max-cost ceiling
- Add `capped: true` to `_treg` response body when waterfall was truncated
- Add `X-Treg-Route-Capped` header for easy detection
- Signal appears on both miss and hit outcomes

**Root cause for #136/#128:** QuickEnrich (~$0.0048/call) was added to the catalog but not to `TREG_PLATFORM_PROVIDERS` in production. When not in the allow-list, `platform_key_for('quickenrich')` returns None, so QuickEnrich is dropped and LeadsForge (~$0.245) becomes the "cheapest" provider, causing 402 when `X-Treg-Route-Max-Cost` is between them.

**Operational fix required:** Add `quickenrich` to `TREG_PLATFORM_PROVIDERS` in the Render dashboard. This PR adds tests to prevent regression.

## How it was tested

```bash
uv run --with pytest-xdist pytest tests/test_routing.py -n auto -q
# 131 passed
```

New tests:
- `test_quickenrich_is_cheapest_phone_provider_and_respects_max_cost` - verifies QuickEnrich is the cheapest and respects max-cost header
- `test_max_cost_below_cheapest_refuses_before_any_call_for_phone` - verifies 402 when max-cost is below QuickEnrich
- `test_capped_signal_when_max_cost_truncates_waterfall` - verifies `capped: true` and header when waterfall is truncated

## Verification steps for production

1. After merging, add `quickenrich` to `TREG_PLATFORM_PROVIDERS` in Render dashboard
2. Test with: `curl -X POST https://treg.to/call/treg.people.phone.find -H "X-Treg-Route-Max-Cost: 0.01" -d '{"linkedin_url": "..."}'`
3. Should succeed with QuickEnrich (~$0.0048) instead of 402

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change (if it affects behavior)
- [x] Updated the relevant `docs/context/` fragment (if a subsystem changed)
- [x] No secrets in the diff (keys, tokens, `.env` values)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-983830ce-a66e-415c-812e-777d7211c114?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-983830ce-a66e-415c-812e-777d7211c114&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

