### PR TITLE
fix(archive): retain DB body when R2 upload fails

### DIFF
--- a/docs/context/architecture/archive.md
+++ b/docs/context/architecture/archive.md
@@ -90,16 +90,17 @@ All switches are settings, with environment prefix `TREG_`:
 
 `both` first uploads, then enters the existing per-key lock / DB semaphore and transaction to
 store the DB body and publish the R2 location. No PUT occurs under a row lock or with a checked-out
-DB connection. On upload failure, `both` retains the DB copy with location `db`; `r2` publishes
-a hash-only snapshot with no body location. A successful upload followed by a failed DB transaction can leave an unreferenced
+DB connection. On upload failure, both R2 write modes retain an eligible DB copy with location
+`db`; the write setting chooses the normal destination, while DB remains the rare failure path.
+A successful upload followed by a failed DB transaction can leave an unreferenced
 content-addressed object; no pointer names a failed upload. Existing policy and size gates apply
 before uploading. Hash-only history stays in DB when bytes are ineligible.
 
 R2 has independent `ARCHIVE_R2_UPLOAD_CONCURRENCY` (8), `ARCHIVE_R2_MAX_PENDING` (256), and
 `ARCHIVE_R2_MAX_PENDING_BYTES` (128 MiB) budgets. A leader holds one upload slot for
 its bounded attempt sequence, including retry jitter; duplicate waiters hold no upload slot. The DB stage keeps its original two slots and 30-second deadline. Upload admission
-failure falls back to the separately bounded DB queue: `both` retains DB bytes, while `r2`
-retains only hash/history/statistics if DB admission succeeds.
+failure falls back to the separately bounded DB queue in both R2 write modes. Bodies rejected by
+policy or size remain hash-only; a later DB queue rejection remains an observable dropped recording.
 `ARCHIVE_R2_TIMEOUT_S` (10 seconds) bounds the complete PUT/retry sequence after upload-slot
 admission, including retry jitter. Upload-slot waiting is outside that timeout and is measured
 separately as `queue_wait_ms`. No extra timeout layer is introduced.
@@ -144,10 +145,11 @@ reads use these logs because they have no `tool_called`. Existing per-path proce
 additional bounded per-path/reason counters distinguish the failure classes.
 
 DB fallback requires a snapshot that still has DB bytes or a DB carrier, normally written during
-`db` or `both`. New `r2`-only writes have no DB copy: an R2 read failure becomes a cache miss and
-calls upstream for lookup; history returns `stored=false` with no response body, and terminal
-views have no archived terminal body. An old `both` snapshot can still fall back after the global
-write switch changes. A failed read does not mean the object was never archived or has been deleted.
+`db`, `both`, or a failed R2-only upload. Successful `r2` writes have no DB copy: an R2 read failure
+becomes a cache miss and calls upstream for lookup; history returns `stored=false` with no response
+body, and terminal views have no archived terminal body. An old `both` snapshot or an R2 upload's
+DB fallback can still serve after the global write switch changes. A failed read does not mean the
+object was never archived or has been deleted.
 Read timeout and fallback observability must precede `r2-first`, so the entire double-write window
 has visible fallback rates. Observing those rates is a prerequisite for closing the double-write
 window and switching new writes to `r2`.
@@ -156,7 +158,7 @@ window and switching new writes to `r2`.
 latency cannot delay it. The separate `archive_body_stored` completion event carries `call_ref`,
 `storage`, `upload_status`, `upload_ms`, `queue_wait_ms`, `dropped` and `drop_reason`. Join by
 `call_ref`. A failed R2 upload followed by a committed DB copy is not dropped. R2-only upload
-failure still records a hash-only snapshot and statistics. These remain best-effort background
+failure follows that same DB fallback for eligible bytes. These remain best-effort background
 writes: a killed process can lose completion events, but cannot withhold the calling event.
 The same completion event measures archive stages, including elapsed work on timeout or cancellation:
 
