### PR TITLE
fix(archive): cap served TTL by the vendor declaration and pair change observations with the TTL baseline

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -277,6 +277,10 @@ statistics — only `last_requested_at` (fire-and-forget `_touch`), the demand s
 Freshness (phase 1) is `archive.ttl_for(entry)`: FIXED guesses per capability prefix
 (`crypto.price` 5 min, `web.search` 1 h, `people.`/`company.` 7 d, default 1 h), always capped by
 a judged `cache.max_age_s` (CoinGecko's 24 h duty). The learner (PR 5) replaces these per key.
+`declared_max_age_s()` supplies the vendor ceiling to defaults, learning and lookup. Serving
+caps even an already-learned positive TTL by that declaration, then by caller `X-Treg-Max-Age`.
+Without a declared ceiling, learned TTLs can exceed capability defaults; lookup never uses the
+static default to cap a positive learned TTL.
 
 Caller controls, always honored: `Cache-Control: no-cache`/`no-store` forces a live call (the
 read-after-write escape — the archive never guesses cross-endpoint effects); `X-Treg-Max-Age`

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -636,8 +636,8 @@ drop reasons, leader timing, and duplicate statuses after rollout before increas
 
 ## Change observation
 
-After `_store_locked` commits, `_observe_change` reports a byte-hash change from the immediately
-preceding snapshot for `caller` and `refresh` origins only. Cache hits and async terminal evidence
+After `_store_locked` commits, `_observe_change` reports a byte-hash change from the baseline
+that actually drove TTL learning for `caller` and `refresh` origins only. Cache hits and async terminal evidence
 never emit `archive_change_observed`. The background task has a separate three-second observation
 budget after the existing 30-second DB stage. Failure cannot undo or prevent the recording.
 `_read_change_body` collects an `archive_bodies.pointer` in a short background session, closes it,
@@ -668,8 +668,8 @@ Non-JSON pairs use `changed_paths: [non_json]`, `path_count: 1`, `leaf_count: 0`
 Analytics emits `archive_change_observed` with distinct ID `archive` and only `endpoint_id`,
 `provider`, `changed_paths`, `path_count`, `truncated`, `leaf_count`, `sole_path` and
 `masked_by_ignore` (true only when a declared ignore comparison actually rescues a stable TTL
-decision). The path report compares the latest historical snapshot; result-aware TTL can instead
-compare an older decisive found snapshot across intervening unknown/error observations. No values, body
+decision). The path report uses that same TTL baseline, including an older decisive snapshot
+across intervening unknown/error observations for result-aware endpoints. No values, body
 snippets, call references or key identities are sent. Paths are structural property names from JSON;
 these reports are not a schema or evidence that a field is safe to ignore. Observation is read-only
 and does not alter admission, learning, stored bytes, deduplication or serving.
@@ -743,9 +743,11 @@ returns exactly the retained answer; the learned expiration can change only for 
 Read/analysis failures preserve strict comparison. No schema migration, new DB write, serving
 allowlist change, production configuration, field selection UI or automated ignore proposal ships.
 
