### PR TITLE
chore(tests): align sandbox fixture background drain discipline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,8 +355,7 @@ async def verified_signup(client, *, json, headers=None):
         json={**response.json(), "id": user_id, "email": email}, request=response.request)
 
 
-@pytest.fixture
-async def clients():
+async def drain_background_writes():
     # Postgres needs a session-scoped event loop so asyncpg can safely pool connections. That also
     # lets fire-and-forget audit writes survive between tests, so drain both sides of reset_db():
     # before it, to keep an old write out of the new schema, and after the test, to finish its own.
@@ -366,6 +365,11 @@ async def clients():
     # forgives it) — the serial CI job hung exactly here, 5-minute faulthandler timeouts on
     # whichever archive test ran next (2026-08-28, twice).
     await archive.drain()
+
+
+@pytest.fixture
+async def clients():
+    await drain_background_writes()
     # The archive report's 30s server-side cache would outlive this reset and serve the previous
     # test's numbers — clear it with the schema.
     from treg.routers import admin as admin_routes
@@ -381,8 +385,7 @@ async def clients():
             c.headers["X-Treg-Token"] = r.json()["token"]  # authed by default from here on
             yield c
     finally:
-        await audit.drain()
-        await archive.drain()
+        await drain_background_writes()
         await app.state.http.aclose()
 
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -155,6 +155,10 @@ async def test_rate_limited_per_ip(anon):
 
 async def test_gc_reaps_expired_sandboxes(anon):
     tok = (await anon.post("/demo/sandbox")).json()["token"]
+    # gc deletes the visitor's org rows. A fire-and-forget audit or archive write still in flight
+    # holds the SQLite write lock, gc skips that visitor rather than raising, and the count comes
+    # back one short. Drain what the requests above scheduled before reaping.
+    await drain_background_writes()
     async with session_maker() as db:
         u = (await db.execute(
             select(User).where(User.email.like(f"visitor-%@{sandbox.SANDBOX_DOMAIN}")))).scalar_one()
@@ -182,6 +186,7 @@ async def test_gc_reaps_a_sandbox_that_made_an_idempotent_call(anon):
     r = await anon.get(f"/call/{STRIPE['base']}/{STRIPE['example']['path']}",
                        headers={**_h(tok), "Idempotency-Key": "retry-1"})
     assert r.status_code == 200, r.text
+    await drain_background_writes()
     async with session_maker() as db:
         assert (await db.execute(select(IdempotentCall))).scalars().all(), (
             "the call did not leave an IdempotentCall row - this test no longer reproduces the bug")
@@ -227,6 +232,7 @@ async def test_gc_skips_a_sandbox_it_cannot_delete_and_reaps_the_rest(anon, monk
         await real_cascade(org, db)
 
     monkeypatch.setattr(onboard_sandbox, "cascade_delete_org", cascade_unless_poisoned)
+    await drain_background_writes()
     async with session_maker() as db:
         for u in (await db.execute(
                 select(User).where(User.email.like(f"visitor-%@{sandbox.SANDBOX_DOMAIN}")))).scalars().all():

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -13,7 +13,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
-from conftest import make_upstream
+from conftest import drain_background_writes, make_upstream
 
 from treg import sandbox
 from treg.routers.onboard import SANDBOX_RATE_MAX
@@ -26,11 +26,15 @@ from treg.models import Secret, Tool, User
 async def anon():
     """A fresh, UNAUTHENTICATED client + clean rate-limit state (the mint endpoint is the anon door).
     reset_db() also clears the DB-backed sandbox throttle (the `ephemeral` table)."""
+    await drain_background_writes()
     await reset_db()
     app.state.http = AsyncClient(transport=ASGITransport(app=make_upstream()), base_url="http://upstream")
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
-        yield c
-    await app.state.http.aclose()
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://registry") as c:
+            yield c
+    finally:
+        await drain_background_writes()
+        await app.state.http.aclose()
 
 
 def _h(tok: str) -> dict:


### PR DESCRIPTION
## Why

`tests/conftest.py`'s `clients` fixture drains the audit and archive background writers on both sides of `reset_db()`, with a comment explaining that fire-and-forget audit writes survive between tests and will otherwise land in the next test's schema. `tests/test_sandbox.py`'s `anon` fixture faced the same situation and had none of that discipline.

This surfaced as a CI failure on run 34564408221: `test_gc_reaps_a_sandbox_that_made_an_idempotent_call` failed with `sqlite3.OperationalError: database is locked`. The Postgres job in the same run passed, which fits a SQLite single-writer conflict, and a rerun with no code change went green.

## What this does and does not claim

The flake could not be reproduced locally despite repeated runs under parallel load and CPU pressure, so this change is **not** presented as its fix. It removes a real and independently justified inconsistency between two fixtures that face the same problem.

## Change

The drain sequence is extracted from `clients` into a shared `drain_background_writes()` helper and used by both fixtures, rather than duplicated. `anon` now drains before `reset_db()` and again after the test, and its client is wrapped so `app.state.http.aclose()` runs even when the test body raises.

No retry loops, no `busy_timeout`, no WAL switch: the problem addressed is test isolation, not lock patience.

Stress runs of the sandbox tests: 700 passed. Full regression 3,715 passed, 6 skipped. Drift check clean.