### PR TITLE
fix(archive): deduplicate R2 uploads and retry transient failures

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -68,7 +68,8 @@ Every object name is the raw body's SHA-256, with no prefix. The caller supplies
 uses `checksum_algorithm=SHA256` so R2 verifies the upload checksum. A successful single PUT
 returns its hash and byte size, with no follow-up HEAD. HEAD makes one request for size. No custom
 sha256 attribute is stored or checked; GET enforces size limits and verifies the downloaded hash.
-Same-body concurrent uploads are harmless. R2 stores raw bytes, independent of the media type of any particular call.
+Same-body concurrent uploads share one PUT in the process; recent successful hashes skip PUT.
+R2 stores raw bytes, independent of the media type of any particular call.
 DB compression remains unchanged. GET verifies the full hash before returning data.
 
 Migration `0032` adds nullable `ArchiveSnapshot.body_storage`: `db`, `both`, or `r2`; NULL is
@@ -94,16 +95,20 @@ content-addressed object; no pointer names a failed upload. Existing policy and 
 before uploading. Hash-only history stays in DB when bytes are ineligible.
 
 R2 has independent `ARCHIVE_R2_UPLOAD_CONCURRENCY` (8), `ARCHIVE_R2_MAX_PENDING` (256), and
-`ARCHIVE_R2_MAX_PENDING_BYTES` (128 MiB) budgets. Only PUT holds an
-upload slot. The DB stage keeps its original two slots and 30-second deadline. Upload admission
+`ARCHIVE_R2_MAX_PENDING_BYTES` (128 MiB) budgets. A leader holds one upload slot for
+its bounded attempt sequence, including retry jitter; duplicate waiters hold no upload slot. The DB stage keeps its original two slots and 30-second deadline. Upload admission
 failure falls back to the separately bounded DB queue: `both` retains DB bytes, while `r2`
 retains only hash/history/statistics if DB admission succeeds.
-`ARCHIVE_R2_TIMEOUT_S` (10 seconds) bounds PUT only; upload-slot waiting is measured separately as `queue_wait_ms`.
+`ARCHIVE_R2_TIMEOUT_S` (10 seconds) bounds the complete PUT/retry sequence after upload-slot
+admission, including retry jitter. Upload-slot waiting is outside that timeout and is measured
+separately as `queue_wait_ms`. No extra timeout layer is introduced.
 `ARCHIVE_R2_READ_TIMEOUT_S` (2 seconds, configurable) separately bounds each lookup/result/terminal
 GET including materializing bytes. The shared SDK transport uses the larger timeout so it cannot
 prematurely cut off either operation; application deadlines enforce the separate budgets.
 Terminal evidence bypasses best-effort queue admission and synchronously retries uploads up to
