### PR TITLE
fix(cache): validate Leadsforge email results and cap pilot freshness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ TREG_ARCHIVE_OBJECT_STORE_SECRET_ACCESS_KEY=
 
 # Optional changed-path reporting (shares archive concurrency and lookup read mode).
 TREG_ARCHIVE_CHANGE_OBSERVATION_ENABLED=true
+
+# Optional operator cache age ceilings by exact endpoint ID (seconds).
+TREG_ARCHIVE_SERVE_MAX_AGE_S={}

--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -751,3 +751,19 @@ The baseline ID is captured during recording; its pointer and bytes are read aft
 existing session discipline, without adding DB writes.
 
 Ignore-path segments may begin with digits, e.g. `2fa_enabled` or `data.123status`.
+
+
+## Leadsforge email cache pilot
+
+`leadsforge.people.email.find` uses strict result admission: a `succeeded` response needs a
+nonempty email string with a basic mailbox/domain shape; `not_found` without an email is empty.
+Other status/field combinations are unknown and cannot serve. This is result validation, not
+mailbox deliverability verification. Historical bytes remain unchanged and are reclassified on lookup.
+
+`TREG_ARCHIVE_SERVE_MAX_AGE_S` is a JSON mapping of exact endpoint IDs to positive integer
+seconds (empty by default). It is an operator freshness ceiling, independent of vendor declarations.
+Lookup takes the minimum of the learned TTL, vendor ceiling, operator ceiling and caller max-age;
+`TTL_NEVER` remains authoritative. The refresh worker also respects the operator ceiling for its
+80% due threshold. It does not reset or rewrite historical learning counters. `/admin/archive`
+reports `serve_max_age_s` so operators can verify the running configuration. The global team cohort
+percentage is unchanged. Production pilot values and rollback live in treg-internal.

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -1206,6 +1206,9 @@ async def lookup(
             cap = declared_max_age_s(entry)
             if cap is not None:
                 window = min(window, cap)
+            operator_cap = get_settings().archive_serve_max_age_s.get(endpoint_id)
+            if operator_cap is not None:
+                window = min(window, operator_cap)
             if wanted is not None:
                 window = min(window, wanted)
             if window <= 0:
@@ -1382,6 +1385,9 @@ async def refresh_once(client) -> int:
         if not storable(entry):
             continue  # judgment changed since recording — never refresh what may not be kept
         window = key.ttl_s if key.ttl_s > 0 else ttl_for(entry)
+        operator_cap = get_settings().archive_serve_max_age_s.get(key.endpoint_id)
+        if operator_cap is not None:
+            window = min(window, operator_cap)
         age = (now - key.fetched_at).total_seconds()
         demanded = key.last_requested_at is not None and key.last_requested_at > key.fetched_at
         if age < window * _DUE_SHARE or not demanded:

--- a/src/treg/config.py
+++ b/src/treg/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, PositiveInt, field_validator
 from urllib.parse import urlsplit
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -328,6 +328,8 @@ class Settings(BaseSettings):
     archive_serve_endpoints: str = ""
     # Stable team/endpoint cohorts; 0 disables serving, 100 includes every team.
     archive_serve_percent: int = 0
+    # Operator freshness ceilings by exact endpoint ID; independent of vendor declarations.
+    archive_serve_max_age_s: dict[str, PositiveInt] = Field(default_factory=dict)
     # Bodies above this size are hash-counted but never stored (skipped whole, not truncated):
     # the archive is for API JSON answers, not downloads. Statistics still record size_bytes.
     archive_max_body_bytes: int = 2_000_000

--- a/src/treg/domain/catalog/results.py
+++ b/src/treg/domain/catalog/results.py
@@ -2,10 +2,12 @@
 from dataclasses import dataclass
 import json
 import math
+import re
 from typing import Literal
 
 
 STRICT_ENDPOINTS = frozenset({
+    "leadsforge.people.email.find",
     "hunter.companies.emails",
     "leadmagic.x.employee-finder",
     "seranking.google.keywords.volume",
@@ -55,6 +57,16 @@ def classify(endpoint_id: str, status: int, body: bytes) -> Result:
         except Exception:  # a predicate failure is not evidence of a business change
             return Result("unknown", "predicate_error")
         return Result("empty", "adapter_miss") if miss else Result("found", "adapter_hit")
+    if endpoint_id == "leadsforge.people.email.find":
+        if not isinstance(doc, dict):
+            return Result("unknown", "invalid_shape")
+        status, email = doc.get("status"), doc.get("email")
+        if status == "not_found" and email is None:
+            return Result("empty", "no_email")
+        if (status == "succeeded" and isinstance(email, str)
+                and re.fullmatch(r"[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+", email)):
+            return Result("found", "email")
+        return Result("unknown", "invalid_shape")
     if endpoint_id == "seranking.google.keywords.volume":
         if not isinstance(doc, list):
             return Result("unknown", "invalid_shape")

--- a/src/treg/routers/admin.py
+++ b/src/treg/routers/admin.py
@@ -427,6 +427,7 @@ async def admin_archive(
               "ttl_policy": "adaptive",
               "serve_endpoints": sorted(archive_mod.serve_endpoints()),
               "serve_percent": get_settings().archive_serve_percent,
+              "serve_max_age_s": get_settings().archive_serve_max_age_s,
               # Cumulative counters include observations from older comparison policies.
               "change_statistics_scope": "lifetime_mixed_comparison_modes",
             "worker_on": archive_mod.worker_enabled(),

--- a/tests/test_cache_result_admission.py
+++ b/tests/test_cache_result_admission.py
@@ -343,3 +343,66 @@ async def test_ignore_cannot_mask_result_transitions_and_uses_decisive_baseline(
     response = await _call(clients, monkeypatch, changed)
     assert response.content == changed and 'x-treg-cache' not in response.headers
     assert (await _key()).change_seen == 2
+
+
+@pytest.mark.parametrize("raw", [
+    b'{"status":"succeeded","email":""}',
+    b'{"status":"failed","email":"person@example.com"}',
+    b'{"status":"succeeded","email":123}',
+    b'{"status":"succeeded","email":"not-an-email"}',
+    b'{"status":"not_found"}',
+])
+async def test_leadsforge_invalid_results_never_serve(clients, monkeypatch, raw):
+    monkeypatch.setenv('TREG_PLATFORM_PROVIDERS', 'leadsforge')
+    monkeypatch.setenv('TREG_PLATFORM_KEY_LEADSFORGE', 'test-key')
+    get_settings.cache_clear()
+    settings = get_settings()
+    monkeypatch.setattr(settings, 'archive_mode', 'serve')
+    monkeypatch.setattr(settings, 'archive_serve_endpoints', 'leadsforge.people.email.find')
+    monkeypatch.setattr(settings, 'archive_serve_percent', 100)
+    try:
+        monkeypatch.setattr(service, 'relay', _fake_relay(200, raw))
+        for _ in range(2):
+            r = await clients.post('/call/leadsforge.people.email.find', json={'personID':'synthetic-person'})
+            await archive.drain()
+            assert r.status_code == 200 and r.content == raw
+            assert r.headers.get('x-treg-cache') != 'hit'
+    finally:
+        get_settings.cache_clear()
+
+
+async def test_operator_cap_bounds_existing_ttl_and_preserves_bypass(clients, cache_on, monkeypatch):
+    from datetime import timedelta
+    settings = get_settings()
+    monkeypatch.setattr(settings, 'archive_serve_max_age_s', {EP: 86400})
+    await _call(clients, monkeypatch, FOUND)
+    async with session_maker() as s:
+        k = (await s.execute(select(ArchiveKey))).scalar_one()
+        k.ttl_s = 30 * 86400
+        snap = await s.get(ArchiveSnapshot, k.result_snapshot_id)
+        snap.fetched_at -= timedelta(hours=23)
+        s.add(k)
+        s.add(snap)
+        await s.commit()
+    assert (await _call(clients, monkeypatch, EMPTY)).headers['x-treg-cache'] == 'hit'
+    async with session_maker() as s:
+        snap = (await s.execute(select(ArchiveSnapshot))).scalar_one()
+        snap.fetched_at -= timedelta(hours=2)
+        s.add(snap)
+        await s.commit()
+    fresh = await _call(clients, monkeypatch, FOUND)
+    assert 'x-treg-cache' not in fresh.headers
+    bypass = await _call(clients, monkeypatch, EMPTY, live=True)
+    assert bypass.content == EMPTY and 'x-treg-cache' not in bypass.headers
+
+
+@pytest.mark.parametrize('body,state', [
+    ({'status':'succeeded','email':'person@example.com'}, 'found'),
+    ({'status':'not_found'}, 'empty'),
+    ({'status':'not_found','email':'person@example.com'}, 'unknown'),
+    ({'email':'person@example.com'}, 'unknown'),
+    ({'status':'succeeded','email':' person@example.com'}, 'unknown'),
+])
+def test_leadsforge_result_contract(body, state):
+    from treg.domain.catalog.results import classify
+    assert classify('leadsforge.people.email.find', 200, json.dumps(body).encode()).state == state


### PR DESCRIPTION
Leadsforge email responses with empty, malformed or non-string emails, or contradictory status fields, could be replayed as cache hits. Require a succeeded response with a basic valid email shape; keep explicit not_found as empty and other shapes unknown.

Add an optional operator-owned per-endpoint freshness ceiling, independent of vendor declarations. Lookup caps historical learned TTLs and the refresh scheduler respects the same operator limit. Expose runtime ceilings in the archive admin report. This enables the separately configured 24-hour Leadsforge pilot without changing global cohort behavior.

Validation: reproduced four invalid cache hits through /call before fixing; 201 archive/admission tests and all 14 import contracts pass. Full suite and CI follow. Updated fragment: architecture/archive.md.

Full local validation: 3,737 passed, 6 skipped in 129 seconds using pytest-xdist. No test failures.
