### PR TITLE
fix(catalog): require Serpstat JSON-RPC id in call templates

### DIFF
--- a/src/treg/catalog/serpstat.yaml
+++ b/src/treg/catalog/serpstat.yaml
@@ -21,8 +21,10 @@ source:
 #
 #  1. JSON-RPC, NOT REST — ONE PATH FOR EVERYTHING. Every call is `POST /` against base_url
 #     (https://api.serpstat.com/v4) with a body of {"id": "1", "method": "<Procedure.method>",
-#     "params": {…}}. So every entry below shares the SAME path and differs only in `body.method`.
-#     The `method` string is the operation; getting it wrong is the only way to call the wrong report.
+#     "params": {…}}. `id` is required by Serpstat's JSON-RPC envelope (any string; echoed back);
+#     omitting it fails the call. Every entry below shares the SAME path and differs only in
+#     `body.method`. The `method` string is the operation; getting it wrong is the only way to
+#     call the wrong report.
 #  2. The token rides as `?token=…` and is INJECTED by treg — never list it as user input.
 #  3. HTTP 200 IS NOT SUCCESS. A bad token, an exhausted limit and a malformed params object all
 #     answer HTTP 200 with an `error` object in the envelope instead of `result`. treg's registry
@@ -68,7 +70,7 @@ endpoints:
       body:
         method: {type: string, required: true, note: "the JSON-RPC operation — this literal string selects the report", example: "SerpstatDomainProcedure.getDomainsInfo"}
         params: {type: object, required: true, note: "see the fields below; they go INSIDE params, not at the top level"}
