### PR TITLE
fix(teams): cap accounts at ten owned teams

### DIFF
--- a/.agents/skills/tools-registry-context/MAP.md
+++ b/.agents/skills/tools-registry-context/MAP.md
@@ -426,6 +426,7 @@ Regenerate via `scripts/build-map.py`.
 | `tests/test_sumble.py` | architecture/sumble.md |
 | `tests/test_tag_billing.py` | architecture/proxy-model.md |
 | `tests/test_tag_billing_adversarial.py` | architecture/proxy-model.md |
+| `tests/test_team_limit.py` | architecture/multi-tenancy.md |
 | `tests/test_token_revocation.py` | architecture/multi-tenancy.md |
 
 ## Fragment → sources
@@ -446,7 +447,7 @@ Regenerate via `scripts/build-map.py`.
 | `architecture/local-run.md` | `localrun.py`, `egress.py`, `fsjail.py` |
 | `architecture/mcp-oauth.md` | `auth.py`, `mcp.py`, `health.py`, `mcp_oauth.py`, `session.py`, `auth.py`, `claude-connector.html`, `connect-demo.html`, `CLAUDE-CONNECTOR-SUBMISSION.md`, `test_mcp.py`, `test_mcp_oauth.py`, `test_mcp_directory.py`, `test_marketplace_call.py` |
 | `architecture/money.md` | `__init__.py`, `settlement.py`, `__init__.py`, `models.py`, `billing.py`, `idempotency.py`, `intake.py`, `resolve.py`, `service.py`, `reserve.py`, `settle.py`, `tomba.yaml`, `asynctasks.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `0019_async_poll_failures.py`, `referrals.py`, `budgets.py`, `__init__.py`, `stripe.py`, `reconcile.py`, `referrals.py`, `api.py`, `signup.py`, `promotions.py`, `0033_signup_promo_eligibility.py`, `admin.py`, `billing.py`, `call.py`, `orgs.py`, `referrals.py`, `test_call_architecture.py`, `test_asynctasks.py` |
-| `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `asynctasks.py`, `resolve.py`, `signup.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `access.py`, `session.py`, `promotions.py`, `test_auth.py`, `test_token_revocation.py`, `auth.py`, `orgs.py`, `resources.py`, `bundles.py`, `db.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `test_router_dependencies.py`, `test_asynctasks.py` |
+| `architecture/multi-tenancy.md` | `models.py`, `api.py`, `caller_metadata.py`, `auth.py`, `asynctasks.py`, `resolve.py`, `signup.py`, `access.py`, `budgets.py`, `publicdemo.py`, `teams.py`, `usage.py`, `access.py`, `session.py`, `promotions.py`, `test_team_limit.py`, `test_auth.py`, `test_token_revocation.py`, `auth.py`, `orgs.py`, `resources.py`, `bundles.py`, `db.py`, `0017_async_task_record.py`, `0018_async_resource_ownership.py`, `test_router_dependencies.py`, `test_asynctasks.py` |
 | `architecture/proxy-model.md` | `relay.py`, `ssrf.py`, `api.py`, `authorize.py`, `idempotency.py`, `intake.py`, `resolve.py`, `reserve.py`, `settle.py`, `evidence.py`, `service.py`, `types.py`, `asynctasks.py`, `client_identity.py`, `call_surface.py`, `sandbox_identity.py`, `access.py`, `publicdemo.py`, `usage.py`, `call.py`, `test_ssrf_public_addresses.py`, `test_call_application_contract.py`, `test_call_cancellation.py`, `test_error_capture.py`, `test_marketplace_call.py`, `test_oauth_billed.py`, `test_passthrough.py`, `test_tag_billing.py`, `test_tag_billing_adversarial.py`, `test_call_architecture.py`, `test_asynctasks.py` |
 | `architecture/sumble.md` | `sumble.yaml`, `sumble.extended.yaml`, `sumble.organizations.json`, `sumble.py`, `test_sumble.py`, `sumble.svg` |
 | `architecture/super-admin.md` | `api.py`, `admin.py`, `access.py`, `config.py` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         run: >-
           uv run --frozen python -m pytest -v -o faulthandler_timeout=300
           tests/callmatrix