-`ARCHIVE_R2_TERMINAL_ATTEMPTS` (3), with bounded backoff, before the DB write. Terminal evidence has an 8-second total upload budget (including queue
+`ARCHIVE_R2_TERMINAL_ATTEMPTS` (3), with bounded backoff, before the DB write.
+429/5xx are capped at two attempts even for terminal evidence; other terminal failures retain
+the configured attempt limit, now within the shared transfer budget. Terminal evidence has an 8-second total upload budget (including queue
 wait and retries), at most 20 seconds for DB, and a 28-second total deadline. Upload exhaustion
 falls back to DB even for terminal evidence in R2-only mode. A cancelled waiter drains that
 bounded evidence operation before propagating cancellation; failures and deadlines log explicitly. Its settlement has
@@ -131,7 +136,9 @@ Read diagnostics are in place before enabling any `r2-first` switch. Lookup adds
 All paths log bounded reasons without exception text, keys, bodies or credentials:
 `not_found` and `timeout` are WARNING; `permission_denied` (including signature failures) and
 `hash_mismatch` are ERROR. Oversized objects are also ERROR (`too_large`); other transport errors
-and an unavailable client are WARNING (`store_error`, `store_unavailable`). Result and terminal
+and an unavailable client are WARNING (`store_error`, `store_unavailable`). HTTP 429 is
+`rate_limited`, HTTP 5xx is `upstream_error`, both WARNING on read fallback. These same reason
+names appear on failed uploads. Logs include the exception class, never the exception text. Result and terminal
 reads use these logs because they have no `tool_called`. Existing per-path process counters remain;
 additional bounded per-path/reason counters distinguish the failure classes.
 
@@ -520,7 +527,7 @@ done callback releases bytes when a task completes, keeping the budget accurate.
 R2 queue adds 128 MiB by default, for a combined 384 MiB body budget before SDK, compression
 and terminal-evidence overhead.
 
-The semaphore is process-local, while production runs multiple processes. An exact in-process key
+The semaphore is process-local; the recorder also supports deployment with multiple processes. An exact in-process key
 lock is acquired before the semaphore, so duplicate recordings queue without consuming both
 database-write slots and unrelated keys keep moving; weak references discard inactive locks. Once
 admitted, the writer locks and refreshes the matching `ArchiveKey` row before reading the newest
@@ -545,7 +552,12 @@ script has no bucket argument and accepts only `treg-archive-dev`.
 
 ObjectStore owns the sole download hash validation; the memory fake follows the same contract.
 `put` accepts the internally computed content hash to avoid rehashing immutable bytes. Read and
-write errors use the same typed classification; SDK text is never parsed or logged.
+write errors use the same classification. `R2ObjectStore._failure` preserves typed auth/not-found/
+timeout reasons. obstore 0.11.1 exposes HTTP 429/5xx as `GenericError` without a status attribute;
+only that SDK type is inspected for its anchored transport-status prefix. Bare numbers and status
+text inside a response body do not qualify. No SDK text is logged or emitted; `ObjectStoreError`
+carries only a bounded reason and the underlying exception class. The real-wheel loopback test
+`test_real_obstore_http_status_classification` covers PUT/GET/HEAD and proves zero SDK retries.
 
 Pruning still strips eligible DB bytes during double writing. A stripped `both` row becomes
 `r2`; its content hash and object remain intact, and logical retained-body statistics do not
@@ -564,3 +576,54 @@ inferred from its storage location; failed R2-only uploads become hash-only plan
 recording emits its completion report from one `finally` block, while queue callbacks release
 budgets and report cancellation of tasks that never started. `tool_called` remains independent.
 The object-store lifespan chooses a real or injected context once and always resets the seam.
+
+
+## Same-hash upload deduplication
+
+`archive_bodies.prepare` keeps a process-local LRU of 20,000 successfully uploaded content hashes.
+An LRU hit returns a successful `WritePlan` with `upload_status=skipped_duplicate`, zero new
+transfer time and no PUT/HEAD. Only a completed PUT with matching `ObjectInfo` enters the LRU.
+Failures and cancellations never do. `configure` resets the cache when the store changes; restart
+or LRU eviction permits a later idempotent re-upload. A GET that finds an object missing or corrupt
+invalidates its recent-success entry so the existing live-refetch path can repair it.
+
+For a new hash, `prepare` registers one in-flight future before waiting for the upload semaphore.
+Followers await its result with `asyncio.shield`, holding no semaphore slot or DB connection, and
+report `upload_status=coalesced` on success. A cancelled follower cannot cancel its leader. A
+cancelled leader releases followers to normal DB fallback and removes the in-flight entry. All
+followers share the failure reason; none publishes an R2 pointer for a failed flight. In-flight
+entries are removed on every exit and stay within the existing admitted recording work.
+
+`submit` checks recent, queued and in-flight hashes before the R2 count/byte admission gates.
+A queued hash is registered synchronously, so even a burst before background tasks start consumes
+only one R2 pending entry and one body-sized byte allocation. Duplicate recordings instead use
+archive's existing bounded DB queue; `prepare` still joins/skips the PUT before any DB session.
+Every admitted call keeps its own history/statistics write as before. Duplicates never turn into
+unbounded work: the DB queue's 512-record/256 MiB limits still apply. Distinct-body bursts can
+still exhaust R2's unchanged 256-record/128 MiB budget; increasing those settings is not part of
+this fix. `duplicate_queue_bypass`, `skipped_duplicate` and `coalesced` process counters supplement
+the existing per-record `archive_body_stored.upload_status` values.
+
+Residual `rate_limited`/`upstream_error` failures get one retry on nonterminal uploads too, with
+1.0-1.5 seconds of jitter before retry. This clears the one-write-per-second same-key window and
+shares the existing transfer deadline rather than restarting it. Exhaustion keeps `storage=db`
+in `both` mode with `upload_status=failed` and the classified `drop_reason`; the DB copy is not
+reported as dropped. R2-only mode retains its existing hash-only fallback. No SDK retries are
+enabled, no new DB writes/columns/tables are added, and no production setting is changed.
+
+### Timing and queue interpretation
+
+Before this fix, `upload_ms` already started after acquiring the upload semaphore and ended after
+`ObjectStore.put` returned/raised. Nonterminal recordings made one attempt. Semaphore wait was
+already isolated in `queue_wait_ms`; a four-second failed nonterminal `upload_ms` was therefore
+four seconds in the SDK/transport operation, not four seconds waiting for a local slot. The
+locked obstore 0.11.1 with `max_retries=0` issues exactly one HTTP request on a 429 in the loopback
+regression; its configured SDK retry count remains zero. Neither fact identifies which part of a
+production network/server operation caused the delay.
+
+After this fix, leader `upload_ms` includes all attempts and jitter under its transfer budget;
+followers record their shared-flight wait in `queue_wait_ms` and zero transfer time. LRU hits have
+zero transfer/wait time. Do not interpret these post-fix per-record values as one SDK request's
+latency, or average duplicate statuses and zero-transfer failed waiters into physical PUT latency. R2 pending accounting spans the
+recording's DB completion too; it is not just the number of active PUTs. Compare existing failure/
+drop reasons, leader timing, and duplicate statuses after rollout before increasing queue budgets.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -320,11 +320,13 @@ def record(
             method=method, endpoint_id=endpoint_id, provider=provider, url=url,
             caller_body=caller_body, headers=headers, status_code=status_code,
             media_type=media_type, body=body, origin=origin, key_hash=kh, body_hash=ch,
-            observation=observation, plan=plan), len(body), observation)
+            observation=observation, plan=plan), len(body), observation, content_hash=ch)
         if rejection is None:
             return kh, ch
-        plan = archive_bodies.WritePlan("db" if plan.keep_db else None, reason=rejection)
-        # Both mode preserves the old DB path even when the separate upload queue sheds.
+        if rejection != "duplicate":
+            plan = archive_bodies.WritePlan("db" if plan.keep_db else None, reason=rejection)
+        # Duplicates use the existing bounded DB queue and still join prepare's shared upload.
+        # Both mode preserves the DB copy when admission of a distinct upload is rejected.
 
     body_len = len(body)
     # Shed on EITHER count OR bytes — whichever bound bites first. The bytes bound prevents OOM

