### PR TITLE
fix(archive): measure write stages and skip unused normalization

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -158,6 +158,22 @@ latency cannot delay it. The separate `archive_body_stored` completion event car
 `call_ref`. A failed R2 upload followed by a committed DB copy is not dropped. R2-only upload
 failure still records a hash-only snapshot and statistics. These remain best-effort background
 writes: a killed process can lose completion events, but cannot withhold the calling event.
+The same completion event measures archive stages, including elapsed work on timeout or cancellation:
+
+| Fields (milliseconds) | Scope |
+| --- | --- |
+| `compare_sem_wait_ms`, `compare_ms` | Precomparison slot wait, then pointer queries/reads and any JSON normalization. Both precede the DB write deadline. |
+| `record_key_wait_ms`, `record_sem_wait_ms` | Same-key lock wait, then write-slot wait, inside the DB write deadline. |
+| `record_db_ms` | Wall time while holding the write slot: pool checkout, body packing, SQL/commit, and integrity retries/backoff. This is not pure SQL time. |
+| `observe_sem_wait_ms`, `observe_ms` | Optional post-commit change-report slot wait and work, outside the DB write deadline. |
+
+Unentered phases are `null`. `failure_phase` names the measured phase interrupted by an escaping
+exception (including cancellation); it is `null` when none was interrupted, including a queue
+rejection before recording starts. Internally handled comparison failures still fall back to raw
+hashes and use the existing counters. A post-commit observation cancellation does not mean the
+snapshot was lost: `storage`/`dropped` continue to describe the committed write. Timings add no
+DB writes or per-call events and do not change deadlines, the two archive slots, or pool sizes.
+
 Stats count snapshots with recoverable bodies in DB or R2, including deduplicated versions;
 `kept_bytes` is logical retained response bytes, not PostgreSQL physical table size.
 
@@ -751,8 +767,11 @@ Deleting `items[*].request_id` keeps all elements; deleting `items[*]` deletes t
 Comparison has no six-level reporting limit and never uses reported/truncated paths as policy.
 
 `_ignored_matches` preloads at most the latest and decisive snapshot bodies before the DB write.