+          tests/test_team_limit.py
           tests/test_ledger.py
           tests/test_ledger_claim_review.py
           tests/test_asynctasks.py

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ See [analytics details](USAGE.md#anonymous-usage-analytics).
 
 ## Teams
 
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
+
 Everything is scoped to an **org**: a token = a `(user, org)` membership, and every secret, tool,
 and skill belongs to the active org. Roles: **owner / admin / member / viewer**.
 

--- a/docs/context/architecture/multi-tenancy.md
+++ b/docs/context/architecture/multi-tenancy.md
@@ -17,6 +17,7 @@ sources:
   - src/treg/domain/identity/access.py
   - src/treg/domain/identity/session.py
   - src/treg/domain/identity/promotions.py
+  - tests/test_team_limit.py
   - tests/test_auth.py
   - tests/test_token_revocation.py
   - src/treg/routers/auth.py
@@ -40,6 +41,18 @@ The registry is **tenant-isolated**: an **Org** owns resources, a **User** is a 
 **Membership** links them with a role and IS where the caller's token lives. A token = a `(user, org)`
 pair, so every list/create/mutation and the proxy are scoped to the caller's org. Design source:
 `docs/MULTI-TENANCY-PLAN.md` (standalone plan).
+
+## Owned-team limit
+
+An account may own at most 10 teams (`MAX_OWNED_TEAMS`). All owner memberships count,
+including demo and suspended teams; joining as a member, admin or viewer does not.
+`require_owned_team_slot` locks the user through the ownership write and commit, then checks
+current owner memberships. The identity `lock_user` uses a no-op update for cross-process
+serialization on Postgres and SQLite. Normal creation, onboarding demo creation and explicit
+owner promotion share the guard. Requests over the limit return HTTP 403 with an actionable message.
+Deleting a team or relinquishing ownership frees a slot. Existing excess teams stay accessible,
+and recovery when an administrator deletes a sole owner is preserved; no migration or balance
+change is required. This is a current-ownership cap, not a daily creation limit.
 
 ## The model (`models.py`)
 

--- a/docs/context/interface/api.md
+++ b/docs/context/interface/api.md
@@ -210,7 +210,7 @@ validated before resolving the shared HTTP client. `/auth/logout` remains an HTT
   stamp `Org.ad_gclid`/`ad_click_id_type`/`ad_landing`/`ad_click_at` on the new org when present - see
   [ads-conversions](../architecture/ads-conversions.md).
   `create_org` (`POST /orgs`, `require_identity` so a
-  zero-org user can make their first team) + `list_orgs` (`GET /orgs`,
+  zero-org user can make their first team; HTTP 403 when already owning 10 teams) + `list_orgs` (`GET /orgs`,
   each org carries a `tool_count` - one grouped query - so the dashboard can land on the org with tools;
   its `active` flag follows `require_member`'s precedence - per-org membership token, else `X-Treg-Org`,
   else a team-pinned identity token's own `org` claim - so `treg login --token <pinned key>` lands on the

--- a/docs/context/interface/onboarding.md
+++ b/docs/context/interface/onboarding.md
@@ -24,7 +24,12 @@ seeded with teammates, a working tool, and a real audit trail — one backend br
 
 ## The one brain - `src/treg/application/onboard/demo.py`
 
-`provision(db, owner, team_name)` seeds a REAL org owned by the caller, marked `Org.demo=True`:
+`provision(db, owner, team_name)` seeds a REAL org owned by the caller, marked `Org.demo=True`.
+It shares the 10-owned-team cap with regular creation, with the user lock held until
+`application.onboard.provision_demo` commits. Existing demo teams can still be reused at the cap;
+a new demo team over the cap returns HTTP 403.
+
+The seeded content includes:
 
 - **Fake teammates** (`TEAMMATES`): Ada·admin, Ben·member, Cora·viewer — roster-only `User` rows
   with `demo=True` on the unusable domain **`demo.treg.local`** (`DEMO_DOMAIN`). Reused across demo

--- a/dsh/skills/treg/SKILL.md
+++ b/dsh/skills/treg/SKILL.md
@@ -305,6 +305,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `https://treg.to/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/plugin/skills/treg/SKILL.md
+++ b/plugin/skills/treg/SKILL.md
@@ -308,6 +308,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `https://treg.to/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -289,6 +289,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `https://treg.to/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -303,6 +303,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `https://treg.to/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -287,6 +287,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `https://treg.to/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/src/treg/application/onboard/__init__.py
+++ b/src/treg/application/onboard/__init__.py
@@ -55,7 +55,9 @@ async def _user(user_id: int, db: AsyncSession) -> User:
 
 async def provision_demo(*, user_id: int, team_name: str) -> dict:
     async with session_maker() as db:
-        return await demo_seed.provision(db, await _user(user_id, db), team_name)
+        response = await demo_seed.provision(db, await _user(user_id, db), team_name)
+        await db.commit()
+        return response
 
 
 async def skip(*, user_id: int) -> dict:

--- a/src/treg/application/onboard/demo.py
+++ b/src/treg/application/onboard/demo.py
@@ -18,7 +18,8 @@ from sqlmodel import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from . import crypto
-from ...domain.governance.teams import cascade_delete_org, drop_member_deny_rules
+from ...domain.governance.teams import cascade_delete_org, drop_member_deny_rules, require_owned_team_slot
+from ...domain.identity.access import lock_user
 from .models import CallRecord, Membership, Org, Secret, Tool, User
 
 DEMO_DOMAIN = "demo.treg.local"      # fake teammates live here; api refuses login for this domain
@@ -64,13 +65,14 @@ async def existing_demo_org(db: AsyncSession, owner: User) -> Org | None:
 
 async def provision(db: AsyncSession, owner: User, team_name: str) -> dict:
     """Create + seed the demo team owned by `owner`. Idempotent: reuses an existing demo org.
-    Marks the owner `onboarded`. Caller need not commit — we commit here."""
+    Marks the owner `onboarded`. Caller commits."""
+    await lock_user(db, owner.id)
     existing = await existing_demo_org(db, owner)
     if existing is not None:
         owner.onboarded = True
-        await db.commit()
         return _view(existing, reused=True)
 
+    await require_owned_team_slot(db, owner.id)
     name = (team_name or "").strip() or "Acme Design"
     org = Org(name=name, slug=await _unique_slug(_slug(name), db), demo=True)
     db.add(org)
@@ -113,7 +115,6 @@ async def provision(db: AsyncSession, owner: User, team_name: str) -> dict:
                           created_at=now - timedelta(minutes=mins)))
 
     owner.onboarded = True
-    await db.commit()
     return _view(org, reused=False)
 
 

--- a/src/treg/domain/governance/teams.py
+++ b/src/treg/domain/governance/teams.py
@@ -41,7 +41,24 @@ from ...models import (
     User,
 )
 from ..identity import session as sess
-from ..identity.access import _membership_by_token, _resolve_org
+from ..identity.access import _membership_by_token, _resolve_org, lock_user
+
+
+MAX_OWNED_TEAMS = 10
+
+
+class OwnedTeamLimitReached(Exception):
+    """The account already owns the maximum number of teams."""
+
+
+async def require_owned_team_slot(db: AsyncSession, user_id: int) -> None:
+    """Hold the user lock through the ownership insert and its commit. No reservation counter."""
+    await lock_user(db, user_id)
+    owned = (await db.execute(select(Membership.id).where(
+        Membership.user_id == user_id, Membership.role == "owner",
+    ).limit(MAX_OWNED_TEAMS))).scalars().all()
+    if len(owned) >= MAX_OWNED_TEAMS:
+        raise OwnedTeamLimitReached
 
 
 def _slugify(text: str) -> str:
@@ -61,6 +78,8 @@ async def _make_org_membership(
     """Create an Org + an owner/role Membership for `user`, minting a fresh org-scoped token.
     Returns (org, plaintext token). Caller commits.
     """
+    if role == "owner":
+        await require_owned_team_slot(db, user.id)
     org = Org(name=name, slug=await _unique_slug(slug_base, db))
     db.add(org)
     await db.flush()

--- a/src/treg/domain/identity/access.py
+++ b/src/treg/domain/identity/access.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import hmac
 
 from fastapi import Cookie, Depends, Header, HTTPException, Request
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
@@ -14,6 +15,16 @@ from ...config import get_settings
 from ...infra.db import get_admin_session, get_session
 from ...models import ROLE_RANK, Membership, Org, User
 from . import session as sess
+
+
+async def lock_user(db: AsyncSession, user_id: int) -> None:
+    """Serialize identity-scoped mutations until the caller commits or rolls back.
+
+    A no-op UPDATE takes a row lock on Postgres and a write lock on SQLite, where
+    SELECT FOR UPDATE is ignored. Identity fields and token validity stay unchanged.
+    """
+    await db.execute(update(User).where(User.id == user_id).values(id=User.id)
+                     .execution_options(synchronize_session=False))
 
 
 @dataclass

--- a/src/treg/routers/onboard.py
+++ b/src/treg/routers/onboard.py
@@ -17,7 +17,8 @@ from ..domain.identity.access import (
 )
 from ..models import User
 from .auth import _client_ip
-from .orgs import _require_admin_of
+from .orgs import _require_admin_of, _owned_team_limit_error
+from ..domain.governance.teams import OwnedTeamLimitReached
 
 
 # app is the APIRouter alias so mechanically moved @app decorators stay byte-identical.
@@ -64,8 +65,11 @@ async def onboard_demo(
     """Seed a sandbox team owned by the caller — fake teammates (one per role) + a working `echo`
     tool + sample activity — so a brand-new user can feel the product immediately. Idempotent
     (reuses an existing demo team); marks the caller onboarded. Same seed for dashboard + CLI."""
-    return await onboard_use_cases.provision_demo(
-        user_id=user.id, team_name=(body.team_name if body else "Acme Design"))
+    try:
+        return await onboard_use_cases.provision_demo(
+            user_id=user.id, team_name=(body.team_name if body else "Acme Design"))
+    except OwnedTeamLimitReached as exc:
+        raise _owned_team_limit_error() from exc
 
 
 @app.post("/onboard/skip")

--- a/src/treg/routers/orgs.py
+++ b/src/treg/routers/orgs.py
@@ -356,6 +356,13 @@ _SIGNUP_HTTP_ERRORS = {
 }
 
 
+def _owned_team_limit_error() -> HTTPException:
+    return HTTPException(status_code=403, detail=(
+        f"You can own at most {teams.MAX_OWNED_TEAMS} teams. "
+        "Delete a team or transfer ownership before creating or owning another."
+    ))
+
+
 def _signup_http_error(exc: signup_use_cases.SignupError) -> HTTPException:
     status_code, detail = _SIGNUP_HTTP_ERRORS[exc.kind]
     return HTTPException(status_code=status_code, detail=detail)
@@ -378,6 +385,8 @@ async def register_user(body: UserIn, request: Request) -> dict:
         )
     except signup_use_cases.SignupError as exc:
         raise _signup_http_error(exc) from exc
+    except teams.OwnedTeamLimitReached as exc:
+        raise _owned_team_limit_error() from exc
 
 
 @app.post("/orgs")
@@ -395,6 +404,8 @@ async def create_org(
         )
     except signup_use_cases.SignupError as exc:
         raise _signup_http_error(exc) from exc
+    except teams.OwnedTeamLimitReached as exc:
+        raise _owned_team_limit_error() from exc
 
 
 app = APIRouter()
@@ -800,6 +811,11 @@ async def set_member_role(
         target = await db.get(User, user_id)
         if target is not None and _is_machine_email(target.email):
             raise HTTPException(status_code=422, detail="a machine identity cannot be an owner")
+    if body.role == "owner" and membership.role != "owner":
+        try:
+            await teams.require_owned_team_slot(db, user_id)
+        except teams.OwnedTeamLimitReached as exc:
+            raise _owned_team_limit_error() from exc
     if membership.role == "owner" and body.role != "owner" and await _count_owners(org_id, db) <= 1:
         raise HTTPException(status_code=409, detail="cannot demote the last owner — promote another owner first")
     membership.role = body.role

--- a/src/treg/web/llms.txt
+++ b/src/treg/web/llms.txt
@@ -508,6 +508,8 @@ are both supported; you do not need to pre-arrange anything with us.
 
 ## Roles (what a member may do)
 
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
+
 - **viewer** - call any tool + read the inventory. Nothing else.
 - **member** - + register secrets/tools/skills, edit/delete their OWN resources.
 - **admin**  - + invite/remove members, edit/delete ANY resource in the team.

--- a/src/treg/web/skill.md
+++ b/src/treg/web/skill.md
@@ -268,6 +268,8 @@ expires. Same storage; a credential can graduate from manual to auto with no mig
   One-time setup: add `{BASE}/oauth/callback` to your OAuth app's redirect URIs.
 
 ## Task — manage the team + monitor
+
+An account can own up to 10 teams. Joining other teams as a member does not count toward this limit.
 ```bash
 treg tool ls / secret ls / skill ls / calls          # inventory + audit log — scoped to the active org
 treg tool rm <id> / secret rm <id> / skill rm <id>   # secret rm is blocked while a tool binds it

--- a/tests/test_team_limit.py
+++ b/tests/test_team_limit.py
@@ -1,0 +1,118 @@
+"""Owned-team limits through the same HTTP routes used by the dashboard and CLI."""
+import asyncio
+
+
+async def test_eleventh_owned_team_is_refused(clients):
+    # The authenticated fixture already owns its first team.
+    for i in range(9):
+        r = await clients.post('/orgs', json={'name': f'team-{i}'})
+        assert r.status_code == 200, r.text
+    before = (await clients.get('/orgs')).json()
+    r = await clients.post('/orgs', json={'name': 'eleventh'})
+    assert r.status_code == 403, r.text
+    assert '10 teams' in r.json()['detail']
+    assert (await clients.get('/orgs')).json() == before
+
+
+async def test_concurrent_creations_share_the_last_slot(clients):
+    for i in range(8):
+        assert (await clients.post('/orgs', json={'name': f'team-{i}'})).status_code == 200
+    responses = await asyncio.gather(*(
+        clients.post('/orgs', json={'name': f'racing-{i}'}) for i in range(4)
+    ))
+    assert sorted(r.status_code for r in responses) == [200, 403, 403, 403]
+    assert len((await clients.get('/orgs')).json()) == 10
+
+
+async def test_deletion_frees_a_slot_and_legacy_first_team_counts(clients):
+    first = (await clients.post('/users', json={'email': 'legacy-limit@example.org'})).json()
+    headers = {'X-Treg-Token': first['token']}
+    for i in range(9):
+        r = await clients.post('/orgs', headers=headers, json={'name': f'legacy-{i}'})
+        assert r.status_code == 200
+    last = r.json()
+    assert (await clients.post('/orgs', headers=headers, json={'name': 'blocked'})).status_code == 403
+    deleted = await clients.delete(f"/orgs/{last['org_id']}", params={'confirm': last['org']},
+                                   headers={'X-Treg-Token': last['token']})
+    assert deleted.status_code == 200, deleted.text
+    assert (await clients.post('/orgs', headers=headers, json={'name': 'replacement'})).status_code == 200
+    assert (await clients.post('/orgs', headers=headers, json={'name': 'blocked-again'})).status_code == 403
+
+
+async def test_joining_does_not_count_but_promotion_does(clients):
+    from sqlmodel import select
+    from treg.infra.db import session_maker
+    from treg.models import User
+
+    other = (await clients.post('/users', json={'email': 'other-owner@example.org'})).json()
+    other_headers = {'X-Treg-Token': other['token']}
+    inv = await clients.post(f"/orgs/{other['org_id']}/invites", headers=other_headers,
+                             json={'email': 'tim@superdesign.dev', 'role': 'member'})
+    accepted = await clients.post('/invites/accept', json={
+        'code': inv.json()['code'], 'email': 'tim@superdesign.dev'})
+    assert accepted.status_code == 200, accepted.text
+    for i in range(9):
+        assert (await clients.post('/orgs', json={'name': f'owned-{i}'})).status_code == 200
+    assert len((await clients.get('/orgs')).json()) == 11
+    async with session_maker() as db:
+        uid = (await db.execute(select(User.id).where(User.email == 'tim@superdesign.dev'))).scalar_one()
+    promoted = await clients.patch(f"/orgs/{other['org_id']}/members/{uid}",
+                                   headers=other_headers, json={'role': 'owner'})
+    assert promoted.status_code == 403, promoted.text
+    assert (await clients.get('/tools', headers={'X-Treg-Token': accepted.json()['token']})).status_code == 200
+
+
+async def test_demo_cannot_bypass_limit_but_existing_demo_can_be_reused(clients):
+    for i in range(8):
+        assert (await clients.post('/orgs', json={'name': f'owned-{i}'})).status_code == 200
+    demo = await clients.post('/onboard/demo', json={'team_name': 'Demo'})
+    assert demo.status_code == 200, demo.text
+    assert (await clients.post('/orgs', json={'name': 'eleventh'})).status_code == 403
+    reused = await clients.post('/onboard/demo', json={'team_name': 'Demo again'})
+    assert reused.status_code == 200, reused.text
+    assert len((await clients.get('/orgs')).json()) == 10
+
+
+async def test_demo_refused_at_ten_and_existing_excess_teams_preserved(clients):
+    from sqlmodel import select
+    from treg.infra.db import session_maker
+    from treg.models import Membership, Org, User
+
+    # Seed the pre-upgrade state, which normal creation can no longer produce.
+    async with session_maker() as db:
+        uid = (await db.execute(select(User.id).where(User.email == 'tim@superdesign.dev'))).scalar_one()
+        for i in range(11):
+            org = Org(name=f'Existing {i}', slug=f'existing-{i}')
+            db.add(org)
+            await db.flush()
+            db.add(Membership(user_id=uid, org_id=org.id, role='owner', token_hash=f'old-{i}'))
+        await db.commit()
+    before = (await clients.get('/orgs')).json()
+    assert len(before) == 12
+    assert (await clients.post('/orgs', json={'name': 'new'})).status_code == 403
+    assert (await clients.post('/onboard/demo', json={'team_name': 'demo'})).status_code == 403
+    assert (await clients.get('/orgs')).json() == before
+    assert (await clients.get('/tools')).status_code == 200
+
+
+async def test_promotion_and_creation_compete_for_same_slot(clients):
+    from sqlmodel import select
+    from treg.infra.db import session_maker
+    from treg.models import User
+
+    other = (await clients.post('/users', json={'email': 'race-owner@example.org'})).json()
+    headers = {'X-Treg-Token': other['token']}
+    inv = await clients.post(f"/orgs/{other['org_id']}/invites", headers=headers,
+                             json={'email': 'tim@superdesign.dev'})
+    assert (await clients.post('/invites/accept', json={
+        'code': inv.json()['code'], 'email': 'tim@superdesign.dev'})).status_code == 200
+    for i in range(8):
+        assert (await clients.post('/orgs', json={'name': f'before-race-{i}'})).status_code == 200
+    async with session_maker() as db:
+        uid = (await db.execute(select(User.id).where(User.email == 'tim@superdesign.dev'))).scalar_one()
+    results = await asyncio.gather(
+        clients.post('/orgs', json={'name': 'last-slot'}),
+        clients.patch(f"/orgs/{other['org_id']}/members/{uid}", headers=headers, json={'role': 'owner'}),
+    )
+    assert sorted(r.status_code for r in results) == [200, 403]
+    assert sum(t['role'] == 'owner' for t in (await clients.get('/orgs')).json()) == 10


### PR DESCRIPTION
Accounts could create unlimited teams even after signup credit became a one-time grant. Cap accounts at 10 currently owned teams: creating an eleventh team returns HTTP 403 with instructions to delete a team or transfer ownership.

- Count owner memberships, including demo and suspended teams; ordinary membership does not consume a slot. Preserve existing excess teams and balances.
- Serialize the capacity check and ownership write with a database user lock, covering regular creation, onboarding demos and explicit owner promotion. Reusing an existing demo remains allowed at the cap.
- Deletion or relinquishing ownership frees a slot. No schema migration is required.
- Update the multi-tenancy, API and onboarding context fragments, README and agent-facing documentation and generated skill mirrors. Add the limit tests to the serial PostgreSQL CI job.

Validation: reproduced the eleventh-team creation through HTTP before the fix; full suite 3,619 passed, 6 skipped; related PostgreSQL suite 39 passed, followed by all 7 final limit tests passing on PostgreSQL and SQLite. All 14 import contracts passed. Tests cover concurrent creation, creation racing with owner promotion, legacy registration, deletion, membership, demo reuse and existing excess teams.