--- a/src/treg/archive_bodies.py
+++ b/src/treg/archive_bodies.py
@@ -1,13 +1,14 @@
 """Archive body I/O and upload scheduling, separate from archive indexing and TTL learning."""
 import asyncio
-from collections import Counter
+from collections import Counter, OrderedDict
 from dataclasses import dataclass
 import logging
 import re
+import random
 import time
 
 from .config import get_settings
-from .infra.object_store import ObjectInfo, ObjectStore, ObjectStoreError
+from .infra.object_store import ObjectInfo, ObjectStore, ObjectStoreError, exception_name, failure_reason
 
 _log = logging.getLogger("treg.archive_bodies")
 _store: ObjectStore | None = None
@@ -15,13 +16,20 @@ _pending: set[asyncio.Task] = set()
 _pending_bytes = 0
 _sem = None
 _sem_loop = None
+_RECENT_UPLOADS = 20_000
+_uploaded: OrderedDict[str, None] = OrderedDict()
+_inflight: dict[str, asyncio.Future] = {}
+_queued_hashes: set[str] = set()
 # Operational counters have bounded labels and no call, team, key or body dimensions.
 outcomes: Counter = Counter()
 
 
 def configure(store: ObjectStore | None) -> None:
-    global _store
+    global _store, _uploaded, _inflight, _queued_hashes
     _store = store
+    # A new store/bucket must not inherit success from the previous one. Leaders retain their
+    # old maps so their completion cannot populate the newly configured cache.
+    _uploaded, _inflight, _queued_hashes = OrderedDict(), {}, set()
 
 
 def uses_r2() -> bool:
@@ -95,46 +103,83 @@ async def prepare(body: bytes, content_hash: str, *, mode: str, observation: Sto
                   terminal: bool = False) -> WritePlan:
     if mode == "db":
         return WritePlan("db")
-    reason = "store_error"
-    attempts = get_settings().archive_r2_terminal_attempts if terminal else 1
-    try:
-        for attempt in range(attempts):
-            try:
-                queued = time.monotonic()
-                async with _upload_sem():
-                    observation.props["archive_body_queue_wait_ms"] += (time.monotonic() - queued) * 1000
-                    transfer = time.monotonic()
-                    try:
-                        async with asyncio.timeout(get_settings().archive_r2_timeout_s):
-                            if _store is None:
-                                raise RuntimeError("archive object store unavailable")
-                            info = await _store.put(body, content_hash=content_hash)
-                            if info != ObjectInfo(content_hash, len(body)):
-                                raise ObjectStoreError("hash_mismatch")
-                    finally:
-                        observation.props["archive_body_upload_ms"] += (time.monotonic() - transfer) * 1000
-                observation.props["archive_body_upload_status"] = "uploaded"
-                return WritePlan(mode)
-            except TimeoutError:
-                reason = "timeout"
-            except ObjectStoreError as exc:
-                reason = exc.reason
-            except Exception:
-                reason = "store_error"
-            if attempt + 1 < attempts:
-                await asyncio.sleep(min(0.1 * 2 ** attempt, 1.0))
-        observation.props["archive_body_upload_status"] = "failed"
-        _log.error("archive body upload failed after %s attempt(s): %s", attempts, reason)
-        # Double write preserves the DB copy when R2 fails, without publishing an R2 pointer.
-        return WritePlan("db" if mode == "both" else None, reason=reason)
-    finally:
-        observation.props["archive_body_upload_ms"] = round(observation.props["archive_body_upload_ms"], 3)
+    uploaded, inflight = _uploaded, _inflight
+    if content_hash in uploaded:
+        uploaded.move_to_end(content_hash)
+        observation.props["archive_body_upload_status"] = "skipped_duplicate"
+        outcomes["skipped_duplicate"] += 1
+        return WritePlan(mode)
+
+    flight = inflight.get(content_hash)
+    if flight is not None:
+        queued = time.monotonic()
+        # Cancelling a waiter (including a terminal deadline) must not cancel the leader.
+        reason = await asyncio.shield(flight)
+        observation.props["archive_body_queue_wait_ms"] += (time.monotonic() - queued) * 1000
+        observation.props["archive_body_upload_status"] = "coalesced" if reason is None else "failed"
+        outcomes["coalesced"] += 1
+    else:
+        flight = asyncio.get_running_loop().create_future()
+        inflight[content_hash] = flight
+        reason = "cancelled"
+        try:
+            error_type, attempt = "none", 0
+            attempts = get_settings().archive_r2_terminal_attempts if terminal else 2
+            queued = time.monotonic()
+            async with _upload_sem():
+                observation.props["archive_body_queue_wait_ms"] += (time.monotonic() - queued) * 1000
+                transfer = time.monotonic()
+                try:
+                    # Attempts and jitter share the existing transfer timeout. Slot waiting stays
+                    # outside it. The terminal caller still has its original overall deadline.
+                    async with asyncio.timeout(get_settings().archive_r2_timeout_s):
+                        for attempt in range(1, attempts + 1):
+                            try:
+                                if _store is None:
+                                    raise ObjectStoreError("store_unavailable")
+                                info = await _store.put(body, content_hash=content_hash)
+                                if info != ObjectInfo(content_hash, len(body)):
+                                    raise ObjectStoreError("hash_mismatch")
+                                reason = None
+                                break
+                            except Exception as exc:
+                                reason, error_type = failure_reason(exc), exception_name(exc)
+                            transient = reason in {"rate_limited", "upstream_error"}
+                            if (attempt == attempts or (transient and attempt >= 2)
+                                    or (not transient and not terminal)):
+                                break
+                            delay = (random.uniform(1.0, 1.5) if transient
+                                     else min(0.1 * 2 ** (attempt - 1), 1.0))
+                            await asyncio.sleep(delay)
+                except TimeoutError:
+                    reason, error_type = "timeout", "TimeoutError"
+                finally:
+                    observation.props["archive_body_upload_ms"] += (time.monotonic() - transfer) * 1000
+            if reason is not None:
+                _log.error("archive body upload failed after %s attempt(s): %s exception_type=%s",
+                           attempt, reason, error_type)
+            if reason is None:
+                uploaded[content_hash] = None
+                if len(uploaded) > _RECENT_UPLOADS:
+                    uploaded.popitem(last=False)
+            observation.props["archive_body_upload_status"] = "uploaded" if reason is None else "failed"
+        finally:
+            # Publish failures too, and never cache them. A cancelled leader releases its waiters
+            # to their normal DB fallback; a later call may attempt the immutable object again.
+            inflight.pop(content_hash, None)
+            flight.set_result(reason)
+            observation.props["archive_body_upload_ms"] = round(observation.props["archive_body_upload_ms"], 3)
+    return WritePlan(mode) if reason is None else WritePlan("db" if mode == "both" else None, reason=reason)
 
 
-def submit(factory, body_len: int, observation: StorageReport) -> str | None:
+def submit(factory, body_len: int, observation: StorageReport, *, content_hash: str) -> str | None:
     """Separate count/byte budgets from archive's DB queue and DB semaphore."""
     global _pending_bytes
     s = get_settings()