-It skips body reads for identical raw hashes. Pointer sessions close before object I/O. The pre-read
-uses the shared archive semaphore and a three-second budget, separate from the write deadline.
+It checks the key and raw hashes first, skipping new-response JSON normalization unless a differing
+candidate has a readable body pointer. New keys and raw-identical baselines therefore need no
+normalization; identical raw hashes also skip body reads. Pointer sessions close before JSON
+normalization or object I/O. The pre-read uses the shared archive semaphore and a three-second
+budget, separate from the write deadline.
 Only matched snapshot IDs are passed to `_store_locked`; a concurrently changed baseline falls
 back to raw hashes without holding a row lock across I/O or adding a reconciliation write.
 `ignore_body_unavailable` and `ignore_comparison_failed` retain their diagnostic names for both

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -536,32 +536,39 @@ async def _store(
         ignore_paths = cache.get("ignore_paths", []) if isinstance(cache, dict) else []
         ignored_matches = set()
         if plan.storage is not None and origin in ("caller", "refresh"):
-            async with _get_sem():
-                ignored_matches = await _ignored_matches(kh, body, ignore_paths)
+            async with observation.wait(_get_sem(), "compare_sem_wait"):
+                with observation.measure("compare"):
+                    ignored_matches = await _ignored_matches(kh, body, ignore_paths)
 
         # Same-key waiters must queue before taking a scarce database-write slot. Otherwise four
         # duplicate recordings can occupy the whole semaphore while only one touches the database.
-        async with asyncio.timeout(_TERMINAL_DB_S if origin == "async_terminal" else _STORE_TIMEOUT_S), _get_key_lock(kh):
-            async with _get_sem():
-                # Postgres row locking handles other processes. A retry also covers the narrow
-                # first-key race and multi-process SQLite, where SELECT FOR UPDATE is ignored.
-                for attempt in range(4):
-                    try:
-                        change = await _store_locked(
-                            method=method, endpoint_id=endpoint_id, provider=provider, url=url,
-                            caller_body=caller_body, headers=headers, status_code=status_code,
-                            media_type=media_type, body=body, origin=origin,
-                            key_hash=kh, body_hash=ch, plan=plan, ignored_matches=ignored_matches)
-                        stored, reason = plan.storage, plan.reason
-                        break
-                    except IntegrityError:
-                        if attempt == 3:
-                            raise
-                        await asyncio.sleep(0.01 * (attempt + 1))
+        async with (
+            asyncio.timeout(_TERMINAL_DB_S if origin == "async_terminal" else _STORE_TIMEOUT_S),
+            observation.wait(_get_key_lock(kh), "record_key_wait"),
+        ):
+            async with observation.wait(_get_sem(), "record_sem_wait"):
+                # Wall time includes pool checkout, packing, SQL/commit and integrity retries.
+                with observation.measure("record_db"):
+                    # Postgres row locking handles other processes. A retry also covers the narrow
+                    # first-key race and multi-process SQLite, where SELECT FOR UPDATE is ignored.
+                    for attempt in range(4):
+                        try:
+                            change = await _store_locked(
+                                method=method, endpoint_id=endpoint_id, provider=provider, url=url,
+                                caller_body=caller_body, headers=headers, status_code=status_code,
+                                media_type=media_type, body=body, origin=origin,
+                                key_hash=kh, body_hash=ch, plan=plan, ignored_matches=ignored_matches)
+                            stored, reason = plan.storage, plan.reason
+                            break
+                        except IntegrityError:
+                            if attempt == 3:
+                                raise
+                            await asyncio.sleep(0.01 * (attempt + 1))
         if change is not None and get_settings().archive_change_observation_enabled:
             previous_id, masked_by_ignore = change
-            async with _get_sem():
-                await _observe_change(previous_id, body, endpoint_id, provider, masked_by_ignore)
+            async with observation.wait(_get_sem(), "observe_sem_wait"):
+                with observation.measure("observe"):
+                    await _observe_change(previous_id, body, endpoint_id, provider, masked_by_ignore)
     except asyncio.CancelledError:
         reason = "cancelled"
         raise
@@ -666,9 +673,6 @@ async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[
     matches = set()
     try:
         async with asyncio.timeout(_CHANGE_TIMEOUT_S):
-            new_hash = await _change_compute(_normalized_hash, body, paths)
-            if new_hash is None:
-                return matches
             async with background_session_maker() as s:
                 key = (await s.execute(select(ArchiveKey).where(
                     ArchiveKey.key_hash == key_hash))).scalar_one_or_none()
@@ -685,6 +689,13 @@ async def _ignored_matches(key_hash: str, body: bytes, paths: list[str]) -> set[
                 matches.update(row.id for row in rows if row.content_hash == raw_hash)
                 pointers = [(row.id, await archive_bodies.pointer(s, row, "observation"))
                             for row in rows if row.content_hash != raw_hash and _has_change_body(row)]
+            if not pointers:
+                return matches
+            # New keys and raw-identical baselines need no JSON parsing or serialization.
+            # Close the pointer session before any off-thread work or object I/O.
+            new_hash = await _change_compute(_normalized_hash, body, paths)
+            if new_hash is None:
+                return matches
             for snapshot_id, pointer in pointers:
                 previous = await archive_bodies.read(pointer, "observation")
                 if previous is None:

--- a/src/treg/archive_bodies.py
+++ b/src/treg/archive_bodies.py
@@ -1,6 +1,7 @@
 """Archive body I/O and upload scheduling, separate from archive indexing and TTL learning."""
 import asyncio
 from collections import Counter, OrderedDict
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 import logging
 import re
@@ -62,6 +63,31 @@ class StorageReport:
         self.finished = False
         self.props = {"archive_body_upload_status": "not_requested", "archive_body_upload_ms": 0.0,
                       "archive_body_queue_wait_ms": 0.0}
+        self.timings = dict.fromkeys(("compare_sem_wait", "compare", "record_key_wait",
+                                     "record_sem_wait", "record_db", "observe_sem_wait", "observe"))
+        self.failure_phase = None
+
+    @contextmanager
+    def measure(self, phase):
+        """Include interrupted work; an unentered phase stays unknown rather than zero."""
+        started = time.monotonic()
+        try:
+            yield
+        except BaseException:
+            self.failure_phase = phase
+            raise
+        finally:
+            self.timings[phase] = (time.monotonic() - started) * 1000
+
+    @asynccontextmanager
+    async def wait(self, gate, phase):
+        # Measure acquisition only, then retain the original lock/semaphore lifetime.
+        with self.measure(phase):
+            await gate.acquire()
+        try:
+            yield
+        finally:
+            gate.release()
 
     def finish(self, *, storage=None, reason=None):
         if self.finished:
@@ -73,6 +99,9 @@ class StorageReport:
                 "upload_ms": round(self.props["archive_body_upload_ms"], 3),
                 "queue_wait_ms": round(self.props["archive_body_queue_wait_ms"], 3),
                 "dropped": storage is None, "drop_reason": reason or "none"}
+        data.update({phase + "_ms": round(ms, 3) if ms is not None else None
+                     for phase, ms in self.timings.items()})
+        data["failure_phase"] = self.failure_phase
         if self.emit is not None:
             self.emit(data)
         elif self.call_ref:

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -89,6 +89,52 @@ async def test_upload_precedes_pointer_and_call_does_not_wait(clients, r2, monke
     assert len(props) == 1 and props[0]['upload_status'] == 'uploaded'
     assert props[0]['upload_ms'] >= 0
     assert props[0]['dropped'] is False
+    assert props[0]['failure_phase'] is None
+    for phase in ('compare_sem_wait', 'compare', 'record_key_wait', 'record_sem_wait', 'record_db'):
+        assert props[0][phase + '_ms'] >= 0
+
+
+@pytest.mark.parametrize('phase', ['record_key_wait', 'record_sem_wait', 'record_db'])
+async def test_call_reports_where_archive_db_deadline_expires(clients, r2, monkeypatch, phase):
+    # The upstream answer and R2 object succeed even when archive indexing cannot finish.
+    monkeypatch.setattr(archive, '_STORE_TIMEOUT_S', .05)
+    blocked = asyncio.Lock()
+    await blocked.acquire()
+    if phase == 'record_key_wait':
+        monkeypatch.setattr(archive, '_get_key_lock', lambda key: blocked)
+    elif phase == 'record_sem_wait':
+        comparison_sem = asyncio.Semaphore(2)
+        calls = 0
+        def get_sem():
+            nonlocal calls
+            calls += 1
+            return comparison_sem if calls == 1 else blocked
+        monkeypatch.setattr(archive, '_get_sem', get_sem)
+    else:
+        async def blocked_store(**kwargs):
+            await asyncio.Event().wait()
+        monkeypatch.setattr(archive, '_store_locked', blocked_store)
+    reports = []
+    monkeypatch.setattr(service.analytics, 'capture',
+                        lambda who, name, props, **kw: reports.append(props)
+                        if name == 'archive_body_stored' else None)
+    try:
+        response = await clients.get(URL)
+        assert response.status_code == 200 and response.content == RAW
+        await archive.drain()
+    finally:
+        blocked.release()
+    assert r2.objects[archive.content_hash(RAW)] == RAW
+    assert await snapshots() == []
+    assert len(reports) == 1
+    report = reports[0]
+    assert report['drop_reason'] == 'record_timeout' and report['dropped'] is True
+    assert report['failure_phase'] == phase
+    assert report[phase + '_ms'] >= 40
+    if phase != 'record_db':
+        assert report['record_db_ms'] is None
+    if phase == 'record_key_wait':
+        assert report['record_sem_wait_ms'] is None
 
 
 @pytest.mark.parametrize('mode,expected_rows', [('both', 1), ('r2', 1)])
@@ -642,6 +688,65 @@ async def test_db_deadline_reports_timeout_not_cancelled(clients, r2, monkeypatc
     assert any('record_timeout' in record.message for record in caplog.records)
 
 
+@pytest.mark.parametrize('phase', [
+    'compare_sem_wait', 'compare', 'record_key_wait', 'record_sem_wait', 'record_db',
+    'observe_sem_wait', 'observe',
+])
+async def test_cancelled_record_reports_elapsed_phase(clients, r2, monkeypatch, phase):
+    entered = asyncio.Event()
+    class BlockedGate(asyncio.Semaphore):
+        async def acquire(self):
+            entered.set()
+            return await super().acquire()
+    blocked_gate = BlockedGate(0)
+    async def blocked_work(*args, **kwargs):
+        entered.set()
+        await asyncio.Event().wait()
+    sem = asyncio.Semaphore(2)
+    key_lock = asyncio.Lock()
+    sem_calls = 0
+    def get_sem():
+        nonlocal sem_calls
+        sem_calls += 1
+        blocked_call = {'compare_sem_wait': 1, 'record_sem_wait': 2, 'observe_sem_wait': 3}.get(phase)
+        return blocked_gate if sem_calls == blocked_call else sem
+    monkeypatch.setattr(archive, '_get_sem', get_sem)
+    monkeypatch.setattr(archive, '_get_key_lock',
+                        lambda key: blocked_gate if phase == 'record_key_wait' else key_lock)
+    if phase == 'compare':
+        monkeypatch.setattr(archive, '_ignored_matches', blocked_work)
+    elif phase == 'record_db':
+        monkeypatch.setattr(archive, '_store_locked', blocked_work)
+    elif phase == 'observe':
+        monkeypatch.setattr(archive, '_observe_change', blocked_work)
+    # A prior version ensures the post-commit observation phases are reached.
+    if phase.startswith('observe'):
+        await archive._store(method='GET', endpoint_id=EP, provider='tikhub', url=URL,
+                             caller_body=b'', headers={}, status_code=200,
+                             media_type='application/json', body=b'{"before":1}',
+                             plan=archive_bodies.WritePlan('db'))
+        sem_calls = 0
+    reports = []
+    task = asyncio.create_task(archive._store(
+        method='GET', endpoint_id=EP, provider='tikhub', url=URL, caller_body=b'',
+        headers={}, status_code=200, media_type='application/json', body=RAW,
+        plan=archive_bodies.WritePlan('db'),
+        observation=archive_bodies.StorageReport(emit=reports.append)))
+    try:
+        await asyncio.wait_for(entered.wait(), 2)
+        await asyncio.sleep(.01)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert len(reports) == 1
+    assert reports[0]['drop_reason'] == 'cancelled'
+    assert reports[0]['failure_phase'] == phase
+    assert reports[0][phase + '_ms'] > 0
+    assert reports[0]['dropped'] is (not phase.startswith('observe'))
+    assert sem._value == 2 and not key_lock.locked() and blocked_gate._value == 0
+
+
 async def test_cancel_before_start_reports_once(clients, r2, monkeypatch):
     reports = []
     archive.record(method='GET', endpoint_id=EP, provider='tikhub', url=URL,
@@ -652,6 +757,8 @@ async def test_cancel_before_start_reports_once(clients, r2, monkeypatch):
         task.cancel()
     await archive.drain()
     assert len(reports) == 1 and reports[0]['drop_reason'] == 'cancelled'
+    assert reports[0]['failure_phase'] is None
+    assert reports[0]['record_key_wait_ms'] is None and reports[0]['record_db_ms'] is None
 
 
 @pytest.mark.parametrize('error,reason', [
@@ -688,6 +795,37 @@ async def test_same_body_refetch_skips_duplicate_put(clients, r2, monkeypatch):
     reports = [p for name, p in events if name == 'archive_body_stored']
     assert [p['upload_status'] for p in reports] == ['uploaded', 'skipped_duplicate']
     assert all(p['storage'] == 'both' and not p['dropped'] for p in reports)
+
+
+@pytest.mark.parametrize('write_mode', ['both', 'r2'])
+async def test_new_and_identical_calls_skip_unused_normalization(clients, r2, monkeypatch, write_mode):
+    monkeypatch.setattr(get_settings(), 'archive_body_write', write_mode)
+    if write_mode == 'r2':
+        monkeypatch.setattr(get_settings(), 'archive_body_read_lookup', 'r2-first')
+    normalized = []
+    real_normalize = archive._normalized_hash
+    def normalize(body, paths):
+        normalized.append(body)
+        return real_normalize(body, paths)
+    monkeypatch.setattr(archive, '_normalized_hash', normalize)
+    for _ in range(2):
+        response = await clients.get(URL, headers={'Cache-Control': 'no-cache'})
+        assert response.status_code == 200 and response.content == RAW
+        await archive.drain()
+        assert normalized == []
+
+    # Default JSON equality still applies when the raw bytes actually differ.
+    reformatted = b'  ' + RAW + b'\n'
+    monkeypatch.setattr(service, 'relay', _fake_relay(200, reformatted))
+    assert (await clients.get(URL, headers={'Cache-Control': 'no-cache'})).content == reformatted
+    await archive.drain()
+    assert RAW in normalized and reformatted in normalized
+    async with db.session_maker() as s:
+        key = (await s.execute(select(ArchiveKey))).scalar_one()
+        assert key.stable_seen == 2 and key.change_seen == 0
+    rows = await snapshots()
+    assert len(rows) == 3
+    assert [row.content_hash for row in rows] == [archive.content_hash(raw) for raw in (RAW, RAW, reformatted)]
 
 
 async def test_concurrent_same_body_calls_share_one_put(clients, r2):

--- a/tests/test_daily_spend_counter.py
+++ b/tests/test_daily_spend_counter.py
@@ -5,7 +5,7 @@ instead of an aggregate over the platform's whole day (revision 0022). These tes
 semantics the journal view (`spent_today_from_ledger`) has always had: settled today plus still
 held from today, reset at the UTC day boundary, with a hold opened yesterday belonging to yesterday.
 """
-from datetime import date, timedelta
+from datetime import timedelta
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -15,6 +15,7 @@ from treg.api import app
 from treg.domain import money as ledger
 from treg.infra.db import reset_db, session_maker
 from treg.models import Hold, Org
+from treg.timeutil import utcnow_naive
 from conftest import make_upstream, verified_signup
 
 EP = "acme.thing.get"
@@ -86,7 +87,7 @@ async def test_counter_resets_on_a_new_utc_day(c: AsyncClient):
     assert await _both(org_id) == (spent, spent)
 
     # Move the counter to "yesterday" - as the day rolling over would leave it - and it reads 0.
-    yesterday = date.today() - timedelta(days=1)
+    yesterday = utcnow_naive().date() - timedelta(days=1)
     async with session_maker() as db:
         await db.execute(update(Org).where(Org.id == org_id).values(spent_today_day=yesterday))
         await db.commit()

--- a/tests/test_usage_caps.py
+++ b/tests/test_usage_caps.py
@@ -90,10 +90,11 @@ async def test_runs_and_calls_share_one_gate(clients: AsyncClient):
     assert src.count("await _enforce_daily_cap(caller, db)") == 2  # local-run grant + server run
     await _mk_echo_tool(clients)
     org_id = await _set_cap(2)
-    await _set_counter(org_id, "tim@superdesign.dev", 2, date.today())  # two prior events today
+    today = _utcnow_naive().date()
+    await _set_counter(org_id, "tim@superdesign.dev", 2, today)  # two prior events today
     blocked = await clients.get("/call/echo/anything")
     assert blocked.status_code == 429 and "2/2" in blocked.json()["detail"]
-    assert await _counter(org_id, "tim@superdesign.dev") == (2, date.today())  # refused = not counted
+    assert await _counter(org_id, "tim@superdesign.dev") == (2, today)  # refused = not counted
 
 
 async def test_cap_is_per_member_not_global(clients: AsyncClient):
@@ -113,9 +114,10 @@ async def test_cap_is_per_member_not_global(clients: AsyncClient):
 async def test_yesterdays_usage_does_not_count_today(clients: AsyncClient):
     await _mk_echo_tool(clients)
     org_id = await _set_cap(1)
-    await _set_counter(org_id, "tim@superdesign.dev", 1, date.today() - timedelta(days=1))  # yesterday's
+    today = _utcnow_naive().date()
+    await _set_counter(org_id, "tim@superdesign.dev", 1, today - timedelta(days=1))  # yesterday's
     assert (await clients.get("/call/echo/anything")).status_code == 200  # a new day starts from 0
-    assert await _counter(org_id, "tim@superdesign.dev") == (1, date.today())  # ...and this was its first
+    assert await _counter(org_id, "tim@superdesign.dev") == (1, today)  # ...and this was its first
     assert (await clients.get("/call/echo/anything")).status_code == 429
 
 
@@ -131,7 +133,7 @@ async def test_setting_a_cap_seeds_the_counter_from_todays_journal(clients: Asyn
     uid = [x["user_id"] for x in (await clients.get(f"/orgs/{org_id}/members")).json()
            if x["email"] == "tim@superdesign.dev"][0]
     assert (await clients.patch(f"/orgs/{org_id}/members/{uid}/cap", json={"daily_call_cap": 5})).status_code == 200
-    assert await _counter(org_id, "tim@superdesign.dev") == (4, date.today())
+    assert await _counter(org_id, "tim@superdesign.dev") == (4, _utcnow_naive().date())
     assert (await clients.get("/call/echo/anything")).status_code == 200  # 5th
     assert (await clients.get("/call/echo/anything")).status_code == 429  # 6th
 
@@ -144,7 +146,8 @@ async def test_counter_agrees_with_the_journal_after_real_calls(clients: AsyncCl
     await audit.drain()
     async with session_maker() as s:
         journal = await count_today(s, org_id, "tim@superdesign.dev")
-    assert await _counter(org_id, "tim@superdesign.dev") == (journal, date.today()) == (4, date.today())
+    today = _utcnow_naive().date()
+    assert await _counter(org_id, "tim@superdesign.dev") == (journal, today) == (4, today)
 
 
 async def _get_org_id(email: str = "tim@superdesign.dev") -> int:


### PR DESCRIPTION
Archive completion events could not distinguish a deadline spent waiting for a key lock, waiting for an archive write slot, or doing the write. New keys and byte-identical responses also performed JSON normalization while holding a scarce archive slot even when there was no body to compare.

This change adds elapsed times for precomparison, key-lock and semaphore waits, the write stage, and post-commit observation to the existing `archive_body_stored` event. Interrupted stages report their elapsed time and `failure_phase`; unentered stages remain null. `record_db_ms` includes pool checkout, packing, SQL/commit and integrity retries. Post-commit cancellation preserves the committed storage outcome.

JSON normalization now runs only after the pointer session closes and only when a differing baseline has a body pointer. Default JSON equality, explicit ignore paths, raw content hashes, returned bytes, deadlines, pool sizes and archive concurrency retain their existing behavior.

A separate test-only commit fixes daily-counter fixtures and assertions to use UTC dates. They previously failed in local timezones whose calendar date differed from UTC.

Validation:
- Reproduced the unused normalization and missing timeout diagnostics through `/call/` before the fix, then passed all six regression cases.
- 353 archive, R2 and result-admission tests passed, including cancellation across seven phases, semaphore release, and DB/R2 I/O discipline.
- All 14 import-boundary contracts passed; `git diff --check` passed.
- Full local suite and GitHub CI are running.
- Updated `docs/context/architecture/archive.md` in the same commit; the context drift check maps both changed sources to that fragment.
