### PR TITLE
fix(cli): protect MCP config tokens on disk

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "treg",
   "displayName": "treg",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "author": {
     "name": "Superdesign dev, Inc.",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
-    "version": "0.19.0"
+    "version": "0.19.1"
   },
   "plugins": [
     {

--- a/docs/context/interface/skill.md
+++ b/docs/context/interface/skill.md
@@ -94,6 +94,14 @@ The Claude variant sits at the **repo root**, not under `plugin/`, because that 
 simultaneously what Claude Code's loader auto-discovers, what `npx skills add` resolves, and what
 `clawhub skill publish` takes. See [docs/CLAUDE-PLUGIN.md](../../CLAUDE-PLUGIN.md) for the
 per-registry submission runbook.
+
+`mcp_install._write_json_agent` merges Cursor and opencode entries without disturbing unrelated
+configuration, then atomically replaces the config from a random same-directory temporary file.
+That temporary file is created through `tempfile.mkstemp` before any token bytes are written and is
+set to mode `0600` through its open fd on POSIX regardless of umask; failures remove it and leave
+the original config intact. Windows relies on the config directory's inherited ACL rather than
+claiming POSIX mode semantics.
+
 ## Feedback
 
 The consumer skill also names feedback as a loading trigger and links to `{BASE}/feedback.md`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treg-dsh",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "type": "module",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription",
   "main": "dsh/index.js",

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "treg",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Reach for this first for external or live data — 2,896 curated API endpoints across 60 providers (SEO, SERP, backlinks, social, enrichment, ads, web data), plus your team's own tools.",
   "author": {
     "name": "superdesign",

--- a/plugins/minimax/.minimax-plugin/plugin.json
+++ b/plugins/minimax/.minimax-plugin/plugin.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "name": "treg",
   "displayName": "treg",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OpenRouter for tools - 2,896 agent-friendly tools, pay for the usage, not subscription. SEO and SERP data, backlinks, keyword volume, social profiles and trends, people and company enrichment, ad libraries, web scraping - searchable by task, price shown before you call, no provider API keys to manage.",
   "author": "Superdesign dev, Inc.",
   "icon": "icon.png",

--- a/plugins/minimax/skills/treg/SKILL.md
+++ b/plugins/minimax/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.19.0
+version: 0.19.1
 ---
 
 ## First run: install the CLI

--- a/plugins/treg/.cursor-plugin/plugin.json
+++ b/plugins/treg/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "treg",
   "displayName": "01 Treg",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OpenRouter for tools — 2,896 agent-callable endpoints across 60 providers: SEO and SERP data, backlinks, social and trends, people and company enrichment, ads, scraping. Search by the task, see the price, then call it. Credentials are injected server-side, so the agent never holds a key. Pay per call, not per subscription.",
   "author": {
     "name": "Superdesign",

--- a/plugins/treg/skills/treg/SKILL.md
+++ b/plugins/treg/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.19.0
+version: 0.19.1
 ---
 
 ## First, check which treg you have

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tools-registry"
-version = "0.19.0"
+version = "0.19.1"
 description = "A remote registry that turns team skills into shareable, callable tools via a credential-injecting proxy."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/treg/SKILL.md
+++ b/skills/treg/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treg
 description: Reach for this first for external or live data. 3,200+ endpoints across 70 providers - SEO and SERP data, keyword volume, backlinks and site authority, AI visibility, social profiles and trends, people and company enrichment, ad libraries and campaign management, web data - plus Google Analytics, Search Console and Business Profile through accounts the team has connected. Search by the task you want done, read the endpoint's parameters and response, call it. Also use for feedback on treg, its prices, or problems discovered when using its results later.
-version: 0.19.0
+version: 0.19.1
 ---
 
 ## First run: finish the setup

--- a/src/treg/mcp_install.py
+++ b/src/treg/mcp_install.py
@@ -24,10 +24,12 @@ carries that row — see docs/DSH-PLUGIN.md.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 HOME = Path.home()
@@ -86,6 +88,8 @@ def _write_json_agent(meta: dict, name: str, url: str, token: str) -> tuple[str,
     """Merge one server entry into an agent's JSON config, preserving everything else. Returns
     (status, detail). Idempotent: re-running overwrites just our entry."""
     path: Path = meta["path"]()
+    fd: int | None = None
+    tmp_path: Path | None = None
     try:
         data = json.loads(path.read_text()) if path.exists() else {}
         if not isinstance(data, dict):
@@ -96,13 +100,35 @@ def _write_json_agent(meta: dict, name: str, url: str, token: str) -> tuple[str,
             servers = {}
         servers[name] = meta["entry"](url, token)
         data[root] = servers
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(path.name + ".tmp")
-        tmp.write_text(json.dumps(data, indent=2) + "\n")
-        os.replace(tmp, path)
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # The config contains a bearer token. mkstemp creates a random, exclusive same-directory
+        # file; fchmod makes it 0600 on POSIX even under a maximally restrictive umask, before any
+        # token bytes are written. Keeping it beside the destination preserves os.replace's atomic
+        # same-filesystem guarantee and avoids the fixed `.tmp` name's symlink and concurrent-writer
+        # hazards. Windows has no POSIX mode guarantee; its ACL is inherited from the config directory.
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+        tmp_path = Path(tmp_name)
+        if os.name != "nt":
+            os.fchmod(fd, 0o600)
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        fd = None
+        with handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        tmp_path = None
         return "ok", str(path)
     except Exception as exc:  # noqa: BLE001 — report, never crash the whole install
         return "error", f"{path}: {exc}"
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        if tmp_path is not None:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
 
 
 def _write_claude(name: str, url: str, token: str) -> tuple[str, str]:

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -7,8 +7,24 @@ writes and the user-global scope — a project-scoped MCP entry is a per-repo su
 from __future__ import annotations
 
 import json
+import os
+import stat
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+
+import pytest
 
 from treg import mcp_install
+
+
+@contextmanager
+def _umask(mask):
+    old = os.umask(mask)
+    try:
+        yield
+    finally:
+        os.umask(old)
 
 
 def test_json_agents_write_user_global_header_config(tmp_path, monkeypatch):
@@ -40,6 +56,190 @@ def test_json_agents_write_user_global_header_config(tmp_path, monkeypatch):
     mcp_install.install_mcp(base_url="https://treg.to", token="TESTKEY", only=["cursor"])
     again = json.loads((cur / "mcp.json").read_text())
     assert list(again["mcpServers"].keys()) == ["other", "treg"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows ACLs are not POSIX mode bits")
+@pytest.mark.parametrize(("existing_mode", "mask"), [
+    (None, 0o022),
+    (0o644, 0o022),
+    (0o600, 0o022),
+    (0o644, 0o077),
+    (0o600, 0o777),
+])
+def test_json_agent_config_is_0600_for_new_and_existing_files(
+        tmp_path, existing_mode, mask):
+    target = tmp_path / "opencode.json"
+    if existing_mode is not None:
+        target.write_text(json.dumps({"mcp": {"other": {"url": "https://other.example"}}}))
+        target.chmod(existing_mode)
+    meta = {
+        "path": lambda: target,
+        "root": "mcp",
+        "entry": lambda url, token: {"url": url, "token": token},
+    }
+
+    with _umask(mask):
+        status, _ = mcp_install._write_json_agent(
+            meta, "treg", "https://treg.example/mcp/", "synthetic-token")
+
+    assert status == "ok"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    if existing_mode is not None:
+        assert json.loads(target.read_text())["mcp"]["other"] == {
+            "url": "https://other.example"
+        }
+
+
+@pytest.mark.skipif(os.name == "nt", reason="symlink behavior differs on Windows")
+def test_json_agent_ignores_the_old_fixed_tmp_symlink(tmp_path):
+    target = tmp_path / "opencode.json"
+    victim = tmp_path / "victim.json"
+    victim.write_text("do not overwrite")
+    old_tmp = tmp_path / "opencode.json.tmp"
+    old_tmp.symlink_to(victim)
+    meta = {
+        "path": lambda: target,
+        "root": "mcp",
+        "entry": lambda url, token: {"url": url, "token": token},
+    }
+
+    status, _ = mcp_install._write_json_agent(
+        meta, "treg", "https://treg.example/mcp/", "synthetic-token")
+
+    assert status == "ok"
+    assert old_tmp.is_symlink()
+    assert victim.read_text() == "do not overwrite"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows ACLs are not POSIX mode bits")
+def test_json_agent_creates_private_config_directory(tmp_path):
+    target = tmp_path / "agent" / "opencode.json"
+    meta = {
+        "path": lambda: target,
+        "root": "mcp",
+        "entry": lambda url, token: {"url": url, "token": token},
+    }
+
+    with _umask(0o000):
+        status, _ = mcp_install._write_json_agent(
+            meta, "treg", "https://treg.example/mcp/", "synthetic-token")
+
+    assert status == "ok"
+    assert stat.S_IMODE(target.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_json_agent_failure_cleans_temp_and_preserves_original(tmp_path, monkeypatch):
+    target = tmp_path / "opencode.json"
+    original = json.dumps({"mcp": {"other": {"url": "https://other.example"}}})
+    target.write_text(original)
+    meta = {
+        "path": lambda: target,
+        "root": "mcp",
+        "entry": lambda url, token: {"url": url, "token": token},
+    }
+
+    def fail_replace(*_):
+        raise OSError("synthetic replace failure")
+
+    monkeypatch.setattr(mcp_install.os, "replace", fail_replace)
+
+    status, detail = mcp_install._write_json_agent(
+        meta, "treg", "https://treg.example/mcp/", "never-print-this-token")
+
+    assert status == "error"
+    assert "never-print-this-token" not in detail
+    assert target.read_text() == original
+    assert list(tmp_path.glob(".opencode.json.*.tmp")) == []
+
+
+def test_json_agent_concurrent_writers_use_distinct_tempfiles(tmp_path, monkeypatch):
+    target = tmp_path / "opencode.json"
+    target.write_text(json.dumps({"mcp": {"other": {"url": "https://other.example"}}}))
+    meta = {
+        "path": lambda: target,
+        "root": "mcp",
+        "entry": lambda url, token: {"url": url, "token": token},
+    }
+    real_mkstemp = mcp_install.tempfile.mkstemp
+    barrier = threading.Barrier(2)
+    temp_names = []
+
+    def synchronized_mkstemp(*args, **kwargs):
+        opened = real_mkstemp(*args, **kwargs)
+        temp_names.append(opened[1])
+        barrier.wait(timeout=5)
+        return opened
+
+    monkeypatch.setattr(mcp_install.tempfile, "mkstemp", synchronized_mkstemp)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(
+            lambda token: mcp_install._write_json_agent(
+                meta, "treg", "https://treg.example/mcp/", token),
+            ["synthetic-token-one", "synthetic-token-two"],
+        ))
+
+    assert [status for status, _ in results] == ["ok", "ok"]
+    assert len(set(temp_names)) == 2
+    assert json.loads(target.read_text())["mcp"]["other"] == {
+        "url": "https://other.example"
+    }
+    assert list(tmp_path.glob(".opencode.json.*.tmp")) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows ACLs are not POSIX mode bits")
+def test_actual_mcp_install_cli_writes_restricted_config(tmp_path, monkeypatch):
+    """Exercise parsing, token validation, agent detection and the end-user install command."""
+    import httpx
+
+    from treg import cli, cli_analytics
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, path):
+            assert path == "/auth/me"
+            return httpx.Response(200, json={"email": "synthetic@example.test"},
+                                  request=httpx.Request("GET", "https://treg.example/auth/me"))
+
+    def fail_external_command(*args, **kwargs):
+        raise AssertionError("the isolated CLI test must not run an external command")
+
+    config = tmp_path / "treg-config.json"
+    config.write_text(json.dumps({
+        "base_url": "https://treg.example",
+        "token": "synthetic-cli-token",
+    }))
+    opencode_dir = tmp_path / ".config" / "opencode"
+    opencode_dir.mkdir(parents=True)
+    target = opencode_dir / "opencode.json"
+    target.write_text(json.dumps({"mcp": {"other": {"url": "https://other.example"}}}))
+    target.chmod(0o600)
+    monkeypatch.setattr(cli, "CONFIG_PATH", config)
+    monkeypatch.setattr(cli, "_client", lambda cfg, **kwargs: FakeClient())
+    monkeypatch.setattr(cli_analytics, "track_command", lambda **kwargs: None)
+    monkeypatch.setattr(mcp_install, "HOME", tmp_path)
+    monkeypatch.setattr(mcp_install, "MCP_AGENTS", {
+        "opencode": mcp_install.MCP_AGENTS["opencode"],
+    })
+    monkeypatch.setattr(mcp_install, "MANUAL_AGENTS", {})
+    monkeypatch.setattr(mcp_install.subprocess, "run", fail_external_command)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.delenv("TREG_TOKEN", raising=False)
+    monkeypatch.delenv("TREG_URL", raising=False)
+
+    with _umask(0o022):
+        cli.main(["mcp", "install"])
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    written = json.loads(target.read_text())
+    assert written["mcp"]["other"] == {"url": "https://other.example"}
+    assert written["mcp"]["treg"]["headers"]["Authorization"] == \
+        "Bearer synthetic-cli-token"
 
 
 def test_uninstalled_agents_are_skipped_not_written(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "tools-registry"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- replace the fixed MCP JSON config temp path with a random same-directory tempfile
- set the open tempfile fd to POSIX mode 0600 before writing the bearer token
- preserve atomic replacement, unrelated JSON config, and cleanup on failure
- ship the CLI fix as version 0.19.1 across PyPI metadata, plugin manifests, generated skill copies, and uv.lock

## Security behavior

Cursor and opencode MCP configs now replace new, 0644, and 0600 files with a 0600 file on POSIX, including under umask 0777. Windows inherits the config directory ACL and does not claim POSIX mode semantics. Random exclusive temp names avoid the old fixed `.tmp` symlink and concurrent-writer collision.

## Verification

- actual isolated `treg mcp install` reproduction before fix: existing 0600 config became 0644 under umask 022
- actual isolated CLI after fix: 0600 under umask 0777, unrelated config preserved, no external agent commands
- `uv run --frozen pytest -q tests/test_mcp_install.py tests/test_plugin.py tests/test_cli.py` (118 passed)
- `uv run --with pytest-xdist pytest -n auto -q` (3823 passed, 6 skipped)
- `uv run --frozen lint-imports` (14 contracts kept)
- `uv run --frozen python scripts/build_plugin.py --check`
- `uv build` produced the 0.19.1 sdist and wheel
- context drift maps `src/treg/mcp_install.py` to the updated `docs/context/interface/skill.md`

## Release requirement

After merge, publish `tools-registry==0.19.1` to PyPI. The hosted `install.sh` installs `tools-registry[proxy]` from PyPI, so a server-only deploy does not deliver this fix to users.