+    queued_hashes = _queued_hashes
+    if content_hash in _uploaded or content_hash in queued_hashes or content_hash in _inflight:
+        outcomes["duplicate_queue_bypass"] += 1
+        return "duplicate"
     reason = ("upload_queue_full" if len(_pending) >= s.archive_r2_max_pending else
               "upload_bytes_full" if _pending_bytes + body_len > s.archive_r2_max_pending_bytes else None)
     if reason:
@@ -142,6 +187,7 @@ def submit(factory, body_len: int, observation: StorageReport) -> str | None:
         observation.props["archive_body_upload_drop_reason"] = reason
         return reason
     _pending_bytes += body_len
+    queued_hashes.add(content_hash)
 
     task = asyncio.create_task(factory())
     _pending.add(task)
@@ -150,6 +196,7 @@ def submit(factory, body_len: int, observation: StorageReport) -> str | None:
         global _pending_bytes
         _pending.discard(task)
         _pending_bytes -= body_len
+        queued_hashes.discard(content_hash)
         if task.cancelled():
             observation.finish(reason="cancelled")
     task.add_done_callback(done)
@@ -199,7 +246,7 @@ async def _db_fallback(pointer):
 
 async def read(pointer: BodyPointer, path: str, *, diagnostics: dict | None = None) -> bytes | None:
     """Call only after closing every DB session owned by the request."""