@@ -610,7 +612,7 @@ a stability comparison. Subsequent observations learn normally. This conservativ
 learning interval avoids object I/O inside a write session or an extra speculative GET per write.
 
 `WritePlan` is the single body-retention decision passed into the DB writer. DB retention is
-inferred from its storage location; failed R2-only uploads become hash-only plans. Each started
+inferred from its storage location; failed eligible R2-only uploads become `db` plans. Each started
 recording emits its completion report from one `finally` block, while queue callbacks release
 budgets and report cancellation of tasks that never started. `tool_called` remains independent.
 The object-store lifespan chooses a real or injected context once and always resets the seam.
@@ -646,8 +648,9 @@ Residual `rate_limited`/`upstream_error` failures get one retry on nonterminal u
 1.0-1.5 seconds of jitter before retry. This clears the one-write-per-second same-key window and
 shares the existing transfer deadline rather than restarting it. Exhaustion keeps `storage=db`
 in `both` mode with `upload_status=failed` and the classified `drop_reason`; the DB copy is not
-reported as dropped. R2-only mode retains its existing hash-only fallback. No SDK retries are
-enabled, no new DB writes/columns/tables are added, and no production setting is changed.
+reported as dropped. R2-only mode now uses the same DB fallback for eligible bytes. No SDK retries
+are enabled, no extra DB transaction or new column/table is added, and no production setting is
+changed.
 
 ### Timing and queue interpretation
 

