### PR TITLE
chore(cursor): rename plugin display name to 01 Treg

### DIFF
--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "displayName": "treg",
+  "displayName": "01 Treg",
   "version": "0.19.0",
   "description": "OpenRouter for tools — 2,896 agent-callable endpoints across 60 providers: SEO and SERP data, backlinks, social and trends, people and company enrichment, ads, scraping. Search by the task, see the price, then call it. Credentials are injected server-side, so the agent never holds a key. Pay per call, not per subscription.",
   "author": {


### PR DESCRIPTION
Renames the Cursor marketplace display name from `treg` to `01 Treg`.

Only `displayName` in `plugins/treg/.cursor-plugin/plugin.json` changes. The kebab-case install id, the `plugins/treg` folder, the marketplace `source`, and the MCP server key all stay `treg`. `tests/test_plugin.py` passes (38). No doc fragments touched; the layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G64yXZ4KWZHJbyMapLe2Ni