### PR TITLE
fix(money): order credit block locks and retry settlement deadlocks

### DIFF
--- a/docs/context/architecture/money.md
+++ b/docs/context/architecture/money.md
@@ -182,6 +182,12 @@ marketing expense and never refundable; purchased credit is a deferred-revenue l
 refundable and disputable - so spending promo first keeps the refundable pool as small as possible
 for as long as possible.
 
+`_consume_blocks` acquires `CreditBlock` row locks with `ORDER BY CreditBlock.id FOR UPDATE`.
+The unique primary-key order is shared by concurrent settlements and prevents opposite scan-order
+locking. It is independent of consumption priority: the subsequent `blocks.sort` still selects
+promotional credit first, then age and ID. Keep both the row lock (which prevents lost deductions)
+and that business sort. This is the repository's sole explicit CreditBlock row-lock query.
+
 **Margin is applied inside the module** (`with_margin`), at reserve AND settle, and the rate in force
 is recorded on every entry - so a rate change cannot retroactively rewrite what a call cost, and two
 call sites cannot disagree.
@@ -504,9 +510,18 @@ so the reserve IS the charge: a wrong entity count is a wrong bill, not a hold t
 The estimate is never a substitute for an available response-derived charge.
 
 `_platform_settle` uses its own short session and never turns a served response into a 500.