--- a/src/treg/archive.py
+++ b/src/treg/archive.py
@@ -327,9 +327,11 @@ def record(
         if rejection is None:
             return kh, ch
         if rejection != "duplicate":
-            plan = archive_bodies.WritePlan("db" if plan.keep_db else None, reason=rejection)
+            # An eligible body rejected by the R2 admission bounds still needs a durable home.
+            # Both and R2-only modes use the separately bounded DB queue as their fallback.
+            plan = archive_bodies.WritePlan("db", reason=rejection)
         # Duplicates use the existing bounded DB queue and still join prepare's shared upload.
-        # Both mode preserves the DB copy when admission of a distinct upload is rejected.
+        # A distinct rejected upload preserves its body in DB in either R2 write mode.
 
     body_len = len(body)
     # Shed on EITHER count OR bytes — whichever bound bites first. The bytes bound prevents OOM

--- a/src/treg/archive_bodies.py
+++ b/src/treg/archive_bodies.py
@@ -198,7 +198,11 @@ async def prepare(body: bytes, content_hash: str, *, mode: str, observation: Sto
             inflight.pop(content_hash, None)
             flight.set_result(reason)
             observation.props["archive_body_upload_ms"] = round(observation.props["archive_body_upload_ms"], 3)
-    return WritePlan(mode) if reason is None else WritePlan("db" if mode == "both" else None, reason=reason)
+    # The write mode selects the normal destination, not the failure policy. Once an eligible
+    # body cannot be published to R2, retain it in DB so the snapshot remains readable. This is
+    # deliberately rare and keeps R2-only operation from turning a transient store fault into
+    # permanent body loss.
+    return WritePlan(mode) if reason is None else WritePlan("db", reason=reason)
 
 
 def submit(factory, body_len: int, observation: StorageReport, *, content_hash: str) -> str | None:

--- a/tests/test_archive_r2.py
+++ b/tests/test_archive_r2.py
@@ -137,8 +137,8 @@ async def test_call_reports_where_archive_db_deadline_expires(clients, r2, monke
         assert report['record_sem_wait_ms'] is None
 
 
-@pytest.mark.parametrize('mode,expected_rows', [('both', 1), ('r2', 1)])
-async def test_upload_failure_never_publishes_r2_pointer(clients, r2, monkeypatch, mode, expected_rows):
+@pytest.mark.parametrize('mode', ['both', 'r2'])
+async def test_upload_failure_falls_back_to_db_without_r2_pointer(clients, r2, monkeypatch, mode):
     monkeypatch.setattr(get_settings(), 'archive_body_write', mode)
     r2.fail_puts = 100
     events = []
@@ -147,12 +147,36 @@ async def test_upload_failure_never_publishes_r2_pointer(clients, r2, monkeypatc
     assert response.content == RAW and response.status_code == 200
     await archive.drain()
     rows = await snapshots()
-    assert len(rows) == expected_rows and all(row.body_storage == ('db' if mode == 'both' else None) for row in rows)
+    assert len(rows) == 1 and rows[0].body_storage == 'db'
+    assert archive._unpack(rows[0].body, rows[0].enc) == RAW
+    assert not r2.objects
     props = [p for name, p in events if name == 'archive_body_stored']
     assert len(props) == 1
     assert props[0]['drop_reason'] == 'store_error'
     assert props[0]['upload_status'] == 'failed'
-    assert props[0]['dropped'] is (mode == 'r2')
+    assert props[0]['storage'] == 'db'
+    assert props[0]['dropped'] is False
+
+
+async def test_r2_only_upload_admission_failure_falls_back_to_db(clients, r2, monkeypatch):
+    monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
+    monkeypatch.setattr(get_settings(), 'archive_r2_max_pending', 0)
+    events = []
+    monkeypatch.setattr(service.analytics, 'capture',
+                        lambda who, name, props, **kw: events.append((name, props)))
+
+    response = await clients.get(URL)
+    assert response.content == RAW and response.status_code == 200
+    await archive.drain()
+
+    rows = await snapshots()
+    assert len(rows) == 1 and rows[0].body_storage == 'db'
+    assert archive._unpack(rows[0].body, rows[0].enc) == RAW
+    assert r2.put_calls == 0 and not r2.objects
+    report = next(p for name, p in events if name == 'archive_body_stored')
+    assert report['upload_status'] == 'dropped'
+    assert report['drop_reason'] == 'upload_queue_full'
+    assert report['storage'] == 'db' and report['dropped'] is False
 
 
 async def test_r2_queue_has_independent_concurrency_and_sheds_observably(clients, r2, monkeypatch):
@@ -293,7 +317,10 @@ async def test_checksum_mismatch_is_not_published(clients, r2, monkeypatch):
     monkeypatch.setattr(get_settings(), 'archive_body_write', 'r2')
     await clients.get(URL)
     await archive.drain()
-    assert (await snapshots())[0].body_storage is None
+    row = (await snapshots())[0]
+    assert row.body_storage == 'db'
+    assert archive._unpack(row.body, row.enc) == RAW
+    assert not r2.objects
 
 
 @pytest.mark.parametrize('path', ['/calls', '/calls/{ref}'])
@@ -871,7 +898,9 @@ async def test_transient_put_retry_and_db_fallback(clients, r2, monkeypatch, sta
     assert report['dropped'] is False
 
 
-async def test_retry_jitter_stays_inside_existing_upload_budget(clients, r2, monkeypatch):
+@pytest.mark.parametrize('mode', ['both', 'r2'])
+async def test_retry_jitter_stays_inside_existing_upload_budget(clients, r2, monkeypatch, mode):
+    monkeypatch.setattr(get_settings(), 'archive_body_write', mode)
     monkeypatch.setattr(get_settings(), 'archive_r2_timeout_s', 0.02)
     r2.put_failures = [429]
     events = []


### PR DESCRIPTION
R2-only archive writes currently turn any upload error, timeout, checksum mismatch, or upload-queue rejection into a hash-only snapshot. At the observed production failure rate this would lose several readable bodies per day after the write switch.

This change treats `r2` as the normal destination while retaining eligible bytes in DB when R2 cannot publish them. The fallback uses the existing bounded DB queue and transaction, records `storage=db` with the R2 failure reason, and never publishes an R2 pointer for a failed upload. Successful R2-only writes remain body-free in DB, and policy/size-ineligible responses remain hash-only.

Updated `docs/context/architecture/archive.md`.

Validation:
- Reproduced the old hash-only R2 failure through `/call/`
- 122 R2 archive tests passed after rebase
- 288 archive tests passed
- Full suite: 3,817 passed, 6 skipped
- 14 import contracts passed
- Context drift maps both changed source files to the updated archive fragment