-    reason, elapsed = "none", 0.0
+    reason, elapsed, error_type = "none", 0.0, "none"
     def observed(body, source):
         if diagnostics is not None:
             diagnostics.update(cache_body_source=source, cache_body_fallback_reason=reason,
@@ -219,20 +266,15 @@ async def read(pointer: BodyPointer, path: str, *, diagnostics: dict | None = No
                 else:
                     elapsed = round((time.monotonic() - started) * 1000, 3)
                     return observed(body, "r2")
-        except TimeoutError:
-            reason = "timeout"
-        except PermissionError:
-            reason = "permission_denied"
-        except ObjectStoreError as exc:
-            reason = exc.reason if exc.reason in {
-                "not_found", "timeout", "permission_denied", "hash_mismatch", "too_large",
-                "store_unavailable", "store_error"} else "store_error"
-        except Exception:
-            reason = "store_error"
+        except Exception as exc:
+            reason, error_type = failure_reason(exc), exception_name(exc)
         elapsed = round((time.monotonic() - started) * 1000, 3)
+        if reason in {"not_found", "hash_mismatch"}:
+            _uploaded.pop(pointer.content_hash, None)
         outcomes["read_fallback_" + path] += 1
         outcomes["read_fallback_" + path + "_" + reason] += 1
         level = logging.ERROR if reason in {"permission_denied", "hash_mismatch", "too_large"} else logging.WARNING
-        _log.log(level, "archive R2 read fallback path=%s reason=%s elapsed_ms=%s", path, reason, elapsed)
+        _log.log(level, "archive R2 read fallback path=%s reason=%s elapsed_ms=%s exception_type=%s",
+                 path, reason, elapsed, error_type)
     body = await _db_fallback(pointer)
     return observed(body, "db" if body is not None else "none")

--- a/src/treg/infra/object_store.py
+++ b/src/treg/infra/object_store.py
@@ -30,15 +30,43 @@ def _key(content_hash: str) -> str:
 
 class ObjectStoreError(ValueError):
     """A bounded, credential-free reason at the SDK boundary."""
-    def __init__(self, reason: str):
+    def __init__(self, reason: str, *, exception_type: str | None = None):
         self.reason = reason
+        self.exception_type = exception_type
         super().__init__(reason)
 
 
+_FAILURE_REASONS = frozenset({"not_found", "timeout", "permission_denied", "hash_mismatch",
+                              "too_large", "store_unavailable", "store_error", "rate_limited",
+                              "upstream_error"})
+# obstore 0.11 GenericError has no status attribute. Match only its transport prefix, never a
+# bare number or provider response body. The SDK exception text must not leave this boundary.
+_HTTP_STATUS = re.compile(
+    r"^Generic S3 error: Error performing (?:PUT|GET|HEAD) \S+ in [^\r\n]+?"
+    r" - Server returned non-2xx status code: ([0-9]{3})\b")
+
+
+def failure_reason(exc: Exception) -> str:
+    if isinstance(exc, ObjectStoreError):
+        return exc.reason if exc.reason in _FAILURE_REASONS else "store_error"
+    if isinstance(exc, PermissionError):
+        return "permission_denied"
+    if isinstance(exc, FileNotFoundError):
+        return "not_found"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    return "store_error"
+
+
+def exception_name(exc: Exception) -> str:
+    return (getattr(exc, "exception_type", None) or type(exc).__name__)[:80]
+
+
 class R2ObjectStore:
-    def __init__(self, client, max_body_bytes: int, *, auth_errors=()):
+    def __init__(self, client, max_body_bytes: int, *, auth_errors=(), status_errors=()):
         self._client, self._max_bytes = client, max_body_bytes
         self._auth_errors = (PermissionError, *auth_errors)
+        self._status_errors = status_errors
 
     async def put(self, body: bytes, *, content_hash: str | None = None) -> ObjectInfo:
         if len(body) > self._max_bytes:
@@ -57,6 +85,8 @@ class R2ObjectStore:
             meta = await self._client.head_async(key)
         except FileNotFoundError:
             return None
+        except Exception as exc:
+            raise self._failure(exc) from None
         return ObjectInfo(key, int(meta["size"]))
 
     async def get(self, content_hash: str) -> bytes | None:
@@ -79,18 +109,23 @@ class R2ObjectStore:
             raise self._failure(exc) from None
 
     def _failure(self, exc):
+        reason = failure_reason(exc)
         if isinstance(exc, self._auth_errors):
-            return ObjectStoreError("permission_denied")
-        if isinstance(exc, FileNotFoundError):
-            return ObjectStoreError("not_found")
-        if isinstance(exc, TimeoutError):
-            return ObjectStoreError("timeout")
-        return ObjectStoreError("store_error")
+            reason = "permission_denied"
+        elif isinstance(exc, self._status_errors):
+            match = _HTTP_STATUS.match(str(exc))
+            if match:
+                status = int(match[1])
+                if status == 429:
+                    reason = "rate_limited"
+                elif 500 <= status < 600:
+                    reason = "upstream_error"
+        return ObjectStoreError(reason, exception_type=type(exc).__name__)
 
 
 @asynccontextmanager
 async def open_r2(settings):
-    from obstore.exceptions import PermissionDeniedError, UnauthenticatedError
+    from obstore.exceptions import GenericError, PermissionDeniedError, UnauthenticatedError
     from obstore.store import S3Store
 
     transport_timeout = max(settings.archive_r2_timeout_s, settings.archive_r2_read_timeout_s)
@@ -108,4 +143,4 @@ async def open_r2(settings):
     # One shared Rust HTTP pool for the lifespan. S3Store has no explicit close operation;
     # dropping the store after archive drains releases its client and pool.
     yield R2ObjectStore(client, settings.archive_max_body_bytes,
-                        auth_errors=(PermissionDeniedError, UnauthenticatedError))
+                        auth_errors=(PermissionDeniedError, UnauthenticatedError), status_errors=(GenericError,))

--- a/tests/fake_object_store.py
+++ b/tests/fake_object_store.py
@@ -11,6 +11,7 @@ class MemoryObjectStore:
         self.put_calls = 0
         self.get_calls = 0
         self.fail_puts = 0
+        self.put_failures: list[int] = []
         self.fail_gets = False
         self.gate = None
         self.entered = asyncio.Event()
@@ -22,6 +23,10 @@ class MemoryObjectStore:
         self.entered.set()
         if self.gate is not None:
             await self.gate.wait()
+        if self.put_failures:
+            status = self.put_failures.pop(0)
+            raise ObjectStoreError('rate_limited' if status == 429 else
+                                   'upstream_error' if 500 <= status < 600 else 'store_error')
         if self.fail_puts:
             self.fail_puts -= 1
             raise ObjectStoreError('store_error')

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -121,6 +121,7 @@ async def test_r2_queue_has_independent_concurrency_and_sheds_observably(clients
     monkeypatch.setattr(service.analytics, 'capture', capture)
     try:
         for i in range(4):
+            monkeypatch.setattr(service, 'relay', _fake_relay(200, RAW + b' ' * i))
             await clients.get(URL + '&count=' + str(i))
         # Wait for the DB fallback's completion event, not an arbitrary scheduling delay.
         await asyncio.wait_for(dropped.wait(), 5)
@@ -129,7 +130,7 @@ async def test_r2_queue_has_independent_concurrency_and_sheds_observably(clients
     finally:
         r2.gate.set()
     await archive.drain()
-    assert len(await snapshots()) == 4 and len(r2.objects) == 1
+    assert len(await snapshots()) == 4 and len(r2.objects) == 3
     assert len([p for name, p in events if name == 'tool_called']) == 4
 
 
@@ -425,7 +426,8 @@ async def test_obstore_factory_configuration_and_missing_objects(monkeypatch, wr
 
 @pytest.mark.parametrize('path', ['lookup', 'result', 'terminal'])
 @pytest.mark.parametrize('reason,level', [('not_found', 'WARNING'), ('timeout', 'WARNING'),
-                                         ('permission_denied', 'ERROR'), ('hash_mismatch', 'ERROR')])
+                                         ('permission_denied', 'ERROR'), ('hash_mismatch', 'ERROR'),
+                                         ('rate_limited', 'WARNING'), ('upstream_error', 'WARNING')])
 async def test_read_fallback_reason_level_and_diagnostics(r2, monkeypatch, caplog, path, reason, level):
     from treg.infra.object_store import ObjectStoreError
     monkeypatch.setattr(get_settings(), 'archive_body_read_' + path, 'r2-first')
@@ -672,3 +674,240 @@ async def test_object_boundary_classifies_put_and_get_by_type(error, reason):
         with pytest.raises(ObjectStoreError) as caught:
             await store.get(archive.content_hash(RAW))
         assert str(caught.value) == reason
+
+
+async def test_same_body_refetch_skips_duplicate_put(clients, r2, monkeypatch):
+    events = []
+    monkeypatch.setattr(service.analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    for _ in range(2):
+        response = await clients.get(URL, headers={'Cache-Control': 'no-cache'})
+        assert response.content == RAW
+        await archive.drain()
+    assert r2.put_calls == 1
+    assert len(await snapshots()) == 2
+    reports = [p for name, p in events if name == 'archive_body_stored']
+    assert [p['upload_status'] for p in reports] == ['uploaded', 'skipped_duplicate']
+    assert all(p['storage'] == 'both' and not p['dropped'] for p in reports)
+
+
+async def test_concurrent_same_body_calls_share_one_put(clients, r2):
+    r2.gate = asyncio.Event()
+    try:
+        for i in range(8):
+            assert (await clients.get(URL + '&count=' + str(i))).content == RAW
+        await asyncio.wait_for(r2.entered.wait(), 2)
+        await asyncio.sleep(0)
+        assert r2.put_calls == 1
+    finally:
+        r2.gate.set()
+    await archive.drain()
+    rows = await snapshots()
+    assert len(rows) == 8 and all(row.body_storage == 'both' for row in rows)
+    assert r2.put_calls == 1 and not archive_bodies._inflight
+
+
+@pytest.mark.parametrize('status', [429, 500, 503])
+@pytest.mark.parametrize('exhausted', [False, True])
+async def test_transient_put_retry_and_db_fallback(clients, r2, monkeypatch, status, exhausted, caplog):
+    r2.put_failures = [status] * (2 if exhausted else 1)
+    events, delays = [], []
+    def jitter(low, high):
+        delays.append((low, high))
+        return 0.001
+    monkeypatch.setattr(archive_bodies.random, 'uniform', jitter)
+    monkeypatch.setattr(service.analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    assert (await clients.get(URL)).content == RAW
+    await archive.drain()
+    assert r2.put_calls == 2 and delays == [(1.0, 1.5)]
+    row = (await snapshots())[0]
+    assert archive._unpack(row.body, row.enc) == RAW
+    report = next(p for name, p in events if name == 'archive_body_stored')
+    reason = 'rate_limited' if status == 429 else 'upstream_error'
+    if exhausted:
+        assert row.body_storage == 'db' and not r2.objects
+        assert report['upload_status'] == 'failed' and report['drop_reason'] == reason
+        assert reason in caplog.text
+        assert archive.content_hash(RAW) not in archive_bodies._uploaded
+    else:
+        assert row.body_storage == 'both' and report['upload_status'] == 'uploaded'
+    assert report['dropped'] is False
+
+
+async def test_retry_jitter_stays_inside_existing_upload_budget(clients, r2, monkeypatch):
+    monkeypatch.setattr(get_settings(), 'archive_r2_timeout_s', 0.02)
+    r2.put_failures = [429]
+    events = []
+    monkeypatch.setattr(service.analytics, 'capture', lambda who, name, props, **kw: events.append((name, props)))
+    await clients.get(URL)
+    await archive.drain()
+    assert r2.put_calls == 1 and (await snapshots())[0].body_storage == 'db'
+    report = next(p for name, p in events if name == 'archive_body_stored')
+    assert report['drop_reason'] == 'timeout' and report['upload_ms'] < 500
+    assert not archive_bodies._inflight and not archive_bodies._uploaded
+
+
+async def test_recent_upload_lru_is_bounded_and_resets_with_store(r2, monkeypatch):
+    monkeypatch.setattr(archive_bodies, '_RECENT_UPLOADS', 2)
+    async def put(raw):
+        return await archive_bodies.prepare(raw, archive.content_hash(raw), mode='both',
+                                            observation=archive_bodies.StorageReport())
+    for raw in (b'a', b'b', b'a', b'c'):
+        assert (await put(raw)).storage == 'both'
+    assert len(archive_bodies._uploaded) == 2 and r2.put_calls == 3
+    assert archive.content_hash(b'b') not in archive_bodies._uploaded
+    await put(b'b')
+    assert r2.put_calls == 4
+    replacement = MemoryObjectStore()
+    archive_bodies.configure(replacement)
+    await put(b'b')
+    assert replacement.put_calls == 1
+
+
+@pytest.mark.parametrize('cancel_leader', [False, True])
+async def test_singleflight_cancellation_releases_waiters(r2, cancel_leader):
+    r2.gate = asyncio.Event()
+    async def put():
+        return await archive_bodies.prepare(RAW, archive.content_hash(RAW), mode='both',
+                                            observation=archive_bodies.StorageReport())
+    leader = asyncio.create_task(put())
+    await asyncio.wait_for(r2.entered.wait(), 2)
+    follower = asyncio.create_task(put())
+    await asyncio.sleep(0)
+    cancelled, remaining = (leader, follower) if cancel_leader else (follower, leader)
+    cancelled.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled
+    r2.gate.set()
+    plan = await asyncio.wait_for(remaining, 2)
+    assert plan.storage == ('db' if cancel_leader else 'both')
+    assert not archive_bodies._inflight
+    assert (await put()).storage == 'both'
+    assert r2.put_calls == (2 if cancel_leader else 1)
+
+
+@pytest.mark.parametrize('path', ['lookup', 'result', 'terminal', 'put'])
+async def test_store_error_logs_only_underlying_exception_class(r2, monkeypatch, caplog, path):
+    from treg.infra.object_store import ObjectStoreError
+    async def fail(*args, **kwargs):
+        raise ObjectStoreError('store_error', exception_type='GenericError')
+    if path == 'put':
+        monkeypatch.setattr(r2, 'put', fail)
+        plan = await archive_bodies.prepare(RAW, archive.content_hash(RAW), mode='both',
+                                            observation=archive_bodies.StorageReport())
+        assert plan.reason == 'store_error'
+    else:
+        monkeypatch.setattr(get_settings(), 'archive_body_read_' + path, 'r2-first')
+        monkeypatch.setattr(r2, 'get', fail)
+        pointer = archive_bodies.BodyPointer(archive.content_hash(RAW), 'both', RAW, None)
+        assert await archive_bodies.read(pointer, path) == RAW
+    assert 'exception_type=GenericError' in caplog.text
+    assert RAW.decode() not in caplog.text and archive.content_hash(RAW) not in caplog.text
+
+
+@pytest.mark.parametrize('status,reason', [(429, 'rate_limited'), (500, 'upstream_error'),
+                                         (503, 'upstream_error'), (400, 'store_error')])
+async def test_real_obstore_http_status_classification(status, reason):
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from threading import Thread
+    from obstore.exceptions import GenericError
+    from obstore.store import S3Store
+    from treg.infra.object_store import R2ObjectStore, ObjectStoreError
+
+    calls = []
+    class Handler(BaseHTTPRequestHandler):
+        def fail(self):
+            calls.append(self.command)
+            self.rfile.read(int(self.headers.get('Content-Length', 0)))
+            self.send_response(status)
+            self.end_headers()
+            if self.command != 'HEAD':
+                self.wfile.write(b'<Error><Code>TestError</Code><Message>private-body-token</Message></Error>')
+        do_PUT = do_GET = do_HEAD = fail
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        sdk = S3Store('test', config={'endpoint': f'http://127.0.0.1:{server.server_port}',
+                                      'region': 'auto', 'access_key_id': 'test', 'secret_access_key': 'test'},
+                      client_options={'allow_http': True}, retry_config={'max_retries': 0})
+        store = R2ObjectStore(sdk, 1000, status_errors=(GenericError,))
+        key = archive.content_hash(RAW)
+        for operation in (lambda: store.put(RAW, content_hash=key), lambda: store.get(key), lambda: store.head(key)):
+            before = len(calls)
+            with pytest.raises(ObjectStoreError) as caught:
+                await operation()
+            assert len(calls) == before + 1  # real SDK max_retries=0, including HTTP 429
+            assert caught.value.reason == reason
+            assert str(caught.value) == reason
+            assert caught.value.exception_type == 'GenericError'
+    finally:
+        await asyncio.to_thread(server.shutdown)
+        server.server_close()
+        thread.join()
+
+
+async def test_generic_sdk_body_cannot_spoof_http_status():
+    from obstore.exceptions import GenericError
+    from treg.infra.object_store import R2ObjectStore
+    store = R2ObjectStore(None, 1000, status_errors=(GenericError,))
+    for text in ('503 secret-body', 'Server returned non-2xx status code: 429 secret-body',
+                 'Generic S3 error: Error performing GET https://test/abc in 1ms - '
+                 'Server returned non-2xx status code: 400 Bad Request: '
+                 'Server returned non-2xx status code: 429 Too Many Requests'):
+        error = store._failure(GenericError(text))
+        assert error.reason == 'store_error' and str(error) == 'store_error'
+
+
+async def test_same_query_burst_bypasses_upload_queue_budget(clients, r2, monkeypatch):
+    # A burst of identical search results, before any upload can finish. Duplicates must not
+    # consume the distinct-upload budget even before the first background task starts.
+    monkeypatch.setattr(get_settings(), 'archive_r2_max_pending', 1)
+    monkeypatch.setattr(get_settings(), 'archive_r2_max_pending_bytes', len(RAW))
+    r2.gate = asyncio.Event()
+    reports = []
+    for _ in range(300):
+        archive.record(method='GET', endpoint_id=EP, provider='tikhub', url=URL,
+                       caller_body=b'', headers={}, status_code=200, media_type='application/json', body=RAW,
+                       observation=archive_bodies.StorageReport(emit=reports.append))
+    assert len(archive_bodies._pending) == 1
+    assert archive_bodies._pending_bytes == len(RAW)
+    try:
+        await asyncio.wait_for(r2.entered.wait(), 2)
+        assert r2.put_calls == 1
+    finally:
+        r2.gate.set()
+    await archive.drain()
+    rows = await snapshots()
+    assert len(rows) == 300 and len({row.key_id for row in rows}) == 1
+    assert len(reports) == 300 and all(p['storage'] == 'both' and not p['dropped'] for p in reports)
+    assert r2.put_calls == 1 and not archive_bodies._queued_hashes
+    assert archive_bodies._pending_bytes == 0
+
+
+async def test_cached_hash_bypasses_saturated_upload_queue(clients, r2, monkeypatch):
+    await clients.get(URL)
+    await archive.drain()
+    monkeypatch.setattr(get_settings(), 'archive_r2_max_pending', 0)
+    response = await clients.get(URL, headers={'Cache-Control': 'no-cache'})
+    await archive.drain()
+    assert response.content == RAW and r2.put_calls == 1
+    assert all(row.body_storage == 'both' for row in await snapshots())
+
+
+async def test_singleflight_shares_exhausted_retry_result(r2, monkeypatch):
+    r2.gate = asyncio.Event()
+    r2.put_failures = [429, 429]
+    monkeypatch.setattr(archive_bodies.random, 'uniform', lambda low, high: 0.001)
+    async def put():
+        return await archive_bodies.prepare(RAW, archive.content_hash(RAW), mode='both',
+                                            observation=archive_bodies.StorageReport())
+    tasks = [asyncio.create_task(put()) for _ in range(30)]
+    await asyncio.wait_for(r2.entered.wait(), 2)
+    r2.gate.set()
+    plans = await asyncio.gather(*tasks)
+    assert all(plan.storage == 'db' and plan.reason == 'rate_limited' for plan in plans)
+    assert r2.put_calls == 2 and not archive_bodies._uploaded and not archive_bodies._inflight
+    assert (await put()).storage == 'both' and r2.put_calls == 3


### PR DESCRIPTION
## What broke

R2 rejects concurrent writes to the same object key at more than one per second (Cloudflare error 10058). Archive objects are content-addressed, so identical response bodies are the same key. When several concurrent calls return byte-identical bodies, their uploads collide and R2 rate-limits them.

Measured on the production bucket from 2026-09-10 12:00 UTC, the first day of double writing:

| PutObject outcome | count |
|---|---|
| 200 | 236,033 |
| 429 rate limited | 6,236 |
| 500 / 503 | 24 |

241,836 PUTs produced only 180,312 objects, so roughly a quarter of all uploads were rewriting an object that already existed. Telemetry agrees with the bucket: 6,276 failed uploads, 2.59%. A further 8,176 recordings were dropped at the upload queue budget, so 5.77% of bodies ended up with no R2 copy.

Failures are concentrated, not spread: 94% come from `apollo.people.search` and `quickenrich.people.search`, whose bursts return identical bodies. `millionverifier.people.email.verify` has comparable volume but distinct bodies per call, and recorded a single failure.

Nothing was lost. `TREG_ARCHIVE_BODY_WRITE` is `both`, so every affected body still has its Postgres copy. But a 5.77% hole in R2 blocks moving any read path to `r2-first`, which is the next step of the migration.

## Fix

- **Skip provably redundant uploads.** Content-addressed objects are immutable, so a hash that this process already uploaded is never uploaded again. Bounded in-memory LRU; a restart re-uploads a few duplicates, which is harmless because the write is idempotent.
- **Coalesce concurrent uploads of the same hash.** The first caller uploads; the rest await its result instead of issuing their own PUT. This is what actually stops the same-key collisions. Waiters hold no upload slot, and cancelling a waiter cannot cancel the leader.
- **One jittered retry for transient failures** (429 and 5xx), inside the existing transfer timeout. No new timeout layer.
- **Real failure classification.** 429 becomes `rate_limited`, 5xx becomes `upstream_error`, and the remaining `store_error` log now carries the exception type. Previously every failure was an unexplained `store_error`, which is why diagnosing this took as long as it did.
- **Telemetry** gains `skipped_duplicate` and `coalesced`, so the effect is measurable after deploy, and queue wait is reported separately from transfer time.

## Notes

Verified against real obstore 0.11.1 that `max_retries=0` issues exactly one request and returns a 429 in about 1.1 ms, so the SDK was not silently retrying. Production failures take about 4 seconds at the median, which is server-side or network time, not local queueing; that remains unexplained and is worth watching after this lands, since slow failures each hold an upload slot and plausibly drive the queue drops.

Upload budgets are deliberately unchanged at 256 / 128 MiB / 8 concurrency. Deduplication should relieve queue pressure on its own; the right move is to observe the remaining drops rather than raise limits pre-emptively.

Full regression passing, import-linter 14 contracts kept, no new database writes, architecture allowlist unchanged.