-A pool timeout gets one retry after 0.5 s; other failures are logged and the remaining hold goes
-to the reaper. The request session must be committed before relay so settlement cannot wait on
-a connection held by that same request. See [connection discipline](proxy-model.md#connection-discipline-a-call-in-flight-holds-no-db-connection).
+A pool timeout or PostgreSQL deadlock gets one retry after the existing 0.5 s delay. Deadlocks are
+identified as SQLAlchemy `DBAPIError` with `orig.sqlstate == "40P01"`, including asyncpg's adapted
+exception; error messages are never matched. The failed session closes and rolls back before the
+whole settlement/release transaction is retried in a fresh session, including any overflow spend.
+A second failure or an unrelated DB error is logged, leaves the hold for the reaper and preserves
+the upstream response. No upstream retry, new timeout or additional ledger operation is introduced.
+Tests inspect both concurrent settlements' compiled PostgreSQL lock order and verify consumption
+priority; SQLite cannot exercise row locks. PostgreSQL runs exercise concurrent settlements and
+real driver-wrapped SQLSTATE injection after staged writes, checking rollback and retry exhaustion.
+SQLSTATE injection tests recovery, not the production planner's original deadlock schedule.
+
+The request session must be committed before relay so settlement cannot wait on a connection held by that same request. See [connection discipline](proxy-model.md#connection-discipline-a-call-in-flight-holds-no-db-connection).
 
 ## Shared-plan pricing: flat-fee providers, and the rate treg sets
 

--- a/src/treg/application/call/settle.py
+++ b/src/treg/application/call/settle.py
@@ -9,7 +9,7 @@ from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from collections.abc import Callable
 
 from sqlalchemy import update
-from sqlalchemy.exc import TimeoutError as PoolTimeoutError
+from sqlalchemy.exc import DBAPIError, TimeoutError as PoolTimeoutError
 
 from ... import adsconv
 from ...domain.capacity import marks as capacity_marks
@@ -560,10 +560,14 @@ async def _platform_settle(
     try:
         try:
             charged = await _close()
-        except PoolTimeoutError:
-            # No pool slot within `pool_timeout`: a transient wait, not a broken ledger. A settle that
-            # gives up here forfeits the charge (the hold is reaped in the org's favour) — real revenue,
-            # so one short retry is worth it. Anything else falls straight through to the log.
+        except (PoolTimeoutError, DBAPIError) as exc:
+            # asyncpg deadlocks arrive as SQLAlchemy DBAPIError with SQLSTATE on its orig wrapper.
+            # Retry only 40P01, never an error-message match or an arbitrary database failure.
+            if isinstance(exc, DBAPIError) and getattr(exc.orig, "sqlstate", None) != "40P01":
+                raise
+            # _close has exited its session, rolling back all staged money/overflow writes.
+            # One fresh transaction gets the same bounded retry as a pool timeout; another failure
+            # goes to the log and leaves the hold for the reaper. No upstream call is repeated.
             await asyncio.sleep(0.5)
             charged = await _close()
     except Exception as exc:  # noqa: BLE001 — loudly, but never into the caller's response

--- a/src/treg/domain/money/__init__.py
+++ b/src/treg/domain/money/__init__.py
@@ -473,8 +473,11 @@ async def _consume_blocks(
     # write wins and one draw is LOST — the blocks then show more credit than the ledger's truth
     # (found live 2026-08-30: $1.70 of draws lost under an agent's parallel burst, org 2867).
     # Postgres locks the rows; SQLite ignores FOR UPDATE and is single-writer anyway.
+    # Lock in unique primary-key order so concurrent settles cannot acquire blocks in reverse
+    # order. This is NOT consumption priority: keep the promotional/age sort below unchanged.
     blocks = (await db.execute(
         select(CreditBlock).where(CreditBlock.org_id == org_id, CreditBlock.remaining_micro > 0)
+        .order_by(CreditBlock.id)
         .with_for_update()
     )).scalars().all()
     blocks.sort(key=lambda b: (_KIND_ORDER.get(b.kind, 99), b.created_at or _now(), b.id))

--- a/tests/test_call_pool_discipline.py
+++ b/tests/test_call_pool_discipline.py
@@ -245,7 +245,7 @@ async def test_a_settle_that_loses_the_pool_once_retries_and_still_charges(
     clients: AsyncClient, platform_on, monkeypatch,
 ):
     """A settle that gives up forfeits real revenue (the hold is reaped in the org's favour), so a
-    transient pool wait gets exactly one retry — and nothing else does."""
+    transient pool wait gets exactly one retry (as does a PostgreSQL deadlock)."""
     original = ledger.settle_in_transaction
     calls = 0
 
@@ -289,3 +289,50 @@ async def test_auth_releases_a_single_slot_pool_before_an_application_session(
     finally:
         session_maker.kw["bind"] = original_bind
         await limited_engine.dispose()
+
+
+@pytest.mark.parametrize('sqlstate,failures,attempts', [('40P01', 1, 2), ('40P01', 2, 2),
+                                                     ('P0001', 1, 1)])
+async def test_wrapped_deadlock_retry_preserves_response_and_transaction(
+    clients, platform_on, monkeypatch, caplog, sqlstate, failures, attempts,
+):
+    """Inject after staged money writes to verify rollback and a fresh transaction on retry.
+
+    PostgreSQL raises the real driver exception with RAISE SQLSTATE; SQLite uses its observed
+    SQLAlchemy/asyncpg wrapper shape. Neither injection claims to reproduce a lock cycle.
+    An unrelated DB error with 'deadlock detected' in its message must not be retried.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.exc import DBAPIError
+    from sqlalchemy.dialects.postgresql.asyncpg import AsyncAdapt_asyncpg_dbapi
+    from treg.models import LedgerEntry
+
+    original = ledger.settle_in_transaction
+    sessions = []
+    async def interrupted(db, *args, **kwargs):
+        sessions.append(db)
+        charged = await original(db, *args, **kwargs)
+        if len(sessions) <= failures:
+            if db.bind.dialect.name == 'postgresql':
+                await db.execute(text("DO $$ BEGIN RAISE EXCEPTION USING ERRCODE = '" + sqlstate
+                                      + "', MESSAGE = 'deadlock detected injection'; END $$"))
+            error = AsyncAdapt_asyncpg_dbapi.Error('deadlock detected injection')
+            error.sqlstate = sqlstate
+            raise DBAPIError(None, None, error)
+        return charged
+    monkeypatch.setattr(ledger, 'settle_in_transaction', interrupted)
+    org_id = (await clients.get('/orgs')).json()[0]['org_id']
+    before = (await clients.get(f'/orgs/{org_id}/balance')).json()['balance_micro']
+    response = await clients.get(f'/call/{EP}?aweme_id=7')
+    assert response.status_code == 200
+    assert len(sessions) == attempts and len({id(s) for s in sessions}) == attempts
+    succeeded = sqlstate == '40P01' and failures == 1
+    assert response.headers['X-Treg-Cost-Micro'] == str(EP_MICRO if succeeded else 0)
+    async with session_maker() as db:
+        holds = (await db.execute(select(Hold).where(Hold.org_id == org_id))).scalars().all()
+        entries = (await db.execute(select(LedgerEntry).where(
+            LedgerEntry.org_id == org_id, LedgerEntry.kind == 'settle'))).scalars().all()
+        assert len(holds) == (0 if succeeded else 1)
+        assert len(entries) == (1 if succeeded else 0)
+        assert await ledger.balance_of(db, org_id) == before - EP_MICRO
+    assert ('settle/release failed' in caplog.text) == (not succeeded)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -903,3 +903,53 @@ async def test_demo_orgs_get_no_promo_credit(c: AsyncClient):
         from treg.application.signup import _grant_signup_promo
         await _grant_signup_promo(db, await db.get(Org, org_id), user_id=-1)
         assert await ledger.balance_of(db, org_id) == 0
+
+
+async def test_concurrent_settles_lock_by_id_but_consume_by_business_priority(c, monkeypatch):
+    """Check both emitted PostgreSQL SQL and consumption, on two sessions for one org.
+
+    SQLite ignores FOR UPDATE: there this verifies the SQL contract and accounting only.
+    The serial PostgreSQL job additionally exercises actual concurrent row locking.
+    This does not force the old planner to choose opposite scan orders.
+    """
+    from datetime import timedelta
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from sqlalchemy.dialects import postgresql
+    from sqlalchemy.sql import Select
+
+    monkeypatch.setattr(get_settings(), 'platform_margin', 0)
+    async with session_maker() as db:
+        org = Org(name='Lock ordering', slug='lock-ordering', balance_micro=3000)
+        db.add(org)
+        await db.flush()
+        org_id = org.id
+        now = ledger._now()
+        for block_id, kind, age in [('a-new', 'purchased', 0), ('b-old', 'purchased', 1),
+                                    ('z-promo', 'promotional', 0)]:
+            db.add(CreditBlock(id=block_id, org_id=org_id, kind=kind, amount_micro=1000,
+                               remaining_micro=1000, created_at=now - timedelta(days=age)))
+        await db.commit()
+        for call_id in ('ordered-one', 'ordered-two'):
+            await ledger.reserve(db, org_id, 'test.operation', 1000, call_id=call_id)
+
+    statements = []
+    execute = AsyncSession.execute
+    async def checked(self, statement, *args, **kwargs):
+        if isinstance(statement, Select) and statement._for_update_arg is not None:
+            sql = str(statement.compile(dialect=postgresql.dialect()))
+            if 'FROM creditblock' in sql:
+                statements.append(sql)
+        return await execute(self, statement, *args, **kwargs)
+    monkeypatch.setattr(AsyncSession, 'execute', checked)
+    ready = asyncio.Barrier(2)
+    async def settle(call_id):
+        async with session_maker() as db:
+            await ready.wait()
+            return await ledger.settle(db, call_id)
+    assert await asyncio.gather(settle('ordered-one'), settle('ordered-two')) == [1000, 1000]
+    assert len(statements) == 2
+    assert all('ORDER BY creditblock.id FOR UPDATE' in sql for sql in statements)
+    async with session_maker() as db:
+        blocks = await ledger.blocks_of(db, org_id)
+        assert {b.id: b.remaining_micro for b in blocks} == {'a-new': 1000, 'b-old': 0, 'z-promo': 0}
+    assert await _assert_invariant(org_id) == 1000


### PR DESCRIPTION
## What happened in production

On 2026-09-10 at 13:28:11 UTC a settlement failed outright:

```
settle/release failed for call 80bf78f05cc147c9ba8a76c2c62ca40f (millionverifier.people.email.verify, status 200)
asyncpg.exceptions.DeadlockDetectedError: deadlock detected
DETAIL: Process 2479576 waits for ShareLock on transaction 21488570; blocked by process 2479703.
        Process 2479703 waits for ShareLock on transaction 21488589; blocked by process 2479576.
```

The statement was the credit-block draw for org 6775.

## Root cause

`_consume_blocks` locks an org's credit blocks with `SELECT ... FOR UPDATE` and no `ORDER BY`, so Postgres acquired row locks in whatever order the scan produced. Two concurrent settlements for the same org could take the same two rows in opposite order and wait on each other. The `blocks.sort(...)` that follows only decides consumption priority; it runs after the locks are already held, so it cannot prevent this.

The consequence was not a double charge. It was a lost charge: `_platform_settle` retried only `PoolTimeoutError`, and its own comment said "anything else falls straight through to the log". The deadlocked settlement was abandoned, the hold was later reaped in the org's favour, and the platform did not collect for a call it had already paid the vendor for.

## Fix

- `ORDER BY CreditBlock.id` on the locking query, so every transaction acquires the same rows in the same sequence. The comment states explicitly that this is lock order and not consumption priority, so nobody later deletes the Python sort as redundant.
- Consumption priority is unchanged: promotional kinds first, then oldest purchased.
- The retry now also covers deadlocks, identified by SQLSTATE `40P01` on the wrapped asyncpg error. No message matching, and any other `DBAPIError` re-raises to the existing log. Still exactly one retry, reusing the existing short wait, and it runs in a fresh transaction because `_close` has already exited and rolled back its staged writes. No upstream call is repeated.

Checked the rest of the codebase for other explicit `CreditBlock` row locks; there are none, so lock order is globally consistent.

## What the tests prove, and what they do not

Added coverage for the deterministic lock ordering of concurrent queries, the preserved consumption order, rollback behaviour, a successful retry after a deadlock, and the response protection when the retry is also exhausted. A real two-transaction experiment produced a deadlock and confirmed how the exception is wrapped.

They do not reproduce the exact production query plan and scheduling that caused the original deadlock, and SQLite is not treated as evidence of real row locking.

Money's five ledger entries, consumption priority, and the call-architecture write allowlist are unchanged. Full regression 3,719 passed; Postgres suite 49 passed; import-linter 14 contracts kept; `money.md` updated in the same commit.