-Known deferred limitation: `changed_paths` compares the immediately previous snapshot, while
-`masked_by_ignore` can refer to a different decisive baseline. No endpoint currently declares
-ignore paths, so the latter is always false. **This must be fixed before the first ignore list
-is introduced.** This delivery only documents the mismatch; it does not change snapshot pairing.
+`changed_paths` and `masked_by_ignore` describe the same pair: the new body and the baseline
+used for its stable/changed TTL decision. Result-aware endpoints use the decisive found/empty
+snapshot, skipping intervening unknown/error evidence; legacy endpoints use the previous snapshot.
+Observations without a learning decision (including repeated empty results) emit no change event.
+The baseline ID is captured during recording; its pointer and bytes are read afterward under the
+existing session discipline, without adding DB writes.
 
 Ignore-path segments may begin with digits, e.g. `2fa_enabled` or `data.123status`.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -882,6 +882,7 @@ async def _store_locked(
         previous_state = key.result_state if result_aware else "found"
         next_state = result.state if result_aware else "found"
         masked_by_ignore = False
+        comparison_baseline = None
         decisive = next_state in ("found", "empty") and origin != "async_terminal"
         if decisive and baseline is not None and (previous_state, next_state) != ("empty", "empty"):
             stable = previous_state == next_state == "found" and (
@@ -893,6 +894,9 @@ async def _store_locked(
                 key.change_seen += 1
                 key.last_changed_at = now
             learn(key, stable=stable, entry=entry)
+            # Both event properties must describe the pair that drove TTL learning. The
+            # newest row may only be intervening unknown/error evidence, not this baseline.
+            comparison_baseline = baseline
         key.fetched_at, key.policy = now, pol
         if origin == "caller":     # a refresh is treg asking itself — never demand
             key.last_requested_at = now
@@ -911,8 +915,9 @@ async def _store_locked(
             stable_d=key.stable_seen - seen_before[0], changed_d=key.change_seen - seen_before[1],
             kept=plan.storage is not None, size=len(body), now=now)
         await s.commit()
-        return ((newest.id, masked_by_ignore) if newest is not None and newest.content_hash != ch
-                and plan.storage is not None and _has_change_body(newest)
+        return ((comparison_baseline.id, masked_by_ignore)
+                if comparison_baseline is not None and comparison_baseline.content_hash != ch
+                and plan.storage is not None and _has_change_body(comparison_baseline)
                 and get_settings().archive_change_observation_enabled
                 and origin in ("caller", "refresh") else None)
 

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -1094,6 +1094,18 @@ _TTL_DEFAULTS: tuple[tuple[str, int], ...] = (
 DEFAULT_TTL_S = 3600
 
 
+def declared_max_age_s(entry: dict[str, Any] | None) -> int | None:
+    """Vendor ceiling only; static capability defaults must not cap learned TTLs."""
+    declared = (entry or {}).get("cache")
+    if not isinstance(declared, dict):
+        return None
+    try:
+        cap = int(declared.get("max_age_s") or 0)
+    except (TypeError, ValueError):
+        return None
+    return cap if cap > 0 else None
+
+
 def ttl_for(entry: dict[str, Any] | None) -> int:
     """The phase-1 freshness window for one endpoint, in seconds. Longest matching capability
     prefix from the fixed table (else the 1-hour default), always capped by the vendor's own
@@ -1104,14 +1116,9 @@ def ttl_for(entry: dict[str, Any] | None) -> int:
     for prefix, seconds in _TTL_DEFAULTS:
         if capability.startswith(prefix) and len(prefix) > best:
             best, ttl = len(prefix), seconds
-    declared = (entry or {}).get("cache")
-    if isinstance(declared, dict):
-        try:
-            cap = int(declared.get("max_age_s") or 0)
-        except (TypeError, ValueError):
-            cap = 0
-        if cap > 0:
-            ttl = min(ttl, cap)
+    cap = declared_max_age_s(entry)
+    if cap is not None:
+        ttl = min(ttl, cap)
     return ttl
 
 
@@ -1191,6 +1198,9 @@ async def lookup(
             if key.ttl_s == TTL_NEVER:
                 return miss("ttl_disabled")
             window = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
+            cap = declared_max_age_s(entry)
+            if cap is not None:
+                window = min(window, cap)
             if wanted is not None:
                 window = min(window, wanted)
             if window <= 0:
@@ -1281,14 +1291,9 @@ def learn(key, *, stable: bool, entry: dict[str, Any] | None) -> None:
     change (×0.5, floored). The vendor's declared ceiling always caps; a key that only ever
     changes marks itself TTL_NEVER and is never served again until a stable refetch resets it."""
     ceiling = TTL_CEILING_S
-    declared = (entry or {}).get("cache")
-    if isinstance(declared, dict):
-        try:
-            cap = int(declared.get("max_age_s") or 0)
-        except (TypeError, ValueError):
-            cap = 0
-        if cap > 0:
-            ceiling = min(ceiling, cap)
+    cap = declared_max_age_s(entry)
+    if cap is not None:
+        ceiling = min(ceiling, cap)
     current = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
     if stable:
         key.ttl_s = min(int(current * 1.5), ceiling)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1313,6 +1313,45 @@ async def test_strict_comparison_preserves_existing_ttl(clients, serve, monkeypa
         assert props["cache_window_s"] == timer
 
 
+@pytest.mark.parametrize("learned,cap,wanted,age,window,outcome", [
+    (86400, 3600, None, 1800, 3600, "hit"),
+    (86400, 3600, None, 7200, 3600, "stale"),
+    (1800, 3600, None, 900, 1800, "hit"),
+    (30 * 86400, None, None, 15 * 86400, 30 * 86400, "hit"),
+    (86400, 3600, 600, 900, 600, "stale"),
+    (86400, 3600, 7200, 1800, 3600, "hit"),
+    (600, 3600, 1800, 900, 600, "stale"),
+])
+async def test_serve_caps_learned_ttl_only_by_declared_and_caller_limits(
+    clients, serve, monkeypatch, learned, cap, wanted, age, window, outcome,
+):
+    from datetime import timedelta
+    entry = catalog_store.load().by_id[EP]
+    monkeypatch.setitem(entry, "cache", {"mode": "transient", "max_age_s": cap})
+    await clients.get(f"/call/{EP}?aweme_id=7")
+    await archive.drain()
+    async with session_maker() as session:
+        key = (await session.execute(select(ArchiveKey))).scalars().one()
+        snap = (await session.execute(select(ArchiveSnapshot))).scalars().one()
+        key.ttl_s = learned
+        snap.fetched_at -= timedelta(seconds=age)
+        session.add(key)
+        session.add(snap)
+        await session.commit()
+    events = []
+    monkeypatch.setattr(call_service.analytics, "capture",
+                        lambda who, event, props, **kw: events.append((event, props)))
+    headers = {} if wanted is None else {"X-Treg-Max-Age": str(wanted)}
+    response = await clients.get(f"/call/{EP}?aweme_id=7", headers=headers)
+    assert response.status_code == 200
+    assert (response.headers.get("x-treg-cache") == "hit") == (outcome == "hit")
+    props = [p for e, p in events if e == "tool_called"][-1]
+    assert props["cache_outcome"] == outcome
+    assert props["cache_window_s"] == window
+    if cap is None:
+        assert learned > archive.ttl_for(entry)
+
+
 @pytest.mark.parametrize("old,new,paths", [
     ({"items": [{"id": 1}, {"id": 2}]}, {"items": [{"id": 3}, {"id": 4}]}, ["items[*].id"]),
     ({"a": 1}, {"b": 2}, ["a", "b"]),

--- a/tests/test_cache_result_admission.py
+++ b/tests/test_cache_result_admission.py
@@ -331,7 +331,13 @@ async def test_ignore_cannot_mask_result_transitions_and_uses_decisive_baseline(
     k = await _key()
     assert (k.stable_seen, k.change_seen, k.result_state) == (1, 1, 'empty')
     observed = [p for name, p in events if name == 'archive_change_observed']
-    assert [p['masked_by_ignore'] for p in observed] == [False, True, False]
+    # Unknown evidence does not drive learning or produce a comparison event. The rescued
+    # found comparison must describe the decisive found body, not the intervening empty object.
+    assert [p['masked_by_ignore'] for p in observed] == [True, False]
+    assert observed[0]['changed_paths'] == ['data.emails[*].value']
+    assert observed[0]['path_count'] == 1
+    assert observed[0]['sole_path'] == 'data.emails[*].value'
+    assert observed[1]['changed_paths'] == ['data.emails[*]', 'meta.results']
     await _call(clients, monkeypatch, EMPTY)
     assert (await _key()).change_seen == 1
     response = await _call(clients, monkeypatch, changed)


### PR DESCRIPTION
Two prerequisites for the first `cache.ignore_paths` list. Both were reproduced through `/call/`
first, then fixed.

## 1. Serving ignored the vendor's declared ceiling

`lookup()` computed `window = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)`. `ttl_for()` is the
only place that applied a judged `cache.max_age_s`, and it is consulted **only** when the key has
not learned a TTL yet. So the moment a key learned any positive TTL it served past the vendor's
declaration for as long as AIMD had grown it.

`declared_max_age_s(entry)` now reads that one field and is shared by the capability defaults,
`learn()` and `lookup()`. Serving caps by the declaration first, then by the caller's
`X-Treg-Max-Age`.

It deliberately does **not** cap by `ttl_for()`. `ttl_for()` returns a static capability default
already narrowed by the declaration; capping a learned TTL with it would pin adaptive growth to
the static guess and defeat the learner. The `(learned 30d, no declaration)` parametrisation
asserts `learned > archive.ttl_for(entry)` still hits, so that regression cannot come back quietly.

## 2. `changed_paths` and `masked_by_ignore` could describe different snapshot pairs

The path report compared the newest snapshot while the ignore decision referred to the decisive
found/empty baseline that actually drove learning. For result-aware endpoints those differ whenever
unknown/error evidence lands in between, so the two event properties disagreed about what was being
compared. That mismatch was documented as a known limitation that had to be fixed before any ignore
list shipped - this is that fix.

Both properties now describe the pair that drove the TTL decision. An observation with no learning
decision emits no change event at all, which drops exactly the events that could never inform an
ignore list.

## Notes

- `docs/context/architecture/archive.md` updated in the same commits; the deferred-limitation
  paragraph is removed.
- No schema change, no new DB write, no change to object-storage or session boundaries, no
  serving-allowlist or production-configuration change.
- Full regression 3722 passed / 6 skipped; 14 import contracts kept; drift check clean.