-        id: {type: string, required: false, note: "JSON-RPC correlation id echoed back in the response; any string", example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.domains": {type: "array[string]", required: true, note: "1 to 10 bare domains", example: ["serpstat.com"]}
         "params.se": {type: string, required: true, note: "search database, e.g. g_us, g_uk, g_de, bing_us", example: "g_us"}
         "params.filters": {type: object, required: false, note: "optional narrowing: traff / traff_from / traff_to (estimated traffic) and visible / visible_from / visible_to (visibility score)"}
@@ -99,7 +101,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatDomainProcedure.getDomainKeywords"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.domain": {type: string, required: true, note: "bare domain, no scheme", example: "serpstat.com"}
         "params.se": {type: string, required: true, note: "search database", example: "g_us"}
         "params.withSubdomains": {type: boolean, required: false, note: "include subdomains in the result"}
@@ -138,7 +140,7 @@ endpoints:
       body:
         method: {type: string, required: true, note: "SerpstatDomainProcedure.getCompetitors is the DEPRECATED spelling of this report — use the Page form below", example: "SerpstatDomainProcedure.getOrganicCompetitorsPage"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.domain": {type: string, required: true, note: "bare domain, no scheme", example: "serpstat.com"}
         "params.se": {type: string, required: true, note: "search database", example: "g_us"}
         "params.size": {type: integer, required: false, note: "COST DIAL — competitors to return, 1 to 100, default 20", example: 10}
@@ -171,7 +173,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatKeywordProcedure.getKeywordsInfo"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.keywords": {type: "array[string]", required: true, note: "1 to 1,000 keywords", example: ["seo"]}
         "params.se": {type: string, required: true, note: "search database", example: "g_us"}
         "params.withIntents": {type: boolean, required: false, note: "attach the search intent of each keyword"}
@@ -204,7 +206,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatKeywordProcedure.getRelatedKeywords"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.keyword": {type: string, required: true, note: "the seed keyword", example: "seo"}
         "params.se": {type: string, required: true, note: "search database", example: "g_us"}
         "params.withIntents": {type: boolean, required: false, note: "default false"}
@@ -242,7 +244,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatKeywordProcedure.getKeywordTop"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.keyword": {type: string, required: true, note: "the keyword whose SERP you want", example: "seo"}
         "params.se": {type: string, required: true, note: "search database", example: "g_us"}
         "params.size": {type: integer, required: false, note: "COST DIAL — rows to return, max 1,000", example: 10}
@@ -283,7 +285,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatBacklinksProcedure.getSummaryV2"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.query": {type: string, required: true, note: "the domain to summarise", example: "serpstat.com"}
         "params.searchType": {type: string, required: false, note: "domain (default) | domain_with_subdomains", example: "domain"}
       note: "the V2 spelling is the current one — `getSummary` (no V2) is DEPRECATED and returns a different shape. Returns link counts, referring domain/IP/subnet counts, the domain authority indicator and link-type breakdown as a single OBJECT under `result.data`, not an array."
@@ -313,7 +315,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatBacklinksProcedure.getNewBacklinks"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.query": {type: string, required: true, note: "the target — a domain or URL, matching searchType", example: "serpstat.com"}
         "params.searchType": {type: string, required: false, note: "url | domain (default) | part_url | domain_with_subdomains", example: "domain"}
         "params.page": {type: integer, required: false, note: "1-based; default 1"}
@@ -352,7 +354,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatBacklinksProcedure.getRefDomains"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.query": {type: string, required: true, note: "the target domain", example: "serpstat.com"}
         "params.searchType": {type: string, required: false, note: "domain (default) | domain_with_subdomains — narrower than the backlink list, which also accepts url and part_url", example: "domain"}
         "params.page": {type: integer, required: false, note: "1-based; default 1"}
@@ -387,7 +389,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatBacklinksProcedure.getAnchors"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.query": {type: string, required: true, note: "the target", example: "serpstat.com"}
         "params.searchType": {type: string, required: true, note: "url | domain | part_url | domain_with_subdomains — REQUIRED here, unlike the sibling backlink methods where it defaults", example: "domain"}
         "params.anchor": {type: string, required: false, note: "only anchors containing this text"}
@@ -424,7 +426,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatBacklinksProcedure.getTopPages"}
         params: {type: object, required: true}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
         "params.query": {type: string, required: true, note: "the target domain", example: "serpstat.com"}
         "params.searchType": {type: string, required: false, note: "domain (default) | domain_with_subdomains", example: "domain"}
         "params.page": {type: integer, required: false, note: "1-based; default 1"}
@@ -461,7 +463,7 @@ endpoints:
       body:
         method: {type: string, required: true, example: "SerpstatLimitsProcedure.getStats"}
         params: {type: object, required: true, note: "takes no fields — send an empty object {}"}
-        id: {type: string, required: false, example: "1"}
+        id: {type: string, required: true, note: "required by Serpstat's JSON-RPC envelope; any string, echoed back in the response", example: "1"}
       note: |
         Takes no parameters but `params` must still be present as `{}`. This is the right call to
         make BEFORE any large `size` sweep, since every list method in this file is metered per row.

--- a/tests/test_catalog_api.py
+++ b/tests/test_catalog_api.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import re
+import shlex
 
 from httpx import AsyncClient
 
@@ -614,6 +615,27 @@ async def test_eligibility_rides_on_the_served_row(clients: AsyncClient):
 async def test_unknown_endpoint_is_404(clients: AsyncClient):
     r = await clients.get("/catalog/endpoints/tikhub.tiktok.nope")
     assert r.status_code == 404 and "tikhub.tiktok.nope" in r.text
+
+
+def test_serpstat_jsonrpc_id_is_required_in_call_template():
+    """Serpstat rejects a JSON-RPC body without top-level `id`. `call_template` only
+    includes required body fields via `_required_examples`, so `id` must be required
+    on every Serpstat endpoint that declares it."""
+    cat = cs.load()
+    serpstat = [ep for ep in cat.endpoints if ep["provider"] == "serpstat"]
+    assert len(serpstat) >= 12, "every curated Serpstat endpoint is in play"
+    for ep in serpstat:
+        field = ((ep.get("input") or {}).get("body") or {}).get("id")
+        assert isinstance(field, dict), ep["id"]
+        assert field.get("required") is True, ep["id"]
+        assert field.get("example") == "1", ep["id"]
+
+    tmpl = cs.call_template(cat.by_id["serpstat.web.backlinks.summary"])
+    assert tmpl.startswith("treg call serpstat.web.backlinks.summary --method POST")
+    argv = shlex.split(tmpl)
+    data = json.loads(argv[argv.index("--data") + 1])
+    assert data["id"] == "1"
+    assert data["method"] == "SerpstatBacklinksProcedure.getSummaryV2"
 
 
 def test_call_template_falls_back_to_documented_examples(tmp_path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this does

Serpstat's JSON-RPC envelope requires a top-level `id` (for example `"1"`). Catalog examples and `call_template` omitted it because every Serpstat endpoint marked `id` as `required: false`, and `call_template` only copies required body fields.

This PR marks `id` as required on all 12 Serpstat endpoints and keeps the example `"1"`. Paste-ready `treg call` lines now include `"id":"1"` in `--data`.

Customer feedback #187 reported `serpstat.web.backlinks.summary` failing without `id`. Related tickets #73 and #147 are the same class of catalog example; this YAML change covers those endpoints too. No separate code paths.

Please review and merge this yourself. Do not auto-merge.

## Out of scope

- Settlement, pricing, and "charge on error" behavior (the reporter also mentioned billing on the failed call)
- Auto-injecting `id` in the proxy or resolve layer

## How it was tested

- New test: every Serpstat endpoint that declares body `id` has `required: true`, and `call_template` for `serpstat.web.backlinks.summary` includes `"id":"1"`
- `uv run --frozen python -m pytest tests/test_catalog_api.py tests/test_catalog_validate.py -q` — 153 passed
- `uv run --with pytest-xdist pytest -n auto -q` — 3826 passed, 6 skipped

## Checklist

- [x] `uv run --with pytest-xdist pytest -n auto -q` passes locally
- [x] Added or updated tests for the change
- [x] No `docs/context/` update: fragments do not claim Serpstat `id` is optional. `serpstat.yaml` is not listed as a catalog fragment source (drift.sh notes that gap); folding it in is out of scope here
- [x] No secrets in the diff

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2526c237-02e6-5dc4-8e6f-3d77808df0c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2526c237-02e6-5dc4-8e6f-3d77808df0c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

